### PR TITLE
docs: overhaul README for users and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to mixpanel_data
+
+Thank you for your interest in contributing to mixpanel_data!
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) (package manager)
+- [just](https://github.com/casey/just) (command runner)
+
+### Recommended: Use the Devcontainer
+
+The repository includes a devcontainer with Python 3.11, uv, just, and all development tools pre-installed. This is the easiest way to get started.
+
+### Manual Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/discohead/mixpanel_data.git
+cd mixpanel_data
+
+# Install dependencies
+uv sync
+
+# Verify setup
+just check
+```
+
+## Development Commands
+
+This project uses [just](https://github.com/casey/just) as a command runner. Run `just` to see all available commands.
+
+| Command | Description |
+|---------|-------------|
+| `just` | List all available commands |
+| `just check` | Run all checks (lint, typecheck, test) |
+| `just test` | Run tests (supports args: `just test -k foo`) |
+| `just test-cov` | Run tests with coverage |
+| `just lint` | Lint code with ruff |
+| `just lint-fix` | Auto-fix lint errors |
+| `just fmt` | Format code with ruff |
+| `just typecheck` | Type check with mypy |
+| `just sync` | Sync dependencies |
+| `just clean` | Remove caches and build artifacts |
+| `just build` | Build package |
+| `just mp` | Run the CLI (supports args: `just mp --help`) |
+
+## Running Tests
+
+```bash
+# Run all tests
+just test
+
+# Run specific tests
+just test -k test_workspace
+
+# Run with coverage
+just test-cov
+```
+
+## Code Quality
+
+Before submitting a PR, run all checks:
+
+```bash
+just check
+```
+
+This runs:
+- `ruff check` — Linting
+- `mypy --strict` — Type checking
+- `pytest` — Tests
+
+## Project Structure
+
+```
+src/mixpanel_data/
+├── __init__.py              # Public API exports
+├── workspace.py             # Workspace facade class
+├── auth.py                  # Public auth module
+├── exceptions.py            # Exception hierarchy
+├── types.py                 # Result types
+├── _internal/               # Private implementation
+│   ├── config.py            # ConfigManager, Credentials
+│   ├── api_client.py        # MixpanelAPIClient
+│   ├── storage.py           # StorageEngine (DuckDB)
+│   └── services/            # Service layer
+│       ├── discovery.py     # DiscoveryService
+│       ├── fetcher.py       # FetcherService
+│       └── live_query.py    # LiveQueryService
+└── cli/
+    ├── main.py              # Typer app entry point
+    ├── utils.py             # Error handling, console
+    ├── formatters.py        # Output formatters
+    ├── validators.py        # Input validation
+    └── commands/            # Command implementations
+        ├── auth.py
+        ├── fetch.py
+        ├── query.py
+        └── inspect.py
+
+tests/
+├── conftest.py              # Shared pytest fixtures
+├── unit/                    # Unit tests
+└── integration/             # Integration tests
+```
+
+## Architecture
+
+```
+CLI Layer (Typer)           → Argument parsing, output formatting
+    ↓
+Public API Layer            → Workspace class, auth module
+    ↓
+Service Layer               → DiscoveryService, FetcherService, LiveQueryService
+    ↓
+Infrastructure Layer        → ConfigManager, MixpanelAPIClient, StorageEngine (DuckDB)
+```
+
+**Two data paths:**
+- **Live queries**: Call Mixpanel API directly (segmentation, funnels, retention)
+- **Local analysis**: Fetch → Store in DuckDB → Query with SQL → Iterate
+
+## Design Principles
+
+- **Explicit table management**: Tables never implicitly overwritten; `TableExistsError` if exists
+- **Streaming ingestion**: API returns iterators, storage accepts iterators (memory efficient)
+- **JSON property storage**: Properties stored as JSON columns, queried with `properties->>'$.field'`
+- **Immutable credentials**: Resolved once at Workspace construction
+- **Dependency injection**: Services accept dependencies as constructor arguments for testing
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Run `just check` to verify quality
+5. Commit your changes with a clear message
+6. Push to your fork
+7. Open a Pull Request
+
+## Questions?
+
+Open an issue on GitHub for questions or discussion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ git clone https://github.com/discohead/mixpanel_data.git
 cd mixpanel_data
 
 # Install dependencies
-uv sync
+uv sync --all-extras
 
 # Verify setup
 just check

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 discohead
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ mp inspect funnels                     # Saved funnels
 ### 3. Fetch Events to Local Storage
 
 ```bash
-mp fetch events --name jan --from 2024-01-01 --to 2024-01-31
+mp fetch events jan --from 2024-01-01 --to 2024-01-31
 ```
 
 ### 4. Query with SQL
@@ -173,7 +173,7 @@ mp inspect events --format json
 mp inspect properties --event Purchase --format json
 
 # 2. Fetch relevant data
-mp fetch events --name data --from 2024-01-01 --to 2024-01-31
+mp fetch events data --from 2024-01-01 --to 2024-01-31
 
 # 3. Iterate with SQL queries
 mp query sql "SELECT ..." --format json

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -140,8 +140,8 @@ mp query sql "SELECT * FROM events" --format jsonl | jq '.event_name'
 ### Complete Workflow
 
 ```bash
-# 1. Set up credentials
-mp auth add production --username sa_... --secret ... --project 12345 --region us
+# 1. Set up credentials (prompts for secret securely)
+mp auth add production --username sa_... --project 12345 --region us
 
 # 2. Explore schema
 mp inspect events

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -148,7 +148,7 @@ mp inspect events
 mp inspect properties --event Purchase
 
 # 3. Fetch data
-mp fetch events --name jan --from 2024-01-01 --to 2024-01-31
+mp fetch events jan --from 2024-01-01 --to 2024-01-31
 
 # 4. Query locally
 mp query sql "SELECT event_name, COUNT(*) FROM jan GROUP BY 1" --format table

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -55,11 +55,22 @@ region = "us"
 Add a new account:
 
 ```bash
+# Interactive prompt (secure, recommended)
 mp auth add production \
     --username sa_abc123... \
-    --secret your-secret \
     --project 12345 \
     --region us
+# You'll be prompted for the secret with hidden input
+```
+
+For CI/CD environments, provide the secret via environment variable or stdin:
+
+```bash
+# Via environment variable
+MP_SECRET=your-secret mp auth add production --username sa_abc123... --project 12345
+
+# Via stdin
+echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 --secret-stdin
 ```
 
 List configured accounts:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -90,7 +90,7 @@ Fetch a month of events into a local DuckDB database:
 === "CLI"
 
     ```bash
-    mp fetch events --name jan_events --from 2024-01-01 --to 2024-01-31
+    mp fetch events jan_events --from 2024-01-01 --to 2024-01-31
     ```
 
 === "Python"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,14 +24,25 @@ export MP_REGION="us"
 ### Option B: Using the CLI
 
 ```bash
+# Interactive prompt (secure, recommended)
 mp auth add production \
     --username sa_abc123... \
-    --secret your-secret-here \
     --project 12345 \
     --region us
+# You'll be prompted for the secret with hidden input
 ```
 
 This stores credentials in `~/.mp/config.toml` and sets `production` as the default account.
+
+For CI/CD environments, provide the secret via environment variable or stdin:
+
+```bash
+# Via environment variable
+MP_SECRET=your-secret mp auth add production --username sa_abc123... --project 12345
+
+# Via stdin
+echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 --secret-stdin
+```
 
 ## Step 2: Test Your Connection
 

--- a/docs/guide/fetching.md
+++ b/docs/guide/fetching.md
@@ -27,7 +27,7 @@ Fetch all events for a date range:
 === "CLI"
 
     ```bash
-    mp fetch events --name jan_events --from 2024-01-01 --to 2024-01-31
+    mp fetch events jan_events --from 2024-01-01 --to 2024-01-31
     ```
 
 ### Filtering Events
@@ -48,8 +48,8 @@ Fetch specific event types:
 === "CLI"
 
     ```bash
-    mp fetch events --name purchases --from 2024-01-01 --to 2024-01-31 \
-        --event Purchase --event "Checkout Started"
+    mp fetch events purchases --from 2024-01-01 --to 2024-01-31 \
+        --events Purchase,"Checkout Started"
     ```
 
 ### Using Where Clauses
@@ -70,7 +70,7 @@ Filter with Mixpanel expression syntax:
 === "CLI"
 
     ```bash
-    mp fetch events --name premium_purchases --from 2024-01-01 --to 2024-01-31 \
+    mp fetch events premium_purchases --from 2024-01-01 --to 2024-01-31 \
         --where 'properties["plan"] == "premium"'
     ```
 
@@ -106,7 +106,7 @@ Fetch user profiles into local storage:
 === "CLI"
 
     ```bash
-    mp fetch profiles --name users
+    mp fetch profiles users
     ```
 
 ### Filtering Profiles
@@ -125,7 +125,7 @@ Use Mixpanel expression syntax:
 === "CLI"
 
     ```bash
-    mp fetch profiles --name premium_users \
+    mp fetch profiles premium_users \
         --where 'properties["plan"] == "premium"'
     ```
 


### PR DESCRIPTION
## Summary

- **Rewrites README** to focus on end users (human and AI agents) rather than development details
- **Creates CONTRIBUTING.md** with development setup, commands, and architecture for contributors  
- **Updates secret handling docs** to reflect secure interactive prompt (no more `--secret` flag)

## Changes

### README.md
- Add PyPI/Python/License badges for credibility
- Add compelling "Why mixpanel_data?" value proposition section
- Streamline Quick Start with CLI-first numbered steps
- Add compact CLI reference table (all 31 commands)
- Add dedicated "For AI Agents" section with typical workflow
- Remove development phases/status (historical, not user-facing)
- Remove architecture diagrams (available in docs)
- Remove technology stack table (available in docs)

### CONTRIBUTING.md (new)
- Development setup (devcontainer recommended)
- All `just` commands
- Project structure
- Architecture overview
- Design principles
- Contribution workflow

### Documentation Updates
- `docs/getting-started/quickstart.md` - Secure secret handling
- `docs/getting-started/configuration.md` - Secure secret handling  
- `docs/cli/index.md` - Updated workflow example

## Motivation

Studied READMEs from popular CLI tools (gh, aws-cli, docker-cli, dlt, kubectl) to identify best practices:
- **gh**: Clear positioning, multiple installation paths, action-oriented navigation
- **dlt**: Progressive disclosure (install → quick start → features), immediate practical value
- **aws-cli**: Jump-to navigation, multiple configuration methods
- **docker-cli**: Extreme brevity, status badges

Applied these lessons to make mixpanel_data's README welcoming to new users while keeping contributor docs accessible in CONTRIBUTING.md.

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify all documentation links work
- [ ] Review README renders well on PyPI (when published)