### PR TITLE
Implement DiscoveryService for schema introspection (Phase 004)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,6 +5,12 @@ echo "Setting up mixpanel_data development environment..."
 
 cd /workspace
 
+# Clean up any stale virtual environment that might cause issues
+if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+    echo "Removing incomplete .venv directory..."
+    rm -rf .venv
+fi
+
 # Install dependencies (uv sync creates venv automatically if needed)
 echo "Installing dependencies..."
 uv sync --all-extras

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,8 @@ src/mixpanel_data/
 │   ├── api_client.py        # ✅ MixpanelAPIClient
 │   ├── storage.py           # ✅ StorageEngine (DuckDB)
 │   └── services/
-│       ├── discovery.py     # ⏳ DiscoveryService
+│       ├── __init__.py      # ✅ Services package
+│       ├── discovery.py     # ✅ DiscoveryService
 │       ├── fetcher.py       # ⏳ FetcherService
 │       └── live_query.py    # ⏳ LiveQueryService
 └── cli/
@@ -118,14 +119,14 @@ Config file: `~/.mp/config.toml`
 | 001 | Foundation Layer | ✅ Complete | `001-foundation-layer` |
 | 002 | API Client | ✅ Complete | `002-api-client` |
 | 003 | Storage Engine | ✅ Complete | `003-storage-engine` |
-| 004 | Discovery Service | ⏳ Next | `004-discovery-service` |
-| 005 | Fetch Service | ⏳ Pending | `005-fetch-service` |
+| 004 | Discovery Service | ✅ Complete | `004-discovery-service` |
+| 005 | Fetch Service | ⏳ Next | `005-fetch-service` |
 | 006 | Live Queries | ⏳ Pending | `006-live-queries` |
 | 007 | Workspace Facade | ⏳ Pending | `007-workspace` |
 | 008 | CLI Application | ⏳ Pending | `008-cli` |
 | 009 | Polish & Release | ⏳ Pending | `009-polish` |
 
-**Next up:** Phase 004 (Discovery Service) - implements `DiscoveryService` for retrieving schema information (events, properties, sample values) from Mixpanel APIs.
+**Next up:** Phase 005 (Fetch Service) - implements `FetcherService` for fetching and storing events/profiles in DuckDB.
 
 ## What's Implemented
 
@@ -172,8 +173,16 @@ All frozen dataclasses with lazy `.df` property and `.to_dict()` method:
 - Table management: `drop_table()` with metadata cleanup
 - Context manager support for resource cleanup
 
+### Discovery Service (`_internal/services/discovery.py`)
+- `DiscoveryService` — Schema introspection with session-scoped caching
+- `list_events()` — List all event names (sorted alphabetically, cached)
+- `list_properties(event)` — List properties for an event (sorted, cached per event)
+- `list_property_values(property, event, limit)` — Sample values for a property (cached)
+- `clear_cache()` — Clear all cached discovery results
+- Constructor injection of `MixpanelAPIClient` for testing
+
 ### Tests
-- Unit tests for exceptions, config, types, storage
+- Unit tests for exceptions, config, types, storage, discovery
 - Integration tests for config file CRUD, foundation layer, storage engine
 - Requires Python 3.11+ (use devcontainer or pyenv)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,10 @@ ruff check src/ tests/
 ```
 
 ## Recent Changes
+- 004-discovery-service: Added Python 3.11+ + httpx (via MixpanelAPIClient from Phase 002)
 - 003-storage-engine: ✅ Complete - Implemented `StorageEngine` with DuckDB lifecycle management, streaming ingestion, query execution, and introspection
 - 002-api-client: ✅ Complete - Implemented `MixpanelAPIClient` with HTTP transport, regional endpoints, rate limiting, and streaming export
-- 001-foundation-layer: ✅ Complete - Implemented foundation layer (exceptions, types, config, auth)
+
+## Active Technologies
+- Python 3.11+ + httpx (via MixpanelAPIClient from Phase 002) (004-discovery-service)
+- N/A (read-only service, in-memory cache only) (004-discovery-service)

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -44,7 +44,7 @@ This document defines the complete implementation roadmap for `mixpanel_data`, o
 │  ┌──────────────────┐           ┌──────────────────┐                        │
 │  │  003-Storage     │           │  004-Discovery   │                        │
 │  │  (DuckDB,        │           │  (Event/Property │                        │
-│  │   Schema, I/O)   │ ✅         │   Introspection) │ ⏳ NEXT                 │
+│  │   Schema, I/O)   │ ✅         │   Introspection) │ ✅                      │
 │  └────────┬─────────┘           └────────┬─────────┘                        │
 │           │                              │                                  │
 │           └──────────────┬───────────────┘                                  │
@@ -84,8 +84,8 @@ This document defines the complete implementation roadmap for `mixpanel_data`, o
 | 001 | Foundation Layer | Exceptions, Types, ConfigManager, Auth | ✅ Complete | `001-foundation-layer` |
 | 002 | API Client | MixpanelAPIClient, HTTP, Rate Limiting | ✅ Complete | `002-api-client` |
 | 003 | Storage Engine | StorageEngine, DuckDB, Schema Management | ✅ Complete | `003-storage-engine` |
-| 004 | Discovery Service | DiscoveryService, Event/Property APIs | ⏳ Pending | `004-discovery-service` |
-| 005 | Fetch Service | FetcherService, Events/Profiles Export | ⏳ Pending | `005-fetch-service` |
+| 004 | Discovery Service | DiscoveryService, Event/Property APIs | ✅ Complete | `004-discovery-service` |
+| 005 | Fetch Service | FetcherService, Events/Profiles Export | ⏳ Next | `005-fetch-service` |
 | 006 | Live Queries | LiveQueryService, Segmentation, Funnels, Retention | ⏳ Pending | `006-live-queries` |
 | 007 | Workspace Facade | Workspace class, Lifecycle Management | ⏳ Pending | `007-workspace` |
 | 008 | CLI Application | Typer app, Commands, Formatters | ⏳ Pending | `008-cli` |
@@ -403,60 +403,42 @@ class StorageEngine:
 
 ---
 
-## Phase 004: Discovery Service ⏳
+## Phase 004: Discovery Service ✅
 
-**Status:** PENDING
+**Status:** COMPLETE
 **Branch:** `004-discovery-service`
 **Dependencies:** Phase 002 (API Client)
+**Spec:** [specs/004-discovery-service/](specs/004-discovery-service/)
 
 ### Overview
 
 The `DiscoveryService` retrieves schema information from Mixpanel—event names, properties, and sample values. This enables agents to understand data shape before querying.
 
-### Components to Build
+### Delivered Components
 
 | Component | Location | Description |
 |-----------|----------|-------------|
-| DiscoveryService | `src/mixpanel_data/_internal/services/discovery.py` | Schema discovery |
+| DiscoveryService | `src/mixpanel_data/_internal/services/discovery.py` | Schema discovery with caching |
+| Unit Tests | `tests/unit/test_discovery.py` | 18 tests with mocked API client |
 
-### Design Reference
+### Key Deliverables
 
-```python
-class DiscoveryService:
-    def __init__(self, api_client: MixpanelAPIClient): ...
-    def list_events(self) -> list[str]: ...
-    def list_properties(self, event: str) -> list[str]: ...
-    def list_property_values(self, event: str, prop: str, limit: int = 100) -> list[str]: ...
-```
-
-### User Stories
-
-1. **Discover what events exist** (P1)
-   - List all event names in the project
-   - Cache results for session
-
-2. **Understand event properties** (P1)
-   - List properties for a specific event
-   - Know property types
-
-3. **Sample property values** (P2)
-   - Get sample values for a property
-   - Understand data distribution
-
-### Tasks (Estimated: 15-20)
-
-- [ ] Create `DiscoveryService` class
-- [ ] Implement `list_events()` with caching
-- [ ] Implement `list_properties(event)`
-- [ ] Implement `list_property_values(event, prop, limit)`
-- [ ] Add optional caching layer
-- [ ] Unit tests with mocked API client
+- [x] Create `DiscoveryService` class with API client injection
+- [x] Implement `list_events()` with alphabetical sorting and caching
+- [x] Implement `list_properties(event)` with per-event caching
+- [x] Implement `list_property_values(property, event, limit)` with caching
+- [x] Implement `clear_cache()` for manual cache invalidation
+- [x] Session-scoped in-memory cache (dict-based)
+- [x] Pass-through error handling from API client
+- [x] Unit tests with mocked API client (18 tests)
+- [x] mypy --strict passes
+- [x] ruff check passes
 
 ### Success Criteria
 
-- [ ] All discovery methods return sorted lists
-- [ ] Caching reduces duplicate API calls
-- [ ] 90%+ test coverage
+- [x] All discovery methods return sorted lists (events and properties)
+- [x] Caching reduces duplicate API calls
+- [x] 100% test coverage for DiscoveryService
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python library and CLI for working with Mixpanel analytics data, designed for AI coding agents.
 
-**Status:** Foundation, API client, and storage engine complete — services layer in progress.
+**Status:** Foundation, API client, storage engine, and discovery service complete — fetch service next.
 
 ## The Problem
 
@@ -177,10 +177,12 @@ Implementation following the phased roadmap in [IMPLEMENTATION_PLAN.md](IMPLEMEN
 1. ✅ **Foundation Layer** — Exceptions, types, ConfigManager, auth module
 2. ✅ **API Client** — MixpanelAPIClient with HTTP transport, rate limiting, streaming
 3. ✅ **Storage Engine** — DuckDB operations, schema management, query execution
-4. ⏳ **Services** — DiscoveryService, FetcherService, LiveQueryService (next)
-5. ⏳ **Workspace** — Facade class, lifecycle management
-6. ⏳ **CLI** — Typer application, all commands
-7. ⏳ **Polish** — SKILL.md, documentation, PyPI release
+4. ✅ **Discovery Service** — DiscoveryService with caching
+5. ⏳ **Fetch Service** — FetcherService for events/profiles (next)
+6. ⏳ **Live Queries** — LiveQueryService for segmentation, funnels, retention
+7. ⏳ **Workspace** — Facade class, lifecycle management
+8. ⏳ **CLI** — Typer application, all commands
+9. ⏳ **Polish** — SKILL.md, documentation, PyPI release
 
 ## License
 

--- a/specs/004-discovery-service/checklists/requirements.md
+++ b/specs/004-discovery-service/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Specification Quality Checklist: Discovery Service
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Summary
+
+**Status**: PASSED
+
+All checklist items passed validation:
+
+1. **Content Quality**: Spec focuses on user needs (AI agents, data analysts) and business value (context window efficiency). No mention of specific technologies, frameworks, or implementation approaches.
+
+2. **Requirement Completeness**:
+   - 12 functional requirements, all testable
+   - 6 measurable success criteria
+   - 4 user stories with clear acceptance scenarios
+   - 5 edge cases identified
+   - Clear out-of-scope boundaries
+   - Dependencies on Phases 001 and 002 documented
+
+3. **Feature Readiness**: Each user story maps to functional requirements and can be independently tested and delivered.
+
+## Notes
+
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- No clarifications needed - all requirements have reasonable defaults documented in Assumptions section
+- P1 stories (Events and Properties) provide standalone MVP value
+- P2/P3 stories (Values, Cache clearing) are enhancements

--- a/specs/004-discovery-service/contracts/discovery_service.py
+++ b/specs/004-discovery-service/contracts/discovery_service.py
@@ -1,0 +1,120 @@
+"""Discovery Service Interface Contract.
+
+This file defines the expected interface for DiscoveryService.
+It is a contract, not implementation—used for planning and validation.
+
+Location: src/mixpanel_data/_internal/services/discovery.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+
+class DiscoveryService:
+    """Schema discovery service for Mixpanel projects.
+
+    Provides methods to explore events, properties, and sample values
+    with session-scoped caching to avoid redundant API calls.
+
+    Example:
+        >>> from mixpanel_data._internal.api_client import MixpanelAPIClient
+        >>> from mixpanel_data._internal.services.discovery import DiscoveryService
+        >>>
+        >>> client = MixpanelAPIClient(credentials)
+        >>> discovery = DiscoveryService(client)
+        >>> events = discovery.list_events()
+        >>> properties = discovery.list_properties("Sign Up")
+    """
+
+    def __init__(self, api_client: MixpanelAPIClient) -> None:
+        """Initialize discovery service.
+
+        Args:
+            api_client: Authenticated Mixpanel API client.
+        """
+        ...
+
+    def list_events(self) -> list[str]:
+        """List all event names in the project.
+
+        Returns:
+            Alphabetically sorted list of event names.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+
+        Note:
+            Results are cached for the lifetime of this service instance.
+        """
+        ...
+
+    def list_properties(self, event: str) -> list[str]:
+        """List all properties for a specific event.
+
+        Args:
+            event: Event name to get properties for.
+
+        Returns:
+            Alphabetically sorted list of property names.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Event does not exist.
+
+        Note:
+            Results are cached per event for the lifetime of this service instance.
+        """
+        ...
+
+    def list_property_values(
+        self,
+        property_name: str,
+        *,
+        event: str | None = None,
+        limit: int = 100,
+    ) -> list[str]:
+        """List sample values for a property.
+
+        Args:
+            property_name: Property name to get values for.
+            event: Optional event name to scope the query.
+            limit: Maximum number of values to return (default: 100).
+
+        Returns:
+            List of sample values as strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+
+        Note:
+            Results are cached per (property, event, limit) combination.
+            Values are returned as strings regardless of original type.
+        """
+        ...
+
+    def clear_cache(self) -> None:
+        """Clear all cached discovery results.
+
+        After calling this method, the next discovery request will
+        fetch fresh data from the Mixpanel API.
+        """
+        ...
+
+
+# =============================================================================
+# Exception Contracts (re-exported from exceptions.py)
+# =============================================================================
+
+# AuthenticationError: Raised when credentials are invalid
+# QueryError: Raised when event does not exist or query is invalid
+# RateLimitError: Raised when Mixpanel rate limits are exceeded
+
+# All exceptions inherit from MixpanelDataError and have:
+# - code: str (machine-readable error code)
+# - message: str (human-readable description)
+# - details: dict (additional context)
+# - to_dict() -> dict (JSON-serializable representation)

--- a/specs/004-discovery-service/data-model.md
+++ b/specs/004-discovery-service/data-model.md
@@ -1,0 +1,113 @@
+# Data Model: Discovery Service
+
+**Date**: 2025-12-21
+**Feature**: 004-discovery-service
+
+## Overview
+
+The Discovery Service is primarily a read-only service that returns data from Mixpanel's API. It introduces minimal new data structures—mainly the cache layer for storing results.
+
+## Entities
+
+### Core Entities (from Mixpanel)
+
+These entities are returned by the service but not owned by it:
+
+#### Event Name
+- **Type**: String
+- **Description**: Name of a tracked event in Mixpanel (e.g., "Sign Up", "Purchase")
+- **Constraints**: Non-empty string; max 255 characters (Mixpanel limit)
+- **Source**: Mixpanel Query API `/events/names`
+
+#### Property Name
+- **Type**: String
+- **Description**: Name of a property associated with an event (e.g., "country", "plan_type")
+- **Constraints**: Non-empty string; max 255 characters
+- **Source**: Mixpanel Query API `/events/properties/top`
+
+#### Property Value
+- **Type**: String
+- **Description**: Sample value for a property (e.g., "US", "premium")
+- **Constraints**: Converted to string; may be empty
+- **Source**: Mixpanel Query API `/events/properties/values`
+
+### Service Entities (internal)
+
+#### Discovery Cache
+
+**Purpose**: Store discovery results to avoid redundant API calls within a session.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | tuple | Composite key: (method_name, *args) |
+| value | list[str] | Cached result (sorted list) |
+
+**Lifecycle**:
+- Created: When first discovery request for a key is made
+- Updated: Never (immutable once cached)
+- Deleted: On `clear_cache()` or service instance destruction
+
+**Cache Key Examples**:
+
+| Method Call | Cache Key |
+|-------------|-----------|
+| `list_events()` | `("list_events",)` |
+| `list_properties("Sign Up")` | `("list_properties", "Sign Up")` |
+| `list_property_values("country", event="Sign Up", limit=100)` | `("list_property_values", "country", "Sign Up", 100)` |
+
+## Relationships
+
+```
+DiscoveryService
+    │
+    ├── owns → Cache (dict[tuple, list[str]])
+    │
+    └── uses → MixpanelAPIClient
+                    │
+                    └── calls → Mixpanel API
+                                    │
+                                    └── returns → Events, Properties, Values
+```
+
+## State Transitions
+
+### Cache State Machine
+
+```
+┌─────────────┐
+│    EMPTY    │ ← Initial state / After clear_cache()
+└─────────────┘
+       │
+       │ First request for key K
+       ▼
+┌─────────────┐
+│   MISS      │ → Call API, store result
+└─────────────┘
+       │
+       │ Result cached
+       ▼
+┌─────────────┐
+│   HIT       │ → Return cached result (no API call)
+└─────────────┘
+       │
+       │ clear_cache()
+       ▼
+┌─────────────┐
+│    EMPTY    │
+└─────────────┘
+```
+
+## Validation Rules
+
+| Entity | Rule | Error |
+|--------|------|-------|
+| Event Name (input) | Must be non-empty string | `QueryError` from API client |
+| Property Name (input) | Must be non-empty string | `QueryError` from API client |
+| Limit (input) | Must be positive integer | ValueError (Python) |
+
+## Notes
+
+- No database storage—all data is transient (in-memory cache)
+- No persistence across sessions
+- All returned lists are sorted alphabetically at the service layer
+- Original API response order is not preserved

--- a/specs/004-discovery-service/plan.md
+++ b/specs/004-discovery-service/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Discovery Service
+
+**Branch**: `004-discovery-service` | **Date**: 2025-12-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-discovery-service/spec.md`
+
+## Summary
+
+The Discovery Service provides schema introspection for Mixpanel projects—listing events, properties, and sample values. It wraps the existing `MixpanelAPIClient` discovery methods with an in-memory cache layer to avoid redundant API calls within a session. This is a thin service layer following the established patterns from Phase 001-003.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: httpx (via MixpanelAPIClient from Phase 002)
+**Storage**: N/A (read-only service, in-memory cache only)
+**Testing**: pytest with mocked API client
+**Target Platform**: Python library (cross-platform)
+**Project Type**: Single project (library)
+**Performance Goals**: <3s uncached, <100ms cached (per SC-001, SC-002)
+**Constraints**: Session-scoped caching, no persistence
+**Scale/Scope**: Typical Mixpanel projects with up to 1,000 events
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Library-First | ✅ PASS | Service is a Python class; no CLI in this phase |
+| II. Agent-Native | ✅ PASS | Returns sorted lists (structured); no interactivity |
+| III. Context Window Efficiency | ✅ PASS | Core purpose: introspection before querying |
+| IV. Two Data Paths | ✅ PASS | Discovery is a "live query" path operation |
+| V. Explicit Over Implicit | ✅ PASS | Cache is session-scoped with explicit clear method |
+| VI. Unix Philosophy | ✅ PASS | Single responsibility: schema discovery only |
+| VII. Secure by Default | ✅ PASS | Uses existing credential system; no new auth paths |
+
+**Gate Status**: PASSED - No violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-discovery-service/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── discovery_service.py  # Service interface contract
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── _internal/
+│   └── services/
+│       ├── __init__.py      # NEW: Package marker
+│       └── discovery.py     # NEW: DiscoveryService class
+└── ...existing modules...
+
+tests/
+├── unit/
+│   └── test_discovery.py    # NEW: Unit tests with mocked client
+└── integration/
+    └── test_discovery_integration.py  # NEW: Integration tests (optional)
+```
+
+**Structure Decision**: Single project structure following existing `_internal/` pattern. The `services/` directory is new but matches the design doc's planned layout.
+
+## Complexity Tracking
+
+> No violations to track. Implementation follows established patterns.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | - | - |

--- a/specs/004-discovery-service/quickstart.md
+++ b/specs/004-discovery-service/quickstart.md
@@ -1,0 +1,212 @@
+# Quickstart: Discovery Service
+
+**Feature**: 004-discovery-service
+**Date**: 2025-12-21
+
+## Overview
+
+The Discovery Service lets you explore Mixpanel schema before querying data. Discover what events exist, what properties they have, and sample values—all with automatic caching.
+
+## Basic Usage
+
+### Setup
+
+```python
+from mixpanel_data._internal.config import ConfigManager
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.services.discovery import DiscoveryService
+
+# Get credentials
+config = ConfigManager()
+credentials = config.resolve_credentials()
+
+# Create services
+with MixpanelAPIClient(credentials) as client:
+    discovery = DiscoveryService(client)
+
+    # Now use discovery methods...
+```
+
+### List All Events
+
+```python
+events = discovery.list_events()
+print(f"Found {len(events)} events")
+for event in events[:10]:
+    print(f"  - {event}")
+```
+
+Output:
+```
+Found 47 events
+  - Add to Cart
+  - Checkout Complete
+  - Login
+  - Page View
+  - ...
+```
+
+### List Properties for an Event
+
+```python
+properties = discovery.list_properties("Purchase")
+print(f"Purchase event has {len(properties)} properties:")
+for prop in properties:
+    print(f"  - {prop}")
+```
+
+Output:
+```
+Purchase event has 12 properties:
+  - amount
+  - currency
+  - item_count
+  - payment_method
+  - ...
+```
+
+### Get Sample Property Values
+
+```python
+# Get sample values for a property
+countries = discovery.list_property_values("country")
+print(f"Countries: {countries[:5]}")
+
+# Scope to a specific event
+payment_methods = discovery.list_property_values(
+    "payment_method",
+    event="Purchase",
+    limit=10
+)
+print(f"Payment methods: {payment_methods}")
+```
+
+Output:
+```
+Countries: ['AU', 'CA', 'DE', 'FR', 'GB']
+Payment methods: ['apple_pay', 'credit_card', 'paypal']
+```
+
+## Caching Behavior
+
+Results are cached automatically for the session:
+
+```python
+# First call: hits Mixpanel API
+events1 = discovery.list_events()  # ~1-2 seconds
+
+# Second call: returns cached result instantly
+events2 = discovery.list_events()  # <1 millisecond
+
+# Same for properties
+props1 = discovery.list_properties("Purchase")  # API call
+props2 = discovery.list_properties("Purchase")  # Cached
+
+# Different event = different cache entry
+props3 = discovery.list_properties("Sign Up")  # API call
+```
+
+### Clearing the Cache
+
+If your Mixpanel schema changes mid-session:
+
+```python
+# Clear all cached results
+discovery.clear_cache()
+
+# Next call fetches fresh data
+events = discovery.list_events()  # API call
+```
+
+## Error Handling
+
+```python
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    QueryError,
+    RateLimitError,
+)
+
+try:
+    events = discovery.list_events()
+except AuthenticationError:
+    print("Invalid credentials. Check your service account.")
+except RateLimitError as e:
+    print(f"Rate limited. Retry after {e.details.get('retry_after')} seconds")
+
+try:
+    props = discovery.list_properties("NonExistentEvent")
+except QueryError as e:
+    print(f"Event not found: {e.message}")
+```
+
+## Common Patterns
+
+### Build a Schema Overview
+
+```python
+def get_schema_overview(discovery: DiscoveryService) -> dict:
+    """Get a complete schema overview of the project."""
+    events = discovery.list_events()
+    schema = {}
+
+    for event in events:
+        properties = discovery.list_properties(event)
+        schema[event] = {
+            "property_count": len(properties),
+            "properties": properties,
+        }
+
+    return schema
+
+overview = get_schema_overview(discovery)
+print(f"Total events: {len(overview)}")
+print(f"Total properties: {sum(e['property_count'] for e in overview.values())}")
+```
+
+### Find Events with a Specific Property
+
+```python
+def find_events_with_property(
+    discovery: DiscoveryService,
+    property_name: str
+) -> list[str]:
+    """Find all events that have a specific property."""
+    events = discovery.list_events()
+    matching = []
+
+    for event in events:
+        properties = discovery.list_properties(event)
+        if property_name in properties:
+            matching.append(event)
+
+    return matching
+
+# Find all events with "user_id" property
+events = find_events_with_property(discovery, "user_id")
+print(f"Events with user_id: {events}")
+```
+
+## Integration with Workspace (Future)
+
+Once Workspace is implemented (Phase 007), usage will be simpler:
+
+```python
+from mixpanel_data import Workspace
+
+ws = Workspace()
+events = ws.events()           # Calls DiscoveryService.list_events()
+props = ws.properties("Login") # Calls DiscoveryService.list_properties()
+```
+
+## Performance Notes
+
+| Operation | Uncached | Cached |
+|-----------|----------|--------|
+| list_events() | 1-3 seconds | <1ms |
+| list_properties(event) | 0.5-2 seconds | <1ms |
+| list_property_values(...) | 0.5-2 seconds | <1ms |
+
+- Cache is in-memory only; cleared when service instance is garbage collected
+- No TTL—cache persists for entire session
+- First request per unique parameters hits the API

--- a/specs/004-discovery-service/research.md
+++ b/specs/004-discovery-service/research.md
@@ -1,0 +1,132 @@
+# Research: Discovery Service
+
+**Date**: 2025-12-21
+**Feature**: 004-discovery-service
+
+## Overview
+
+Research findings for implementing the DiscoveryService. This feature is straightforward—wrapping existing API client methods with caching—so research focuses on caching patterns and integration with existing code.
+
+## Research Items
+
+### 1. Caching Strategy
+
+**Decision**: Simple dictionary-based in-memory cache with composite keys
+
+**Rationale**:
+- Session-scoped caching only (per spec A-002)
+- No TTL required—cache lives as long as service instance
+- Small data volume (event names, property lists) fits comfortably in memory
+- Dictionary lookup is O(1) and sufficient for <100ms cached response requirement
+
+**Alternatives Considered**:
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| `functools.lru_cache` | Harder to clear selectively; decorator-based doesn't allow explicit clear |
+| `cachetools.TTLCache` | TTL not required per spec; adds dependency |
+| Redis/external cache | Overkill for session-scoped, single-process use case |
+
+**Implementation Pattern**:
+```python
+# Cache key format: (method_name, *sorted_args)
+# Examples:
+#   ("list_events",)
+#   ("list_properties", "Sign Up")
+#   ("list_property_values", "country", "Sign Up", 100)
+```
+
+### 2. API Client Integration
+
+**Decision**: Accept `MixpanelAPIClient` via constructor injection
+
+**Rationale**:
+- Matches established pattern from `StorageEngine` and other services
+- Enables easy testing with mock clients
+- No direct httpx dependency in DiscoveryService
+
+**Existing Methods Available** (from `api_client.py` lines 487-553):
+
+| Method | Returns | Endpoint |
+|--------|---------|----------|
+| `get_events()` | `list[str]` | `/events/names` |
+| `get_event_properties(event)` | `list[str]` | `/events/properties/top` |
+| `get_property_values(property_name, event, limit)` | `list[str]` | `/events/properties/values` |
+
+All methods already handle:
+- Authentication
+- Regional endpoint routing
+- Rate limiting with backoff
+- Error conversion to library exceptions
+
+### 3. Error Handling
+
+**Decision**: Pass through exceptions from API client; no wrapping
+
+**Rationale**:
+- API client already raises appropriate exceptions (`AuthenticationError`, `QueryError`, `RateLimitError`)
+- Adding wrapper exceptions would violate DRY
+- Spec FR-010/FR-011 satisfied by existing client exceptions
+
+**Exception Flow**:
+```
+User → DiscoveryService → MixpanelAPIClient → Mixpanel API
+                           ↓
+          AuthenticationError | QueryError | RateLimitError
+```
+
+### 4. Sorting Behavior
+
+**Decision**: Sort results at service layer, not relying on API
+
+**Rationale**:
+- Spec FR-002/FR-004 require alphabetical sorting
+- API response order is not guaranteed to be alphabetical
+- Sorting at service layer ensures consistency regardless of API changes
+
+**Implementation**: `sorted(result)` on all list returns
+
+### 5. Testing Strategy
+
+**Decision**: Unit tests with mocked API client; optional integration tests
+
+**Rationale**:
+- Unit tests verify caching, sorting, error propagation
+- Integration tests require live credentials (environment-dependent)
+- Mock pattern already established in `tests/unit/test_api_client.py`
+
+**Mock Pattern** (from existing tests):
+```python
+@pytest.fixture
+def mock_client_factory(mock_credentials):
+    def factory(handler):
+        transport = httpx.MockTransport(handler)
+        return MixpanelAPIClient(mock_credentials, _transport=transport)
+    return factory
+```
+
+## Unknowns Resolved
+
+| Unknown | Resolution |
+|---------|------------|
+| Cache TTL | Session-only, no TTL (spec A-002) |
+| Cache clearing | Explicit `clear_cache()` method (spec FR-009) |
+| All properties method | Not included—per-event only (spec FR-003) |
+| Property types | Out of scope (spec Out of Scope section) |
+
+## Dependencies Verified
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| MixpanelAPIClient | ✅ Available | Phase 002 complete |
+| Exception hierarchy | ✅ Available | Phase 001 complete |
+| Test fixtures | ✅ Available | `conftest.py` has mock patterns |
+
+## Conclusion
+
+No blockers identified. Implementation can proceed with:
+1. Simple dict-based cache
+2. Constructor injection of API client
+3. Pass-through error handling
+4. Service-layer sorting
+5. Unit tests with mocked client

--- a/specs/004-discovery-service/spec.md
+++ b/specs/004-discovery-service/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Discovery Service
+
+**Feature Branch**: `004-discovery-service`
+**Created**: 2025-12-21
+**Status**: Draft
+**Input**: User description: "Phase 004 Discovery Service"
+
+## Overview
+
+The Discovery Service enables users to explore and understand the schema of their Mixpanel data before querying or fetching it. This is critical for AI coding agents and data analysts who need to understand what events exist, what properties those events have, and what values those properties contain—all without consuming context window tokens on raw data exploration.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover Available Events (Priority: P1)
+
+As an AI coding agent or data analyst, I want to list all event names in a Mixpanel project so I can understand what data is available before writing queries or fetching data.
+
+**Why this priority**: This is the foundational discovery operation. Without knowing what events exist, users cannot proceed with any meaningful data analysis. Every other discovery operation depends on knowing valid event names first.
+
+**Independent Test**: Can be fully tested by requesting the list of events and verifying a complete, sorted list is returned. Delivers immediate value by revealing the data vocabulary.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid Mixpanel credentials, **When** I request the list of events, **Then** I receive a complete alphabetically-sorted list of all event names in the project.
+2. **Given** valid credentials, **When** I request events multiple times within a session, **Then** subsequent requests return cached results without additional network calls.
+3. **Given** invalid or missing credentials, **When** I request the list of events, **Then** I receive a clear authentication error.
+
+---
+
+### User Story 2 - Explore Event Properties (Priority: P1)
+
+As an AI coding agent or data analyst, I want to list all properties associated with a specific event so I can understand the data structure and write accurate queries.
+
+**Why this priority**: Understanding event properties is essential for building queries. This is equally important as listing events because users need both to construct meaningful analyses.
+
+**Independent Test**: Can be fully tested by providing a valid event name and verifying all associated properties are returned in a sorted list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid event name, **When** I request properties for that event, **Then** I receive an alphabetically-sorted list of all property names associated with that event.
+2. **Given** an event name that doesn't exist, **When** I request its properties, **Then** I receive a clear error indicating the event was not found.
+3. **Given** valid credentials and event, **When** I request properties multiple times for the same event, **Then** subsequent requests return cached results.
+
+---
+
+### User Story 3 - Sample Property Values (Priority: P2)
+
+As an AI coding agent or data analyst, I want to see sample values for a specific property so I can understand the data distribution and format before writing filter conditions.
+
+**Why this priority**: While valuable for understanding data shape, this is secondary to knowing what events and properties exist. Users can proceed with basic queries without sample values, but sample values improve query accuracy.
+
+**Independent Test**: Can be fully tested by providing a property name (and optionally an event scope) and verifying sample values are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid property name, **When** I request sample values, **Then** I receive a list of actual values that property contains in the data.
+2. **Given** a property name and specific event, **When** I request sample values scoped to that event, **Then** I receive values only from that event's data.
+3. **Given** a request for sample values, **When** I specify a limit, **Then** the returned list contains at most that many values.
+4. **Given** valid parameters, **When** I request sample values multiple times, **Then** subsequent requests return cached results.
+
+---
+
+### User Story 4 - Clear Discovery Cache (Priority: P3)
+
+As a user working with evolving data, I want to clear cached discovery results so I can see the latest schema information when my Mixpanel project has changed.
+
+**Why this priority**: Cache management is a convenience feature. Most users will create new sessions when they need fresh data. However, for long-running sessions where the underlying data evolves, manual cache clearing provides flexibility.
+
+**Independent Test**: Can be fully tested by populating the cache, clearing it, and verifying the next request fetches fresh data.
+
+**Acceptance Scenarios**:
+
+1. **Given** cached discovery results exist, **When** I clear the cache, **Then** subsequent discovery requests fetch fresh data from the source.
+2. **Given** no cached results exist, **When** I clear the cache, **Then** the operation completes without error.
+
+---
+
+### Edge Cases
+
+- What happens when the Mixpanel project has no events? → Return an empty list, not an error.
+- What happens when an event has no custom properties? → Return an empty list (or only system properties if applicable).
+- What happens when a property has no recorded values? → Return an empty list.
+- How does the system handle rate limiting from the data source? → Respect rate limits with appropriate waiting and retry, surfacing clear errors if limits are exceeded.
+- What happens when credentials become invalid mid-session? → Surface authentication errors clearly on the next discovery request.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a method to list all event names in a Mixpanel project.
+- **FR-002**: System MUST return event lists in alphabetical order for consistent, predictable output.
+- **FR-003**: System MUST provide a method to list all properties for a specified event.
+- **FR-004**: System MUST return property lists in alphabetical order.
+- **FR-005**: System MUST provide a method to retrieve sample values for a specified property.
+- **FR-006**: System MUST support scoping property value queries to a specific event.
+- **FR-007**: System MUST support limiting the number of sample values returned.
+- **FR-008**: System MUST cache discovery results within a session to avoid redundant network requests.
+- **FR-009**: System MUST provide a method to clear the discovery cache.
+- **FR-010**: System MUST surface authentication errors clearly when credentials are invalid.
+- **FR-011**: System MUST surface clear errors when referencing non-existent events.
+- **FR-012**: System MUST handle empty results gracefully, returning empty lists rather than errors.
+
+### Key Entities
+
+- **Event**: A named action tracked in Mixpanel (e.g., "Sign Up", "Purchase"). Key attributes: name.
+- **Property**: A data field associated with events (e.g., "country", "plan_type"). Key attributes: name, associated event(s).
+- **Property Value**: An actual value recorded for a property (e.g., "US", "premium"). Key attributes: value as string.
+- **Discovery Cache**: Temporary storage of discovery results to avoid redundant requests. Key attributes: cache key (method + parameters), cached result, session scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can retrieve the complete list of events in under 3 seconds for typical projects (up to 1,000 events).
+- **SC-002**: Cached discovery requests return results in under 100 milliseconds.
+- **SC-003**: All discovery results are returned in consistent alphabetical order across repeated requests.
+- **SC-004**: 100% of discovery operations that encounter errors provide actionable error messages identifying the cause (authentication, invalid event, rate limit, etc.).
+- **SC-005**: Repeated discovery requests within a session result in zero additional network calls when cache is populated.
+- **SC-006**: The discovery feature reduces AI agent context window consumption by enabling schema exploration before data fetching.
+
+## Assumptions
+
+- **A-001**: Discovery results are relatively stable within a session. Events and properties don't change frequently enough to require real-time updates during typical usage.
+- **A-002**: Session-scoped caching is sufficient. Users who need fresh data can create a new session or manually clear the cache.
+- **A-003**: The default limit for sample property values (when not specified) will be a reasonable number that balances completeness with performance (assumed: 100 values).
+- **A-004**: All string values (event names, property names, property values) will be returned as-is from the data source without transformation.
+- **A-005**: The discovery service operates in read-only mode and does not modify any Mixpanel project data.
+
+## Dependencies
+
+- **D-001**: Requires valid Mixpanel credentials (service account with read access).
+- **D-002**: Depends on the existing authentication/configuration system (Phase 001).
+- **D-003**: Depends on the existing API client for network communication (Phase 002).
+
+## Out of Scope
+
+- Property type information (string, number, boolean, etc.) - not reliably available from discovery endpoints.
+- Event metadata beyond names (descriptions, tags, schemas).
+- Profile property discovery (separate from event properties).
+- Cross-project discovery.
+- Persistent caching across sessions.
+- Real-time cache invalidation when Mixpanel data changes.

--- a/specs/004-discovery-service/tasks.md
+++ b/specs/004-discovery-service/tasks.md
@@ -23,8 +23,8 @@
 
 **Purpose**: Create services directory structure
 
-- [ ] T001 Create services package directory at src/mixpanel_data/_internal/services/
-- [ ] T002 Create package marker at src/mixpanel_data/_internal/services/__init__.py
+- [X] T001 Create services package directory at src/mixpanel_data/_internal/services/
+- [X] T002 Create package marker at src/mixpanel_data/_internal/services/__init__.py
 
 ---
 
@@ -34,13 +34,13 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Create DiscoveryService class skeleton in src/mixpanel_data/_internal/services/discovery.py with:
+- [X] T003 Create DiscoveryService class skeleton in src/mixpanel_data/_internal/services/discovery.py with:
   - Module docstring and imports
   - Class definition with `__init__(self, api_client: MixpanelAPIClient)`
   - Private `_cache: dict[tuple, list[str]]` attribute
   - Private `_api_client` attribute
   - Module-level logger: `_logger = logging.getLogger(__name__)`
-- [ ] T004 Create test file skeleton at tests/unit/test_discovery.py with:
+- [X] T004 Create test file skeleton at tests/unit/test_discovery.py with:
   - Imports for pytest, httpx.MockTransport, and discovery service
   - Fixtures for mock API client (reuse pattern from tests/unit/test_api_client.py)
   - TestDiscoveryService class placeholder
@@ -57,19 +57,19 @@
 
 ### Tests for User Story 1
 
-- [ ] T005 [P] [US1] Unit test for list_events() returns sorted list in tests/unit/test_discovery.py
-- [ ] T006 [P] [US1] Unit test for list_events() caching behavior in tests/unit/test_discovery.py
-- [ ] T007 [P] [US1] Unit test for list_events() with authentication error in tests/unit/test_discovery.py
-- [ ] T008 [P] [US1] Unit test for list_events() with empty result in tests/unit/test_discovery.py
+- [X] T005 [P] [US1] Unit test for list_events() returns sorted list in tests/unit/test_discovery.py
+- [X] T006 [P] [US1] Unit test for list_events() caching behavior in tests/unit/test_discovery.py
+- [X] T007 [P] [US1] Unit test for list_events() with authentication error in tests/unit/test_discovery.py
+- [X] T008 [P] [US1] Unit test for list_events() with empty result in tests/unit/test_discovery.py
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Implement list_events() method in src/mixpanel_data/_internal/services/discovery.py:
+- [X] T009 [US1] Implement list_events() method in src/mixpanel_data/_internal/services/discovery.py:
   - Check cache for key `("list_events",)`
   - If miss: call `self._api_client.get_events()`
   - Sort result alphabetically with `sorted()`
   - Store in cache and return
-- [ ] T010 [US1] Run tests for User Story 1 and verify all pass
+- [X] T010 [US1] Run tests for User Story 1 and verify all pass
 
 **Checkpoint**: User Story 1 fully functional - can list all events with caching
 
@@ -83,19 +83,19 @@
 
 ### Tests for User Story 2
 
-- [ ] T011 [P] [US2] Unit test for list_properties() returns sorted list in tests/unit/test_discovery.py
-- [ ] T012 [P] [US2] Unit test for list_properties() caching per event in tests/unit/test_discovery.py
-- [ ] T013 [P] [US2] Unit test for list_properties() with QueryError on invalid event in tests/unit/test_discovery.py
-- [ ] T014 [P] [US2] Unit test for list_properties() with empty result in tests/unit/test_discovery.py
+- [X] T011 [P] [US2] Unit test for list_properties() returns sorted list in tests/unit/test_discovery.py
+- [X] T012 [P] [US2] Unit test for list_properties() caching per event in tests/unit/test_discovery.py
+- [X] T013 [P] [US2] Unit test for list_properties() with QueryError on invalid event in tests/unit/test_discovery.py
+- [X] T014 [P] [US2] Unit test for list_properties() with empty result in tests/unit/test_discovery.py
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Implement list_properties(event: str) method in src/mixpanel_data/_internal/services/discovery.py:
+- [X] T015 [US2] Implement list_properties(event: str) method in src/mixpanel_data/_internal/services/discovery.py:
   - Check cache for key `("list_properties", event)`
   - If miss: call `self._api_client.get_event_properties(event)`
   - Sort result alphabetically with `sorted()`
   - Store in cache and return
-- [ ] T016 [US2] Run tests for User Story 2 and verify all pass
+- [X] T016 [US2] Run tests for User Story 2 and verify all pass
 
 **Checkpoint**: User Stories 1 AND 2 both work independently
 
@@ -109,20 +109,20 @@
 
 ### Tests for User Story 3
 
-- [ ] T017 [P] [US3] Unit test for list_property_values() basic call in tests/unit/test_discovery.py
-- [ ] T018 [P] [US3] Unit test for list_property_values() with event scope in tests/unit/test_discovery.py
-- [ ] T019 [P] [US3] Unit test for list_property_values() with custom limit in tests/unit/test_discovery.py
-- [ ] T020 [P] [US3] Unit test for list_property_values() caching per (property, event, limit) in tests/unit/test_discovery.py
-- [ ] T021 [P] [US3] Unit test for list_property_values() with empty result in tests/unit/test_discovery.py
+- [X] T017 [P] [US3] Unit test for list_property_values() basic call in tests/unit/test_discovery.py
+- [X] T018 [P] [US3] Unit test for list_property_values() with event scope in tests/unit/test_discovery.py
+- [X] T019 [P] [US3] Unit test for list_property_values() with custom limit in tests/unit/test_discovery.py
+- [X] T020 [P] [US3] Unit test for list_property_values() caching per (property, event, limit) in tests/unit/test_discovery.py
+- [X] T021 [P] [US3] Unit test for list_property_values() with empty result in tests/unit/test_discovery.py
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Implement list_property_values(property_name: str, *, event: str | None = None, limit: int = 100) method in src/mixpanel_data/_internal/services/discovery.py:
+- [X] T022 [US3] Implement list_property_values(property_name: str, *, event: str | None = None, limit: int = 100) method in src/mixpanel_data/_internal/services/discovery.py:
   - Check cache for key `("list_property_values", property_name, event, limit)`
   - If miss: call `self._api_client.get_property_values(property_name, event=event, limit=limit)`
   - Return result (no sorting per research.md - values are not alphabetically ordered)
   - Store in cache and return
-- [ ] T023 [US3] Run tests for User Story 3 and verify all pass
+- [X] T023 [US3] Run tests for User Story 3 and verify all pass
 
 **Checkpoint**: User Stories 1, 2, AND 3 all work independently
 
@@ -136,15 +136,15 @@
 
 ### Tests for User Story 4
 
-- [ ] T024 [P] [US4] Unit test for clear_cache() clears all cached results in tests/unit/test_discovery.py
-- [ ] T025 [P] [US4] Unit test for clear_cache() on empty cache does not error in tests/unit/test_discovery.py
-- [ ] T026 [P] [US4] Unit test for clear_cache() causes next request to hit API in tests/unit/test_discovery.py
+- [X] T024 [P] [US4] Unit test for clear_cache() clears all cached results in tests/unit/test_discovery.py
+- [X] T025 [P] [US4] Unit test for clear_cache() on empty cache does not error in tests/unit/test_discovery.py
+- [X] T026 [P] [US4] Unit test for clear_cache() causes next request to hit API in tests/unit/test_discovery.py
 
 ### Implementation for User Story 4
 
-- [ ] T027 [US4] Implement clear_cache() method in src/mixpanel_data/_internal/services/discovery.py:
+- [X] T027 [US4] Implement clear_cache() method in src/mixpanel_data/_internal/services/discovery.py:
   - Set `self._cache = {}`
-- [ ] T028 [US4] Run tests for User Story 4 and verify all pass
+- [X] T028 [US4] Run tests for User Story 4 and verify all pass
 
 **Checkpoint**: All user stories now independently functional
 
@@ -154,12 +154,12 @@
 
 **Purpose**: Quality gates and documentation
 
-- [ ] T029 [P] Add module docstring and class docstring to src/mixpanel_data/_internal/services/discovery.py per Google style
-- [ ] T030 [P] Add method docstrings to all public methods (list_events, list_properties, list_property_values, clear_cache)
-- [ ] T031 Run mypy --strict on src/mixpanel_data/_internal/services/discovery.py and fix any type errors
-- [ ] T032 Run ruff check on src/mixpanel_data/_internal/services/discovery.py and fix any linting issues
-- [ ] T033 Run full test suite: pytest tests/unit/test_discovery.py -v
-- [ ] T034 Validate against quickstart.md examples (manual verification)
+- [X] T029 [P] Add module docstring and class docstring to src/mixpanel_data/_internal/services/discovery.py per Google style
+- [X] T030 [P] Add method docstrings to all public methods (list_events, list_properties, list_property_values, clear_cache)
+- [X] T031 Run mypy --strict on src/mixpanel_data/_internal/services/discovery.py and fix any type errors
+- [X] T032 Run ruff check on src/mixpanel_data/_internal/services/discovery.py and fix any linting issues
+- [X] T033 Run full test suite: pytest tests/unit/test_discovery.py -v
+- [X] T034 Validate against quickstart.md examples (manual verification)
 
 ---
 

--- a/specs/004-discovery-service/tasks.md
+++ b/specs/004-discovery-service/tasks.md
@@ -1,0 +1,252 @@
+# Tasks: Discovery Service
+
+**Input**: Design documents from `/specs/004-discovery-service/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Unit tests included per constitution quality gates (pytest with mocked API client).
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/mixpanel_data/_internal/services/`, `tests/unit/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create services directory structure
+
+- [ ] T001 Create services package directory at src/mixpanel_data/_internal/services/
+- [ ] T002 Create package marker at src/mixpanel_data/_internal/services/__init__.py
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core DiscoveryService class with cache infrastructure
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Create DiscoveryService class skeleton in src/mixpanel_data/_internal/services/discovery.py with:
+  - Module docstring and imports
+  - Class definition with `__init__(self, api_client: MixpanelAPIClient)`
+  - Private `_cache: dict[tuple, list[str]]` attribute
+  - Private `_api_client` attribute
+  - Module-level logger: `_logger = logging.getLogger(__name__)`
+- [ ] T004 Create test file skeleton at tests/unit/test_discovery.py with:
+  - Imports for pytest, httpx.MockTransport, and discovery service
+  - Fixtures for mock API client (reuse pattern from tests/unit/test_api_client.py)
+  - TestDiscoveryService class placeholder
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Discover Available Events (Priority: P1) 🎯 MVP
+
+**Goal**: List all event names in a Mixpanel project with caching
+
+**Independent Test**: Request list of events, verify complete alphabetically-sorted list returned; verify caching on second call
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] Unit test for list_events() returns sorted list in tests/unit/test_discovery.py
+- [ ] T006 [P] [US1] Unit test for list_events() caching behavior in tests/unit/test_discovery.py
+- [ ] T007 [P] [US1] Unit test for list_events() with authentication error in tests/unit/test_discovery.py
+- [ ] T008 [P] [US1] Unit test for list_events() with empty result in tests/unit/test_discovery.py
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Implement list_events() method in src/mixpanel_data/_internal/services/discovery.py:
+  - Check cache for key `("list_events",)`
+  - If miss: call `self._api_client.get_events()`
+  - Sort result alphabetically with `sorted()`
+  - Store in cache and return
+- [ ] T010 [US1] Run tests for User Story 1 and verify all pass
+
+**Checkpoint**: User Story 1 fully functional - can list all events with caching
+
+---
+
+## Phase 4: User Story 2 - Explore Event Properties (Priority: P1)
+
+**Goal**: List all properties for a specific event with caching
+
+**Independent Test**: Provide valid event name, verify sorted properties returned; verify error on invalid event
+
+### Tests for User Story 2
+
+- [ ] T011 [P] [US2] Unit test for list_properties() returns sorted list in tests/unit/test_discovery.py
+- [ ] T012 [P] [US2] Unit test for list_properties() caching per event in tests/unit/test_discovery.py
+- [ ] T013 [P] [US2] Unit test for list_properties() with QueryError on invalid event in tests/unit/test_discovery.py
+- [ ] T014 [P] [US2] Unit test for list_properties() with empty result in tests/unit/test_discovery.py
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Implement list_properties(event: str) method in src/mixpanel_data/_internal/services/discovery.py:
+  - Check cache for key `("list_properties", event)`
+  - If miss: call `self._api_client.get_event_properties(event)`
+  - Sort result alphabetically with `sorted()`
+  - Store in cache and return
+- [ ] T016 [US2] Run tests for User Story 2 and verify all pass
+
+**Checkpoint**: User Stories 1 AND 2 both work independently
+
+---
+
+## Phase 5: User Story 3 - Sample Property Values (Priority: P2)
+
+**Goal**: Get sample values for a property with optional event scope and limit
+
+**Independent Test**: Provide property name, verify values returned; verify scoping to event; verify limit respected
+
+### Tests for User Story 3
+
+- [ ] T017 [P] [US3] Unit test for list_property_values() basic call in tests/unit/test_discovery.py
+- [ ] T018 [P] [US3] Unit test for list_property_values() with event scope in tests/unit/test_discovery.py
+- [ ] T019 [P] [US3] Unit test for list_property_values() with custom limit in tests/unit/test_discovery.py
+- [ ] T020 [P] [US3] Unit test for list_property_values() caching per (property, event, limit) in tests/unit/test_discovery.py
+- [ ] T021 [P] [US3] Unit test for list_property_values() with empty result in tests/unit/test_discovery.py
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Implement list_property_values(property_name: str, *, event: str | None = None, limit: int = 100) method in src/mixpanel_data/_internal/services/discovery.py:
+  - Check cache for key `("list_property_values", property_name, event, limit)`
+  - If miss: call `self._api_client.get_property_values(property_name, event=event, limit=limit)`
+  - Return result (no sorting per research.md - values are not alphabetically ordered)
+  - Store in cache and return
+- [ ] T023 [US3] Run tests for User Story 3 and verify all pass
+
+**Checkpoint**: User Stories 1, 2, AND 3 all work independently
+
+---
+
+## Phase 6: User Story 4 - Clear Discovery Cache (Priority: P3)
+
+**Goal**: Manually clear cached discovery results
+
+**Independent Test**: Populate cache, clear it, verify next request fetches fresh data
+
+### Tests for User Story 4
+
+- [ ] T024 [P] [US4] Unit test for clear_cache() clears all cached results in tests/unit/test_discovery.py
+- [ ] T025 [P] [US4] Unit test for clear_cache() on empty cache does not error in tests/unit/test_discovery.py
+- [ ] T026 [P] [US4] Unit test for clear_cache() causes next request to hit API in tests/unit/test_discovery.py
+
+### Implementation for User Story 4
+
+- [ ] T027 [US4] Implement clear_cache() method in src/mixpanel_data/_internal/services/discovery.py:
+  - Set `self._cache = {}`
+- [ ] T028 [US4] Run tests for User Story 4 and verify all pass
+
+**Checkpoint**: All user stories now independently functional
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates and documentation
+
+- [ ] T029 [P] Add module docstring and class docstring to src/mixpanel_data/_internal/services/discovery.py per Google style
+- [ ] T030 [P] Add method docstrings to all public methods (list_events, list_properties, list_property_values, clear_cache)
+- [ ] T031 Run mypy --strict on src/mixpanel_data/_internal/services/discovery.py and fix any type errors
+- [ ] T032 Run ruff check on src/mixpanel_data/_internal/services/discovery.py and fix any linting issues
+- [ ] T033 Run full test suite: pytest tests/unit/test_discovery.py -v
+- [ ] T034 Validate against quickstart.md examples (manual verification)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - US1 and US2 can proceed in parallel (both P1, different methods)
+  - US3 can start after Foundational (independent of US1/US2)
+  - US4 can start after Foundational (independent of all others)
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational - No dependencies on other stories (can parallel with US1)
+- **User Story 3 (P2)**: Can start after Foundational - No dependencies on other stories
+- **User Story 4 (P3)**: Can start after Foundational - No dependencies on other stories
+
+### Within Each User Story
+
+- Tests written first (TDD approach)
+- Implementation follows tests
+- Verify tests pass before marking story complete
+
+### Parallel Opportunities
+
+Within each user story phase, all test tasks marked [P] can run in parallel:
+- US1: T005, T006, T007, T008 can run in parallel
+- US2: T011, T012, T013, T014 can run in parallel
+- US3: T017, T018, T019, T020, T021 can run in parallel
+- US4: T024, T025, T026 can run in parallel
+
+Different user stories can be worked on in parallel by different developers after Foundational completes.
+
+---
+
+## Parallel Example: All US1 Tests
+
+```bash
+# Launch all tests for User Story 1 together:
+Task: "Unit test for list_events() returns sorted list in tests/unit/test_discovery.py"
+Task: "Unit test for list_events() caching behavior in tests/unit/test_discovery.py"
+Task: "Unit test for list_events() with authentication error in tests/unit/test_discovery.py"
+Task: "Unit test for list_events() with empty result in tests/unit/test_discovery.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T004)
+3. Complete Phase 3: User Story 1 (T005-T010)
+4. **STOP and VALIDATE**: Test list_events() independently
+5. Can deploy/demo with basic event discovery
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test → Deploy (MVP: event listing)
+3. Add User Story 2 → Test → Deploy (property listing)
+4. Add User Story 3 → Test → Deploy (value sampling)
+5. Add User Story 4 → Test → Deploy (cache management)
+6. Polish → Final release
+
+### Single Developer Strategy (Recommended)
+
+Since this is a single service class, work sequentially by priority:
+1. Setup + Foundational
+2. US1 (P1) - Complete with tests
+3. US2 (P1) - Complete with tests
+4. US3 (P2) - Complete with tests
+5. US4 (P3) - Complete with tests
+6. Polish
+
+---
+
+## Notes
+
+- All user story methods are in the same file (discovery.py) but can be implemented independently
+- Cache key format: tuple of (method_name, *args) for unique identification
+- Sorting applies to events and properties but NOT to property values
+- Error handling is pass-through from API client (no wrapping needed)
+- Default limit for property values is 100 (per spec A-003)

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -10,7 +10,7 @@ import os
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import tomli_w
 from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
@@ -246,11 +246,15 @@ class ConfigManager:
 
         # All four must be set to use env vars
         if username and secret and project_id and region:
+            if region not in VALID_REGIONS:
+                raise ConfigError(
+                    f"Invalid MP_REGION: '{region}'. Must be 'us', 'eu', or 'in'."
+                )
             return Credentials(
                 username=username,
                 secret=SecretStr(secret),
                 project_id=project_id,
-                region=region,
+                region=cast(RegionType, region),
             )
         return None
 

--- a/src/mixpanel_data/_internal/services/__init__.py
+++ b/src/mixpanel_data/_internal/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for mixpanel_data.
+
+This package contains high-level service classes that orchestrate
+operations using the lower-level API client and storage components.
+"""

--- a/src/mixpanel_data/_internal/services/discovery.py
+++ b/src/mixpanel_data/_internal/services/discovery.py
@@ -38,7 +38,10 @@ class DiscoveryService:
             api_client: Authenticated Mixpanel API client.
         """
         self._api_client = api_client
-        # Cache key can contain str, None, or int values
+        # Cache keys by method:
+        #   ("list_events",)
+        #   ("list_properties", event: str)
+        #   ("list_property_values", property: str, event: str | None, limit: int)
         self._cache: dict[tuple[str | int | None, ...], list[str]] = {}
 
     def list_events(self) -> list[str]:
@@ -120,7 +123,8 @@ class DiscoveryService:
             property_name, event=event, limit=limit
         )
         # Note: values are NOT sorted per research.md
-        self._cache[cache_key] = result
+        # Store a copy to prevent mutation if API client retains reference
+        self._cache[cache_key] = list(result)
         return list(result)
 
     def clear_cache(self) -> None:

--- a/src/mixpanel_data/_internal/services/discovery.py
+++ b/src/mixpanel_data/_internal/services/discovery.py
@@ -1,0 +1,131 @@
+"""Discovery Service for Mixpanel schema introspection.
+
+Provides methods to explore events, properties, and sample values
+with session-scoped caching to avoid redundant API calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+_logger = logging.getLogger(__name__)
+
+
+class DiscoveryService:
+    """Schema discovery service for Mixpanel projects.
+
+    Provides methods to explore events, properties, and sample values
+    with session-scoped caching to avoid redundant API calls.
+
+    Example:
+        >>> from mixpanel_data._internal.api_client import MixpanelAPIClient
+        >>> from mixpanel_data._internal.services.discovery import DiscoveryService
+        >>>
+        >>> client = MixpanelAPIClient(credentials)
+        >>> discovery = DiscoveryService(client)
+        >>> events = discovery.list_events()
+        >>> properties = discovery.list_properties("Sign Up")
+    """
+
+    def __init__(self, api_client: MixpanelAPIClient) -> None:
+        """Initialize discovery service.
+
+        Args:
+            api_client: Authenticated Mixpanel API client.
+        """
+        self._api_client = api_client
+        self._cache: dict[tuple[str, ...], list[str]] = {}
+
+    def list_events(self) -> list[str]:
+        """List all event names in the project.
+
+        Returns:
+            Alphabetically sorted list of event names.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+
+        Note:
+            Results are cached for the lifetime of this service instance.
+        """
+        cache_key = ("list_events",)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        result = self._api_client.get_events()
+        sorted_result = sorted(result)
+        self._cache[cache_key] = sorted_result
+        return sorted_result
+
+    def list_properties(self, event: str) -> list[str]:
+        """List all properties for a specific event.
+
+        Args:
+            event: Event name to get properties for.
+
+        Returns:
+            Alphabetically sorted list of property names.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Event does not exist.
+
+        Note:
+            Results are cached per event for the lifetime of this service instance.
+        """
+        cache_key = ("list_properties", event)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        result = self._api_client.get_event_properties(event)
+        sorted_result = sorted(result)
+        self._cache[cache_key] = sorted_result
+        return sorted_result
+
+    def list_property_values(
+        self,
+        property_name: str,
+        *,
+        event: str | None = None,
+        limit: int = 100,
+    ) -> list[str]:
+        """List sample values for a property.
+
+        Args:
+            property_name: Property name to get values for.
+            event: Optional event name to scope the query.
+            limit: Maximum number of values to return (default: 100).
+
+        Returns:
+            List of sample values as strings.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+
+        Note:
+            Results are cached per (property, event, limit) combination.
+            Values are returned as strings regardless of original type.
+        """
+        # Use str(event) to handle None in cache key consistently
+        cache_key = ("list_property_values", property_name, str(event), str(limit))
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        result = self._api_client.get_property_values(
+            property_name, event=event, limit=limit
+        )
+        # Note: values are NOT sorted per research.md
+        self._cache[cache_key] = result
+        return result
+
+    def clear_cache(self) -> None:
+        """Clear all cached discovery results.
+
+        After calling this method, the next discovery request will
+        fetch fresh data from the Mixpanel API.
+        """
+        self._cache = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 if TYPE_CHECKING:
     from mixpanel_data._internal.api_client import MixpanelAPIClient
@@ -60,7 +61,7 @@ def mock_credentials() -> Credentials:
 
     return Credentials(
         username="test_user",
-        secret="test_secret",
+        secret=SecretStr("test_secret"),
         project_id="12345",
         region="us",
     )

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 from mixpanel_data._internal.api_client import ENDPOINTS, MixpanelAPIClient
 from mixpanel_data._internal.config import Credentials
@@ -25,7 +26,7 @@ def test_credentials() -> Credentials:
     """Create test credentials."""
     return Credentials(
         username="test_user",
-        secret="test_secret",
+        secret=SecretStr("test_secret"),
         project_id="12345",
         region="us",
     )
@@ -36,7 +37,7 @@ def eu_credentials() -> Credentials:
     """Create EU region test credentials."""
     return Credentials(
         username="test_user",
-        secret="test_secret",
+        secret=SecretStr("test_secret"),
         project_id="12345",
         region="eu",
     )
@@ -47,7 +48,7 @@ def india_credentials() -> Credentials:
     """Create India region test credentials."""
     return Credentials(
         username="test_user",
-        secret="test_secret",
+        secret=SecretStr("test_secret"),
         project_id="12345",
         region="in",
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import dataclasses
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from mixpanel_data._internal.config import (
     AccountInfo,
@@ -27,7 +27,7 @@ class TestCredentials:
         """Test creating valid credentials."""
         creds = Credentials(
             username="sa_test",
-            secret="secret123",
+            secret=SecretStr("secret123"),
             project_id="12345",
             region="us",
         )
@@ -43,7 +43,7 @@ class TestCredentials:
         for region in ("us", "eu", "in", "US", "EU", "IN"):
             creds = Credentials(
                 username="user",
-                secret="secret",
+                secret=SecretStr("secret"),
                 project_id="123",
                 region=region,
             )
@@ -53,7 +53,7 @@ class TestCredentials:
         with pytest.raises(ValueError, match="Region must be one of"):
             Credentials(
                 username="user",
-                secret="secret",
+                secret=SecretStr("secret"),
                 project_id="123",
                 region="invalid",
             )
@@ -63,7 +63,7 @@ class TestCredentials:
         with pytest.raises(ValueError, match="cannot be empty"):
             Credentials(
                 username="",
-                secret="secret",
+                secret=SecretStr("secret"),
                 project_id="123",
                 region="us",
             )
@@ -71,7 +71,7 @@ class TestCredentials:
         with pytest.raises(ValueError, match="cannot be empty"):
             Credentials(
                 username="user",
-                secret="secret",
+                secret=SecretStr("secret"),
                 project_id="   ",
                 region="us",
             )
@@ -80,7 +80,7 @@ class TestCredentials:
         """Secret should never appear in repr/str output."""
         creds = Credentials(
             username="sa_test",
-            secret="my_super_secret_value",
+            secret=SecretStr("my_super_secret_value"),
             project_id="12345",
             region="us",
         )
@@ -98,7 +98,7 @@ class TestCredentials:
         """Credentials should be immutable (frozen)."""
         creds = Credentials(
             username="sa_test",
-            secret="secret123",
+            secret=SecretStr("secret123"),
             project_id="12345",
             region="us",
         )

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,452 @@
+"""Unit tests for DiscoveryService.
+
+Tests use httpx.MockTransport for deterministic HTTP mocking.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from mixpanel_data._internal.services.discovery import DiscoveryService
+from mixpanel_data.exceptions import AuthenticationError, QueryError
+
+if TYPE_CHECKING:
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+
+@pytest.fixture
+def discovery_factory(
+    mock_client_factory: Callable[
+        [Callable[[httpx.Request], httpx.Response]], MixpanelAPIClient
+    ],
+) -> Callable[[Callable[[httpx.Request], httpx.Response]], DiscoveryService]:
+    """Factory for creating DiscoveryService with mock API client.
+
+    Usage:
+        def test_something(discovery_factory):
+            def handler(request):
+                return httpx.Response(200, json=["event1", "event2"])
+
+            discovery = discovery_factory(handler)
+            result = discovery.list_events()
+    """
+
+    def factory(
+        handler: Callable[[httpx.Request], httpx.Response],
+    ) -> DiscoveryService:
+        client = mock_client_factory(handler)
+        # Enter context to ensure client is initialized
+        client.__enter__()
+        return DiscoveryService(client)
+
+    return factory
+
+
+class TestDiscoveryService:
+    """Tests for DiscoveryService initialization."""
+
+    def test_init_with_api_client(
+        self,
+        mock_client_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], MixpanelAPIClient
+        ],
+        success_handler: Callable[[httpx.Request], httpx.Response],
+    ) -> None:
+        """DiscoveryService should accept an API client."""
+        client = mock_client_factory(success_handler)
+        discovery = DiscoveryService(client)
+        assert discovery._api_client is client
+
+    def test_init_creates_empty_cache(
+        self,
+        mock_client_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], MixpanelAPIClient
+        ],
+        success_handler: Callable[[httpx.Request], httpx.Response],
+    ) -> None:
+        """DiscoveryService should initialize with empty cache."""
+        client = mock_client_factory(success_handler)
+        discovery = DiscoveryService(client)
+        assert discovery._cache == {}
+
+
+# =============================================================================
+# User Story 1: list_events() Tests
+# =============================================================================
+
+
+class TestListEvents:
+    """Tests for DiscoveryService.list_events()."""
+
+    def test_list_events_returns_sorted_list(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_events() should return events sorted alphabetically."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            # Return unsorted list to verify sorting
+            return httpx.Response(
+                200, json=["Signup", "Login", "Purchase", "Add to Cart"]
+            )
+
+        discovery = discovery_factory(handler)
+        events = discovery.list_events()
+
+        assert events == ["Add to Cart", "Login", "Purchase", "Signup"]
+
+    def test_list_events_caching_behavior(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_events() should cache results and not call API on second request."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=["Event1", "Event2"])
+
+        discovery = discovery_factory(handler)
+
+        # First call
+        events1 = discovery.list_events()
+        assert call_count == 1
+
+        # Second call should use cache
+        events2 = discovery.list_events()
+        assert call_count == 1  # Still 1, not incremented
+
+        # Results should be identical
+        assert events1 == events2
+
+    def test_list_events_with_authentication_error(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_events() should propagate AuthenticationError from API client."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "Invalid credentials"})
+
+        discovery = discovery_factory(handler)
+
+        with pytest.raises(AuthenticationError):
+            discovery.list_events()
+
+    def test_list_events_with_empty_result(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_events() should return empty list when no events exist."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        discovery = discovery_factory(handler)
+        events = discovery.list_events()
+
+        assert events == []
+
+
+# =============================================================================
+# User Story 2: list_properties() Tests
+# =============================================================================
+
+
+class TestListProperties:
+    """Tests for DiscoveryService.list_properties()."""
+
+    def test_list_properties_returns_sorted_list(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_properties() should return properties sorted alphabetically."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            # Return unsorted dict to verify sorting (API returns dict with counts)
+            return httpx.Response(
+                200, json={"user_id": 100, "amount": 50, "currency": 75}
+            )
+
+        discovery = discovery_factory(handler)
+        properties = discovery.list_properties("Purchase")
+
+        assert properties == ["amount", "currency", "user_id"]
+
+    def test_list_properties_caching_per_event(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_properties() should cache results per event name."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            # Return different results based on the event parameter
+            if "event=Purchase" in str(request.url):
+                return httpx.Response(200, json={"amount": 1, "currency": 1})
+            return httpx.Response(200, json={"user_id": 1, "email": 1})
+
+        discovery = discovery_factory(handler)
+
+        # First call for Purchase
+        props1 = discovery.list_properties("Purchase")
+        assert call_count == 1
+
+        # Second call for Purchase should use cache
+        props2 = discovery.list_properties("Purchase")
+        assert call_count == 1  # Still 1
+
+        # Call for different event should hit API
+        props3 = discovery.list_properties("Signup")
+        assert call_count == 2
+
+        # Results should be correct
+        assert props1 == props2 == ["amount", "currency"]
+        assert props3 == ["email", "user_id"]
+
+    def test_list_properties_with_query_error(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_properties() should propagate QueryError for invalid event."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json={"error": "Invalid event name"})
+
+        discovery = discovery_factory(handler)
+
+        with pytest.raises(QueryError):
+            discovery.list_properties("NonExistentEvent")
+
+    def test_list_properties_with_empty_result(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_properties() should return empty list when event has no properties."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})
+
+        discovery = discovery_factory(handler)
+        properties = discovery.list_properties("EmptyEvent")
+
+        assert properties == []
+
+
+# =============================================================================
+# User Story 3: list_property_values() Tests
+# =============================================================================
+
+
+class TestListPropertyValues:
+    """Tests for DiscoveryService.list_property_values()."""
+
+    def test_list_property_values_basic_call(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_property_values() should return values from API."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["US", "CA", "GB", "DE"])
+
+        discovery = discovery_factory(handler)
+        values = discovery.list_property_values("country")
+
+        # Note: values are NOT sorted per research.md
+        assert values == ["US", "CA", "GB", "DE"]
+
+    def test_list_property_values_with_event_scope(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_property_values() should pass event parameter to API."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Verify event parameter is passed
+            if "event=Purchase" in str(request.url):
+                return httpx.Response(200, json=["credit_card", "paypal"])
+            return httpx.Response(200, json=["all_values"])
+
+        discovery = discovery_factory(handler)
+        values = discovery.list_property_values("payment_method", event="Purchase")
+
+        assert values == ["credit_card", "paypal"]
+
+    def test_list_property_values_with_custom_limit(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_property_values() should pass limit parameter to API."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Verify limit parameter is passed
+            if "limit=10" in str(request.url):
+                return httpx.Response(200, json=["v1", "v2", "v3"])
+            return httpx.Response(200, json=["all_values"])
+
+        discovery = discovery_factory(handler)
+        values = discovery.list_property_values("country", limit=10)
+
+        assert values == ["v1", "v2", "v3"]
+
+    def test_list_property_values_caching(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_property_values() should cache per (property, event, limit)."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=["value1", "value2"])
+
+        discovery = discovery_factory(handler)
+
+        # First call
+        values1 = discovery.list_property_values("country", event="Purchase", limit=50)
+        assert call_count == 1
+
+        # Same params should use cache
+        values2 = discovery.list_property_values("country", event="Purchase", limit=50)
+        assert call_count == 1
+
+        # Different limit should hit API
+        discovery.list_property_values("country", event="Purchase", limit=100)
+        assert call_count == 2
+
+        # Different event should hit API
+        discovery.list_property_values("country", event="Signup", limit=50)
+        assert call_count == 3
+
+        # Results should match
+        assert values1 == values2 == ["value1", "value2"]
+
+    def test_list_property_values_with_empty_result(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """list_property_values() should return empty list when no values exist."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        discovery = discovery_factory(handler)
+        values = discovery.list_property_values("nonexistent_property")
+
+        assert values == []
+
+
+# =============================================================================
+# User Story 4: clear_cache() Tests
+# =============================================================================
+
+
+class TestClearCache:
+    """Tests for DiscoveryService.clear_cache()."""
+
+    def test_clear_cache_clears_all_results(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """clear_cache() should clear all cached results."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["event1", "event2"])
+
+        discovery = discovery_factory(handler)
+
+        # Populate cache
+        discovery.list_events()
+        assert len(discovery._cache) > 0
+
+        # Clear cache
+        discovery.clear_cache()
+        assert discovery._cache == {}
+
+    def test_clear_cache_on_empty_cache(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """clear_cache() should not error when cache is empty."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        discovery = discovery_factory(handler)
+
+        # Cache should be empty initially
+        assert discovery._cache == {}
+
+        # Clearing empty cache should not raise
+        discovery.clear_cache()
+        assert discovery._cache == {}
+
+    def test_clear_cache_causes_api_call(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """clear_cache() should cause next request to hit API."""
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=["event1", "event2"])
+
+        discovery = discovery_factory(handler)
+
+        # First call hits API
+        discovery.list_events()
+        assert call_count == 1
+
+        # Second call uses cache
+        discovery.list_events()
+        assert call_count == 1
+
+        # Clear cache
+        discovery.clear_cache()
+
+        # Third call should hit API again
+        discovery.list_events()
+        assert call_count == 2


### PR DESCRIPTION
## Summary

- Implements `DiscoveryService` class for Mixpanel schema introspection with session-scoped caching
- Adds `list_events()`, `list_properties()`, `list_property_values()`, and `clear_cache()` methods
- Includes 18 unit tests with httpx.MockTransport for deterministic HTTP mocking
- Updates documentation (CLAUDE.md, IMPLEMENTATION_PLAN.md, README.md) to reflect Phase 004 completion

## Implementation Details

The DiscoveryService provides schema discovery for Mixpanel projects:

| Method | Purpose |
|--------|---------|
| `list_events()` | Returns alphabetically sorted list of all event names |
| `list_properties(event)` | Returns sorted property names for a specific event |
| `list_property_values(property, event?, limit?)` | Returns sample values for a property |
| `clear_cache()` | Clears all cached discovery results |

**Key design decisions:**
- Session-scoped in-memory caching using `dict[tuple, list[str]]`
- Cache keys are tuples of (method_name, *args) for unique identification
- Dependency injection of MixpanelAPIClient for testability
- Pass-through error handling (no exception wrapping)

## Test plan

- [x] All 18 unit tests pass (`pytest tests/unit/test_discovery.py -v`)
- [x] mypy --strict passes on discovery.py
- [x] ruff check passes on all modified files
- [x] Full test suite (242 tests) passes