### PR TITLE
feat: implement MixpanelAPIClient (Phase 002)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,57 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [labeled]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.py"
@@ -10,11 +10,10 @@ on:
     #   - "pyproject.toml"
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run when the "claude-review" label is applied by the repository owner
+    if: |
+      github.event.label.name == 'claude-review' &&
+      github.event.sender.login == github.repository_owner
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,11 +5,9 @@ on:
     types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-
+    #   - "src/**/*.py"
+    #   - "tests/**/*.py"
+    #   - "pyproject.toml"
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -53,5 +51,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(pytest *),Bash(ruff check *),Bash(mypy *)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,8 +5,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,14 +13,31 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR') &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR') &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR') &&
+        contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR') &&
+        (contains(github.event.issue.body, '@claude') ||
+         contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -43,8 +60,10 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Restrict Claude to only the Bash commands needed in this repository
+          # (install dev dependencies, run tests, lint, and type check).
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          # or https://code.claude.com/docs/en/cli-reference for available options.
+          claude_args: >
+            --allowed-tools
+            Bash(pip install -e ".[dev]"*|pytest*|ruff*|mypy*)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,4 +173,9 @@ ruff check src/ tests/
 ```
 
 ## Recent Changes
+- 002-api-client: Added Python 3.11+ (Constitution requirement) + httpx (HTTP client per Constitution), pydantic (validation)
 - 001-foundation-layer: Implemented complete foundation layer (exceptions, types, config, auth)
+
+## Active Technologies
+- Python 3.11+ (Constitution requirement) + httpx (HTTP client per Constitution), pydantic (validation) (002-api-client)
+- N/A (client has no storage responsibility; Phase 003 handles DuckDB) (002-api-client)

--- a/specs/002-api-client/checklists/requirements.md
+++ b/specs/002-api-client/checklists/requirements.md
@@ -1,0 +1,63 @@
+# Specification Quality Checklist: Mixpanel API Client
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+### Content Quality Review
+- Spec describes WHAT the client does (authentication, rate limiting, streaming) without specifying HOW (no mention of httpx internals, specific algorithms, etc.)
+- User stories focus on developer experience and data access needs
+- Written in terms of behaviors and outcomes, not code
+
+### Requirement Completeness Review
+- 26 functional requirements, all testable with clear pass/fail criteria
+- 8 user stories with prioritization (P1-P3) and acceptance scenarios
+- 6 edge cases identified with expected behaviors
+- Dependencies clearly stated (Phase 001, httpx)
+- Assumptions documented (service accounts, synchronous, etc.)
+
+### Technology-Agnostic Verification
+- SC-001: "accessible via single client instance" - describes capability, not implementation
+- SC-002: "95%+ of rate-limited requests succeed" - measurable outcome
+- SC-003: "1 million+ records without memory exhaustion" - performance outcome
+- SC-004: "90%+ errors mapped to exception types" - coverage metric
+- SC-005: "Credentials never appear in..." - security requirement
+- SC-006: "90%+ test coverage" - quality metric
+
+### No Clarifications Needed
+All requirements are concrete and actionable. Design decisions are reasonable defaults:
+- HTTP Basic auth (standard for Mixpanel service accounts)
+- Exponential backoff with jitter (industry standard)
+- Streaming for exports (memory efficiency)
+- Context manager pattern (Python convention)
+
+## Status: READY FOR PLANNING
+
+All checklist items pass. Specification is ready for `/speckit.plan`.

--- a/specs/002-api-client/contracts/api_client.py
+++ b/specs/002-api-client/contracts/api_client.py
@@ -1,0 +1,296 @@
+"""API Client Contract - Type stubs for MixpanelAPIClient.
+
+This file defines the public interface that MixpanelAPIClient must implement.
+It serves as a contract between the client and its consumers (services).
+
+DO NOT import this file in production code. It is for documentation and
+type checking reference only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any, Protocol
+
+from mixpanel_data._internal.config import Credentials
+
+
+class MixpanelAPIClientProtocol(Protocol):
+    """Protocol defining the MixpanelAPIClient interface.
+
+    All methods must be implemented by the concrete MixpanelAPIClient class.
+    """
+
+    def __init__(
+        self,
+        credentials: Credentials,
+        *,
+        timeout: float = 30.0,
+        export_timeout: float = 300.0,
+        max_retries: int = 3,
+    ) -> None:
+        """Initialize the API client.
+
+        Args:
+            credentials: Immutable authentication credentials.
+            timeout: Request timeout in seconds for regular requests.
+            export_timeout: Request timeout for export operations.
+            max_retries: Maximum retry attempts for rate-limited requests.
+        """
+        ...
+
+    # =========================================================================
+    # Lifecycle
+    # =========================================================================
+
+    def close(self) -> None:
+        """Close the HTTP client and release resources."""
+        ...
+
+    def __enter__(self) -> MixpanelAPIClientProtocol:
+        """Enter context manager."""
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit context manager, closing client."""
+        ...
+
+    # =========================================================================
+    # Export API - Streaming
+    # =========================================================================
+
+    def export_events(
+        self,
+        from_date: str,
+        to_date: str,
+        *,
+        events: list[str] | None = None,
+        where: str | None = None,
+        on_batch: Callable[[int], None] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream events from the Export API.
+
+        Args:
+            from_date: Start date (YYYY-MM-DD, inclusive).
+            to_date: End date (YYYY-MM-DD, inclusive).
+            events: Optional list of event names to filter.
+            where: Optional filter expression.
+            on_batch: Optional callback invoked with count after each batch.
+
+        Yields:
+            Event dictionaries with 'event' and 'properties' keys.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            RateLimitError: Rate limit exceeded after max retries.
+            QueryError: Invalid parameters.
+        """
+        ...
+
+    def export_profiles(
+        self,
+        *,
+        where: str | None = None,
+        on_batch: Callable[[int], None] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream profiles from the Engage API.
+
+        Args:
+            where: Optional filter expression.
+            on_batch: Optional callback invoked with count after each page.
+
+        Yields:
+            Profile dictionaries with '$distinct_id' and '$properties' keys.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            RateLimitError: Rate limit exceeded after max retries.
+        """
+        ...
+
+    # =========================================================================
+    # Discovery API
+    # =========================================================================
+
+    def get_events(self) -> list[str]:
+        """List all event names in the project.
+
+        Returns:
+            List of event name strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+        """
+        ...
+
+    def get_event_properties(self, event: str) -> list[str]:
+        """List properties for a specific event.
+
+        Args:
+            event: Event name.
+
+        Returns:
+            List of property name strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid event name.
+        """
+        ...
+
+    def get_property_values(
+        self,
+        property_name: str,
+        *,
+        event: str | None = None,
+        limit: int = 255,
+    ) -> list[str]:
+        """List sample values for a property.
+
+        Args:
+            property_name: Property name.
+            event: Optional event name to scope the property.
+            limit: Maximum number of values to return.
+
+        Returns:
+            List of property value strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+        """
+        ...
+
+    # =========================================================================
+    # Query API - Raw Responses
+    # =========================================================================
+
+    def segmentation(
+        self,
+        event: str,
+        from_date: str,
+        to_date: str,
+        *,
+        on: str | None = None,
+        unit: str = "day",
+        type: str = "general",
+        where: str | None = None,
+    ) -> dict[str, Any]:
+        """Run a segmentation query.
+
+        Args:
+            event: Event name to segment.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            on: Optional property to segment by.
+            unit: Time unit (minute, hour, day, week, month).
+            type: Aggregation type (general, unique, average).
+            where: Optional filter expression.
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid query parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        ...
+
+    def funnel(
+        self,
+        funnel_id: int,
+        from_date: str,
+        to_date: str,
+        *,
+        unit: str | None = None,
+        on: str | None = None,
+        where: str | None = None,
+        length: int | None = None,
+        length_unit: str | None = None,
+    ) -> dict[str, Any]:
+        """Run a funnel analysis query.
+
+        Args:
+            funnel_id: Funnel identifier.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            unit: Time unit for grouping.
+            on: Optional property to segment by.
+            where: Optional filter expression.
+            length: Conversion window length.
+            length_unit: Conversion window unit.
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid funnel ID or parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        ...
+
+    def retention(
+        self,
+        born_event: str,
+        event: str,
+        from_date: str,
+        to_date: str,
+        *,
+        retention_type: str = "birth",
+        born_where: str | None = None,
+        where: str | None = None,
+        interval: int = 1,
+        interval_count: int = 8,
+        unit: str = "day",
+    ) -> dict[str, Any]:
+        """Run a retention analysis query.
+
+        Args:
+            born_event: Event that defines cohort membership.
+            event: Event that defines return.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            retention_type: Retention type (birth, compounded).
+            born_where: Optional filter for born event.
+            where: Optional filter for return event.
+            interval: Retention interval size.
+            interval_count: Number of intervals to track.
+            unit: Interval unit (day, week, month).
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        ...
+
+    def jql(
+        self,
+        script: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        """Execute a JQL (JavaScript Query Language) script.
+
+        Args:
+            script: JQL script code.
+            params: Optional parameters to pass to the script.
+
+        Returns:
+            List of results from script execution.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Script execution error.
+            RateLimitError: Rate limit exceeded.
+        """
+        ...

--- a/specs/002-api-client/data-model.md
+++ b/specs/002-api-client/data-model.md
@@ -1,0 +1,200 @@
+# Data Model: Mixpanel API Client
+
+**Date**: 2025-12-20
+**Feature**: 002-api-client
+
+## Overview
+
+The API Client is a stateless HTTP layer. It doesn't persist data—it transforms Mixpanel API responses into Python data structures. The "data model" here describes the shape of data flowing through the client.
+
+## Entities
+
+### 1. MixpanelAPIClient
+
+The client itself is the primary entity. It holds connection state but no application data.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| credentials | Credentials | Immutable auth data (from Phase 001) |
+| timeout | float | Request timeout in seconds |
+| max_retries | int | Maximum retry attempts for rate limits |
+| _client | httpx.Client | Internal HTTP client with connection pooling |
+
+**State Transitions**:
+- `Created` → `Open` (on first request or context entry)
+- `Open` → `Closed` (on close() or context exit)
+- Once `Closed`, cannot be reopened
+
+**Validation Rules**:
+- credentials: Must be valid Credentials instance
+- timeout: Must be positive number
+- max_retries: Must be non-negative integer
+
+---
+
+### 2. Export Event (Output)
+
+Raw event data from Export API. Caller receives as Python dict.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| event | string | Event name |
+| properties | object | Event properties including: |
+| properties.time | integer | Unix timestamp (seconds) |
+| properties.distinct_id | string | User identifier |
+| properties.$insert_id | string | Unique event identifier |
+| properties.mp_processing_time_ms | integer | Server processing time |
+| properties.* | any | Custom event properties |
+
+**Example**:
+```json
+{
+    "event": "Purchase",
+    "properties": {
+        "time": 1704067200,
+        "distinct_id": "user_123",
+        "$insert_id": "abc123",
+        "amount": 99.99,
+        "currency": "USD"
+    }
+}
+```
+
+---
+
+### 3. Profile (Output)
+
+User profile data from Engage API. Caller receives as Python dict.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| $distinct_id | string | User identifier |
+| $properties | object | Profile properties |
+| $properties.$last_seen | string | ISO timestamp of last activity |
+| $properties.$name | string | Display name (optional) |
+| $properties.$email | string | Email (optional) |
+| $properties.* | any | Custom profile properties |
+
+**Example**:
+```json
+{
+    "$distinct_id": "user_123",
+    "$properties": {
+        "$last_seen": "2024-01-15T10:30:00",
+        "$name": "Jane Doe",
+        "plan": "premium",
+        "signup_date": "2023-06-01"
+    }
+}
+```
+
+---
+
+### 4. Query Responses (Output)
+
+#### 4.1 Segmentation Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| legend_size | integer | Number of segments |
+| data.series | object | Time series by segment |
+| data.values | object | Values by segment and date |
+
+#### 4.2 Funnel Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| meta.dates | object | Date range |
+| data | array | Step-by-step conversion data |
+| data[].count | integer | Users at step |
+| data[].step_conv_ratio | float | Conversion from previous |
+| data[].overall_conv_ratio | float | Conversion from first |
+
+#### 4.3 Retention Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| data | object | Cohort retention data |
+| data.{date}.counts | array | Retention counts by period |
+| data.{date}.first | integer | Cohort size |
+
+#### 4.4 JQL Response
+
+| Type | Description |
+|------|-------------|
+| list | Array of results from JQL script |
+
+---
+
+### 5. Discovery Responses (Output)
+
+#### 5.1 Event Names
+
+| Type | Description |
+|------|-------------|
+| list[string] | Array of event names |
+
+#### 5.2 Event Properties
+
+| Type | Description |
+|------|-------------|
+| list[string] | Array of property names for an event |
+
+#### 5.3 Property Values
+
+| Type | Description |
+|------|-------------|
+| list[string] | Sample values for a property |
+
+---
+
+## Data Flow
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         Callers                                   │
+│  (FetcherService, LiveQueryService, DiscoveryService, Workspace) │
+└─────────────────────────────┬────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                    MixpanelAPIClient                              │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ Input: Credentials, method params                          │  │
+│  │ Output: Iterator[dict] for exports                         │  │
+│  │         dict for queries                                   │  │
+│  │         list[str] for discovery                            │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────┬────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                     Mixpanel APIs                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐   │
+│  │ Export API   │  │ Query API    │  │ Events/Discovery API │   │
+│  │ (JSONL)      │  │ (JSON)       │  │ (JSON)               │   │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Relationships
+
+```
+Credentials (Phase 001)
+    │
+    └──► MixpanelAPIClient (this phase)
+              │
+              ├──► Iterator[ExportEvent]
+              ├──► Iterator[Profile]
+              ├──► SegmentationResponse
+              ├──► FunnelResponse
+              ├──► RetentionResponse
+              ├──► JQLResponse
+              └──► list[str] (discovery)
+```
+
+## Notes
+
+- All output types are raw Python dicts/lists, not Pydantic models
+- Response transformation to result types (FetchResult, SegmentationResult, etc.) happens in service layer, not client
+- The client is intentionally thin—it's HTTP + parsing, nothing more

--- a/specs/002-api-client/plan.md
+++ b/specs/002-api-client/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Mixpanel API Client
+
+**Branch**: `002-api-client` | **Date**: 2025-12-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-api-client/spec.md`
+
+## Summary
+
+The Mixpanel API Client (`MixpanelAPIClient`) is a unified HTTP interface for all Mixpanel APIs. It handles service account authentication via HTTP Basic auth, regional endpoint routing (US/EU/India), automatic rate limit handling with exponential backoff, and streaming JSONL parsing for large exports. The client operates as a pure HTTP layer with no storage knowledge, returning raw API responses for upstream services to transform.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (Constitution requirement)
+**Primary Dependencies**: httpx (HTTP client per Constitution), pydantic (validation)
+**Storage**: N/A (client has no storage responsibility; Phase 003 handles DuckDB)
+**Testing**: pytest with httpx.MockTransport for deterministic HTTP mocking
+**Target Platform**: Cross-platform Python (Linux, macOS, Windows)
+**Project Type**: Single project library with CLI wrapper
+**Performance Goals**: Stream 1M+ events without memory exhaustion; support 60 requests/hour rate limit
+**Constraints**: <300s timeout for exports; constant memory during streaming; credentials never in logs
+**Scale/Scope**: Single client instance per Workspace; handles all Mixpanel API endpoints
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Library-First | ✅ PASS | `MixpanelAPIClient` is a Python class, not CLI; all methods are importable |
+| II. Agent-Native | ✅ PASS | Returns structured dicts/lists; no interactive prompts; streaming for large data |
+| III. Context Window Efficiency | ✅ PASS | Streaming iterators for exports; discovery methods for introspection |
+| IV. Two Data Paths | ✅ PASS | Client supports both live queries (segmentation) and export APIs |
+| V. Explicit Over Implicit | ✅ PASS | No automatic retry beyond configured max; explicit exceptions for all errors |
+| VI. Unix Philosophy | ✅ PASS | Client does one thing (HTTP); raw responses composable with other tools |
+| VII. Secure by Default | ✅ PASS | FR-004 mandates no credentials in logs/errors; SecretStr for secrets |
+
+**Technology Stack Compliance**:
+- [x] httpx for HTTP (not requests) per Constitution
+- [x] Pydantic for credential validation (already in Phase 001)
+- [x] Type hints throughout
+- [x] Depends on existing exceptions from Phase 001
+
+**Gate Result**: ✅ PASSED - Proceed to Phase 0
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-api-client/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api-client.py    # Type stubs / interface contract
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── __init__.py              # Exports (add MixpanelAPIClient if public)
+├── exceptions.py            # ✅ Exists: AuthenticationError, RateLimitError, QueryError
+├── types.py                 # ✅ Exists: Result types (used by services, not client)
+├── _internal/
+│   ├── __init__.py          # ✅ Exists
+│   ├── config.py            # ✅ Exists: Credentials class
+│   └── api_client.py        # 🆕 NEW: MixpanelAPIClient implementation
+└── cli/                     # (Phase 008 - not this phase)
+
+tests/
+├── unit/
+│   └── test_api_client.py   # 🆕 NEW: Unit tests with mock transport
+├── integration/
+│   └── test_api_client_integration.py  # 🆕 NEW: Real API tests (optional)
+└── conftest.py              # ✅ Exists: Add fixtures for mock client
+```
+
+**Structure Decision**: Single project layout (already established in Phase 001). API client is a private implementation detail in `_internal/`, exposed to services but not directly to users.
+
+## Constitution Re-Check (Post-Design)
+
+*Verified after Phase 1 design completion.*
+
+| Principle | Status | Post-Design Evidence |
+|-----------|--------|---------------------|
+| I. Library-First | ✅ PASS | Contract defines pure Python Protocol; no CLI dependencies |
+| II. Agent-Native | ✅ PASS | All methods return Iterator/dict/list; on_batch callback for progress |
+| III. Context Window Efficiency | ✅ PASS | data-model.md shows streaming iterators throughout |
+| IV. Two Data Paths | ✅ PASS | export_events() + segmentation/funnel/retention methods |
+| V. Explicit Over Implicit | ✅ PASS | Contract shows explicit exceptions for all error cases |
+| VI. Unix Philosophy | ✅ PASS | Client is pure HTTP; raw responses for composability |
+| VII. Secure by Default | ✅ PASS | Contract uses Credentials (SecretStr); no credential exposure |
+
+**Post-Design Gate Result**: ✅ PASSED - Ready for `/speckit.tasks`
+
+## Complexity Tracking
+
+No constitution violations. All requirements align with established principles.
+
+| Aspect | Decision | Rationale |
+|--------|----------|-----------|
+| Rate limiting | Per-instance, not global | Simpler; each client handles its own retry state |
+| Streaming | Line-by-line parsing | Memory-efficient; matches JSONL format |
+| Error mapping | Exception hierarchy | Reuses Phase 001 exceptions; no new exception types needed |
+
+## Generated Artifacts
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| Research | [research.md](research.md) | Technical decisions and alternatives |
+| Data Model | [data-model.md](data-model.md) | Entity definitions and data flow |
+| Contract | [contracts/api_client.py](contracts/api_client.py) | Type stubs / interface definition |
+| Quickstart | [quickstart.md](quickstart.md) | Developer usage guide |

--- a/specs/002-api-client/quickstart.md
+++ b/specs/002-api-client/quickstart.md
@@ -1,0 +1,209 @@
+# Quickstart: Mixpanel API Client
+
+**Date**: 2025-12-20
+**Feature**: 002-api-client
+
+## Overview
+
+The `MixpanelAPIClient` is a low-level HTTP client for Mixpanel APIs. It handles authentication, rate limiting, and response parsing. Most users won't use it directly—they'll use the `Workspace` class instead. This quickstart is for developers working on the library internals.
+
+## Prerequisites
+
+```bash
+# Ensure you're on the feature branch
+git checkout 002-api-client
+
+# Install dependencies
+uv sync --all-extras
+```
+
+## Basic Usage
+
+### Creating a Client
+
+```python
+from mixpanel_data._internal.config import ConfigManager
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+# Resolve credentials from config
+config = ConfigManager()
+credentials = config.resolve_credentials()
+
+# Create client
+client = MixpanelAPIClient(credentials)
+
+# Use as context manager (recommended)
+with MixpanelAPIClient(credentials) as client:
+    events = client.get_events()
+    print(events)
+```
+
+### Exporting Events
+
+```python
+from datetime import date
+
+with MixpanelAPIClient(credentials) as client:
+    # Stream events (memory efficient)
+    for event in client.export_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31"
+    ):
+        print(f"{event['event']}: {event['properties']['distinct_id']}")
+
+    # With progress callback
+    count = 0
+    def on_batch(batch_size: int) -> None:
+        nonlocal count
+        count += batch_size
+        print(f"Processed {count} events...")
+
+    events = list(client.export_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        on_batch=on_batch
+    ))
+```
+
+### Discovery
+
+```python
+with MixpanelAPIClient(credentials) as client:
+    # List events
+    events = client.get_events()
+    print(f"Found {len(events)} events")
+
+    # List properties for an event
+    props = client.get_event_properties("Purchase")
+    print(f"Purchase has {len(props)} properties")
+
+    # Get sample values
+    values = client.get_property_values("country", event="Purchase", limit=10)
+    print(f"Countries: {values}")
+```
+
+### Live Queries
+
+```python
+with MixpanelAPIClient(credentials) as client:
+    # Segmentation
+    result = client.segmentation(
+        event="Purchase",
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        on="properties.country",
+        unit="day"
+    )
+    print(result["data"]["values"])
+
+    # Funnel
+    result = client.funnel(
+        funnel_id=12345,
+        from_date="2024-01-01",
+        to_date="2024-01-31"
+    )
+    print(f"Conversion: {result['data'][-1]['overall_conv_ratio']:.1%}")
+
+    # JQL
+    result = client.jql("""
+        function main() {
+            return Events({from_date: params.from, to_date: params.to})
+                .groupBy(["name"], mixpanel.reducer.count());
+        }
+    """, params={"from": "2024-01-01", "to": "2024-01-31"})
+    print(result)
+```
+
+### Error Handling
+
+```python
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    RateLimitError,
+    QueryError,
+)
+
+try:
+    with MixpanelAPIClient(credentials) as client:
+        result = client.segmentation(
+            event="NonExistentEvent",
+            from_date="2024-01-01",
+            to_date="2024-01-31"
+        )
+except AuthenticationError:
+    print("Check your credentials")
+except RateLimitError as e:
+    print(f"Rate limited. Retry after {e.retry_after} seconds")
+except QueryError as e:
+    print(f"Query failed: {e.message}")
+```
+
+## Testing with Mock Transport
+
+For unit tests, inject a mock transport:
+
+```python
+import httpx
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.config import Credentials
+
+def test_export_events():
+    # Create mock credentials
+    credentials = Credentials(
+        username="test",
+        secret="test",
+        project_id="12345",
+        region="us"
+    )
+
+    # Define mock response
+    mock_response = b'{"event":"A","properties":{"time":1}}\n{"event":"B","properties":{"time":2}}\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=mock_response)
+
+    # Create client with mock transport
+    transport = httpx.MockTransport(handler)
+    with MixpanelAPIClient(credentials, _transport=transport) as client:
+        events = list(client.export_events("2024-01-01", "2024-01-31"))
+
+    assert len(events) == 2
+    assert events[0]["event"] == "A"
+    assert events[1]["event"] == "B"
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `timeout` | 30.0 | Request timeout (seconds) |
+| `export_timeout` | 300.0 | Export request timeout (seconds) |
+| `max_retries` | 3 | Max retries for rate limits |
+
+```python
+client = MixpanelAPIClient(
+    credentials,
+    timeout=60.0,
+    export_timeout=600.0,
+    max_retries=5
+)
+```
+
+## Regional Endpoints
+
+The client automatically routes to the correct regional endpoint based on `credentials.region`:
+
+| Region | Query API | Export API |
+|--------|-----------|------------|
+| `us` | mixpanel.com/api/query | data.mixpanel.com/api/2.0 |
+| `eu` | eu.mixpanel.com/api/query | data-eu.mixpanel.com/api/2.0 |
+| `in` | in.mixpanel.com/api/query | data-in.mixpanel.com/api/2.0 |
+
+## Next Steps
+
+After implementing the API client:
+
+1. Run tests: `pytest tests/unit/test_api_client.py -v`
+2. Type check: `mypy src/mixpanel_data/_internal/api_client.py`
+3. Lint: `ruff check src/mixpanel_data/_internal/api_client.py`
+4. Proceed to Phase 003 (Storage Engine)

--- a/specs/002-api-client/research.md
+++ b/specs/002-api-client/research.md
@@ -1,0 +1,226 @@
+# Research: Mixpanel API Client
+
+**Date**: 2025-12-20
+**Feature**: 002-api-client
+
+## Research Topics
+
+1. Mixpanel API Authentication
+2. Regional Endpoint Routing
+3. Rate Limiting Strategies
+4. Streaming JSONL Parsing with httpx
+5. Profile Export Pagination
+6. Error Response Formats
+
+---
+
+## 1. Mixpanel API Authentication
+
+### Decision: HTTP Basic Auth with Service Account Credentials
+
+### Rationale
+Mixpanel supports three authentication methods, but service accounts are the recommended approach for automated systems:
+
+| Method | Support | Use Case |
+|--------|---------|----------|
+| Service Account (Basic Auth) | ✅ Recommended | Automated systems, libraries |
+| Project Secret (Basic Auth) | ⚠️ Deprecated | Legacy systems |
+| OAuth Token (Bearer) | Limited | GDPR/privacy APIs only |
+
+### Implementation
+```python
+import base64
+
+auth = base64.b64encode(f"{username}:{secret}".encode()).decode()
+headers = {"Authorization": f"Basic {auth}"}
+# Plus: project_id in query params
+```
+
+### Alternatives Considered
+- **OAuth2**: Only supported for limited privacy APIs; adds complexity without benefit
+- **API Key in Header**: Not supported by Mixpanel
+
+---
+
+## 2. Regional Endpoint Routing
+
+### Decision: Build URLs dynamically based on region from Credentials
+
+### Rationale
+Mixpanel uses different base URLs for different data residency regions. The URL structure varies by API type (Query vs Export).
+
+| Region | Query API Base | Export API Base |
+|--------|---------------|-----------------|
+| US (default) | `https://mixpanel.com/api/query` | `https://data.mixpanel.com/api/2.0/export` |
+| EU | `https://eu.mixpanel.com/api/query` | `https://data-eu.mixpanel.com/api/2.0/export` |
+| India | `https://in.mixpanel.com/api/query` | `https://data-in.mixpanel.com/api/2.0/export` |
+
+### Implementation
+```python
+ENDPOINTS = {
+    "us": {"query": "https://mixpanel.com/api/query", "export": "https://data.mixpanel.com/api/2.0"},
+    "eu": {"query": "https://eu.mixpanel.com/api/query", "export": "https://data-eu.mixpanel.com/api/2.0"},
+    "in": {"query": "https://in.mixpanel.com/api/query", "export": "https://data-in.mixpanel.com/api/2.0"},
+}
+```
+
+### Alternatives Considered
+- **Single endpoint with header**: Not supported by Mixpanel
+- **Environment variable override**: Added complexity; region is already in Credentials
+
+---
+
+## 3. Rate Limiting Strategies
+
+### Decision: Exponential backoff with jitter, respecting Retry-After header
+
+### Rationale
+Mixpanel rate limits vary by API:
+
+| API | Rate Limit | Concurrent |
+|-----|-----------|------------|
+| Export | 60/hour, 3/second | 100 |
+| Query | 60/hour | 5 |
+| Lexicon | 5/minute | N/A |
+
+When rate limited, Mixpanel returns HTTP 429 with optional `Retry-After` header.
+
+### Implementation
+```python
+def calculate_backoff(attempt: int, base: float = 1.0, max_delay: float = 60.0) -> float:
+    delay = min(base * (2 ** attempt), max_delay)
+    jitter = random.uniform(0, delay * 0.1)  # 10% jitter
+    return delay + jitter
+```
+
+### Alternatives Considered
+- **Fixed delay**: Less adaptive to burst patterns
+- **Per-endpoint tracking**: Adds complexity; not needed for single-client use
+- **Global rate limiter**: Would require shared state; complicates testing
+
+---
+
+## 4. Streaming JSONL Parsing with httpx
+
+### Decision: Use httpx streaming with line-by-line parsing
+
+### Rationale
+The Export API returns JSONL (newline-delimited JSON) as `text/plain`. Each line is a complete JSON object representing one event. For 1M+ events, we must stream to avoid memory exhaustion.
+
+### Implementation
+```python
+def export_events(self, ...) -> Iterator[dict]:
+    with self._client.stream("GET", url, params=params) as response:
+        for line in response.iter_lines():
+            if line.strip():
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(f"Skipping malformed line: {line[:100]}")
+```
+
+### Key Considerations
+- `iter_lines()` handles buffering across chunk boundaries
+- Skip empty lines (trailing newlines)
+- Log and skip malformed JSON (don't fail entire export)
+- Support gzip via `Accept-Encoding: gzip` header
+
+### Alternatives Considered
+- **Load all into memory**: Fails for large exports
+- **ijson streaming parser**: Overkill for JSONL; adds dependency
+- **Custom chunked parser**: httpx already handles this well
+
+---
+
+## 5. Profile Export Pagination
+
+### Decision: Iterate with session_id pagination, yield profiles as iterator
+
+### Rationale
+Unlike events (JSONL stream), profiles use `POST /engage` with JSON response and pagination via `session_id`. The response includes:
+- `results`: Array of profile objects
+- `session_id`: Token for next page (omit on first request)
+- `page`: Current page number
+
+### Implementation
+```python
+def export_profiles(self, ...) -> Iterator[dict]:
+    session_id = None
+    page = 0
+    while True:
+        params = {"page": page}
+        if session_id:
+            params["session_id"] = session_id
+        response = self._client.post(url, json=params).json()
+
+        for profile in response.get("results", []):
+            yield profile
+
+        if not response.get("results"):
+            break
+        session_id = response.get("session_id")
+        page += 1
+```
+
+### Alternatives Considered
+- **Return all profiles at once**: Memory issues for large profile sets
+- **Async pagination**: Adds complexity; sync is sufficient for MVP
+
+---
+
+## 6. Error Response Formats
+
+### Decision: Parse error body, map to exception hierarchy
+
+### Rationale
+Mixpanel returns errors in consistent format:
+```json
+{
+    "error": "Details about the error",
+    "status": "error"
+}
+```
+
+HTTP status codes map to exceptions:
+
+| Status | Exception | Behavior |
+|--------|-----------|----------|
+| 400 | QueryError | Include error message in details |
+| 401 | AuthenticationError | Check credentials |
+| 429 | (retry) or RateLimitError | Retry with backoff; raise after max attempts |
+| 5xx | MixpanelDataError | Suggest retry |
+
+### Implementation
+```python
+def _handle_response(self, response: httpx.Response) -> Any:
+    if response.status_code == 401:
+        raise AuthenticationError("Invalid credentials")
+    if response.status_code == 429:
+        raise RateLimitError(retry_after=response.headers.get("Retry-After"))
+    if response.status_code == 400:
+        error = response.json().get("error", "Unknown error")
+        raise QueryError(error)
+    if response.status_code >= 500:
+        raise MixpanelDataError(f"Server error: {response.status_code}")
+    response.raise_for_status()
+    return response.json()
+```
+
+### Alternatives Considered
+- **Generic exception for all errors**: Loses specificity for callers
+- **httpx default exception handling**: Doesn't provide Mixpanel-specific context
+
+---
+
+## Summary
+
+All research questions resolved. No NEEDS CLARIFICATION items remain.
+
+| Topic | Decision | Confidence |
+|-------|----------|------------|
+| Authentication | HTTP Basic with service account | High |
+| Regional routing | Dynamic URL by region | High |
+| Rate limiting | Exponential backoff + jitter | High |
+| Streaming | httpx iter_lines() for JSONL | High |
+| Profile pagination | session_id iteration | High |
+| Error handling | Map to exception hierarchy | High |

--- a/specs/002-api-client/spec.md
+++ b/specs/002-api-client/spec.md
@@ -1,0 +1,235 @@
+# Feature Specification: Mixpanel API Client
+
+**Feature Branch**: `002-api-client`
+**Created**: 2025-12-20
+**Status**: Draft
+**Input**: User description: "Phase 002: API Client - HTTP client for Mixpanel API with authentication, rate limiting, and streaming export"
+
+## Overview
+
+The Mixpanel API Client provides a unified interface for communicating with all Mixpanel APIs. It handles authentication, regional endpoint routing, rate limiting with automatic retry, and response parsing. This component is the foundation for all remote data operations in the library.
+
+The client operates as a pure HTTP layer with no knowledge of local storage—it fetches data from Mixpanel and returns it to callers, who decide what to do with it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Make Authenticated API Requests (Priority: P1)
+
+A developer using the library needs to make authenticated requests to Mixpanel APIs using their service account credentials. The client should handle authentication transparently so developers can focus on what data they need, not how to authenticate.
+
+**Why this priority**: Without authentication working, no other API operations are possible. This is the foundational capability that enables all other features.
+
+**Independent Test**: Can be fully tested by making a simple API request (e.g., listing events) and verifying the response contains expected data. Delivers immediate value by proving credentials work.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid service account credentials, **When** making any API request, **Then** the request includes proper Basic authentication headers and the project_id parameter
+2. **Given** invalid credentials, **When** making any API request, **Then** the system raises an AuthenticationError with a clear message
+3. **Given** credentials with wrong permissions, **When** accessing a protected resource, **Then** the system raises an AuthenticationError indicating insufficient permissions
+
+---
+
+### User Story 2 - Handle Rate Limiting Gracefully (Priority: P1)
+
+A developer running data fetches should not need to worry about Mixpanel's rate limits. The client should automatically detect rate limit responses and retry with appropriate backoff, only raising an error when retries are exhausted.
+
+**Why this priority**: Rate limiting affects all API operations. Without automatic handling, every user would need to implement their own retry logic, leading to inconsistent behavior and poor user experience.
+
+**Independent Test**: Can be tested by simulating 429 responses and verifying the client retries with exponential backoff before eventually succeeding or raising RateLimitError.
+
+**Acceptance Scenarios**:
+
+1. **Given** an API request that receives a 429 response, **When** the Retry-After header is present, **Then** the client waits for the specified duration before retrying
+2. **Given** an API request that receives a 429 response, **When** no Retry-After header is present, **Then** the client uses exponential backoff with jitter
+3. **Given** an API request that exceeds maximum retry attempts, **When** still receiving 429 responses, **Then** the client raises RateLimitError with retry timing information
+4. **Given** an API request that receives a 429 and then succeeds on retry, **When** the operation completes, **Then** the caller receives the successful response with no indication of the retry
+
+---
+
+### User Story 3 - Stream Large Event Exports (Priority: P1)
+
+A developer needs to export millions of events from Mixpanel without running out of memory. The client should stream events one at a time so the caller can process them incrementally.
+
+**Why this priority**: Event export is a core use case for the library. Without streaming, large exports would exhaust memory, making the library unusable for production workloads.
+
+**Independent Test**: Can be tested by exporting events for a date range and verifying events are yielded as an iterator without loading all into memory. Delivers value by enabling large-scale data analysis.
+
+**Acceptance Scenarios**:
+
+1. **Given** a date range with events, **When** calling export_events, **Then** the client returns an iterator that yields individual event dictionaries
+2. **Given** a large export with millions of events, **When** iterating through results, **Then** memory usage remains constant regardless of total event count
+3. **Given** an export in progress, **When** providing an on_batch callback, **Then** the callback is invoked periodically with batch counts for progress reporting
+4. **Given** optional event name filters, **When** calling export_events with events parameter, **Then** only matching events are returned
+
+---
+
+### User Story 4 - Query Segmentation Data (Priority: P2)
+
+A developer needs to run segmentation queries to understand event trends over time, optionally segmented by a property. The client should provide the raw API response for the service layer to transform.
+
+**Why this priority**: Segmentation is the most common live query type. It enables quick trend analysis without fetching raw events.
+
+**Independent Test**: Can be tested by running a segmentation query for a known event and verifying the response contains time-series data.
+
+**Acceptance Scenarios**:
+
+1. **Given** an event name and date range, **When** calling segmentation, **Then** the client returns a dictionary with time-series counts
+2. **Given** a segmentation query with "on" parameter, **When** the query executes, **Then** results are segmented by the specified property
+3. **Given** a segmentation query with "where" filter, **When** the query executes, **Then** only matching events are counted
+
+---
+
+### User Story 5 - Discover Available Events and Properties (Priority: P2)
+
+A developer exploring a Mixpanel project needs to discover what events exist and what properties they have. The client should provide methods to list events, properties, and sample property values.
+
+**Why this priority**: Discovery enables users to explore data before querying. It's essential for building interactive tools and for agents to understand available data.
+
+**Independent Test**: Can be tested by listing events and verifying the response contains event names from the project.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid project, **When** calling get_events, **Then** the client returns a list of event names
+2. **Given** an event name, **When** calling get_event_properties, **Then** the client returns a list of property names for that event
+3. **Given** an event and property name, **When** calling get_property_values, **Then** the client returns sample values for that property
+
+---
+
+### User Story 6 - Export User Profiles (Priority: P2)
+
+A developer needs to export user profiles from Mixpanel for local analysis. Unlike events, profiles use pagination rather than streaming.
+
+**Why this priority**: Profile data complements event data for user-level analysis. It's a common use case but secondary to event export.
+
+**Independent Test**: Can be tested by exporting profiles and verifying user records are returned as an iterator.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with user profiles, **When** calling export_profiles, **Then** the client returns an iterator of profile dictionaries
+2. **Given** a large profile dataset, **When** iterating through results, **Then** the client handles pagination automatically
+3. **Given** a "where" filter, **When** calling export_profiles, **Then** only matching profiles are returned
+
+---
+
+### User Story 7 - Run Funnel and Retention Queries (Priority: P3)
+
+A developer needs to run funnel conversion analysis and retention cohort analysis. The client should provide raw API responses for these query types.
+
+**Why this priority**: Funnel and retention are important analytics but less frequently used than segmentation. They follow similar patterns.
+
+**Independent Test**: Can be tested by running funnel/retention queries and verifying structured responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a funnel ID and date range, **When** calling funnel, **Then** the client returns step-by-step conversion data
+2. **Given** born/return events and date range, **When** calling retention, **Then** the client returns cohort retention data
+
+---
+
+### User Story 8 - Execute Custom JQL Queries (Priority: P3)
+
+A developer with complex analysis needs can write custom JavaScript queries using Mixpanel's JQL. The client should execute these scripts and return results.
+
+**Why this priority**: JQL is a power-user feature. Most users will use the standard query methods, but JQL enables advanced use cases.
+
+**Independent Test**: Can be tested by executing a simple JQL script and verifying results.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid JQL script, **When** calling jql, **Then** the client returns the script execution results as a list
+2. **Given** a JQL script with parameters, **When** providing params dictionary, **Then** parameters are passed to the script
+
+---
+
+### Edge Cases
+
+- **Network interruption during export**: The export iterator raises an appropriate exception; caller can retry from scratch
+- **Malformed JSON in JSONL export**: The client skips malformed lines and logs a warning; continues processing valid events
+- **Credential expiration during long export**: The client raises AuthenticationError; caller must refresh credentials and retry
+- **Mixpanel API maintenance/downtime**: 5xx errors trigger retries with backoff; persistent failures raise MixpanelDataError
+- **Empty date range**: Export returns empty iterator; query methods return empty results structure
+- **Invalid event/property names**: QueryError raised with details about what was invalid
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Authentication & Routing**
+- **FR-001**: Client MUST authenticate all requests using HTTP Basic authentication with service account credentials
+- **FR-002**: Client MUST include project_id as a query parameter on all requests
+- **FR-003**: Client MUST route requests to the correct regional endpoint based on credentials.region (US, EU, India)
+- **FR-004**: Client MUST NOT expose credentials in error messages, logs, or exceptions
+
+**Rate Limiting**
+- **FR-005**: Client MUST detect HTTP 429 responses and automatically retry with backoff
+- **FR-006**: Client MUST respect Retry-After headers when present in 429 responses
+- **FR-007**: Client MUST implement exponential backoff with random jitter for retries
+- **FR-008**: Client MUST raise RateLimitError after configurable maximum retry attempts (default: 3)
+
+**Export API**
+- **FR-009**: Client MUST stream event exports as an iterator, not loading all events into memory
+- **FR-010**: Client MUST parse JSONL (newline-delimited JSON) response format for event exports
+- **FR-011**: Client MUST support optional gzip decompression for export responses
+- **FR-012**: Client MUST support on_batch callback for export progress reporting
+
+**Profile API**
+- **FR-013**: Client MUST handle paginated profile responses using session_id mechanism
+- **FR-014**: Client MUST expose profiles as an iterator despite underlying pagination
+
+**Discovery API**
+- **FR-015**: Client MUST provide method to list all event names in a project
+- **FR-016**: Client MUST provide method to list properties for a specific event
+- **FR-017**: Client MUST provide method to list sample values for a property
+
+**Query API**
+- **FR-018**: Client MUST provide methods for segmentation, funnel, retention, and JQL queries
+- **FR-019**: Client MUST return raw API responses (dict/list) for query methods
+- **FR-020**: Client MUST support all standard query parameters for each query type
+
+**Error Handling**
+- **FR-021**: Client MUST map HTTP 401 responses to AuthenticationError
+- **FR-022**: Client MUST map HTTP 400 responses to QueryError with error details
+- **FR-023**: Client MUST map HTTP 429 responses to automatic retry or RateLimitError
+- **FR-024**: Client MUST map HTTP 5xx responses to MixpanelDataError with retry suggestion
+
+**Lifecycle**
+- **FR-025**: Client MUST support context manager protocol for resource cleanup
+- **FR-026**: Client MUST provide configurable request timeout (default: 30 seconds, export: 300 seconds)
+
+### Key Entities
+
+- **Credentials**: Immutable authentication data including username, secret, project_id, and region (already implemented in Phase 001)
+- **API Response**: Raw dictionary or list returned from Mixpanel API endpoints
+- **Export Event**: Single event dictionary with event name, timestamp, distinct_id, and properties
+- **Profile**: Single user profile dictionary with distinct_id and properties
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All Mixpanel API endpoints (export, query, discovery) are accessible via single client instance
+- **SC-002**: Rate limiting is transparent to callers—automatic retry succeeds without caller intervention in 95%+ of rate-limited requests
+- **SC-003**: Event exports of 1 million+ records complete without memory exhaustion (constant memory usage)
+- **SC-004**: 90%+ of API errors are mapped to appropriate exception types with actionable messages
+- **SC-005**: Credentials never appear in exception messages, log output, or error details
+- **SC-006**: Test coverage reaches 90%+ for all client methods
+
+## Assumptions
+
+1. **Service accounts only**: The client assumes service account authentication (not project secrets or OAuth)
+2. **Synchronous operation**: The client is synchronous; async support may be added in a future phase
+3. **Credentials provided externally**: The client receives resolved Credentials from ConfigManager; it does not resolve credentials itself
+4. **Regional consistency**: All requests for a client instance use the same region; switching regions requires a new client
+5. **Standard rate limits**: Default rate limits follow Mixpanel's documented limits (60/hour for most endpoints)
+
+## Dependencies
+
+- **Phase 001 (Foundation Layer)**: Credentials class, exception hierarchy (AuthenticationError, RateLimitError, QueryError, MixpanelDataError)
+- **httpx library**: HTTP client with connection pooling (already in pyproject.toml dependencies)
+
+## Out of Scope
+
+- Local storage (handled by Phase 003: Storage Engine)
+- Response transformation to result types (handled by service layer)
+- CLI integration (handled by Phase 008: CLI)
+- Async/await support (potential future enhancement)

--- a/specs/002-api-client/tasks.md
+++ b/specs/002-api-client/tasks.md
@@ -1,0 +1,365 @@
+# Tasks: Mixpanel API Client
+
+**Input**: Design documents from `/specs/002-api-client/`
+**Prerequisites**: plan.md, spec.md, data-model.md, contracts/api_client.py, research.md
+
+**Tests**: Included per SC-006 requirement (90%+ test coverage)
+
+**Organization**: Tasks grouped by user story for independent implementation and testing
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1-US8)
+- File paths are relative to repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project initialization - verify dependencies and create file structure
+
+- [X] T001 Verify httpx and pydantic dependencies in pyproject.toml
+- [X] T002 [P] Create empty src/mixpanel_data/_internal/api_client.py with module docstring
+- [X] T003 [P] Create tests/unit/test_api_client.py with module docstring
+
+---
+
+## Phase 2: Foundational (Core Client Infrastructure)
+
+**Purpose**: Core client class structure that ALL user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Define ENDPOINTS dict with regional URL routing in src/mixpanel_data/_internal/api_client.py
+- [X] T005 Implement MixpanelAPIClient.__init__() with Credentials injection in src/mixpanel_data/_internal/api_client.py
+- [X] T006 Implement _get_auth_header() for HTTP Basic auth in src/mixpanel_data/_internal/api_client.py
+- [X] T007 Implement _build_url() for regional endpoint routing in src/mixpanel_data/_internal/api_client.py
+- [X] T008 Implement close(), __enter__(), __exit__() lifecycle methods in src/mixpanel_data/_internal/api_client.py
+- [X] T009 Implement _handle_response() for error mapping in src/mixpanel_data/_internal/api_client.py
+- [X] T010 Add mock client fixtures to tests/conftest.py for httpx.MockTransport
+
+**Checkpoint**: Core client structure ready - user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 - Make Authenticated API Requests (Priority: P1) 🎯 MVP
+
+**Goal**: Enable authenticated requests to Mixpanel APIs with proper Basic auth and regional routing
+
+**Independent Test**: Make a simple API request and verify auth headers are present
+
+### Tests for User Story 1
+
+- [X] T011 [P] [US1] Test auth header generation in tests/unit/test_api_client.py
+- [X] T012 [P] [US1] Test regional endpoint routing for US/EU/IN in tests/unit/test_api_client.py
+- [X] T013 [P] [US1] Test project_id included in query params in tests/unit/test_api_client.py
+- [X] T014 [P] [US1] Test AuthenticationError on 401 response in tests/unit/test_api_client.py
+- [X] T015 [P] [US1] Test credentials not in error messages in tests/unit/test_api_client.py
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Implement _request() method with auth headers in src/mixpanel_data/_internal/api_client.py
+- [X] T017 [US1] Add project_id to all request params in src/mixpanel_data/_internal/api_client.py
+- [X] T018 [US1] Map HTTP 401 to AuthenticationError in src/mixpanel_data/_internal/api_client.py
+- [X] T019 [US1] Ensure credentials redacted in all exception messages in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Client can make authenticated requests to any Mixpanel endpoint
+
+---
+
+## Phase 4: User Story 2 - Handle Rate Limiting Gracefully (Priority: P1)
+
+**Goal**: Automatic retry with exponential backoff on 429 responses
+
+**Independent Test**: Simulate 429 responses and verify retry behavior
+
+### Tests for User Story 2
+
+- [X] T020 [P] [US2] Test retry on 429 with Retry-After header in tests/unit/test_api_client.py
+- [X] T021 [P] [US2] Test exponential backoff without Retry-After in tests/unit/test_api_client.py
+- [X] T022 [P] [US2] Test RateLimitError after max retries in tests/unit/test_api_client.py
+- [X] T023 [P] [US2] Test successful response after retry in tests/unit/test_api_client.py
+
+### Implementation for User Story 2
+
+- [X] T024 [US2] Implement _calculate_backoff() with jitter in src/mixpanel_data/_internal/api_client.py
+- [X] T025 [US2] Implement retry loop in _request() method in src/mixpanel_data/_internal/api_client.py
+- [X] T026 [US2] Parse Retry-After header when present in src/mixpanel_data/_internal/api_client.py
+- [X] T027 [US2] Raise RateLimitError with retry_after when retries exhausted in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: All requests automatically retry on rate limits
+
+---
+
+## Phase 5: User Story 3 - Stream Large Event Exports (Priority: P1)
+
+**Goal**: Stream events as iterator without memory exhaustion
+
+**Independent Test**: Export events for a date range and verify iterator behavior
+
+### Tests for User Story 3
+
+- [X] T028 [P] [US3] Test export_events returns iterator in tests/unit/test_api_client.py
+- [X] T029 [P] [US3] Test JSONL parsing line by line in tests/unit/test_api_client.py
+- [X] T030 [P] [US3] Test on_batch callback invocation in tests/unit/test_api_client.py
+- [X] T031 [P] [US3] Test event name filtering in tests/unit/test_api_client.py
+- [X] T032 [P] [US3] Test malformed JSON skipped with warning in tests/unit/test_api_client.py
+
+### Implementation for User Story 3
+
+- [X] T033 [US3] Implement export_events() with streaming in src/mixpanel_data/_internal/api_client.py
+- [X] T034 [US3] Parse JSONL with iter_lines() in src/mixpanel_data/_internal/api_client.py
+- [X] T035 [US3] Add on_batch callback support in src/mixpanel_data/_internal/api_client.py
+- [X] T036 [US3] Handle malformed JSON lines gracefully in src/mixpanel_data/_internal/api_client.py
+- [X] T037 [US3] Add gzip decompression support in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Can export millions of events without memory exhaustion
+
+---
+
+## Phase 6: User Story 4 - Query Segmentation Data (Priority: P2)
+
+**Goal**: Run segmentation queries and return raw API response
+
+**Independent Test**: Run segmentation query and verify response structure
+
+### Tests for User Story 4
+
+- [X] T038 [P] [US4] Test segmentation() basic call in tests/unit/test_api_client.py
+- [X] T039 [P] [US4] Test segmentation with "on" parameter in tests/unit/test_api_client.py
+- [X] T040 [P] [US4] Test segmentation with "where" filter in tests/unit/test_api_client.py
+
+### Implementation for User Story 4
+
+- [X] T041 [US4] Implement segmentation() method in src/mixpanel_data/_internal/api_client.py
+- [X] T042 [US4] Add all query parameters (unit, type, on, where) in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Segmentation queries work with all parameters
+
+---
+
+## Phase 7: User Story 5 - Discover Available Events and Properties (Priority: P2)
+
+**Goal**: List events, properties, and property values for project exploration
+
+**Independent Test**: List events and verify response contains event names
+
+### Tests for User Story 5
+
+- [X] T043 [P] [US5] Test get_events() returns list in tests/unit/test_api_client.py
+- [X] T044 [P] [US5] Test get_event_properties() in tests/unit/test_api_client.py
+- [X] T045 [P] [US5] Test get_property_values() with limit in tests/unit/test_api_client.py
+
+### Implementation for User Story 5
+
+- [X] T046 [US5] Implement get_events() in src/mixpanel_data/_internal/api_client.py
+- [X] T047 [US5] Implement get_event_properties() in src/mixpanel_data/_internal/api_client.py
+- [X] T048 [US5] Implement get_property_values() in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Can explore project data schema
+
+---
+
+## Phase 8: User Story 6 - Export User Profiles (Priority: P2)
+
+**Goal**: Export profiles with automatic pagination as iterator
+
+**Independent Test**: Export profiles and verify pagination handling
+
+### Tests for User Story 6
+
+- [X] T049 [P] [US6] Test export_profiles() returns iterator in tests/unit/test_api_client.py
+- [X] T050 [P] [US6] Test pagination with session_id in tests/unit/test_api_client.py
+- [X] T051 [P] [US6] Test "where" filter for profiles in tests/unit/test_api_client.py
+
+### Implementation for User Story 6
+
+- [X] T052 [US6] Implement export_profiles() with pagination in src/mixpanel_data/_internal/api_client.py
+- [X] T053 [US6] Handle session_id pagination loop in src/mixpanel_data/_internal/api_client.py
+- [X] T054 [US6] Add on_batch callback for profile export in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Can export all profiles with automatic pagination
+
+---
+
+## Phase 9: User Story 7 - Run Funnel and Retention Queries (Priority: P3)
+
+**Goal**: Run funnel and retention analysis queries
+
+**Independent Test**: Run funnel/retention query and verify response structure
+
+### Tests for User Story 7
+
+- [X] T055 [P] [US7] Test funnel() method in tests/unit/test_api_client.py
+- [X] T056 [P] [US7] Test retention() method in tests/unit/test_api_client.py
+
+### Implementation for User Story 7
+
+- [X] T057 [US7] Implement funnel() method in src/mixpanel_data/_internal/api_client.py
+- [X] T058 [US7] Implement retention() method in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: Funnel and retention analysis working
+
+---
+
+## Phase 10: User Story 8 - Execute Custom JQL Queries (Priority: P3)
+
+**Goal**: Execute JQL scripts with parameters
+
+**Independent Test**: Execute JQL script and verify results
+
+### Tests for User Story 8
+
+- [X] T059 [P] [US8] Test jql() basic execution in tests/unit/test_api_client.py
+- [X] T060 [P] [US8] Test jql() with params in tests/unit/test_api_client.py
+
+### Implementation for User Story 8
+
+- [X] T061 [US8] Implement jql() method in src/mixpanel_data/_internal/api_client.py
+- [X] T062 [US8] Pass params to JQL script in src/mixpanel_data/_internal/api_client.py
+
+**Checkpoint**: JQL queries working with parameters
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality improvements
+
+- [X] T063 [P] Add type hints to all public methods in src/mixpanel_data/_internal/api_client.py
+- [X] T064 [P] Add docstrings (Google style) to all public methods in src/mixpanel_data/_internal/api_client.py
+- [X] T065 Run ruff check on src/mixpanel_data/_internal/api_client.py
+- [X] T066 Run mypy --strict on src/mixpanel_data/_internal/api_client.py
+- [X] T067 Run pytest with coverage report
+- [X] T068 Validate quickstart.md examples work
+- [X] T069 Export MixpanelAPIClient from src/mixpanel_data/_internal/__init__.py
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies - start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 - **BLOCKS all user stories**
+- **Phases 3-10 (User Stories)**: All depend on Phase 2 completion
+  - P1 stories (US1-US3): Should complete first for MVP
+  - P2 stories (US4-US6): Can start after P1 or in parallel
+  - P3 stories (US7-US8): Can start after P2 or in parallel
+- **Phase 11 (Polish)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+| Story | Depends On | Can Run In Parallel With |
+|-------|------------|-------------------------|
+| US1 (Auth) | Phase 2 only | - |
+| US2 (Rate Limit) | US1 (uses _request) | - |
+| US3 (Export) | US1, US2 | - |
+| US4 (Segmentation) | US1, US2 | US5, US6 |
+| US5 (Discovery) | US1, US2 | US4, US6 |
+| US6 (Profiles) | US1, US2 | US4, US5 |
+| US7 (Funnel/Retention) | US1, US2 | US8 |
+| US8 (JQL) | US1, US2 | US7 |
+
+### Within Each User Story
+
+1. Write tests FIRST (all [P] tests can run in parallel)
+2. Verify tests FAIL
+3. Implement code to make tests pass
+4. Verify story works independently
+
+---
+
+## Parallel Execution Examples
+
+### Phase 2 (Foundational) - All in parallel:
+```bash
+T004 "Define ENDPOINTS dict..."
+T005 "Implement __init__()..."
+T006 "Implement _get_auth_header()..."
+T007 "Implement _build_url()..."
+T008 "Implement lifecycle methods..."
+T009 "Implement _handle_response()..."
+T010 "Add mock client fixtures..."
+```
+
+### User Story 1 Tests - All in parallel:
+```bash
+T011 "Test auth header generation..."
+T012 "Test regional endpoint routing..."
+T013 "Test project_id in query params..."
+T014 "Test AuthenticationError on 401..."
+T015 "Test credentials not in errors..."
+```
+
+### P2 Stories (US4, US5, US6) - All in parallel after US1-3:
+```bash
+# Developer A: US4 (Segmentation)
+T038-T042
+
+# Developer B: US5 (Discovery)
+T043-T048
+
+# Developer C: US6 (Profiles)
+T049-T054
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1-3 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (**CRITICAL GATE**)
+3. Complete Phase 3: US1 - Authenticated Requests
+4. Complete Phase 4: US2 - Rate Limiting
+5. Complete Phase 5: US3 - Event Export
+6. **STOP and VALIDATE**: All P1 stories working independently
+7. Run tests: `pytest tests/unit/test_api_client.py -v`
+
+### Incremental Delivery
+
+| Checkpoint | What's Working |
+|------------|---------------|
+| After US1 | Auth + regional routing |
+| After US2 | + Rate limit handling |
+| After US3 | + Event streaming (MVP!) |
+| After US4 | + Segmentation queries |
+| After US5 | + Data discovery |
+| After US6 | + Profile export |
+| After US7 | + Funnel/retention |
+| After US8 | + JQL (full feature) |
+
+---
+
+## Summary
+
+| Phase | Task Count | Parallel Opportunities |
+|-------|-----------|----------------------|
+| Setup | 3 | 2 |
+| Foundational | 7 | 6 |
+| US1 (P1) | 9 | 5 tests |
+| US2 (P1) | 8 | 4 tests |
+| US3 (P1) | 10 | 5 tests |
+| US4 (P2) | 5 | 3 tests |
+| US5 (P2) | 6 | 3 tests |
+| US6 (P2) | 6 | 3 tests |
+| US7 (P3) | 4 | 2 tests |
+| US8 (P3) | 4 | 2 tests |
+| Polish | 7 | 2 |
+| **Total** | **69** | **37** |
+
+**MVP Scope**: Phases 1-5 (US1-US3) = 37 tasks
+**Full Feature**: All phases = 69 tasks
+
+---
+
+## Notes
+
+- All tests use httpx.MockTransport for deterministic behavior
+- Credentials from Phase 001 (Credentials class) are injected
+- Exceptions from Phase 001 are reused (no new exception types)
+- Client is in _internal/ - not exported publicly (for now)
+- Each user story is independently testable per spec requirements

--- a/src/mixpanel_data/_internal/__init__.py
+++ b/src/mixpanel_data/_internal/__init__.py
@@ -1,1 +1,6 @@
 """Internal implementation modules. Not part of the public API."""
+
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.config import ConfigManager, Credentials
+
+__all__ = ["ConfigManager", "Credentials", "MixpanelAPIClient"]

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -1,0 +1,741 @@
+"""Mixpanel API Client.
+
+Low-level HTTP client for all Mixpanel APIs. Handles:
+- Service account authentication via HTTP Basic auth
+- Regional endpoint routing (US, EU, India)
+- Automatic rate limit handling with exponential backoff
+- Streaming JSONL parsing for large exports
+
+This is a private implementation detail. Users should use the Workspace class
+or service layer instead of accessing this module directly.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import random
+import time
+from collections.abc import Callable, Iterator
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from mixpanel_data._internal.config import Credentials
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    MixpanelDataError,
+    QueryError,
+    RateLimitError,
+)
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+# Regional endpoint configuration
+# Each region has separate URLs for query APIs and export/data APIs
+ENDPOINTS: dict[str, dict[str, str]] = {
+    "us": {
+        "query": "https://mixpanel.com/api/query",
+        "export": "https://data.mixpanel.com/api/2.0",
+        "engage": "https://mixpanel.com/api/2.0/engage",
+    },
+    "eu": {
+        "query": "https://eu.mixpanel.com/api/query",
+        "export": "https://data-eu.mixpanel.com/api/2.0",
+        "engage": "https://eu.mixpanel.com/api/2.0/engage",
+    },
+    "in": {
+        "query": "https://in.mixpanel.com/api/query",
+        "export": "https://data-in.mixpanel.com/api/2.0",
+        "engage": "https://in.mixpanel.com/api/2.0/engage",
+    },
+}
+
+
+class MixpanelAPIClient:
+    """Low-level HTTP client for Mixpanel APIs.
+
+    Handles authentication, rate limiting, and response parsing. Most users
+    won't use this directly—they'll use the Workspace class instead.
+
+    Example:
+        >>> from mixpanel_data._internal.config import ConfigManager
+        >>> from mixpanel_data._internal.api_client import MixpanelAPIClient
+        >>>
+        >>> config = ConfigManager()
+        >>> credentials = config.resolve_credentials()
+        >>>
+        >>> with MixpanelAPIClient(credentials) as client:
+        ...     events = client.get_events()
+        ...     print(events)
+    """
+
+    def __init__(
+        self,
+        credentials: Credentials,
+        *,
+        timeout: float = 30.0,
+        export_timeout: float = 300.0,
+        max_retries: int = 3,
+        _transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        """Initialize the API client.
+
+        Args:
+            credentials: Immutable authentication credentials.
+            timeout: Request timeout in seconds for regular requests.
+            export_timeout: Request timeout for export operations.
+            max_retries: Maximum retry attempts for rate-limited requests.
+            _transport: Internal parameter for testing with MockTransport.
+        """
+        self._credentials = credentials
+        self._timeout = timeout
+        self._export_timeout = export_timeout
+        self._max_retries = max_retries
+        self._client: httpx.Client | None = None
+        self._transport = _transport
+
+    def _get_auth_header(self) -> str:
+        """Generate HTTP Basic auth header value.
+
+        Returns:
+            Base64-encoded "username:secret" prefixed with "Basic ".
+        """
+        secret = self._credentials.secret.get_secret_value()
+        auth_string = f"{self._credentials.username}:{secret}"
+        encoded = base64.b64encode(auth_string.encode()).decode()
+        return f"Basic {encoded}"
+
+    def _build_url(self, api_type: str, path: str) -> str:
+        """Build full URL for the given API type and path.
+
+        Args:
+            api_type: One of "query", "export", or "engage".
+            path: API endpoint path (e.g., "/segmentation").
+
+        Returns:
+            Full URL for the endpoint.
+        """
+        region = self._credentials.region
+        base = ENDPOINTS[region][api_type]
+        # Ensure path starts with /
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{base}{path}"
+
+    def _ensure_client(self) -> httpx.Client:
+        """Ensure HTTP client is initialized.
+
+        Returns:
+            The httpx.Client instance.
+        """
+        if self._client is None:
+            self._client = httpx.Client(
+                timeout=self._timeout,
+                transport=self._transport,
+            )
+        return self._client
+
+    def close(self) -> None:
+        """Close the HTTP client and release resources."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> MixpanelAPIClient:
+        """Enter context manager."""
+        self._ensure_client()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager, closing client."""
+        self.close()
+
+    def _handle_response(self, response: httpx.Response) -> Any:
+        """Handle API response, raising appropriate exceptions.
+
+        Args:
+            response: The HTTP response to handle.
+
+        Returns:
+            Parsed JSON response.
+
+        Raises:
+            AuthenticationError: On 401 response.
+            QueryError: On 400 response.
+            MixpanelDataError: On 5xx response.
+        """
+        if response.status_code == 401:
+            raise AuthenticationError(
+                "Invalid credentials. Check username, secret, and project_id."
+            )
+        if response.status_code == 400:
+            try:
+                body = response.json()
+                error_msg = body.get("error", "Unknown error")
+            except json.JSONDecodeError:
+                error_msg = response.text[:200] if response.text else "Unknown error"
+            raise QueryError(error_msg)
+        if response.status_code >= 500:
+            raise MixpanelDataError(
+                f"Server error: {response.status_code}",
+                code="SERVER_ERROR",
+                details={"status_code": response.status_code},
+            )
+        response.raise_for_status()
+        return response.json()
+
+    def _calculate_backoff(self, attempt: int) -> float:
+        """Calculate backoff delay with jitter.
+
+        Args:
+            attempt: Zero-based attempt number.
+
+        Returns:
+            Delay in seconds.
+        """
+        base = 1.0
+        max_delay = 60.0
+        delay: float = min(base * (2**attempt), max_delay)
+        jitter: float = random.uniform(0, delay * 0.1)  # noqa: S311
+        return delay + jitter
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Make an authenticated request with retry on rate limit.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            url: Full URL to request.
+            params: Query parameters.
+            data: Request body (for POST).
+            timeout: Override default timeout.
+
+        Returns:
+            Parsed JSON response.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            RateLimitError: Rate limit exceeded after max retries.
+            QueryError: Invalid parameters.
+        """
+        client = self._ensure_client()
+
+        # Add project_id to all requests
+        if params is None:
+            params = {}
+        params["project_id"] = self._credentials.project_id
+
+        headers = {"Authorization": self._get_auth_header()}
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=data,
+                    headers=headers,
+                    timeout=timeout or self._timeout,
+                )
+
+                if response.status_code == 429:
+                    if attempt >= self._max_retries:
+                        retry_after = self._parse_retry_after(response)
+                        raise RateLimitError(
+                            "Rate limit exceeded after max retries",
+                            retry_after=retry_after,
+                        )
+                    # Calculate wait time
+                    retry_after = self._parse_retry_after(response)
+                    if retry_after is not None:
+                        wait_time = float(retry_after)
+                    else:
+                        wait_time = self._calculate_backoff(attempt)
+                    logger.warning(
+                        "Rate limited, retrying in %.1f seconds (attempt %d/%d)",
+                        wait_time,
+                        attempt + 1,
+                        self._max_retries,
+                    )
+                    time.sleep(wait_time)
+                    continue
+
+                return self._handle_response(response)
+
+            except httpx.HTTPError as e:
+                # Re-raise our exceptions
+                if isinstance(
+                    e.__cause__, AuthenticationError | RateLimitError | QueryError
+                ):
+                    raise e.__cause__ from None
+                raise MixpanelDataError(
+                    f"HTTP error: {e}",
+                    code="HTTP_ERROR",
+                    details={"error": str(e)},
+                ) from e
+
+        # Should not reach here, but satisfy type checker
+        raise RateLimitError("Rate limit exceeded after max retries")
+
+    def _parse_retry_after(self, response: httpx.Response) -> int | None:
+        """Parse Retry-After header if present.
+
+        Args:
+            response: HTTP response.
+
+        Returns:
+            Seconds to wait, or None if header not present.
+        """
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is not None:
+            try:
+                return int(retry_after)
+            except ValueError:
+                pass
+        return None
+
+    # =========================================================================
+    # Export API - Streaming
+    # =========================================================================
+
+    def export_events(
+        self,
+        from_date: str,
+        to_date: str,
+        *,
+        events: list[str] | None = None,
+        where: str | None = None,
+        on_batch: Callable[[int], None] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream events from the Export API.
+
+        Args:
+            from_date: Start date (YYYY-MM-DD, inclusive).
+            to_date: End date (YYYY-MM-DD, inclusive).
+            events: Optional list of event names to filter.
+            where: Optional filter expression.
+            on_batch: Optional callback invoked with count after each batch.
+
+        Yields:
+            Event dictionaries with 'event' and 'properties' keys.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            RateLimitError: Rate limit exceeded after max retries.
+            QueryError: Invalid parameters.
+        """
+        url = self._build_url("export", "/export")
+
+        params: dict[str, Any] = {
+            "project_id": self._credentials.project_id,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+        if events:
+            params["event"] = json.dumps(events)
+        if where:
+            params["where"] = where
+
+        client = self._ensure_client()
+        headers = {
+            "Authorization": self._get_auth_header(),
+            "Accept-Encoding": "gzip",
+        }
+
+        batch_count = 0
+
+        # Stream with retry logic
+        for attempt in range(self._max_retries + 1):
+            try:
+                with client.stream(
+                    "GET",
+                    url,
+                    params=params,
+                    headers=headers,
+                    timeout=self._export_timeout,
+                ) as response:
+                    if response.status_code == 429:
+                        if attempt >= self._max_retries:
+                            retry_after = self._parse_retry_after(response)
+                            raise RateLimitError(
+                                "Rate limit exceeded after max retries",
+                                retry_after=retry_after,
+                            )
+                        retry_after = self._parse_retry_after(response)
+                        if retry_after is not None:
+                            wait_time = float(retry_after)
+                        else:
+                            wait_time = self._calculate_backoff(attempt)
+                        time.sleep(wait_time)
+                        continue
+
+                    if response.status_code == 401:
+                        raise AuthenticationError(
+                            "Invalid credentials. Check username, secret, and project_id."
+                        )
+                    if response.status_code == 400:
+                        # Need to read body for error
+                        body = response.read()
+                        try:
+                            error_data = json.loads(body)
+                            error_msg = error_data.get("error", "Unknown error")
+                        except json.JSONDecodeError:
+                            error_msg = body.decode()[:200] if body else "Unknown error"
+                        raise QueryError(error_msg)
+
+                    response.raise_for_status()
+
+                    for line in response.iter_lines():
+                        if not line.strip():
+                            continue
+                        try:
+                            event = json.loads(line)
+                            yield event
+                            batch_count += 1
+                            if on_batch and batch_count % 1000 == 0:
+                                on_batch(batch_count)
+                        except json.JSONDecodeError:
+                            logger.warning("Skipping malformed line: %s", line[:100])
+
+                    # Call on_batch with final count if there was a partial batch
+                    if on_batch and batch_count % 1000 != 0:
+                        on_batch(batch_count)
+                    return  # Success, exit retry loop
+
+            except httpx.HTTPError as e:
+                if isinstance(
+                    e.__cause__, AuthenticationError | RateLimitError | QueryError
+                ):
+                    raise e.__cause__ from None
+                if attempt >= self._max_retries:
+                    raise MixpanelDataError(
+                        f"HTTP error during export: {e}",
+                        code="HTTP_ERROR",
+                        details={"error": str(e)},
+                    ) from e
+                time.sleep(self._calculate_backoff(attempt))
+
+    def export_profiles(
+        self,
+        *,
+        where: str | None = None,
+        on_batch: Callable[[int], None] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream profiles from the Engage API.
+
+        Args:
+            where: Optional filter expression.
+            on_batch: Optional callback invoked with count after each page.
+
+        Yields:
+            Profile dictionaries with '$distinct_id' and '$properties' keys.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            RateLimitError: Rate limit exceeded after max retries.
+        """
+        url = self._build_url("engage", "")
+
+        session_id: str | None = None
+        page = 0
+        total_count = 0
+
+        while True:
+            params: dict[str, Any] = {
+                "project_id": self._credentials.project_id,
+                "page": page,
+            }
+            if session_id:
+                params["session_id"] = session_id
+            if where:
+                params["where"] = where
+
+            response = self._request("POST", url, data=params)
+
+            results = response.get("results", [])
+            if not results:
+                break
+
+            for profile in results:
+                yield profile
+                total_count += 1
+
+            if on_batch:
+                on_batch(total_count)
+
+            session_id = response.get("session_id")
+            if not session_id:
+                break
+            page += 1
+
+    # =========================================================================
+    # Discovery API
+    # =========================================================================
+
+    def get_events(self) -> list[str]:
+        """List all event names in the project.
+
+        Returns:
+            List of event name strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+        """
+        url = self._build_url("query", "/events/names")
+        response = self._request("GET", url, params={"type": "general"})
+        # Response is a list of event names
+        if isinstance(response, list):
+            return [str(e) for e in response]
+        return []
+
+    def get_event_properties(self, event: str) -> list[str]:
+        """List properties for a specific event.
+
+        Args:
+            event: Event name.
+
+        Returns:
+            List of property name strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid event name.
+        """
+        url = self._build_url("query", "/events/properties/top")
+        response = self._request("GET", url, params={"event": event})
+        # Response is a dict with property names as keys and counts as values
+        if isinstance(response, dict):
+            return list(response.keys())
+        return []
+
+    def get_property_values(
+        self,
+        property_name: str,
+        *,
+        event: str | None = None,
+        limit: int = 255,
+    ) -> list[str]:
+        """List sample values for a property.
+
+        Args:
+            property_name: Property name.
+            event: Optional event name to scope the property.
+            limit: Maximum number of values to return.
+
+        Returns:
+            List of property value strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+        """
+        url = self._build_url("query", "/events/properties/values")
+        params: dict[str, Any] = {
+            "name": property_name,
+            "limit": limit,
+        }
+        if event:
+            params["event"] = event
+        response = self._request("GET", url, params=params)
+        if isinstance(response, list):
+            return [str(v) for v in response]
+        return []
+
+    # =========================================================================
+    # Query API - Raw Responses
+    # =========================================================================
+
+    def segmentation(
+        self,
+        event: str,
+        from_date: str,
+        to_date: str,
+        *,
+        on: str | None = None,
+        unit: str = "day",
+        type: str = "general",
+        where: str | None = None,
+    ) -> dict[str, Any]:
+        """Run a segmentation query.
+
+        Args:
+            event: Event name to segment.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            on: Optional property to segment by.
+            unit: Time unit (minute, hour, day, week, month).
+            type: Aggregation type (general, unique, average).
+            where: Optional filter expression.
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid query parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        url = self._build_url("query", "/segmentation")
+        params: dict[str, Any] = {
+            "event": event,
+            "from_date": from_date,
+            "to_date": to_date,
+            "unit": unit,
+            "type": type,
+        }
+        if on:
+            params["on"] = on
+        if where:
+            params["where"] = where
+        result: dict[str, Any] = self._request("GET", url, params=params)
+        return result
+
+    def funnel(
+        self,
+        funnel_id: int,
+        from_date: str,
+        to_date: str,
+        *,
+        unit: str | None = None,
+        on: str | None = None,
+        where: str | None = None,
+        length: int | None = None,
+        length_unit: str | None = None,
+    ) -> dict[str, Any]:
+        """Run a funnel analysis query.
+
+        Args:
+            funnel_id: Funnel identifier.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            unit: Time unit for grouping.
+            on: Optional property to segment by.
+            where: Optional filter expression.
+            length: Conversion window length.
+            length_unit: Conversion window unit.
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid funnel ID or parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        url = self._build_url("query", "/funnels")
+        params: dict[str, Any] = {
+            "funnel_id": funnel_id,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+        if unit:
+            params["unit"] = unit
+        if on:
+            params["on"] = on
+        if where:
+            params["where"] = where
+        if length is not None:
+            params["length"] = length
+        if length_unit:
+            params["length_unit"] = length_unit
+        result: dict[str, Any] = self._request("GET", url, params=params)
+        return result
+
+    def retention(
+        self,
+        born_event: str,
+        event: str,
+        from_date: str,
+        to_date: str,
+        *,
+        retention_type: str = "birth",
+        born_where: str | None = None,
+        where: str | None = None,
+        interval: int = 1,
+        interval_count: int = 8,
+        unit: str = "day",
+    ) -> dict[str, Any]:
+        """Run a retention analysis query.
+
+        Args:
+            born_event: Event that defines cohort membership.
+            event: Event that defines return.
+            from_date: Start date (YYYY-MM-DD).
+            to_date: End date (YYYY-MM-DD).
+            retention_type: Retention type (birth, compounded).
+            born_where: Optional filter for born event.
+            where: Optional filter for return event.
+            interval: Retention interval size.
+            interval_count: Number of intervals to track.
+            unit: Interval unit (day, week, month).
+
+        Returns:
+            Raw API response dictionary.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid parameters.
+            RateLimitError: Rate limit exceeded.
+        """
+        url = self._build_url("query", "/retention")
+        params: dict[str, Any] = {
+            "born_event": born_event,
+            "event": event,
+            "from_date": from_date,
+            "to_date": to_date,
+            "retention_type": retention_type,
+            "interval": interval,
+            "interval_count": interval_count,
+            "unit": unit,
+        }
+        if born_where:
+            params["born_where"] = born_where
+        if where:
+            params["where"] = where
+        result: dict[str, Any] = self._request("GET", url, params=params)
+        return result
+
+    def jql(
+        self,
+        script: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        """Execute a JQL (JavaScript Query Language) script.
+
+        Args:
+            script: JQL script code.
+            params: Optional parameters to pass to the script.
+
+        Returns:
+            List of results from script execution.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Script execution error.
+            RateLimitError: Rate limit exceeded.
+        """
+        url = self._build_url("query", "/jql")
+        data: dict[str, Any] = {"script": script}
+        if params:
+            data["params"] = json.dumps(params)
+        response = self._request("POST", url, data=data)
+        if isinstance(response, list):
+            return response
+        return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import tempfile
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
 import pytest
 
 if TYPE_CHECKING:
-    from mixpanel_data._internal.config import ConfigManager
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+    from mixpanel_data._internal.config import ConfigManager, Credentials
 
 
 @pytest.fixture
@@ -44,3 +46,77 @@ def sample_credentials() -> dict[str, str]:
         "project_id": "12345",
         "region": "us",
     }
+
+
+# =============================================================================
+# API Client Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_credentials() -> Credentials:
+    """Create mock credentials for API client testing."""
+    from mixpanel_data._internal.config import Credentials
+
+    return Credentials(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="us",
+    )
+
+
+@pytest.fixture
+def mock_client_factory(
+    mock_credentials: Credentials,
+) -> Callable[[Callable[[httpx.Request], httpx.Response]], MixpanelAPIClient]:
+    """Factory for creating mock API clients.
+
+    Usage:
+        def test_something(mock_client_factory):
+            def handler(request):
+                return httpx.Response(200, json={"data": []})
+
+            client = mock_client_factory(handler)
+            with client:
+                result = client.get_events()
+    """
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+    def factory(
+        handler: Callable[[httpx.Request], httpx.Response],
+    ) -> MixpanelAPIClient:
+        transport = httpx.MockTransport(handler)
+        return MixpanelAPIClient(mock_credentials, _transport=transport)
+
+    return factory
+
+
+@pytest.fixture
+def success_handler() -> Callable[[httpx.Request], httpx.Response]:
+    """Handler that returns 200 with empty list."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    return handler
+
+
+@pytest.fixture
+def auth_error_handler() -> Callable[[httpx.Request], httpx.Response]:
+    """Handler that returns 401 authentication error."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "Invalid credentials"})
+
+    return handler
+
+
+@pytest.fixture
+def rate_limit_handler() -> Callable[[httpx.Request], httpx.Response]:
+    """Handler that returns 429 rate limit error."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "60"})
+
+    return handler

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1,0 +1,798 @@
+"""Unit tests for MixpanelAPIClient.
+
+Tests use httpx.MockTransport for deterministic HTTP mocking.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from mixpanel_data._internal.api_client import ENDPOINTS, MixpanelAPIClient
+from mixpanel_data._internal.config import Credentials
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    QueryError,
+    RateLimitError,
+)
+
+
+@pytest.fixture
+def test_credentials() -> Credentials:
+    """Create test credentials."""
+    return Credentials(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="us",
+    )
+
+
+@pytest.fixture
+def eu_credentials() -> Credentials:
+    """Create EU region test credentials."""
+    return Credentials(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="eu",
+    )
+
+
+@pytest.fixture
+def india_credentials() -> Credentials:
+    """Create India region test credentials."""
+    return Credentials(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="in",
+    )
+
+
+def create_mock_client(
+    credentials: Credentials,
+    handler: Any,
+) -> MixpanelAPIClient:
+    """Create a client with mock transport."""
+    transport = httpx.MockTransport(handler)
+    return MixpanelAPIClient(credentials, _transport=transport)
+
+
+# =============================================================================
+# Phase 2: Foundational Tests
+# =============================================================================
+
+
+class TestEndpoints:
+    """Test ENDPOINTS configuration."""
+
+    def test_us_endpoints_defined(self) -> None:
+        """US endpoints should be defined."""
+        assert "us" in ENDPOINTS
+        assert "query" in ENDPOINTS["us"]
+        assert "export" in ENDPOINTS["us"]
+        assert "engage" in ENDPOINTS["us"]
+
+    def test_eu_endpoints_defined(self) -> None:
+        """EU endpoints should be defined."""
+        assert "eu" in ENDPOINTS
+        assert "query" in ENDPOINTS["eu"]
+        assert "export" in ENDPOINTS["eu"]
+
+    def test_india_endpoints_defined(self) -> None:
+        """India endpoints should be defined."""
+        assert "in" in ENDPOINTS
+        assert "query" in ENDPOINTS["in"]
+        assert "export" in ENDPOINTS["in"]
+
+
+class TestClientInit:
+    """Test client initialization."""
+
+    def test_init_with_credentials(self, test_credentials: Credentials) -> None:
+        """Client should accept credentials."""
+        client = MixpanelAPIClient(test_credentials)
+        assert client._credentials == test_credentials
+        client.close()
+
+    def test_init_with_custom_timeout(self, test_credentials: Credentials) -> None:
+        """Client should accept custom timeout."""
+        client = MixpanelAPIClient(test_credentials, timeout=60.0)
+        assert client._timeout == 60.0
+        client.close()
+
+    def test_init_with_custom_export_timeout(
+        self, test_credentials: Credentials
+    ) -> None:
+        """Client should accept custom export timeout."""
+        client = MixpanelAPIClient(test_credentials, export_timeout=600.0)
+        assert client._export_timeout == 600.0
+        client.close()
+
+    def test_init_with_max_retries(self, test_credentials: Credentials) -> None:
+        """Client should accept max retries."""
+        client = MixpanelAPIClient(test_credentials, max_retries=5)
+        assert client._max_retries == 5
+        client.close()
+
+
+class TestClientLifecycle:
+    """Test client lifecycle methods."""
+
+    def test_context_manager(self, test_credentials: Credentials) -> None:
+        """Client should work as context manager."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            assert client._client is not None
+        assert client._client is None
+
+    def test_close_releases_resources(self, test_credentials: Credentials) -> None:
+        """Close should release HTTP client."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        client = create_mock_client(test_credentials, handler)
+        client._ensure_client()
+        assert client._client is not None
+        client.close()
+        assert client._client is None
+
+
+class TestAuthHeader:
+    """Test auth header generation."""
+
+    def test_auth_header_format(self, test_credentials: Credentials) -> None:
+        """Auth header should be Base64 encoded Basic auth."""
+        client = MixpanelAPIClient(test_credentials)
+        header = client._get_auth_header()
+        assert header.startswith("Basic ")
+        # Decode and verify
+        import base64
+
+        encoded = header.replace("Basic ", "")
+        decoded = base64.b64decode(encoded).decode()
+        assert decoded == "test_user:test_secret"
+        client.close()
+
+
+class TestBuildUrl:
+    """Test URL building."""
+
+    def test_build_query_url_us(self, test_credentials: Credentials) -> None:
+        """Should build correct US query URL."""
+        client = MixpanelAPIClient(test_credentials)
+        url = client._build_url("query", "/segmentation")
+        assert url == "https://mixpanel.com/api/query/segmentation"
+        client.close()
+
+    def test_build_query_url_eu(self, eu_credentials: Credentials) -> None:
+        """Should build correct EU query URL."""
+        client = MixpanelAPIClient(eu_credentials)
+        url = client._build_url("query", "/segmentation")
+        assert url == "https://eu.mixpanel.com/api/query/segmentation"
+        client.close()
+
+    def test_build_query_url_india(self, india_credentials: Credentials) -> None:
+        """Should build correct India query URL."""
+        client = MixpanelAPIClient(india_credentials)
+        url = client._build_url("query", "/segmentation")
+        assert url == "https://in.mixpanel.com/api/query/segmentation"
+        client.close()
+
+    def test_build_export_url_us(self, test_credentials: Credentials) -> None:
+        """Should build correct US export URL."""
+        client = MixpanelAPIClient(test_credentials)
+        url = client._build_url("export", "/export")
+        assert url == "https://data.mixpanel.com/api/2.0/export"
+        client.close()
+
+    def test_build_export_url_eu(self, eu_credentials: Credentials) -> None:
+        """Should build correct EU export URL."""
+        client = MixpanelAPIClient(eu_credentials)
+        url = client._build_url("export", "/export")
+        assert url == "https://data-eu.mixpanel.com/api/2.0/export"
+        client.close()
+
+    def test_build_url_adds_leading_slash(self, test_credentials: Credentials) -> None:
+        """Should add leading slash if missing."""
+        client = MixpanelAPIClient(test_credentials)
+        url = client._build_url("query", "segmentation")
+        assert url == "https://mixpanel.com/api/query/segmentation"
+        client.close()
+
+
+# =============================================================================
+# User Story 1: Authenticated API Requests
+# =============================================================================
+
+
+class TestAuthenticatedRequests:
+    """Test authenticated request handling (US1)."""
+
+    def test_auth_header_sent(self, test_credentials: Credentials) -> None:
+        """Auth header should be sent with requests."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert "authorization" in captured_headers
+        assert captured_headers["authorization"].startswith("Basic ")
+
+    def test_project_id_in_query_params(self, test_credentials: Credentials) -> None:
+        """Project ID should be in query params."""
+        captured_url: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_url
+            captured_url = str(request.url)
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert "project_id=12345" in captured_url
+
+    def test_authentication_error_on_401(self, test_credentials: Credentials) -> None:
+        """Should raise AuthenticationError on 401."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "Invalid credentials"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(AuthenticationError) as exc_info,
+        ):
+            client.get_events()
+
+        assert "credentials" in str(exc_info.value).lower()
+
+    def test_credentials_not_in_error_messages(
+        self, test_credentials: Credentials
+    ) -> None:
+        """Credentials should never appear in error messages."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "Auth failed"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(AuthenticationError) as exc_info,
+        ):
+            client.get_events()
+
+        error_str = str(exc_info.value)
+        assert "test_secret" not in error_str
+        assert "test_user" not in error_str
+
+    def test_regional_routing_us(self, test_credentials: Credentials) -> None:
+        """US region should use US endpoints."""
+        captured_url: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_url
+            captured_url = str(request.url)
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert "mixpanel.com" in captured_url
+
+    def test_regional_routing_eu(self, eu_credentials: Credentials) -> None:
+        """EU region should use EU endpoints."""
+        captured_url: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_url
+            captured_url = str(request.url)
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(eu_credentials, handler) as client:
+            client.get_events()
+
+        assert "eu.mixpanel.com" in captured_url
+
+    def test_regional_routing_india(self, india_credentials: Credentials) -> None:
+        """India region should use India endpoints."""
+        captured_url: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_url
+            captured_url = str(request.url)
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(india_credentials, handler) as client:
+            client.get_events()
+
+        assert "in.mixpanel.com" in captured_url
+
+
+# =============================================================================
+# User Story 2: Rate Limiting
+# =============================================================================
+
+
+class TestRateLimiting:
+    """Test rate limit handling (US2)."""
+
+    def test_retry_on_429_with_retry_after(self, test_credentials: Credentials) -> None:
+        """Should retry on 429 with Retry-After header."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(429, headers={"Retry-After": "0"})
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            result = client.get_events()
+
+        assert call_count == 2
+        assert result == ["event1"]
+
+    def test_exponential_backoff_without_retry_after(
+        self, test_credentials: Credentials
+    ) -> None:
+        """Should use exponential backoff without Retry-After."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(429)  # No Retry-After
+            return httpx.Response(200, json=["event1"])
+
+        # Use low max_retries for faster test
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            test_credentials, max_retries=2, _transport=transport
+        )
+
+        with client:
+            result = client.get_events()
+
+        assert call_count == 2
+        assert result == ["event1"]
+
+    def test_rate_limit_error_after_max_retries(
+        self, test_credentials: Credentials
+    ) -> None:
+        """Should raise RateLimitError after max retries."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "60"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            test_credentials, max_retries=1, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.get_events()
+
+        assert exc_info.value.retry_after == 60
+
+    def test_successful_response_after_retry(
+        self, test_credentials: Credentials
+    ) -> None:
+        """Should return successful response after retry."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return httpx.Response(429, headers={"Retry-After": "0"})
+            return httpx.Response(200, json={"data": "success"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            test_credentials, max_retries=3, _transport=transport
+        )
+
+        with client:
+            result = client.segmentation("event", "2024-01-01", "2024-01-31")
+
+        assert call_count == 3
+        assert result == {"data": "success"}
+
+
+# =============================================================================
+# User Story 3: Stream Large Event Exports
+# =============================================================================
+
+
+class TestEventExport:
+    """Test event export streaming (US3)."""
+
+    def test_export_events_returns_iterator(
+        self, test_credentials: Credentials
+    ) -> None:
+        """export_events should return an iterator."""
+        mock_data = b'{"event":"A","properties":{"time":1}}\n{"event":"B","properties":{"time":2}}\n'
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=mock_data)
+
+        with create_mock_client(test_credentials, handler) as client:
+            result = client.export_events("2024-01-01", "2024-01-31")
+            # Should be an iterator
+            assert hasattr(result, "__iter__")
+            assert hasattr(result, "__next__")
+
+    def test_jsonl_parsing_line_by_line(self, test_credentials: Credentials) -> None:
+        """Should parse JSONL line by line."""
+        mock_data = b'{"event":"A","properties":{"time":1}}\n{"event":"B","properties":{"time":2}}\n'
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=mock_data)
+
+        with create_mock_client(test_credentials, handler) as client:
+            events = list(client.export_events("2024-01-01", "2024-01-31"))
+
+        assert len(events) == 2
+        assert events[0]["event"] == "A"
+        assert events[1]["event"] == "B"
+
+    def test_on_batch_callback(self, test_credentials: Credentials) -> None:
+        """Should invoke on_batch callback."""
+        # Create enough events to trigger callback
+        events_data = "\n".join(
+            json.dumps({"event": f"E{i}", "properties": {"time": i}})
+            for i in range(1500)
+        )
+        mock_data = events_data.encode() + b"\n"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=mock_data)
+
+        batch_counts: list[int] = []
+
+        def on_batch(count: int) -> None:
+            batch_counts.append(count)
+
+        with create_mock_client(test_credentials, handler) as client:
+            list(client.export_events("2024-01-01", "2024-01-31", on_batch=on_batch))
+
+        # Should have called on_batch at 1000 and final count
+        assert 1000 in batch_counts
+        assert 1500 in batch_counts
+
+    def test_event_name_filtering(self, test_credentials: Credentials) -> None:
+        """Should filter by event names."""
+        captured_url: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_url
+            captured_url = str(request.url)
+            return httpx.Response(200, content=b"")
+
+        with create_mock_client(test_credentials, handler) as client:
+            list(
+                client.export_events(
+                    "2024-01-01", "2024-01-31", events=["Purchase", "View"]
+                )
+            )
+
+        # Events should be JSON-encoded in URL
+        assert "event=" in captured_url
+
+    def test_malformed_json_skipped(self, test_credentials: Credentials) -> None:
+        """Should skip malformed JSON lines with warning."""
+        mock_data = b'{"event":"A","properties":{"time":1}}\nNOT JSON\n{"event":"B","properties":{"time":2}}\n'
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=mock_data)
+
+        with create_mock_client(test_credentials, handler) as client:
+            events = list(client.export_events("2024-01-01", "2024-01-31"))
+
+        # Should have skipped malformed line
+        assert len(events) == 2
+        assert events[0]["event"] == "A"
+        assert events[1]["event"] == "B"
+
+
+# =============================================================================
+# User Story 4: Segmentation Queries
+# =============================================================================
+
+
+class TestSegmentation:
+    """Test segmentation queries (US4)."""
+
+    def test_segmentation_basic(self, test_credentials: Credentials) -> None:
+        """Should make basic segmentation query."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json={"data": {"values": {}}})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.segmentation("Purchase", "2024-01-01", "2024-01-31")
+
+        assert captured_params["event"] == "Purchase"
+        assert captured_params["from_date"] == "2024-01-01"
+        assert captured_params["to_date"] == "2024-01-31"
+
+    def test_segmentation_with_on(self, test_credentials: Credentials) -> None:
+        """Should include 'on' parameter."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json={"data": {}})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.segmentation(
+                "Purchase", "2024-01-01", "2024-01-31", on="properties.country"
+            )
+
+        assert captured_params["on"] == "properties.country"
+
+    def test_segmentation_with_where(self, test_credentials: Credentials) -> None:
+        """Should include 'where' filter."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json={"data": {}})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.segmentation(
+                "Purchase",
+                "2024-01-01",
+                "2024-01-31",
+                where='properties["amount"] > 100',
+            )
+
+        assert "where" in captured_params
+
+
+# =============================================================================
+# User Story 5: Discovery
+# =============================================================================
+
+
+class TestDiscovery:
+    """Test discovery APIs (US5)."""
+
+    def test_get_events(self, test_credentials: Credentials) -> None:
+        """Should list events with type=general parameter."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json=["event1", "event2", "event3"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            events = client.get_events()
+
+        assert events == ["event1", "event2", "event3"]
+        assert captured_params["type"] == "general"
+
+    def test_get_event_properties(self, test_credentials: Credentials) -> None:
+        """Should list event properties from /events/properties/top endpoint."""
+        captured_params: dict[str, Any] = {}
+        captured_path: str = ""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_path
+            captured_path = request.url.path
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            # /events/properties/top returns dict with property names as keys
+            return httpx.Response(200, json={"prop1": 100.0, "prop2": 50.5})
+
+        with create_mock_client(test_credentials, handler) as client:
+            props = client.get_event_properties("Purchase")
+
+        assert captured_path.endswith("/events/properties/top")
+        assert captured_params["event"] == "Purchase"
+        assert set(props) == {"prop1", "prop2"}
+
+    def test_get_property_values(self, test_credentials: Credentials) -> None:
+        """Should list property values with limit."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json=["value1", "value2"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            values = client.get_property_values("country", limit=10)
+
+        assert captured_params["name"] == "country"
+        assert captured_params["limit"] == "10"
+        assert values == ["value1", "value2"]
+
+
+# =============================================================================
+# User Story 6: Profile Export
+# =============================================================================
+
+
+class TestProfileExport:
+    """Test profile export (US6)."""
+
+    def test_export_profiles_returns_iterator(
+        self, test_credentials: Credentials
+    ) -> None:
+        """export_profiles should return an iterator."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"$distinct_id": "u1", "$properties": {}}],
+                    "session_id": None,
+                },
+            )
+
+        with create_mock_client(test_credentials, handler) as client:
+            result = client.export_profiles()
+            assert hasattr(result, "__iter__")
+
+    def test_pagination_with_session_id(self, test_credentials: Credentials) -> None:
+        """Should handle pagination with session_id."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [{"$distinct_id": "u1"}],
+                        "session_id": "abc123",
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={"results": [], "session_id": None},
+            )
+
+        with create_mock_client(test_credentials, handler) as client:
+            profiles = list(client.export_profiles())
+
+        assert len(profiles) == 1
+        assert call_count == 2
+
+    def test_where_filter(self, test_credentials: Credentials) -> None:
+        """Should include where filter."""
+        captured_body: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.content:
+                nonlocal captured_body
+                captured_body = json.loads(request.content)
+            return httpx.Response(200, json={"results": []})
+
+        with create_mock_client(test_credentials, handler) as client:
+            list(client.export_profiles(where='properties["plan"] == "premium"'))
+
+        assert "where" in captured_body
+
+
+# =============================================================================
+# User Story 7: Funnel and Retention
+# =============================================================================
+
+
+class TestFunnelAndRetention:
+    """Test funnel and retention queries (US7)."""
+
+    def test_funnel(self, test_credentials: Credentials) -> None:
+        """Should execute funnel query."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json={"data": []})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.funnel(12345, "2024-01-01", "2024-01-31")
+
+        assert captured_params["funnel_id"] == "12345"
+
+    def test_retention(self, test_credentials: Credentials) -> None:
+        """Should execute retention query."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json={"data": {}})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.retention("Signup", "Purchase", "2024-01-01", "2024-01-31")
+
+        assert captured_params["born_event"] == "Signup"
+        assert captured_params["event"] == "Purchase"
+
+
+# =============================================================================
+# User Story 8: JQL
+# =============================================================================
+
+
+class TestJQL:
+    """Test JQL queries (US8)."""
+
+    def test_jql_basic(self, test_credentials: Credentials) -> None:
+        """Should execute JQL script."""
+        captured_body: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.content:
+                nonlocal captured_body
+                captured_body = json.loads(request.content)
+            return httpx.Response(200, json=[{"key": "value"}])
+
+        with create_mock_client(test_credentials, handler) as client:
+            result = client.jql("function main() { return []; }")
+
+        assert "script" in captured_body
+        assert result == [{"key": "value"}]
+
+    def test_jql_with_params(self, test_credentials: Credentials) -> None:
+        """Should pass params to JQL script."""
+        captured_body: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.content:
+                nonlocal captured_body
+                captured_body = json.loads(request.content)
+            return httpx.Response(200, json=[])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.jql("function main() { return []; }", params={"from": "2024-01-01"})
+
+        assert "params" in captured_body
+
+
+# =============================================================================
+# Error Handling
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Test error handling."""
+
+    def test_query_error_on_400(self, test_credentials: Credentials) -> None:
+        """Should raise QueryError on 400."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json={"error": "Invalid query"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert "Invalid query" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Implements complete `MixpanelAPIClient` with httpx, Basic auth, and regional endpoint routing (US/EU/IN)
- Adds automatic rate limit handling with exponential backoff and jitter
- Implements streaming event export via JSONL with memory-efficient iterators
- Adds profile export with automatic session-based pagination
- Implements discovery APIs: `get_events()`, `get_event_properties()`, `get_property_values()`
- Implements query APIs: `segmentation()`, `funnel()`, `retention()`, `jql()`

## Test plan

- [x] All 139 tests pass (46 new API client tests + 93 existing)
- [x] Ruff check passes
- [x] mypy --strict passes
- [x] Integration tested with real Mixpanel credentials (ai_demo account)
- [x] Quickstart examples validated

## Files changed

- `src/mixpanel_data/_internal/api_client.py` - Main implementation (~740 lines)
- `tests/unit/test_api_client.py` - 46 unit tests
- `tests/conftest.py` - Mock client fixtures
- `specs/002-api-client/` - Design docs, contracts, tasks