### PR TITLE
docs: enhance docstrings for final polish

### DIFF
--- a/src/mixpanel_data/_internal/storage.py
+++ b/src/mixpanel_data/_internal/storage.py
@@ -409,8 +409,8 @@ class StorageEngine:
         Args:
             name: Table name.
             data: Iterator yielding event dictionaries.
-            progress_callback: Optional callback invoked with row count.
-            batch_size: Number of rows per batch.
+            progress_callback: Optional callback invoked with cumulative row count.
+            batch_size: Number of rows per batch. Default: 2000.
 
         Returns:
             Total number of rows inserted.
@@ -479,8 +479,8 @@ class StorageEngine:
         Args:
             name: Table name.
             data: Iterator yielding profile dictionaries.
-            progress_callback: Optional callback invoked with row count.
-            batch_size: Number of rows per batch.
+            progress_callback: Optional callback invoked with cumulative row count.
+            batch_size: Number of rows per batch. Default: 2000.
 
         Returns:
             Total number of rows inserted.

--- a/src/mixpanel_data/auth.py
+++ b/src/mixpanel_data/auth.py
@@ -3,6 +3,14 @@
 This module provides public access to credential management functionality.
 It re-exports the ConfigManager and related types for public use.
 
+Re-exported classes:
+    ConfigManager: TOML-based account management (~/.mp/config.toml).
+    Credentials: Immutable credential container with SecretStr for secrets.
+    AccountInfo: Named account metadata (name, username, project_id, region).
+
+For full documentation of these classes, see:
+    mixpanel_data._internal.config
+
 Example usage:
     from mixpanel_data.auth import ConfigManager, Credentials
 

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -217,7 +217,17 @@ def switch_account(
 
 
 def _find_default_account(config: ConfigManager) -> AccountInfo | None:
-    """Find the default account from accounts list."""
+    """Find the account marked as default in the configuration.
+
+    Iterates through all configured accounts and returns the one
+    with is_default=True.
+
+    Args:
+        config: ConfigManager instance to query for accounts.
+
+    Returns:
+        The default AccountInfo if one exists, None if no default is set.
+    """
     accounts = config.list_accounts()
     for acc in accounts:
         if acc.is_default:

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -63,7 +63,13 @@ def fetch_events(
 ) -> None:
     """Fetch events from Mixpanel into local storage.
 
-    Events are stored in a DuckDB table for SQL querying.
+    Events are stored in a DuckDB table for SQL querying. A progress bar
+    shows fetch progress (disable with --no-progress or --quiet).
+
+    Use --events to filter by event name (comma-separated list).
+    Use --where for Mixpanel expression filters (e.g., 'properties["country"]=="US"').
+
+    Output shows table name, row count, duration, and date range.
     """
     # Validate required options
     if not from_date:
@@ -122,7 +128,12 @@ def fetch_profiles(
 ) -> None:
     """Fetch user profiles from Mixpanel into local storage.
 
-    Profiles are stored in a DuckDB table for SQL querying.
+    Profiles are stored in a DuckDB table for SQL querying. A progress bar
+    shows fetch progress (disable with --no-progress or --quiet).
+
+    Use --where for Mixpanel expression filters on profile properties.
+
+    Output shows table name, row count, and fetch duration.
     """
     workspace = get_workspace(ctx)
 

--- a/src/mixpanel_data/cli/commands/inspect.py
+++ b/src/mixpanel_data/cli/commands/inspect.py
@@ -192,7 +192,12 @@ def inspect_schema(
     ] = False,
     format: FormatOption = "json",
 ) -> None:
-    """Show schema for a table in local database."""
+    """Show schema for a table in local database.
+
+    Lists all columns with their types and nullability constraints.
+
+    Note: The --sample option is reserved for future implementation.
+    """
     # Note: _sample is reserved for future implementation
     workspace = get_workspace(ctx)
     schema = workspace.schema(table)

--- a/src/mixpanel_data/cli/formatters.py
+++ b/src/mixpanel_data/cli/formatters.py
@@ -20,7 +20,18 @@ from rich.table import Table
 
 
 def _json_serializer(obj: Any) -> str:
-    """Custom JSON serializer for non-standard types."""
+    """Serialize non-standard types to JSON-compatible strings.
+
+    Used as the default serializer for json.dumps() to handle types
+    that aren't natively JSON-serializable.
+
+    Args:
+        obj: The object to serialize. Handles datetime, date, and
+            falls back to str() for other types.
+
+    Returns:
+        ISO format string for datetime/date objects, or str(obj) for others.
+    """
     if isinstance(obj, datetime | date):
         return obj.isoformat()
     return str(obj)
@@ -102,7 +113,19 @@ def format_table(
 
 
 def _format_cell(value: Any) -> str:
-    """Format a single cell value for table display."""
+    """Format a single cell value for Rich table display.
+
+    Converts various Python types to human-readable string representations
+    suitable for display in terminal tables.
+
+    Args:
+        value: The value to format. Handles None, bool, datetime, date,
+            list, dict, and other types.
+
+    Returns:
+        Formatted string: empty for None, "Yes"/"No" for bool, ISO format
+        for dates, JSON for collections, str() for others.
+    """
     if value is None:
         return ""
     if isinstance(value, bool):
@@ -156,7 +179,19 @@ def format_csv(data: dict[str, Any] | list[Any]) -> str:
 
 
 def _csv_value(value: Any) -> str:
-    """Format a value for CSV output."""
+    """Format a value for CSV output.
+
+    Converts various Python types to string representations suitable for
+    CSV files. Uses lowercase for booleans (common CSV convention).
+
+    Args:
+        value: The value to format. Handles None, bool, datetime, date,
+            list, dict, and other types.
+
+    Returns:
+        Formatted string: empty for None, lowercase "true"/"false" for bool,
+        ISO format for dates, JSON for collections, str() for others.
+    """
     if value is None:
         return ""
     if isinstance(value, bool):

--- a/src/mixpanel_data/cli/validators.py
+++ b/src/mixpanel_data/cli/validators.py
@@ -41,18 +41,51 @@ def validate_literal(value: str, literal_type: Any, param_name: str) -> Any:
 
 
 def validate_time_unit(value: str, param_name: str = "--unit") -> TimeUnit:
-    """Validate time unit (day, week, month)."""
+    """Validate time unit for aggregation.
+
+    Args:
+        value: String value from CLI (should be "day", "week", or "month").
+        param_name: Parameter name for error message. Default: "--unit".
+
+    Returns:
+        Validated value as TimeUnit literal type.
+
+    Raises:
+        typer.Exit: With code 3 (INVALID_ARGS) if value is invalid.
+    """
     validate_literal(value, TimeUnit, param_name)
     return cast(TimeUnit, value)
 
 
 def validate_hour_day_unit(value: str, param_name: str = "--unit") -> HourDayUnit:
-    """Validate hour/day unit."""
+    """Validate hour/day unit for numeric queries.
+
+    Args:
+        value: String value from CLI (should be "hour" or "day").
+        param_name: Parameter name for error message. Default: "--unit".
+
+    Returns:
+        Validated value as HourDayUnit literal type.
+
+    Raises:
+        typer.Exit: With code 3 (INVALID_ARGS) if value is invalid.
+    """
     validate_literal(value, HourDayUnit, param_name)
     return cast(HourDayUnit, value)
 
 
 def validate_count_type(value: str, param_name: str = "--type") -> CountType:
-    """Validate count type (general, unique, average)."""
+    """Validate count type for event counting.
+
+    Args:
+        value: String value from CLI (should be "general", "unique", or "average").
+        param_name: Parameter name for error message. Default: "--type".
+
+    Returns:
+        Validated value as CountType literal type.
+
+    Raises:
+        typer.Exit: With code 3 (INVALID_ARGS) if value is invalid.
+    """
     validate_literal(value, CountType, param_name)
     return cast(CountType, value)

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -258,7 +258,11 @@ class Workspace:
         return instance
 
     def __enter__(self) -> Workspace:
-        """Enter context manager."""
+        """Enter context manager.
+
+        Returns:
+            Self for use in 'with' statement.
+        """
         return self
 
     def __exit__(
@@ -267,7 +271,11 @@ class Workspace:
         exc_val: BaseException | None,
         exc_tb: Any,
     ) -> None:
-        """Exit context manager, closing all resources."""
+        """Exit context manager, closing all resources.
+
+        Closes the database connection and HTTP client. Exceptions are
+        NOT suppressed - they propagate normally after cleanup.
+        """
         self.close()
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

Comprehensive docstring improvements across all layers for Phase 011 (Polish & Release):

- **CLI layer**: Add missing docstrings to private helpers, enhance 12 query command docstrings with purpose/examples, improve fetch/inspect command docs
- **API/Service layer**: Document backoff algorithm, status code handling, export callbacks, caching behavior, and transform function calculations
- **Types module**: Add immutability notes, structure examples for complex nested dicts
- **Minor polish**: Validator consistency, cross-references, context manager behavior, default values

### Files Changed (13)

| Layer | Files | Changes |
|-------|-------|---------|
| CLI | formatters.py, validators.py, auth.py, query.py, fetch.py, inspect.py | Docstring additions and enhancements |
| Internal | api_client.py, storage.py, discovery.py, live_query.py | Algorithm docs, caching behavior, edge cases |
| Public API | types.py, auth.py, workspace.py | Structure examples, cross-references, context manager |

## Test plan

- [x] All 721 tests pass
- [x] Linting passes (ruff)
- [x] Type checking passes (mypy)