### PR TITLE
test: improve test coverage from 85% to 93%

### DIFF
--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -9,12 +9,77 @@ import pytest
 from typer.testing import CliRunner
 
 from mixpanel_data._internal.config import AccountInfo
+from mixpanel_data.types import (
+    FetchResult,
+    SegmentationResult,
+    TableInfo,
+    WorkspaceInfo,
+)
 
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
     """Create a CLI runner for testing commands."""
     return CliRunner()
+
+
+@pytest.fixture
+def mock_workspace() -> MagicMock:
+    """Create a mock Workspace for testing commands."""
+    workspace = MagicMock()
+
+    # Set up common return values
+    workspace.events.return_value = ["Event1", "Event2", "Event3"]
+    workspace.properties.return_value = ["property1", "property2"]
+    workspace.property_values.return_value = ["value1", "value2", "value3"]
+    workspace.funnels.return_value = []
+    workspace.cohorts.return_value = []
+    workspace.top_events.return_value = []
+
+    workspace.tables.return_value = [
+        TableInfo(
+            name="events",
+            type="events",
+            row_count=1000,
+            fetched_at="2024-01-01T00:00:00Z",
+        ),
+    ]
+
+    workspace.info.return_value = WorkspaceInfo(
+        path="/tmp/workspace.db",
+        account="default",
+        project_id="12345",
+        region="us",
+        tables=["events"],
+        size_mb=1.5,
+        created_at=None,
+    )
+
+    workspace.sql_rows.return_value = [{"count": 100}]
+    workspace.sql_scalar.return_value = 100
+
+    from datetime import datetime
+
+    workspace.fetch_events.return_value = FetchResult(
+        table="events",
+        rows=1000,
+        type="events",
+        date_range=("2024-01-01", "2024-01-31"),
+        duration_seconds=5.0,
+        fetched_at=datetime.now(),
+    )
+
+    workspace.segmentation.return_value = SegmentationResult(
+        event="Signup",
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        unit="day",
+        segment_property=None,
+        total=500,
+        series={"$overall": {"2024-01-01": 100}},
+    )
+
+    return workspace
 
 
 @pytest.fixture

--- a/tests/integration/cli/test_fetch_commands.py
+++ b/tests/integration/cli/test_fetch_commands.py
@@ -1,0 +1,366 @@
+"""Integration tests for fetch CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import app
+from mixpanel_data.types import FetchResult
+
+
+class TestFetchEvents:
+    """Tests for mp fetch events command."""
+
+    def test_events_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test fetching events with required options."""
+        mock_workspace.fetch_events.return_value = FetchResult(
+            table="events",
+            rows=1000,
+            type="events",
+            date_range=("2024-01-01", "2024-01-31"),
+            duration_seconds=5.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "my_events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["table"] == "events"
+        assert data["rows"] == 1000
+        mock_workspace.fetch_events.assert_called_once()
+        call_kwargs = mock_workspace.fetch_events.call_args.kwargs
+        assert call_kwargs["name"] == "my_events"
+        assert call_kwargs["from_date"] == "2024-01-01"
+        assert call_kwargs["to_date"] == "2024-01-31"
+
+    def test_events_missing_from_date(self, cli_runner: CliRunner) -> None:
+        """Test that missing --from date returns error."""
+        result = cli_runner.invoke(
+            app,
+            ["fetch", "events", "--to", "2024-01-31", "--format", "json"],
+        )
+
+        assert result.exit_code == 3
+        assert "--from is required" in result.output
+
+    def test_events_missing_to_date(self, cli_runner: CliRunner) -> None:
+        """Test that missing --to date returns error."""
+        result = cli_runner.invoke(
+            app,
+            ["fetch", "events", "--from", "2024-01-01", "--format", "json"],
+        )
+
+        assert result.exit_code == 3
+        assert "--to is required" in result.output
+
+    def test_events_with_replace_flag(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --replace flag drops existing table first."""
+        mock_workspace.fetch_events.return_value = FetchResult(
+            table="events",
+            rows=500,
+            type="events",
+            date_range=("2024-01-01", "2024-01-31"),
+            duration_seconds=3.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--replace",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.drop.assert_called_once_with("events")
+
+    def test_events_with_event_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --events filter is passed to workspace."""
+        mock_workspace.fetch_events.return_value = FetchResult(
+            table="events",
+            rows=100,
+            type="events",
+            date_range=("2024-01-01", "2024-01-31"),
+            duration_seconds=1.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--events",
+                    "Signup,Login,Purchase",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_events.call_args.kwargs
+        assert call_kwargs["events"] == ["Signup", "Login", "Purchase"]
+
+    def test_events_with_where_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --where filter is passed to workspace."""
+        mock_workspace.fetch_events.return_value = FetchResult(
+            table="events",
+            rows=50,
+            type="events",
+            date_range=("2024-01-01", "2024-01-31"),
+            duration_seconds=1.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--where",
+                    'properties["country"] == "US"',
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_events.call_args.kwargs
+        assert call_kwargs["where"] == 'properties["country"] == "US"'
+
+    def test_events_with_no_progress(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --no-progress flag disables progress bar."""
+        mock_workspace.fetch_events.return_value = FetchResult(
+            table="events",
+            rows=100,
+            type="events",
+            date_range=("2024-01-01", "2024-01-31"),
+            duration_seconds=1.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--no-progress",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_events.call_args.kwargs
+        assert call_kwargs["progress"] is False
+
+
+class TestFetchProfiles:
+    """Tests for mp fetch profiles command."""
+
+    def test_profiles_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test fetching profiles with default options."""
+        mock_workspace.fetch_profiles.return_value = FetchResult(
+            table="profiles",
+            rows=500,
+            type="profiles",
+            date_range=None,
+            duration_seconds=2.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["fetch", "profiles", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["table"] == "profiles"
+        assert data["rows"] == 500
+        mock_workspace.fetch_profiles.assert_called_once()
+
+    def test_profiles_with_custom_name(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test fetching profiles with custom table name."""
+        mock_workspace.fetch_profiles.return_value = FetchResult(
+            table="users",
+            rows=300,
+            type="profiles",
+            date_range=None,
+            duration_seconds=1.5,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["fetch", "profiles", "users", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_profiles.call_args.kwargs
+        assert call_kwargs["name"] == "users"
+
+    def test_profiles_with_replace_flag(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --replace flag drops existing table first."""
+        mock_workspace.fetch_profiles.return_value = FetchResult(
+            table="profiles",
+            rows=200,
+            type="profiles",
+            date_range=None,
+            duration_seconds=1.0,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["fetch", "profiles", "--replace", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.drop.assert_called_once_with("profiles")
+
+    def test_profiles_with_where_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --where filter is passed to workspace."""
+        mock_workspace.fetch_profiles.return_value = FetchResult(
+            table="profiles",
+            rows=100,
+            type="profiles",
+            date_range=None,
+            duration_seconds=0.5,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "profiles",
+                    "--where",
+                    'properties["$city"] == "San Francisco"',
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_profiles.call_args.kwargs
+        assert call_kwargs["where"] == 'properties["$city"] == "San Francisco"'
+
+    def test_profiles_with_no_progress(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --no-progress flag disables progress bar."""
+        mock_workspace.fetch_profiles.return_value = FetchResult(
+            table="profiles",
+            rows=100,
+            type="profiles",
+            date_range=None,
+            duration_seconds=0.5,
+            fetched_at=datetime.now(),
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.fetch.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["fetch", "profiles", "--no-progress", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.fetch_profiles.call_args.kwargs
+        assert call_kwargs["progress"] is False

--- a/tests/integration/cli/test_inspect_commands.py
+++ b/tests/integration/cli/test_inspect_commands.py
@@ -1,0 +1,418 @@
+"""Integration tests for inspect CLI commands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import app
+from mixpanel_data.types import (
+    ColumnInfo,
+    FunnelInfo,
+    SavedCohort,
+    TableInfo,
+    TableSchema,
+    TopEvent,
+    WorkspaceInfo,
+)
+
+
+class TestInspectEvents:
+    """Tests for mp inspect events command."""
+
+    def test_events_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing events in JSON format."""
+        mock_workspace.events.return_value = ["Event A", "Event B", "Event C"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "events", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == ["Event A", "Event B", "Event C"]
+
+    def test_events_plain_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing events in plain format."""
+        mock_workspace.events.return_value = ["Event A", "Event B"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "events", "--format", "plain"])
+
+        assert result.exit_code == 0
+        assert "Event A" in result.stdout
+        assert "Event B" in result.stdout
+
+
+class TestInspectProperties:
+    """Tests for mp inspect properties command."""
+
+    def test_properties_for_event(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing properties for an event."""
+        mock_workspace.properties.return_value = ["prop1", "prop2", "prop3"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app, ["inspect", "properties", "--event", "Sign Up", "--format", "json"]
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == ["prop1", "prop2", "prop3"]
+        mock_workspace.properties.assert_called_once_with("Sign Up")
+
+
+class TestInspectValues:
+    """Tests for mp inspect values command."""
+
+    def test_values_with_all_options(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing values with event and limit options."""
+        mock_workspace.property_values.return_value = ["value1", "value2"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "inspect",
+                    "values",
+                    "--property",
+                    "country",
+                    "--event",
+                    "Purchase",
+                    "--limit",
+                    "50",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == ["value1", "value2"]
+        mock_workspace.property_values.assert_called_once_with(
+            property_name="country", event="Purchase", limit=50
+        )
+
+    def test_values_without_event(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing values without event filter."""
+        mock_workspace.property_values.return_value = ["US", "EU", "APAC"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "values", "--property", "region", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.property_values.assert_called_once_with(
+            property_name="region", event=None, limit=100
+        )
+
+
+class TestInspectFunnels:
+    """Tests for mp inspect funnels command."""
+
+    def test_funnels_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing funnels in JSON format."""
+        mock_workspace.funnels.return_value = [
+            FunnelInfo(funnel_id=123, name="Checkout Funnel"),
+            FunnelInfo(funnel_id=456, name="Signup Flow"),
+        ]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "funnels", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 2
+        assert data[0]["funnel_id"] == 123
+        assert data[0]["name"] == "Checkout Funnel"
+
+
+class TestInspectCohorts:
+    """Tests for mp inspect cohorts command."""
+
+    def test_cohorts_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing cohorts in JSON format."""
+        mock_workspace.cohorts.return_value = [
+            SavedCohort(
+                id=1,
+                name="Power Users",
+                count=1000,
+                description="Active users",
+                created="2024-01-01 12:00:00",
+                is_visible=True,
+            ),
+            SavedCohort(
+                id=2,
+                name="New Users",
+                count=500,
+                description="Recent signups",
+                created="2024-01-15 10:00:00",
+                is_visible=True,
+            ),
+        ]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "cohorts", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 2
+        assert data[0]["id"] == 1
+        assert data[0]["name"] == "Power Users"
+        assert data[0]["count"] == 1000
+
+
+class TestInspectTopEvents:
+    """Tests for mp inspect top-events command."""
+
+    def test_top_events_default_options(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing top events with default options."""
+        mock_workspace.top_events.return_value = [
+            TopEvent(event="Page View", count=10000, percent_change=5.2),
+            TopEvent(event="Sign Up", count=500, percent_change=-2.1),
+        ]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app, ["inspect", "top-events", "--format", "json"]
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 2
+        assert data[0]["event"] == "Page View"
+        assert data[0]["count"] == 10000
+        mock_workspace.top_events.assert_called_once_with(type="general", limit=10)
+
+    def test_top_events_with_type_and_limit(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing top events with custom type and limit."""
+        mock_workspace.top_events.return_value = []
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "inspect",
+                    "top-events",
+                    "--type",
+                    "unique",
+                    "--limit",
+                    "5",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.top_events.assert_called_once_with(type="unique", limit=5)
+
+
+class TestInspectInfo:
+    """Tests for mp inspect info command."""
+
+    def test_info_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test showing workspace info in JSON format."""
+        mock_workspace.info.return_value = WorkspaceInfo(
+            path="/tmp/test.db",
+            account="production",
+            project_id="12345",
+            region="us",
+            tables=["events", "profiles", "other"],
+            size_mb=10.5,
+            created_at=None,
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "info", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["path"] == "/tmp/test.db"
+        assert data["project_id"] == "12345"
+        assert data["tables"] == ["events", "profiles", "other"]
+
+
+class TestInspectTables:
+    """Tests for mp inspect tables command."""
+
+    def test_tables_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test listing tables in JSON format."""
+        mock_workspace.tables.return_value = [
+            TableInfo(
+                name="events_jan",
+                type="events",
+                row_count=1000,
+                fetched_at="2024-01-31T12:00:00Z",
+            ),
+            TableInfo(
+                name="profiles",
+                type="profiles",
+                row_count=500,
+                fetched_at="2024-01-30T10:00:00Z",
+            ),
+        ]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["inspect", "tables", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 2
+        assert data[0]["name"] == "events_jan"
+        assert data[0]["row_count"] == 1000
+
+
+class TestInspectSchema:
+    """Tests for mp inspect schema command."""
+
+    def test_schema_json_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test showing table schema in JSON format."""
+        mock_workspace.schema.return_value = TableSchema(
+            table_name="events",
+            columns=[
+                ColumnInfo(name="event", type="VARCHAR", nullable=False),
+                ColumnInfo(name="time", type="TIMESTAMP", nullable=False),
+                ColumnInfo(name="properties", type="JSON", nullable=True),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app, ["inspect", "schema", "--table", "events", "--format", "json"]
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["table"] == "events"
+        assert len(data["columns"]) == 3
+        assert data["columns"][0]["name"] == "event"
+        assert data["columns"][0]["type"] == "VARCHAR"
+
+
+class TestInspectDrop:
+    """Tests for mp inspect drop command."""
+
+    def test_drop_with_force_flag(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test dropping table with --force flag skips confirmation."""
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "inspect",
+                    "drop",
+                    "--table",
+                    "old_events",
+                    "--force",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["dropped"] == "old_events"
+        mock_workspace.drop.assert_called_once_with("old_events")
+
+    def test_drop_confirms_with_user(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test dropping table prompts for confirmation."""
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            # Simulate user confirming 'y'
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "drop", "--table", "test_table", "--format", "json"],
+                input="y\n",
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.drop.assert_called_once_with("test_table")
+
+    def test_drop_cancelled_by_user(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test dropping table cancelled when user declines."""
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            # Simulate user declining 'n'
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "drop", "--table", "test_table"],
+                input="n\n",
+            )
+
+        assert result.exit_code == 2  # Cancelled
+        mock_workspace.drop.assert_not_called()

--- a/tests/integration/cli/test_query_commands.py
+++ b/tests/integration/cli/test_query_commands.py
@@ -1,0 +1,737 @@
+"""Integration tests for query CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import app
+from mixpanel_data.types import (
+    ActivityFeedResult,
+    EventCountsResult,
+    FrequencyResult,
+    FunnelResult,
+    FunnelStep,
+    InsightsResult,
+    JQLResult,
+    NumericAverageResult,
+    NumericBucketResult,
+    NumericSumResult,
+    PropertyCountsResult,
+    RetentionResult,
+    SegmentationResult,
+    UserEvent,
+)
+
+
+class TestQuerySql:
+    """Tests for mp query sql command."""
+
+    def test_sql_with_query_argument(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test SQL query with inline argument."""
+        mock_workspace.sql_rows.return_value = [{"count": 100}]
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "sql",
+                    "SELECT COUNT(*) as count FROM events",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == [{"count": 100}]
+
+    def test_sql_with_file_option(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test SQL query from file."""
+        sql_file = tmp_path / "query.sql"
+        sql_file.write_text("SELECT * FROM events LIMIT 10")
+
+        mock_workspace.sql_rows.return_value = [{"event": "Signup"}]
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["query", "sql", "--file", str(sql_file), "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        mock_workspace.sql_rows.assert_called_once_with("SELECT * FROM events LIMIT 10")
+
+    def test_sql_file_not_found(self, cli_runner: CliRunner) -> None:
+        """Test error when SQL file doesn't exist."""
+        result = cli_runner.invoke(
+            app,
+            ["query", "sql", "--file", "/nonexistent/query.sql", "--format", "json"],
+        )
+
+        assert result.exit_code == 4  # NOT_FOUND
+        assert "File not found" in result.output
+
+    def test_sql_no_query_or_file(self, cli_runner: CliRunner) -> None:
+        """Test error when neither query nor file provided."""
+        result = cli_runner.invoke(app, ["query", "sql", "--format", "json"])
+
+        assert result.exit_code == 3
+        assert "Provide a query or use --file" in result.output
+
+    def test_sql_scalar_mode(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test --scalar flag returns single value."""
+        mock_workspace.sql_scalar.return_value = 42
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "sql",
+                    "SELECT COUNT(*) FROM events",
+                    "--scalar",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == {"value": 42}
+
+
+class TestQuerySegmentation:
+    """Tests for mp query segmentation command."""
+
+    def test_segmentation_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test segmentation query with required options."""
+        mock_workspace.segmentation.return_value = SegmentationResult(
+            event="Signup",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            segment_property=None,
+            total=500,
+            series={"$overall": {"2024-01-01": 100}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation",
+                    "--event",
+                    "Signup",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event"] == "Signup"
+        assert data["total"] == 500
+
+    def test_segmentation_with_segment_property(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test segmentation with --on option."""
+        mock_workspace.segmentation.return_value = SegmentationResult(
+            event="Signup",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            segment_property="country",
+            total=500,
+            series={"US": {"2024-01-01": 50}, "EU": {"2024-01-01": 30}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation",
+                    "--event",
+                    "Signup",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--on",
+                    "country",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.segmentation.call_args.kwargs
+        assert call_kwargs["on"] == "country"
+
+
+class TestQueryFunnel:
+    """Tests for mp query funnel command."""
+
+    def test_funnel_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test funnel query with required options."""
+        mock_workspace.funnel.return_value = FunnelResult(
+            funnel_id=123,
+            funnel_name="Signup Funnel",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            conversion_rate=0.5,
+            steps=[
+                FunnelStep(
+                    event="View Page",
+                    count=1000,
+                    conversion_rate=1.0,
+                ),
+                FunnelStep(
+                    event="Sign Up",
+                    count=500,
+                    conversion_rate=0.5,
+                ),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "funnel",
+                    "123",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["funnel_id"] == 123
+        assert len(data["steps"]) == 2
+
+
+class TestQueryRetention:
+    """Tests for mp query retention command."""
+
+    def test_retention_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test retention query with required options."""
+        mock_workspace.retention.return_value = RetentionResult(
+            born_event="Signup",
+            return_event="Login",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            cohorts=[],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "retention",
+                    "--born",
+                    "Signup",
+                    "--return",
+                    "Login",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["born_event"] == "Signup"
+        assert data["return_event"] == "Login"
+
+
+class TestQueryJql:
+    """Tests for mp query jql command."""
+
+    def test_jql_with_inline_script(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test JQL with inline script."""
+        mock_workspace.jql.return_value = JQLResult(_raw=[])
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "jql",
+                    "--script",
+                    "function main() { return []; }",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+
+    def test_jql_with_file(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test JQL with script file."""
+        jql_file = tmp_path / "query.js"
+        jql_file.write_text("function main() { return Events({}); }")
+
+        mock_workspace.jql.return_value = JQLResult(_raw=[{"event": "Test"}])
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["query", "jql", str(jql_file), "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+
+    def test_jql_file_not_found(self, cli_runner: CliRunner) -> None:
+        """Test error when JQL file doesn't exist."""
+        result = cli_runner.invoke(
+            app,
+            ["query", "jql", "/nonexistent/query.js", "--format", "json"],
+        )
+
+        assert result.exit_code == 4  # NOT_FOUND
+
+    def test_jql_no_script_or_file(self, cli_runner: CliRunner) -> None:
+        """Test error when neither script nor file provided."""
+        result = cli_runner.invoke(app, ["query", "jql", "--format", "json"])
+
+        assert result.exit_code == 3
+        assert "Provide a file or use --script" in result.output
+
+    def test_jql_with_params(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test JQL with parameters."""
+        mock_workspace.jql.return_value = JQLResult(_raw=["Signup"])
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "jql",
+                    "--script",
+                    "function main() { return params.event; }",
+                    "--param",
+                    "event=Signup",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_workspace.jql.call_args.kwargs
+        assert call_kwargs["params"] == {"event": "Signup"}
+
+    def test_jql_invalid_param_format(self, cli_runner: CliRunner) -> None:
+        """Test error with invalid parameter format."""
+        result = cli_runner.invoke(
+            app,
+            [
+                "query",
+                "jql",
+                "--script",
+                "function main() {}",
+                "--param",
+                "invalid-no-equals",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 3
+        assert "Invalid parameter format" in result.output
+
+
+class TestQueryEventCounts:
+    """Tests for mp query event-counts command."""
+
+    def test_event_counts_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test event-counts with required options."""
+        mock_workspace.event_counts.return_value = EventCountsResult(
+            events=["Signup", "Login"],
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            type="general",
+            unit="day",
+            series={"Signup": {"2024-01-01": 100}, "Login": {"2024-01-01": 200}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "event-counts",
+                    "--events",
+                    "Signup,Login",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["events"] == ["Signup", "Login"]
+
+
+class TestQueryPropertyCounts:
+    """Tests for mp query property-counts command."""
+
+    def test_property_counts_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test property-counts with required options."""
+        mock_workspace.property_counts.return_value = PropertyCountsResult(
+            event="Signup",
+            property_name="country",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            type="general",
+            unit="day",
+            series={"US": {"2024-01-01": 50}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "property-counts",
+                    "--event",
+                    "Signup",
+                    "--property",
+                    "country",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event"] == "Signup"
+        assert data["property_name"] == "country"
+
+
+class TestQueryActivityFeed:
+    """Tests for mp query activity-feed command."""
+
+    def test_activity_feed_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test activity-feed with required options."""
+        mock_workspace.activity_feed.return_value = ActivityFeedResult(
+            distinct_ids=["user1", "user2"],
+            from_date=None,
+            to_date=None,
+            events=[
+                UserEvent(
+                    event="Login", time=datetime(2024, 1, 1, 10, 0, 0), properties={}
+                ),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "activity-feed",
+                    "--users",
+                    "user1,user2",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["distinct_ids"] == ["user1", "user2"]
+
+
+class TestQueryInsights:
+    """Tests for mp query insights command."""
+
+    def test_insights_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test insights with bookmark ID."""
+        mock_workspace.insights.return_value = InsightsResult(
+            bookmark_id=12345,
+            computed_at="2024-02-01T00:00:00Z",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            headers=["Signup"],
+            series={"Signup": {"2024-01-01": 100}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["query", "insights", "12345", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["bookmark_id"] == 12345
+
+
+class TestQueryFrequency:
+    """Tests for mp query frequency command."""
+
+    def test_frequency_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test frequency with required options."""
+        mock_workspace.frequency.return_value = FrequencyResult(
+            event=None,
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            addiction_unit="hour",
+            data={"2024-01-01": [100, 50, 20]},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "frequency",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "data" in data
+
+
+class TestQuerySegmentationNumeric:
+    """Tests for mp query segmentation-numeric command."""
+
+    def test_segmentation_numeric_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test segmentation-numeric with required options."""
+        mock_workspace.segmentation_numeric.return_value = NumericBucketResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr="price",
+            unit="day",
+            series={"0-10": {"2024-01-01": 20}, "10-50": {"2024-01-01": 50}},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-numeric",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "price",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event"] == "Purchase"
+        assert data["property_expr"] == "price"
+
+
+class TestQuerySegmentationSum:
+    """Tests for mp query segmentation-sum command."""
+
+    def test_segmentation_sum_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test segmentation-sum with required options."""
+        mock_workspace.segmentation_sum.return_value = NumericSumResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr="revenue",
+            unit="day",
+            results={"2024-01-01": 500.25, "2024-01-02": 600.50},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-sum",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "revenue",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event"] == "Purchase"
+        assert data["property_expr"] == "revenue"
+
+
+class TestQuerySegmentationAverage:
+    """Tests for mp query segmentation-average command."""
+
+    def test_segmentation_average_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test segmentation-average with required options."""
+        mock_workspace.segmentation_average.return_value = NumericAverageResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr="price",
+            unit="day",
+            results={"2024-01-01": 45.50, "2024-01-02": 52.25},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-average",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "price",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event"] == "Purchase"
+        assert data["property_expr"] == "price"

--- a/tests/unit/cli/test_formatters.py
+++ b/tests/unit/cli/test_formatters.py
@@ -10,12 +10,37 @@ from datetime import date, datetime
 from rich.table import Table
 
 from mixpanel_data.cli.formatters import (
+    _json_serializer,
     format_csv,
     format_json,
     format_jsonl,
     format_plain,
     format_table,
 )
+
+
+class TestJsonSerializer:
+    """Tests for _json_serializer helper."""
+
+    def test_serializes_datetime(self) -> None:
+        """Test serializing datetime."""
+        result = _json_serializer(datetime(2024, 1, 15, 10, 30))
+        assert result == "2024-01-15T10:30:00"
+
+    def test_serializes_date(self) -> None:
+        """Test serializing date."""
+        result = _json_serializer(date(2024, 1, 15))
+        assert result == "2024-01-15"
+
+    def test_serializes_unknown_type_as_str(self) -> None:
+        """Test that unknown types are converted to string."""
+
+        class CustomClass:
+            def __str__(self) -> str:
+                return "custom-string-repr"
+
+        result = _json_serializer(CustomClass())
+        assert result == "custom-string-repr"
 
 
 class TestFormatJson:
@@ -163,6 +188,22 @@ class TestFormatTable:
         table = format_table(data)
 
         assert isinstance(table, Table)
+
+    def test_format_with_datetime_values(self) -> None:
+        """Test formatting data with datetime values."""
+        data = [{"timestamp": datetime(2024, 1, 15, 10, 30, 0)}]
+        table = format_table(data)
+
+        assert isinstance(table, Table)
+        assert table.row_count == 1
+
+    def test_format_with_nested_list(self) -> None:
+        """Test formatting data with nested list values."""
+        data = [{"tags": ["a", "b", "c"]}]
+        table = format_table(data)
+
+        assert isinstance(table, Table)
+        assert table.row_count == 1
 
 
 class TestFormatCsv:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,0 +1,76 @@
+"""Unit tests for CLI main module."""
+
+from __future__ import annotations
+
+import signal
+
+import pytest
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import _handle_interrupt, app
+from mixpanel_data.cli.utils import ExitCode
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing commands."""
+    return CliRunner()
+
+
+class TestVersionCallback:
+    """Tests for version callback."""
+
+    def test_version_flag_shows_version(self, cli_runner: CliRunner) -> None:
+        """Test that --version shows version and exits."""
+        result = cli_runner.invoke(app, ["--version"])
+
+        assert result.exit_code == 0
+        assert "mp version" in result.stdout
+
+    def test_version_flag_with_command(self, cli_runner: CliRunner) -> None:
+        """Test that --version takes precedence over commands."""
+        result = cli_runner.invoke(app, ["--version", "auth", "list"])
+
+        assert result.exit_code == 0
+        assert "mp version" in result.stdout
+
+
+class TestInterruptHandler:
+    """Tests for SIGINT (Ctrl+C) handling."""
+
+    def test_handle_interrupt_exits_with_code_130(self) -> None:
+        """Test that interrupt handler exits with code 130."""
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_interrupt(signal.SIGINT, None)
+
+        assert exc_info.value.code == ExitCode.INTERRUPTED
+
+    def test_handle_interrupt_prints_message(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that interrupt handler prints interrupted message."""
+        with pytest.raises(SystemExit):
+            _handle_interrupt(signal.SIGINT, None)
+
+        # Rich prints to stderr
+        captured = capsys.readouterr()
+        assert "Interrupted" in captured.err
+
+
+class TestMainCallback:
+    """Tests for main callback and context setup."""
+
+    def test_no_args_shows_help(self, cli_runner: CliRunner) -> None:
+        """Test that no arguments shows help (exit code 2 per Typer convention)."""
+        result = cli_runner.invoke(app, [])
+
+        # Typer returns exit code 2 when no_args_is_help=True and no args provided
+        assert result.exit_code == 2
+        assert "Usage:" in result.stdout or "usage:" in result.stdout.lower()
+
+    def test_help_flag_shows_help(self, cli_runner: CliRunner) -> None:
+        """Test that --help shows help."""
+        result = cli_runner.invoke(app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Mixpanel data CLI" in result.stdout

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -207,6 +207,22 @@ class TestSegmentationResult:
         assert len(df) == 0
         assert "date" in df.columns
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = SegmentationResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            segment_property=None,
+            total=0,
+            series={},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_serializable(self) -> None:
         """to_dict should be JSON serializable."""
         result = SegmentationResult(
@@ -303,6 +319,22 @@ class TestFunnelResult:
         assert "conversion_rate" in df.columns
         assert len(df) == 2
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        steps = [FunnelStep(event="View", count=1000, conversion_rate=1.0)]
+        result = FunnelResult(
+            funnel_id=1,
+            funnel_name="Test",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            conversion_rate=1.0,
+            steps=steps,
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_serializable(self) -> None:
         """to_dict should be JSON serializable."""
         steps = [
@@ -381,6 +413,22 @@ class TestRetentionResult:
         assert "period_1" in df.columns
         assert "period_2" in df.columns
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        cohorts = [CohortInfo(date="2024-01-01", size=1000, retention=[1.0, 0.5])]
+        result = RetentionResult(
+            born_event="Sign Up",
+            return_event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="week",
+            cohorts=cohorts,
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_serializable(self) -> None:
         """to_dict should be JSON serializable."""
         cohorts = [
@@ -438,6 +486,14 @@ class TestJQLResult:
 
         df = result.df
         assert len(df) == 0
+
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = JQLResult(_raw=[{"a": 1}, {"a": 2}])
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
 
     def test_to_dict_serializable(self) -> None:
         """to_dict should be JSON serializable."""

--- a/tests/unit/test_types_phase008.py
+++ b/tests/unit/test_types_phase008.py
@@ -233,6 +233,21 @@ class TestNumericSumResult:
         assert len(df) == 0
         assert "date" in df.columns
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = NumericSumResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr='properties["amount"]',
+            unit="day",
+            results={"2024-01-01": 100.0},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_with_computed_at(self) -> None:
         """to_dict should include computed_at when present."""
         result = NumericSumResult(
@@ -316,6 +331,21 @@ class TestNumericAverageResult:
         assert len(df) == 0
         assert "date" in df.columns
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = NumericAverageResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr='properties["amount"]',
+            unit="day",
+            results={"2024-01-01": 50.0},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_serializable(self) -> None:
         """to_dict output should be JSON serializable."""
         result = NumericAverageResult(
@@ -393,6 +423,21 @@ class TestFrequencyResult:
         df = result.df
         assert len(df) == 0
         assert "date" in df.columns
+
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = FrequencyResult(
+            event="App Open",
+            from_date="2024-01-01",
+            to_date="2024-01-01",
+            unit="day",
+            addiction_unit="hour",
+            data={"2024-01-01": [100, 50]},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
 
     def test_event_can_be_none(self) -> None:
         """event can be None for all events query."""
@@ -487,6 +532,21 @@ class TestNumericBucketResult:
         assert len(df) == 0
         assert "date" in df.columns
 
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = NumericBucketResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr='properties["amount"]',
+            unit="day",
+            series={"0 - 100": {"2024-01-01": 50}},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
+
     def test_to_dict_serializable(self) -> None:
         """to_dict output should be JSON serializable."""
         result = NumericBucketResult(
@@ -565,6 +625,21 @@ class TestInsightsResult:
         df = result.df
         assert len(df) == 0
         assert "date" in df.columns
+
+    def test_df_cached(self) -> None:
+        """df should be cached on first access."""
+        result = InsightsResult(
+            bookmark_id=12345,
+            computed_at="2024-01-15T10:30:00+00:00",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            headers=["$event"],
+            series={"Sign Up": {"2024-01-01": 100}},
+        )
+
+        df1 = result.df
+        df2 = result.df
+        assert df1 is df2  # Same object, not recomputed
 
     def test_to_dict_serializable(self) -> None:
         """to_dict output should be JSON serializable."""


### PR DESCRIPTION
## Summary

- Improved test coverage from 85% to 93% (718 tests, up from 636)
- Added comprehensive tests across multiple areas without over-engineering
- All 718 tests pass with 3 skipped

## Test Changes

### Tier 1: Quick Wins
- **CLI version & interrupt handling** - Tests for `--version` flag and SIGINT handler
- **Environment variable validation** - Tests for invalid `MP_REGION` handling
- **Storage ephemeral validation** - Tests for invalid path combinations
- **DataFrame cache hit tests** - Tests for lazy `.df` property caching on result types

### Tier 2: CLI Command Tests
- **Inspect commands (15 tests)** - All 10 inspect subcommands tested
- **Fetch commands (12 tests)** - Events and profiles fetch with all options
- **Query commands (23 tests)** - All 13 query subcommands tested

### Tier 3: Core Library Edge Cases
- **API client errors (4 tests)** - 400 with plain text, 5xx server errors
- **Storage rollback (3 tests)** - Transaction rollback on failure
- **Workspace credentials (4 tests)** - project_id/region overrides, query-only mode

### Tier 4: Defensive Code
- **Formatter edge cases (5 tests)** - `_json_serializer`, datetime in tables, nested data

## Coverage by Module (Before → After)

| Module | Coverage |
|--------|----------|
| cli/commands/fetch.py | 30% → **100%** |
| cli/commands/inspect.py | 45% → **100%** |
| cli/commands/query.py | 30% → **99%** |
| cli/formatters.py | 92% → **96%** |
| types.py | 96% → **99%** |
| **Overall** | **85% → 93%** |

## Test plan

- [x] All existing tests pass
- [x] New tests pass
- [x] Coverage improved from 85% to 93%
- [x] Pre-commit hooks pass (ruff, ruff-format)