### PR TITLE
feat: add streaming API for events and profiles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,14 +163,13 @@ Config file: `~/.mp/config.toml` (TOML format)
 ### Architecture Enforcement
 
 **Layer Boundaries**: Flag any code that:
-- Imports from `_internal/` in public modules (only `auth.py` is allowed to re-export)
 - Has CLI code directly accessing storage or API clients (should go through Workspace facade)
 - Has services calling other services horizontally (they should only call infrastructure)
 
-**Private API Leakage**: The `src/mixpanel_data/_internal/` directory is private implementation. Flag any:
-- Direct imports of `_internal` modules in user-facing code
-- Types from `_internal/` appearing in public function signatures
+**Private API for External Consumers**: The `src/mixpanel_data/_internal/` directory is private implementation that external consumers should not import. However, internal package code (like `workspace.py`, `auth.py`, CLI commands) legitimately imports from `_internal/` to implement the public API. Flag any:
+- Types from `_internal/` appearing in public function signatures (return types, parameters)
 - `__all__` exports that include `_internal` symbols
+- Documentation or examples that tell users to import from `_internal`
 
 ### Exception Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,3 +131,10 @@ Design documents in `context/`:
 - [mixpanel_data-design.md](context/mixpanel_data-design.md) — Architecture and public API
 - [mp-cli-project-spec.md](context/mp-cli-project-spec.md) — CLI specification
 - [mixpanel-http-api-specification.md](context/mixpanel-http-api-specification.md) — Mixpanel API reference
+
+## Active Technologies
+- Python 3.11+ + Typer (CLI), httpx (HTTP), Rich (progress to stderr) (011-streaming-api)
+- N/A for streaming (bypasses DuckDB entirely) (011-streaming-api)
+
+## Recent Changes
+- 011-streaming-api: Added Python 3.11+ + Typer (CLI), httpx (HTTP), Rich (progress to stderr)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/mixpanel_data)](https://pypi.org/project/mixpanel_data/)
 [![License](https://img.shields.io/github/license/discohead/mixpanel_data)](LICENSE)
 
-A Python library and CLI for working with Mixpanel analytics data—fetch once, query repeatedly with SQL.
+A Python library and CLI for working with Mixpanel analytics data—fetch once, query repeatedly with SQL, or stream directly to ETL pipelines.
 
 ## Why mixpanel_data?
 
@@ -74,6 +74,13 @@ mp query sql "SELECT event_name, COUNT(*) FROM jan GROUP BY 1 ORDER BY 2 DESC" -
 mp query segmentation --event Purchase --from 2024-01-01 --to 2024-01-31 --on country
 ```
 
+### 6. Or Stream Directly (No Storage)
+
+```bash
+# Stream events as JSONL for piping to other tools
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | jq '.event_name'
+```
+
 ## Python API
 
 ```python
@@ -116,6 +123,16 @@ with mp.Workspace.ephemeral() as ws:
 # Database automatically deleted
 ```
 
+### Streaming
+
+For ETL pipelines or one-time processing without storage:
+
+```python
+# Stream events directly to external system
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    send_to_warehouse(event)
+```
+
 ## CLI Reference
 
 The `mp` CLI provides 31 commands across four groups:
@@ -128,6 +145,8 @@ The `mp` CLI provides 31 commands across four groups:
 | `mp inspect` | `events`, `properties`, `values`, `funnels`, `cohorts`, `top-events`, `info`, `tables`, `schema`, `drop` |
 
 All commands support `--format` (json, jsonl, table, csv, plain) and `--help`.
+
+`mp fetch` commands also support `--stdout` (stream as JSONL) and `--raw` (raw API format).
 
 ## DuckDB JSON Queries
 
@@ -152,6 +171,7 @@ Full documentation: [discohead.github.io/mixpanel_data](https://discohead.github
 - [Quick Start](https://discohead.github.io/mixpanel_data/getting-started/quickstart/)
 - [CLI Reference](https://discohead.github.io/mixpanel_data/cli/)
 - [Python API](https://discohead.github.io/mixpanel_data/api/)
+- [Streaming Guide](https://discohead.github.io/mixpanel_data/guide/streaming/)
 - [SQL Query Guide](https://discohead.github.io/mixpanel_data/guide/sql-queries/)
 - [Live Analytics](https://discohead.github.io/mixpanel_data/guide/live-analytics/)
 
@@ -160,6 +180,7 @@ Full documentation: [discohead.github.io/mixpanel_data](https://discohead.github
 `mixpanel_data` is designed with AI coding agents in mind:
 
 - **Context preservation**: Fetch data once, query repeatedly without re-fetching
+- **Streaming for ETL**: Stream data directly to external systems with `--stdout`
 - **Structured output**: All commands support `--format json` for machine-readable responses
 - **Discoverable schema**: `mp inspect` commands reveal events, properties, and values before querying
 - **Local SQL**: Complex analysis via SQL instead of multiple API round-trips
@@ -172,7 +193,7 @@ Typical agent workflow:
 mp inspect events --format json
 mp inspect properties --event Purchase --format json
 
-# 2. Fetch relevant data
+# 2. Fetch relevant data (or stream with --stdout for ETL)
 mp fetch events data --from 2024-01-01 --to 2024-01-31
 
 # 3. Iterate with SQL queries

--- a/context/streaming-api-feature-plan.md
+++ b/context/streaming-api-feature-plan.md
@@ -1,0 +1,338 @@
+# Implementation Plan: Streaming API (No-DB Mode)
+
+**Created**: 2024-12-24
+**Status**: Draft
+**Input**: Add the ability to bypass the database and directly return raw data from the Mixpanel API, enabling the library and CLI to function as a pure Python SDK for the Mixpanel HTTP API without local storage.
+
+## Problem Statement
+
+Currently, all data fetching operations in `mixpanel_data` require storing data in a local DuckDB database. This forces users into the "fetch once, query repeatedly" paradigm even when they just want to:
+
+- Pipe data directly to another system (ETL pipelines, data warehouses)
+- Process events in a streaming fashion without disk I/O
+- Use the library as a conventional API SDK in existing workflows
+- Avoid disk space usage for one-time data exports
+
+## Proposed Solution
+
+Add `stream_events()` and `stream_profiles()` methods to the `Workspace` class that return iterators of event/profile dictionaries directly from the Mixpanel API, bypassing local storage entirely.
+
+**Key Insight**: The raw streaming capability already exists in the codebase. `MixpanelAPIClient.export_events()` and `export_profiles()` return memory-efficient iterators. We just need to expose this through the Workspace facade.
+
+### Naming Convention
+
+| Method | Behavior |
+|--------|----------|
+| `fetch_events()` | Fetch from API → Store in DuckDB → Return FetchResult |
+| `stream_events()` | Fetch from API → Yield directly → No storage |
+
+This naming clearly communicates intent: "fetch" implies persistence, "stream" implies flow-through.
+
+## Python Library Changes
+
+### New Workspace Methods
+
+```python
+def stream_events(
+    self,
+    *,
+    from_date: str,
+    to_date: str,
+    events: list[str] | None = None,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Stream events directly from Mixpanel API without storing.
+
+    Args:
+        from_date: Start date (YYYY-MM-DD).
+        to_date: End date (YYYY-MM-DD).
+        events: Optional list of event names to filter.
+        where: Optional WHERE clause for filtering.
+        raw: If True, return raw API format. If False (default),
+             return normalized format matching stored events.
+
+    Yields:
+        Event dictionaries.
+
+    Raises:
+        ConfigError: If API credentials not available.
+        AuthenticationError: If credentials are invalid.
+    """
+
+def stream_profiles(
+    self,
+    *,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Stream user profiles directly from Mixpanel API without storing.
+
+    Args:
+        where: Optional WHERE clause for filtering.
+        raw: If True, return raw API format. If False (default),
+             return normalized format matching stored profiles.
+
+    Yields:
+        Profile dictionaries.
+
+    Raises:
+        ConfigError: If API credentials not available.
+        AuthenticationError: If credentials are invalid.
+    """
+```
+
+### The `raw` Parameter
+
+Two output formats are supported:
+
+**`raw=True`** - Exact Mixpanel API format:
+```python
+# Events
+{"event": "PageView", "properties": {"distinct_id": "user123", "time": 1703433600, "$insert_id": "abc", "page": "/home"}}
+
+# Profiles
+{"$distinct_id": "user123", "$properties": {"$last_seen": "2024-01-01", "plan": "pro"}}
+```
+
+**`raw=False`** (default) - Normalized format matching what gets stored in DuckDB:
+```python
+# Events
+{"event_name": "PageView", "event_time": datetime(...), "distinct_id": "user123", "insert_id": "abc", "properties": {"page": "/home"}}
+
+# Profiles
+{"distinct_id": "user123", "last_seen": "2024-01-01", "properties": {"plan": "pro"}}
+```
+
+The normalized format:
+- Converts Unix timestamps to Python datetime objects
+- Extracts standard fields (distinct_id, time, $insert_id) from properties
+- Provides consistency with data stored via `fetch_*` methods
+
+### Implementation Approach
+
+The implementation is minimal because infrastructure already exists:
+
+```python
+# In Workspace class
+
+def stream_events(
+    self,
+    *,
+    from_date: str,
+    to_date: str,
+    events: list[str] | None = None,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]:
+    api = self._require_api_client()
+    events_iter = api.export_events(
+        from_date=from_date,
+        to_date=to_date,
+        events=events,
+        where=where,
+    )
+
+    if raw:
+        yield from events_iter
+    else:
+        from mixpanel_data._internal.services.fetcher import _transform_event
+        for event in events_iter:
+            yield _transform_event(event)
+```
+
+**Note**: The `_transform_event` and `_transform_profile` functions in `fetcher.py` are already standalone functions, making them easy to reuse.
+
+## CLI Changes
+
+### Option A: Flag on Existing Command (Recommended)
+
+Add `--stdout` flag to existing fetch commands:
+
+```bash
+# Current behavior (stores to DB)
+mp fetch events --from 2024-01-01 --to 2024-01-31 my_events
+
+# New: Stream to stdout as JSONL
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+
+# With raw format
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout --raw
+```
+
+When `--stdout` is provided:
+- The `TABLE_NAME` argument becomes optional (not needed)
+- Output is JSONL (one JSON object per line) to stdout
+- No database interaction occurs
+- Progress output goes to stderr (if enabled)
+
+### Option B: Separate Command
+
+```bash
+# Dedicated streaming command
+mp stream events --from 2024-01-01 --to 2024-01-31
+mp stream profiles --where 'properties["plan"] == "pro"'
+```
+
+**Recommendation**: Option A (`--stdout` flag) is preferred because:
+- Fewer commands to learn
+- Natural extension of existing mental model
+- Consistent with Unix philosophy (commands can output to stdout or files)
+
+### Output Format
+
+JSONL (JSON Lines) format - one JSON object per line:
+
+```jsonl
+{"event_name": "PageView", "event_time": "2024-01-01T12:00:00Z", "distinct_id": "user1", ...}
+{"event_name": "Click", "event_time": "2024-01-01T12:01:00Z", "distinct_id": "user2", ...}
+```
+
+This format:
+- Streams naturally (no need to buffer entire response)
+- Pipes cleanly to `jq`, other CLI tools, or file redirection
+- Is the standard for streaming JSON data
+
+### CLI Implementation Notes
+
+```python
+@events_app.command("events")
+def fetch_events(
+    # ... existing params ...
+    stdout: Annotated[bool, typer.Option("--stdout", help="Stream to stdout instead of storing")] = False,
+    raw: Annotated[bool, typer.Option("--raw", help="Output raw API format (with --stdout)")] = False,
+):
+    if stdout:
+        # Stream mode - output JSONL to stdout
+        ws = Workspace(account=account)
+        try:
+            for event in ws.stream_events(from_date=from_date, to_date=to_date, events=event_filter, where=where, raw=raw):
+                # Use json.dumps for datetime serialization
+                console.print(json.dumps(event, default=str))
+        finally:
+            ws.close()
+    else:
+        # Existing storage mode
+        ...
+```
+
+## Design Decisions
+
+### 1. Why not a "no-db" Workspace?
+
+A separate `StreamingWorkspace` or `Workspace(no_db=True)` was considered but rejected:
+- Would duplicate significant code
+- Creates confusion about which class to use
+- The streaming capability is orthogonal to workspace lifecycle
+
+### 2. Why not modify FetcherService?
+
+Adding a `store=False` parameter to `FetcherService.fetch_events()` was considered but rejected:
+- Muddies the service's single responsibility (fetch → store)
+- Would require changing return types (FetchResult vs Iterator)
+- The transformation logic can be cleanly reused without modifying the service
+
+### 3. Why default `raw=False`?
+
+The normalized format is the default because:
+- Consistency with stored data (users can switch between fetch and stream)
+- More useful for Python consumers (datetime objects vs Unix timestamps)
+- Users wanting raw API format can explicitly opt in
+
+### 4. Why `--stdout` instead of `--stream`?
+
+`--stdout` better describes what happens (output goes to stdout) and follows Unix conventions. `--stream` might be confused with "streaming mode" which is always true for large exports.
+
+## Files to Modify
+
+### Python Library
+
+| File | Changes |
+|------|---------|
+| `src/mixpanel_data/workspace.py` | Add `stream_events()` and `stream_profiles()` methods |
+| `src/mixpanel_data/__init__.py` | No changes needed (methods are on Workspace class) |
+
+### CLI
+
+| File | Changes |
+|------|---------|
+| `src/mixpanel_data/cli/commands/fetch.py` | Add `--stdout` and `--raw` options to fetch commands |
+
+### Tests
+
+| File | Changes |
+|------|---------|
+| `tests/test_workspace.py` | Add tests for `stream_events()` and `stream_profiles()` |
+| `tests/cli/test_fetch.py` | Add tests for `--stdout` flag |
+
+### Documentation
+
+| File | Changes |
+|------|---------|
+| `README.md` or docs | Document streaming usage patterns |
+
+## User Scenarios
+
+### Scenario 1: ETL Pipeline Integration
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    # Send to data warehouse, Kafka, etc.
+    send_to_warehouse(event)
+ws.close()
+```
+
+### Scenario 2: CLI Data Export
+
+```bash
+# Export to file
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout > events.jsonl
+
+# Pipe to jq for filtering
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | jq 'select(.event_name == "Purchase")'
+
+# Pipe to another tool
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | my-ingestion-tool
+```
+
+### Scenario 3: Memory-Constrained Environment
+
+```python
+# Process millions of events without loading all into memory
+ws = mp.Workspace()
+purchase_total = 0
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-12-31", events=["Purchase"]):
+    purchase_total += event["properties"].get("amount", 0)
+print(f"Total purchases: ${purchase_total}")
+ws.close()
+```
+
+### Scenario 4: Raw API Access for Compatibility
+
+```python
+# Get exact API format for systems expecting Mixpanel's native schema
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31", raw=True):
+    # event has original {"event": ..., "properties": {...}} structure
+    legacy_system.ingest(event)
+```
+
+## Success Criteria
+
+- **SC-001**: Users can iterate over events/profiles without any database file being created
+- **SC-002**: Memory usage remains constant regardless of dataset size (streaming, not buffering)
+- **SC-003**: `--stdout` CLI flag outputs valid JSONL that can be piped to other tools
+- **SC-004**: Both raw and normalized output formats work correctly
+- **SC-005**: All existing fetch functionality remains unchanged (backward compatible)
+- **SC-006**: Error handling (auth errors, rate limits) works identically to fetch methods
+
+## Estimated Scope
+
+This is a small, surgical change:
+- ~30 lines of new code in `workspace.py`
+- ~20 lines of new code in CLI
+- ~50-100 lines of tests
+- No changes to existing code paths
+- No new dependencies

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,6 +26,7 @@ The main entry point for all operations:
 
 - **Discovery** — Explore events, properties, funnels, cohorts
 - **Fetching** — Download events and profiles to local storage
+- **Streaming** — Stream data directly without storage (ETL, pipelines)
 - **Local Queries** — SQL queries against DuckDB
 - **Live Queries** — Real-time analytics from Mixpanel API
 - **Introspection** — Examine local tables and schemas

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -7,7 +7,7 @@ The `Workspace` class is the unified entry point for all Mixpanel data operation
 Workspace orchestrates four internal services:
 
 - **DiscoveryService** — Schema exploration (events, properties, funnels, cohorts)
-- **FetcherService** — Data ingestion from Mixpanel to DuckDB
+- **FetcherService** — Data ingestion from Mixpanel to DuckDB, or streaming without storage
 - **LiveQueryService** — Real-time analytics queries
 - **StorageEngine** — Local SQL query execution
 
@@ -32,6 +32,8 @@ Workspace orchestrates four internal services:
         - clear_discovery_cache
         - fetch_events
         - fetch_profiles
+        - stream_events
+        - stream_profiles
         - sql
         - sql_scalar
         - sql_rows

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -54,11 +54,12 @@ Schema introspection with session-scoped caching:
 
 #### FetcherService
 
-Coordinates data ingestion from Mixpanel API to DuckDB:
+Coordinates data ingestion from Mixpanel API to DuckDB, or direct streaming:
 
 - Streaming transformation (memory efficient)
 - Progress callback integration
-- Returns `FetchResult` with metadata
+- Returns `FetchResult` with metadata (fetch mode)
+- Returns `Iterator[dict]` without storage (stream mode)
 
 #### LiveQueryService
 
@@ -129,6 +130,23 @@ Best for:
 - Custom SQL logic
 - Context window preservation (AI agents)
 - Offline analysis
+
+### Streaming Path
+
+```
+User Request → Workspace → MixpanelAPIClient → Mixpanel Export API
+                                    ↓
+                          Iterator[dict] (no storage)
+                                    ↓
+                          Process each record inline
+```
+
+Best for:
+
+- ETL pipelines to external systems
+- One-time processing without storage
+- Memory-constrained environments
+- Unix pipeline integration (CLI `--stdout`)
 
 ## Key Design Decisions
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -43,12 +43,19 @@ Manage stored credentials and accounts.
 
 ### fetch — Data Fetching
 
-Fetch data from Mixpanel into local storage.
+Fetch data from Mixpanel into local storage, or stream directly to stdout.
 
 | Command | Description |
 |---------|-------------|
 | `mp fetch events` | Fetch events to local DuckDB |
 | `mp fetch profiles` | Fetch user profiles to local DuckDB |
+
+**Streaming Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--stdout` | Stream data as JSONL to stdout instead of storing |
+| `--raw` | Output raw Mixpanel API format (requires `--stdout`) |
 
 ### query — Query Operations
 
@@ -169,6 +176,28 @@ mp query segmentation --event Login --from 2024-01-01 --to 2024-01-31 --format j
 
 # Count lines
 mp query sql "SELECT * FROM events" --format jsonl | wc -l
+```
+
+### Streaming to Stdout
+
+Stream data directly without storing locally:
+
+```bash
+# Stream events as JSONL
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+
+# Stream profiles
+mp fetch profiles --stdout
+
+# Pipe to jq for filtering
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout \
+    | jq 'select(.event_name == "Purchase")'
+
+# Save to file
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout > events.jsonl
+
+# Raw Mixpanel API format
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout --raw
 ```
 
 ## Full Command Reference

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -163,6 +163,31 @@ For real-time analytics, query Mixpanel directly:
     print(result.df)
     ```
 
+## Alternative: Stream Data Without Storage
+
+For ETL pipelines or one-time processing, stream data directly without storing:
+
+=== "CLI"
+
+    ```bash
+    # Stream events as JSONL
+    mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+
+    # Pipe to other tools
+    mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | jq '.event_name'
+    ```
+
+=== "Python"
+
+    ```python
+    import mixpanel_data as mp
+
+    ws = mp.Workspace()
+    for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+        send_to_warehouse(event)
+    ws.close()
+    ```
+
 ## Using Ephemeral Workspaces
 
 For one-off analysis without persisting data:
@@ -181,5 +206,6 @@ with mp.Workspace.ephemeral() as ws:
 
 - [Configuration](configuration.md) — Multiple accounts and advanced settings
 - [Fetching Data](../guide/fetching.md) — Filtering and progress callbacks
+- [Streaming Data](../guide/streaming.md) — Process data without local storage
 - [SQL Queries](../guide/sql-queries.md) — DuckDB JSON syntax and patterns
 - [Live Analytics](../guide/live-analytics.md) — Segmentation, funnels, retention

--- a/docs/guide/fetching.md
+++ b/docs/guide/fetching.md
@@ -247,7 +247,25 @@ with mp.Workspace.ephemeral() as ws:
 # Database automatically deleted
 ```
 
+## Streaming as an Alternative
+
+If you don't need to store data locally, use streaming instead:
+
+| Approach | Storage | Best For |
+|----------|---------|----------|
+| `fetch_events()` | DuckDB table | Repeated SQL analysis |
+| `stream_events()` | None | ETL pipelines, one-time processing |
+
+```python
+# Stream directly without storage
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    send_to_warehouse(event)
+```
+
+See [Streaming Data](streaming.md) for details.
+
 ## Next Steps
 
+- [Streaming Data](streaming.md) — Process data without local storage
 - [SQL Queries](sql-queries.md) — Query your fetched data with SQL
 - [Live Analytics](live-analytics.md) — Query Mixpanel directly for real-time data

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -1,0 +1,324 @@
+# Streaming Data
+
+Stream events and user profiles directly from Mixpanel without storing to local database. Ideal for ETL pipelines, one-time exports, and Unix-style piping.
+
+## When to Stream vs Fetch
+
+| Use Case | Recommended | Why |
+|----------|-------------|-----|
+| Repeated analysis | `fetch_events()` | Query once, analyze many times |
+| ETL to external system | `stream_events()` | No intermediate storage needed |
+| Memory-constrained | `stream_events()` | Constant memory usage |
+| Ad-hoc exploration | `fetch_events()` | SQL iteration is faster |
+| Piping to tools | `--stdout` | JSONL integrates with jq, grep, etc. |
+
+## Streaming Events
+
+### Basic Usage
+
+Stream all events for a date range:
+
+=== "Python"
+
+    ```python
+    import mixpanel_data as mp
+
+    ws = mp.Workspace()
+
+    for event in ws.stream_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31"
+    ):
+        print(f"{event['event_name']}: {event['distinct_id']}")
+        # event_time is a datetime object
+        # properties contains remaining fields
+
+    ws.close()
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+    ```
+
+### Filtering Events
+
+Filter by event name or expression:
+
+=== "Python"
+
+    ```python
+    # Filter by event names
+    for event in ws.stream_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        events=["Purchase", "Signup"]
+    ):
+        process(event)
+
+    # Filter with WHERE clause
+    for event in ws.stream_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        where='properties["country"]=="US"'
+    ):
+        process(event)
+    ```
+
+=== "CLI"
+
+    ```bash
+    # Filter by event names
+    mp fetch events --from 2024-01-01 --to 2024-01-31 \
+        --events "Purchase,Signup" --stdout
+
+    # Filter with WHERE clause
+    mp fetch events --from 2024-01-01 --to 2024-01-31 \
+        --where 'properties["country"]=="US"' --stdout
+    ```
+
+### Raw API Format
+
+By default, streaming returns normalized data with `event_time` as a datetime. Use `raw=True` to get the exact Mixpanel API format:
+
+=== "Python"
+
+    ```python
+    for event in ws.stream_events(
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        raw=True
+    ):
+        # event has {"event": "...", "properties": {...}} structure
+        # properties["time"] is Unix timestamp
+        legacy_system.ingest(event)
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout --raw
+    ```
+
+## Streaming Profiles
+
+### Basic Usage
+
+Stream all user profiles:
+
+=== "Python"
+
+    ```python
+    for profile in ws.stream_profiles():
+        sync_to_crm(profile)
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch profiles --stdout
+    ```
+
+### Filtering Profiles
+
+=== "Python"
+
+    ```python
+    for profile in ws.stream_profiles(
+        where='properties["plan"]=="premium"'
+    ):
+        send_survey(profile)
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch profiles --where 'properties["plan"]=="premium"' --stdout
+    ```
+
+## CLI Pipeline Examples
+
+The `--stdout` flag outputs JSONL (one JSON object per line), perfect for Unix pipelines:
+
+```bash
+# Filter with jq
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout \
+    | jq 'select(.event_name == "Purchase")'
+
+# Count events
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | wc -l
+
+# Save to file
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout > events.jsonl
+
+# Process with custom script
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout \
+    | python process_events.py
+
+# Extract specific fields
+mp fetch profiles --stdout | jq -r '.distinct_id'
+```
+
+## Output Formats
+
+### Normalized Format (Default)
+
+Events:
+
+```json
+{
+  "event_name": "Purchase",
+  "distinct_id": "user_123",
+  "event_time": "2024-01-15T10:30:00+00:00",
+  "insert_id": "abc123",
+  "properties": {
+    "amount": 99.99,
+    "currency": "USD"
+  }
+}
+```
+
+Profiles:
+
+```json
+{
+  "distinct_id": "user_123",
+  "last_seen": "2024-01-15T14:30:00",
+  "properties": {
+    "name": "Alice",
+    "plan": "premium"
+  }
+}
+```
+
+### Raw Format (`raw=True` or `--raw`)
+
+Events:
+
+```json
+{
+  "event": "Purchase",
+  "properties": {
+    "distinct_id": "user_123",
+    "time": 1705319400,
+    "$insert_id": "abc123",
+    "amount": 99.99,
+    "currency": "USD"
+  }
+}
+```
+
+Profiles:
+
+```json
+{
+  "$distinct_id": "user_123",
+  "$properties": {
+    "$last_seen": "2024-01-15T14:30:00",
+    "name": "Alice",
+    "plan": "premium"
+  }
+}
+```
+
+## Common Patterns
+
+### ETL Pipeline
+
+Batch events and send to external system:
+
+```python
+import mixpanel_data as mp
+from your_warehouse import send_batch
+
+ws = mp.Workspace()
+batch = []
+
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    batch.append(event)
+    if len(batch) >= 1000:
+        send_batch(batch)
+        batch = []
+
+# Send remaining
+if batch:
+    send_batch(batch)
+
+ws.close()
+```
+
+### Aggregation Without Storage
+
+Compute statistics without creating a local table:
+
+```python
+from collections import Counter
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+event_counts = Counter()
+
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    event_counts[event["event_name"]] += 1
+
+print(event_counts.most_common(10))
+ws.close()
+```
+
+### Context Manager
+
+Use `with` for automatic cleanup:
+
+```python
+import mixpanel_data as mp
+
+with mp.Workspace() as ws:
+    for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+        process(event)
+# No need to call ws.close()
+```
+
+## Method Signatures
+
+### stream_events()
+
+```python
+def stream_events(
+    *,
+    from_date: str,
+    to_date: str,
+    events: list[str] | None = None,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_date` | `str` | Start date (YYYY-MM-DD) |
+| `to_date` | `str` | End date (YYYY-MM-DD) |
+| `events` | `list[str] \| None` | Event names to include |
+| `where` | `str \| None` | Mixpanel expression filter |
+| `raw` | `bool` | Return raw API format |
+
+### stream_profiles()
+
+```python
+def stream_profiles(
+    *,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `where` | `str \| None` | Mixpanel expression filter |
+| `raw` | `bool` | Return raw API format |
+
+## Next Steps
+
+- [Fetching Data](fetching.md) — Store data locally for repeated SQL queries
+- [SQL Queries](sql-queries.md) — Query stored data with DuckDB SQL
+- [Live Analytics](live-analytics.md) — Real-time Mixpanel reports

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Fetch data once, store it locally in DuckDB, query repeatedly with SQL. Data liv
 ## Features
 
 - **Local Data Store** — Fetch events and profiles from Mixpanel, store in DuckDB, query with SQL
+- **Streaming** — Stream data directly without storage for ETL pipelines and one-time processing
 - **Live Queries** — Run Mixpanel reports (segmentation, funnels, retention) directly when fresh data is needed
 - **Data Discovery** — Introspect events, properties, values, saved funnels, and cohorts before writing queries
 - **Event Analytics** — Query multi-event time series and property breakdowns across date ranges

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Configuration: getting-started/configuration.md
   - User Guide:
       - Fetching Data: guide/fetching.md
+      - Streaming Data: guide/streaming.md
       - Local SQL Queries: guide/sql-queries.md
       - Live Analytics: guide/live-analytics.md
       - Data Discovery: guide/discovery.md

--- a/specs/011-streaming-api/checklists/requirements.md
+++ b/specs/011-streaming-api/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Streaming API
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2024-12-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- The feature scope is well-defined: streaming methods for library + stdout flag for CLI
+- Backward compatibility requirements ensure existing functionality is preserved

--- a/specs/011-streaming-api/contracts/workspace-streaming.md
+++ b/specs/011-streaming-api/contracts/workspace-streaming.md
@@ -1,0 +1,195 @@
+# Contract: Workspace Streaming Methods
+
+**Feature**: 011-streaming-api
+**Date**: 2024-12-24
+
+## Overview
+
+This document defines the API contract for streaming methods added to the `Workspace` class.
+
+## Python Library API
+
+### Workspace.stream_events()
+
+```python
+def stream_events(
+    self,
+    *,
+    from_date: str,
+    to_date: str,
+    events: list[str] | None = None,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Stream events directly from Mixpanel API without storing.
+
+    Yields events one at a time as they are received from the API.
+    No database files or tables are created.
+
+    Args:
+        from_date: Start date inclusive (YYYY-MM-DD format).
+        to_date: End date inclusive (YYYY-MM-DD format).
+        events: Optional list of event names to filter. If None, all events returned.
+        where: Optional Mixpanel filter expression (e.g., 'properties["country"]=="US"').
+        raw: If True, return events in raw Mixpanel API format.
+             If False (default), return normalized format with datetime objects.
+
+    Yields:
+        dict[str, Any]: Event dictionaries in normalized or raw format.
+
+    Raises:
+        ConfigError: If API credentials are not available (e.g., opened with Workspace.open()).
+        AuthenticationError: If credentials are invalid.
+        RateLimitError: If rate limit exceeded after max retries.
+        QueryError: If filter expression is invalid.
+
+    Example:
+        >>> ws = Workspace()
+        >>> for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+        ...     process(event)
+        >>> ws.close()
+
+        >>> # With raw format
+        >>> for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31", raw=True):
+        ...     legacy_system.ingest(event)
+    """
+```
+
+### Workspace.stream_profiles()
+
+```python
+def stream_profiles(
+    self,
+    *,
+    where: str | None = None,
+    raw: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Stream user profiles directly from Mixpanel API without storing.
+
+    Yields profiles one at a time as they are received from the API.
+    No database files or tables are created.
+
+    Args:
+        where: Optional Mixpanel filter expression for profile properties.
+        raw: If True, return profiles in raw Mixpanel API format.
+             If False (default), return normalized format.
+
+    Yields:
+        dict[str, Any]: Profile dictionaries in normalized or raw format.
+
+    Raises:
+        ConfigError: If API credentials are not available.
+        AuthenticationError: If credentials are invalid.
+        RateLimitError: If rate limit exceeded after max retries.
+
+    Example:
+        >>> ws = Workspace()
+        >>> for profile in ws.stream_profiles():
+        ...     sync_to_crm(profile)
+        >>> ws.close()
+
+        >>> # Filter to premium users
+        >>> for profile in ws.stream_profiles(where='properties["plan"]=="premium"'):
+        ...     send_survey(profile)
+    """
+```
+
+## CLI Interface
+
+### mp fetch events (with streaming options)
+
+```
+mp fetch events [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]    Table name for storing events. [default: events]
+            Ignored when --stdout is set.
+
+Options:
+  --from TEXT           Start date (YYYY-MM-DD). [required]
+  --to TEXT             End date (YYYY-MM-DD). [required]
+  -e, --events TEXT     Comma-separated event filter.
+  -w, --where TEXT      Mixpanel filter expression.
+  --replace             Replace existing table.
+  --no-progress         Hide progress bar.
+  --stdout              Stream to stdout as JSONL instead of storing.
+  --raw                 Output raw API format (only with --stdout).
+  --format [json|table|csv|jsonl]
+                        Output format. [default: json]
+  --help                Show this message and exit.
+
+Examples:
+  # Stream events to stdout
+  mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+
+  # Stream with raw format, pipe to jq
+  mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout --raw | jq '.event'
+
+  # Stream to file
+  mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout > events.jsonl
+
+  # Filter and stream
+  mp fetch events --from 2024-01-01 --to 2024-01-31 --events "Purchase,Signup" --stdout
+```
+
+### mp fetch profiles (with streaming options)
+
+```
+mp fetch profiles [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]    Table name for storing profiles. [default: profiles]
+            Ignored when --stdout is set.
+
+Options:
+  -w, --where TEXT      Mixpanel filter expression.
+  --replace             Replace existing table.
+  --no-progress         Hide progress bar.
+  --stdout              Stream to stdout as JSONL instead of storing.
+  --raw                 Output raw API format (only with --stdout).
+  --format [json|table|csv|jsonl]
+                        Output format. [default: json]
+  --help                Show this message and exit.
+
+Examples:
+  # Stream all profiles
+  mp fetch profiles --stdout
+
+  # Stream premium users only
+  mp fetch profiles --where 'properties["plan"]=="premium"' --stdout
+```
+
+## Output Formats
+
+### JSONL (stdout mode)
+
+Each line is a complete JSON object:
+
+```jsonl
+{"event_name":"PageView","event_time":"2024-01-01T12:00:00+00:00","distinct_id":"user1","insert_id":"abc","properties":{"page":"/home"}}
+{"event_name":"Click","event_time":"2024-01-01T12:01:00+00:00","distinct_id":"user1","insert_id":"def","properties":{"button":"signup"}}
+```
+
+### Progress Output (stderr)
+
+When `--stdout` is set, progress goes to stderr:
+
+```
+Streaming events... 1000 rows
+Streaming events... 2000 rows
+```
+
+## Error Handling
+
+| Error | Exit Code | Behavior |
+|-------|-----------|----------|
+| Invalid credentials | 2 | Error message to stderr, no data output |
+| Invalid filter expression | 3 | Error message to stderr, no data output |
+| Rate limit (after retries) | 5 | Error message to stderr, partial data may have been output |
+| Network error | 1 | Error message to stderr, partial data may have been output |
+
+## Backward Compatibility
+
+- Default behavior (without `--stdout`) is unchanged
+- `--raw` without `--stdout` is ignored (no effect on stored data format)
+- All existing options continue to work as before

--- a/specs/011-streaming-api/data-model.md
+++ b/specs/011-streaming-api/data-model.md
@@ -1,0 +1,153 @@
+# Data Model: Streaming API
+
+**Feature**: 011-streaming-api
+**Date**: 2024-12-24
+
+## Overview
+
+The streaming API feature introduces no new persistent data models. It exposes existing data structures (events, profiles) through a streaming interface without storage.
+
+## Entities
+
+### Streamed Event (Normalized Format)
+
+When `raw=False` (default), events are yielded with this structure:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event_name` | `str` | Name of the event (e.g., "PageView", "Purchase") |
+| `event_time` | `datetime` | UTC timestamp when event occurred |
+| `distinct_id` | `str` | User identifier |
+| `insert_id` | `str` | Unique event identifier (UUID if not provided by Mixpanel) |
+| `properties` | `dict[str, Any]` | Remaining event properties (excluding extracted fields) |
+
+**Example**:
+```json
+{
+  "event_name": "Purchase",
+  "event_time": "2024-01-15T14:30:00+00:00",
+  "distinct_id": "user_abc123",
+  "insert_id": "evt_xyz789",
+  "properties": {
+    "amount": 99.99,
+    "product": "Pro Plan",
+    "currency": "USD"
+  }
+}
+```
+
+### Streamed Event (Raw Format)
+
+When `raw=True`, events are yielded in Mixpanel's native API format:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | `str` | Name of the event |
+| `properties` | `dict[str, Any]` | All properties including `distinct_id`, `time`, `$insert_id` |
+
+**Example**:
+```json
+{
+  "event": "Purchase",
+  "properties": {
+    "distinct_id": "user_abc123",
+    "time": 1705328400,
+    "$insert_id": "evt_xyz789",
+    "amount": 99.99,
+    "product": "Pro Plan",
+    "currency": "USD"
+  }
+}
+```
+
+### Streamed Profile (Normalized Format)
+
+When `raw=False` (default), profiles are yielded with this structure:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `distinct_id` | `str` | User identifier |
+| `last_seen` | `str \| None` | ISO timestamp of last activity |
+| `properties` | `dict[str, Any]` | User profile properties (excluding `$last_seen`) |
+
+**Example**:
+```json
+{
+  "distinct_id": "user_abc123",
+  "last_seen": "2024-01-15T14:30:00",
+  "properties": {
+    "name": "Alice Smith",
+    "email": "alice@example.com",
+    "plan": "pro"
+  }
+}
+```
+
+### Streamed Profile (Raw Format)
+
+When `raw=True`, profiles are yielded in Mixpanel's native API format:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `$distinct_id` | `str` | User identifier (with $ prefix) |
+| `$properties` | `dict[str, Any]` | All properties including `$last_seen` |
+
+**Example**:
+```json
+{
+  "$distinct_id": "user_abc123",
+  "$properties": {
+    "$last_seen": "2024-01-15T14:30:00",
+    "name": "Alice Smith",
+    "email": "alice@example.com",
+    "plan": "pro"
+  }
+}
+```
+
+## Data Flow
+
+```
+┌─────────────────────┐
+│  Mixpanel API       │
+│  (JSONL stream)     │
+└──────────┬──────────┘
+           │ Iterator[dict]
+           ▼
+┌─────────────────────┐
+│  MixpanelAPIClient  │
+│  export_events()    │
+│  export_profiles()  │
+└──────────┬──────────┘
+           │ Iterator[dict] (raw format)
+           ▼
+┌─────────────────────┐     raw=True
+│  Workspace          │ ─────────────────► yield as-is
+│  stream_events()    │
+│  stream_profiles()  │     raw=False
+└──────────┬──────────┘ ─────────────────► _transform_*()
+           │                                     │
+           │ Iterator[dict]                      │
+           ▼                                     ▼
+┌─────────────────────┐              ┌─────────────────────┐
+│  Consumer           │              │  Normalized dict    │
+│  (ETL, CLI, etc.)   │              │  (datetime objects) │
+└─────────────────────┘              └─────────────────────┘
+```
+
+## Validation Rules
+
+No validation is performed on streamed data—it passes through as received from the API. This is intentional:
+
+1. **Performance**: Validation would add overhead to streaming
+2. **Fidelity**: Users may want exact API output for debugging
+3. **Existing behavior**: Matches how `fetch_events()` works (validation happens at API level)
+
+## State Transitions
+
+N/A - Streaming is stateless. No data persists; each record is yielded and forgotten.
+
+## Relationships
+
+- **Events ↔ Profiles**: No relationship enforced at streaming level
+- **Streaming ↔ Storage**: Mutually exclusive paths; streaming bypasses storage entirely

--- a/specs/011-streaming-api/plan.md
+++ b/specs/011-streaming-api/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Streaming API
+
+**Branch**: `011-streaming-api` | **Date**: 2024-12-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-streaming-api/spec.md`
+
+## Summary
+
+Add streaming methods (`stream_events()`, `stream_profiles()`) to the Workspace class that return iterators of event/profile dictionaries directly from the Mixpanel API, bypassing local DuckDB storage. Also add `--stdout` and `--raw` flags to CLI fetch commands for JSONL output to stdout.
+
+**Technical Approach**: Reuse existing `MixpanelAPIClient.export_events()` and `export_profiles()` iterators, and existing `_transform_event()` / `_transform_profile()` functions from the fetcher service. New methods simply wire these together without the storage step.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: Typer (CLI), httpx (HTTP), Rich (progress to stderr)
+**Storage**: N/A for streaming (bypasses DuckDB entirely)
+**Testing**: pytest with mocked API responses
+**Target Platform**: Linux/macOS/Windows (cross-platform Python)
+**Project Type**: Single project (library + CLI)
+**Performance Goals**: Constant memory usage regardless of dataset size (true streaming)
+**Constraints**: Must not buffer entire response; must maintain backward compatibility
+**Scale/Scope**: Support datasets of 1M+ events without memory issues
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Library-First | ✅ PASS | Streaming methods added to Workspace class first; CLI delegates to library |
+| II. Agent-Native Design | ✅ PASS | No interactive prompts; JSONL output; progress to stderr; meaningful exit codes |
+| III. Context Window Efficiency | ✅ PASS | Streaming enables precise data retrieval without local storage overhead |
+| IV. Two Data Paths | ✅ PASS | Extends "live queries" path; complements existing local storage path |
+| V. Explicit Over Implicit | ✅ PASS | `raw=False` default is explicit; no hidden state changes |
+| VI. Unix Philosophy | ✅ PASS | JSONL pipes to jq/grep; progress to stderr; composable |
+| VII. Secure by Default | ✅ PASS | No credential exposure; uses existing auth infrastructure |
+
+**Gate Result**: PASS - All principles satisfied
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-streaming-api/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── workspace-streaming.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── workspace.py              # Add stream_events(), stream_profiles() methods
+├── _internal/
+│   └── services/
+│       └── fetcher.py        # No changes (reuse _transform_event, _transform_profile)
+└── cli/
+    └── commands/
+        └── fetch.py          # Add --stdout, --raw options
+
+tests/
+├── unit/
+│   └── test_workspace_streaming.py    # Unit tests for streaming methods
+└── cli/
+    └── test_fetch_streaming.py        # CLI tests for --stdout flag
+```
+
+**Structure Decision**: Single project structure (existing). No new directories needed—streaming is a surgical addition to existing modules.
+
+## Complexity Tracking
+
+> No Constitution violations requiring justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |
+
+## Implementation Notes
+
+### Key Implementation Details
+
+1. **Workspace.stream_events()**: Call `self._require_api_client().export_events()` directly, optionally transform with `_transform_event()` based on `raw` parameter.
+
+2. **Workspace.stream_profiles()**: Call `self._require_api_client().export_profiles()` directly, optionally transform with `_transform_profile()` based on `raw` parameter.
+
+3. **CLI --stdout flag**: When enabled, iterate over `workspace.stream_events()` and print each dict as JSON line. Use `sys.stdout` for data, `err_console` for progress.
+
+4. **CLI --raw flag**: Pass through to streaming method; only valid with `--stdout`.
+
+5. **Table name handling**: When `--stdout` is set, the table name argument becomes optional (use `typer.Argument(default=None)`).
+
+### Dependencies Between Tasks
+
+```
+stream_events() ──┐
+                  ├──> CLI --stdout flag ──> Integration tests
+stream_profiles() ┘
+```
+
+Events and profiles streaming can be implemented in parallel. CLI depends on both. Tests depend on all.

--- a/specs/011-streaming-api/quickstart.md
+++ b/specs/011-streaming-api/quickstart.md
@@ -1,0 +1,199 @@
+# Quickstart: Streaming API
+
+**Feature**: 011-streaming-api
+**Date**: 2024-12-24
+
+## Overview
+
+The Streaming API enables you to retrieve Mixpanel data directly without storing it locally. This is ideal for:
+- ETL pipelines that send data to external systems
+- One-time exports without disk usage
+- Memory-constrained environments processing large datasets
+- Unix-style piping to other tools
+
+## Python Library
+
+### Stream Events
+
+```python
+import mixpanel_data as mp
+
+# Create workspace with credentials
+ws = mp.Workspace()
+
+# Stream events (normalized format by default)
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    print(f"{event['event_name']}: {event['distinct_id']}")
+    # event['event_time'] is a datetime object
+    # event['properties'] contains remaining fields
+
+ws.close()
+```
+
+### Stream with Filters
+
+```python
+# Filter by event names
+for event in ws.stream_events(
+    from_date="2024-01-01",
+    to_date="2024-01-31",
+    events=["Purchase", "Signup"],
+):
+    process(event)
+
+# Filter with WHERE clause
+for event in ws.stream_events(
+    from_date="2024-01-01",
+    to_date="2024-01-31",
+    where='properties["country"]=="US"',
+):
+    process(event)
+```
+
+### Raw API Format
+
+```python
+# Get exact Mixpanel API format (for legacy systems)
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31", raw=True):
+    # event has {"event": "...", "properties": {...}} structure
+    # event['properties']['time'] is Unix timestamp
+    legacy_system.ingest(event)
+```
+
+### Stream Profiles
+
+```python
+# Stream all profiles
+for profile in ws.stream_profiles():
+    sync_to_crm(profile)
+
+# Filter profiles
+for profile in ws.stream_profiles(where='properties["plan"]=="premium"'):
+    send_survey(profile)
+```
+
+### Context Manager Usage
+
+```python
+# Recommended: use context manager for automatic cleanup
+with mp.Workspace() as ws:
+    for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+        process(event)
+# No need to call ws.close()
+```
+
+## CLI
+
+### Stream to Stdout
+
+```bash
+# Stream events as JSONL
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
+
+# Stream profiles
+mp fetch profiles --stdout
+```
+
+### Pipe to Other Tools
+
+```bash
+# Filter with jq
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | jq 'select(.event_name == "Purchase")'
+
+# Count events
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | wc -l
+
+# Save to file
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout > events.jsonl
+
+# Pipe to custom script
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout | python process_events.py
+```
+
+### Raw Format
+
+```bash
+# Get Mixpanel's native API format
+mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout --raw
+```
+
+### With Filters
+
+```bash
+# Filter by event names
+mp fetch events --from 2024-01-01 --to 2024-01-31 --events "Purchase,Signup" --stdout
+
+# Filter with WHERE clause
+mp fetch events --from 2024-01-01 --to 2024-01-31 --where 'properties["country"]=="US"' --stdout
+```
+
+## Comparison: Fetch vs Stream
+
+| Aspect | `fetch_events()` | `stream_events()` |
+|--------|------------------|-------------------|
+| Storage | Creates DuckDB table | No storage |
+| Memory | Depends on table size | Constant (streaming) |
+| Return value | `FetchResult` | `Iterator[dict]` |
+| Query afterwards | Yes (SQL) | No |
+| Use case | Repeated analysis | One-time processing |
+
+## Common Patterns
+
+### ETL Pipeline
+
+```python
+import mixpanel_data as mp
+from your_warehouse import send_batch
+
+ws = mp.Workspace()
+batch = []
+
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    batch.append(event)
+    if len(batch) >= 1000:
+        send_batch(batch)
+        batch = []
+
+# Send remaining
+if batch:
+    send_batch(batch)
+
+ws.close()
+```
+
+### Aggregation Without Storage
+
+```python
+from collections import Counter
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+event_counts = Counter()
+
+for event in ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"):
+    event_counts[event["event_name"]] += 1
+
+print(event_counts.most_common(10))
+ws.close()
+```
+
+### Parallel Processing with Generator
+
+```python
+import mixpanel_data as mp
+from concurrent.futures import ThreadPoolExecutor
+
+def process(event):
+    # Your processing logic
+    return transform(event)
+
+ws = mp.Workspace()
+events = ws.stream_events(from_date="2024-01-01", to_date="2024-01-31")
+
+with ThreadPoolExecutor(max_workers=4) as executor:
+    results = executor.map(process, events)
+    for result in results:
+        save(result)
+
+ws.close()
+```

--- a/specs/011-streaming-api/research.md
+++ b/specs/011-streaming-api/research.md
@@ -1,0 +1,119 @@
+# Research: Streaming API
+
+**Feature**: 011-streaming-api
+**Date**: 2024-12-24
+
+## Overview
+
+This research documents the findings and decisions for implementing streaming API capability in `mixpanel_data`.
+
+## Research Tasks
+
+### 1. Existing Iterator Infrastructure
+
+**Question**: Can we reuse existing API client iterators for streaming?
+
+**Finding**: Yes. The `MixpanelAPIClient` class already has:
+- `export_events()` → Returns `Iterator[dict[str, Any]]` (line 446-582 in api_client.py)
+- `export_profiles()` → Returns `Iterator[dict[str, Any]]` (line 584-640 in api_client.py)
+
+Both methods already stream data line-by-line from Mixpanel's JSONL export endpoints without buffering the entire response in memory.
+
+**Decision**: Reuse these existing iterators. No modifications needed to the API client.
+
+**Alternatives Considered**:
+- Create new streaming-specific API methods: Rejected (would duplicate logic)
+- Modify FetcherService to optionally skip storage: Rejected (muddies service responsibility)
+
+---
+
+### 2. Transformation Function Reusability
+
+**Question**: Can we reuse existing transformation functions outside FetcherService?
+
+**Finding**: Yes. The transformation functions are module-level functions in `fetcher.py`:
+- `_transform_event(event: dict[str, Any]) -> dict[str, Any]` (line 24-57)
+- `_transform_profile(profile: dict[str, Any]) -> dict[str, Any]` (line 60-81)
+
+These are pure functions with no side effects or dependencies on FetcherService state.
+
+**Decision**: Import and reuse these functions directly in Workspace streaming methods.
+
+**Alternatives Considered**:
+- Move functions to a shared module: Not needed (import from fetcher.py works fine)
+- Duplicate transformation logic: Rejected (DRY violation)
+
+---
+
+### 3. CLI Output to Stdout
+
+**Question**: How should CLI handle JSONL output while keeping progress on stderr?
+
+**Finding**: The existing CLI uses:
+- `rich.console.Console()` for stdout (via `console` in utils.py)
+- `rich.console.Console(stderr=True)` for errors (via `err_console` in utils.py)
+
+For streaming, we need raw JSON output (not Rich-formatted) to stdout.
+
+**Decision**: Use `print()` or `sys.stdout.write()` for JSONL data output. Use `err_console` for progress/status. This aligns with Constitution Principle II (Agent-Native Design) and VI (Unix Philosophy).
+
+**Alternatives Considered**:
+- Use Rich console for JSONL: Rejected (adds formatting, breaks piping)
+- Disable Rich entirely in streaming mode: Not needed (just bypass for data output)
+
+---
+
+### 4. Datetime Serialization in JSONL
+
+**Question**: How should datetime objects be serialized in JSONL output?
+
+**Finding**: Normalized events contain `event_time` as a Python `datetime` object. JSON doesn't support datetime natively.
+
+**Decision**: Use ISO 8601 format via `json.dumps(event, default=str)` which handles datetime automatically. This produces `"2024-01-01T12:00:00+00:00"` format.
+
+**Alternatives Considered**:
+- Unix timestamps: Rejected (less human-readable, harder to debug)
+- Custom JSON encoder: Overkill for this use case
+- Raw mode only: Rejected (normalized format is more useful for most users)
+
+---
+
+### 5. Optional Table Name Argument
+
+**Question**: How should Typer handle optional positional arguments when `--stdout` is set?
+
+**Finding**: Typer supports `Optional[str]` with default `None` for arguments. The table name can be made optional by changing:
+```python
+name: Annotated[str, typer.Argument(...)] = "events"
+```
+to:
+```python
+name: Annotated[str | None, typer.Argument(...)] = None
+```
+
+When `--stdout` is set and `name` is `None`, streaming proceeds without storage. When `--stdout` is not set and `name` is `None`, default to `"events"` or `"profiles"`.
+
+**Decision**: Make table name `Optional[str]` with logic:
+- If `--stdout`: ignore table name entirely
+- If not `--stdout` and name is None: use default ("events" or "profiles")
+- If not `--stdout` and name provided: use provided name
+
+**Alternatives Considered**:
+- Separate `mp stream` command: Rejected (more commands to learn, less discoverable)
+- Require table name always: Rejected (confusing when streaming)
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Iterator source | Reuse `MixpanelAPIClient` iterators | Already streaming, no buffering |
+| Transformation | Import from `fetcher.py` | DRY, pure functions |
+| JSONL output | `print()` to stdout | Clean for piping, no Rich formatting |
+| Datetime format | ISO 8601 via `default=str` | Human-readable, standard format |
+| Table name | Optional with `--stdout` | Natural UX, no forced argument |
+
+## No Outstanding Clarifications
+
+All technical questions resolved. Ready for Phase 1 design.

--- a/specs/011-streaming-api/spec.md
+++ b/specs/011-streaming-api/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Streaming API
+
+**Feature Branch**: `011-streaming-api`
+**Created**: 2024-12-24
+**Status**: Draft
+**Input**: User description: "Add streaming API capability to bypass database and return raw data directly from Mixpanel API, enabling the library and CLI to function as a pure SDK for the Mixpanel HTTP API without local storage."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stream Events for ETL Pipeline (Priority: P1)
+
+A data engineer needs to export Mixpanel events to their data warehouse without creating local files. They want to iterate through events one-by-one and send each to their ingestion pipeline, processing millions of events without exhausting memory.
+
+**Why this priority**: This is the core use case—enabling the library to function as a pure API SDK for data pipelines, which is currently impossible since all fetches require database storage.
+
+**Independent Test**: Can be fully tested by calling the streaming method and iterating over results while verifying no database files are created. Delivers immediate value for ETL workflows.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid credentials are configured, **When** user calls the event streaming method with a date range, **Then** events are yielded one at a time without creating any database files
+2. **Given** a streaming operation is in progress, **When** 1 million events are processed, **Then** memory usage remains constant (not proportional to dataset size)
+3. **Given** valid credentials, **When** user streams events with event name filters, **Then** only matching events are returned
+4. **Given** valid credentials, **When** user streams events with a WHERE filter, **Then** only events matching the filter expression are returned
+
+---
+
+### User Story 2 - CLI Export to Standard Output (Priority: P1)
+
+A developer wants to export Mixpanel data and pipe it to other command-line tools (jq, grep, custom scripts) or redirect to a file. They need the CLI to output data to stdout in a format suitable for streaming.
+
+**Why this priority**: CLI streaming is essential for Unix-style workflows and automation scripts. It enables integration with the broader command-line ecosystem.
+
+**Independent Test**: Can be fully tested by running the CLI with streaming output and piping to standard tools like `jq` or redirecting to a file. Delivers value for automation and scripting.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid credentials, **When** user runs the fetch command with stdout mode, **Then** events are output line-by-line to stdout
+2. **Given** stdout mode is enabled, **When** output is piped to another tool, **Then** each line is valid JSON that can be parsed independently
+3. **Given** stdout mode is enabled, **When** user redirects output to a file, **Then** the resulting file contains one JSON object per line
+4. **Given** stdout mode is enabled, **When** no table name is provided, **Then** the operation succeeds (table name is not required for streaming)
+
+---
+
+### User Story 3 - Stream User Profiles (Priority: P2)
+
+A data analyst needs to export user profiles for processing in an external system. Similar to events, they want to stream profiles without local storage.
+
+**Why this priority**: Profiles are the second major data type in Mixpanel. Enabling streaming for both events and profiles provides complete coverage.
+
+**Independent Test**: Can be fully tested by calling the profile streaming method and verifying profiles are returned without database files. Delivers value for user data export workflows.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid credentials, **When** user calls the profile streaming method, **Then** profiles are yielded one at a time without creating any database files
+2. **Given** valid credentials, **When** user streams profiles with a WHERE filter, **Then** only profiles matching the filter expression are returned
+3. **Given** a project with many profiles, **When** user streams all profiles, **Then** memory usage remains constant regardless of profile count
+
+---
+
+### User Story 4 - Choose Output Format (Priority: P2)
+
+A developer integrating with a legacy system needs events in Mixpanel's exact API format. Another developer wants the normalized format that matches stored data. Both should be supported.
+
+**Why this priority**: Format flexibility enables integration with diverse downstream systems. The normalized format provides consistency with stored data while raw format enables direct API pass-through.
+
+**Independent Test**: Can be fully tested by streaming with each format option and verifying the output structure matches expectations. Delivers value for integration flexibility.
+
+**Acceptance Scenarios**:
+
+1. **Given** default settings, **When** user streams events, **Then** events are returned in normalized format with extracted standard fields and converted timestamps
+2. **Given** raw format is requested, **When** user streams events, **Then** events are returned in exact Mixpanel API format with nested properties
+3. **Given** default settings, **When** user streams profiles, **Then** profiles are returned in normalized format
+4. **Given** raw format is requested, **When** user streams profiles, **Then** profiles are returned in exact Mixpanel API format with `$distinct_id` and `$properties` keys
+
+---
+
+### Edge Cases
+
+- What happens when streaming is interrupted mid-operation? The iterator stops yielding; already-processed records are not lost since they were consumed in real-time
+- How does system handle rate limiting during streaming? Same as fetch operations—automatic retry with backoff (transparent to user)
+- What happens when credentials are invalid? Authentication error is raised immediately, before any data is yielded
+- What happens when the date range returns zero events? The iterator completes immediately with no items yielded (not an error)
+- How does CLI streaming handle progress display? Progress goes to stderr so stdout remains clean for piping
+- What happens when stdout mode is combined with a table name argument? The table name is ignored when streaming to stdout
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Library Streaming Methods:**
+
+- **FR-001**: System MUST provide a method to stream events directly from the API without storing locally
+- **FR-002**: System MUST provide a method to stream profiles directly from the API without storing locally
+- **FR-003**: Streaming methods MUST accept the same filter parameters as fetch methods (date range, event names, WHERE clause)
+- **FR-004**: Streaming methods MUST yield records one at a time (not buffer the entire response)
+- **FR-005**: Streaming methods MUST NOT create any database files or tables
+- **FR-006**: Streaming methods MUST support two output formats: normalized (default) and raw API format
+- **FR-007**: Normalized format MUST match the structure of data stored by fetch methods
+- **FR-008**: Raw format MUST return data exactly as received from the Mixpanel API
+
+**CLI Streaming Support:**
+
+- **FR-009**: CLI fetch commands MUST support an option to output to stdout instead of storing
+- **FR-010**: CLI stdout mode MUST output one JSON object per line (JSONL format)
+- **FR-011**: CLI stdout mode MUST make the table name argument optional
+- **FR-012**: CLI MUST support selecting between normalized and raw output formats
+- **FR-013**: CLI MUST send progress information to stderr when stdout mode is enabled
+
+**Error Handling:**
+
+- **FR-014**: Streaming MUST handle authentication errors by raising an error before yielding any data
+- **FR-015**: Streaming MUST handle rate limiting transparently with automatic retry
+- **FR-016**: Streaming MUST handle network errors consistently with fetch operations
+
+**Backward Compatibility:**
+
+- **FR-017**: All existing fetch functionality MUST remain unchanged
+- **FR-018**: Default behavior of fetch commands (without stdout flag) MUST continue to store data
+
+### Key Entities
+
+- **Streamed Event**: A single event record from Mixpanel, either in normalized format (event_name, event_time, distinct_id, insert_id, properties) or raw API format (event, properties with embedded fields)
+- **Streamed Profile**: A single user profile record from Mixpanel, either in normalized format (distinct_id, last_seen, properties) or raw API format ($distinct_id, $properties)
+- **JSONL Output**: A text stream where each line is a complete, valid JSON object representing one record
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can process 1 million events with constant memory usage (no growth proportional to dataset size)
+- **SC-002**: Streaming operation completes without any database files being created on disk
+- **SC-003**: CLI output can be successfully piped to `jq` and parsed without errors
+- **SC-004**: 100% of filter parameters available in fetch methods work identically in streaming methods
+- **SC-005**: Existing fetch operations continue to work without any changes to user code
+- **SC-006**: Users can switch between fetch (store) and stream modes using the same credential configuration
+- **SC-007**: Both normalized and raw output formats produce valid, parseable data structures
+
+## Assumptions
+
+- The underlying API client already supports streaming responses (iterators) without buffering
+- Transformation functions for normalizing event/profile data are already implemented and reusable
+- Rate limiting and retry logic from fetch operations can be reused for streaming
+- CLI framework supports sending output to stdout while keeping progress on stderr
+- JSONL is an acceptable output format for CLI streaming (no request for CSV, XML, or other formats)

--- a/specs/011-streaming-api/tasks.md
+++ b/specs/011-streaming-api/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: Streaming API
+
+**Input**: Design documents from `/specs/011-streaming-api/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included per project quality gates (Constitution: mypy, ruff, pytest)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify project is ready for streaming API implementation
+
+- [X] T001 Verify existing workspace.py has _require_api_client() method available
+- [X] T002 Verify _transform_event and _transform_profile functions are importable from src/mixpanel_data/_internal/services/fetcher.py
+
+**Checkpoint**: Dependencies verified - implementation can begin
+
+---
+
+## Phase 2: Foundational (None Required)
+
+**Purpose**: No foundational work needed - streaming is a surgical addition to existing infrastructure
+
+**Note**: This feature adds to an existing, complete codebase. The API client iterators (`export_events`, `export_profiles`) and transformation functions (`_transform_event`, `_transform_profile`) already exist.
+
+**Checkpoint**: Foundation ready - user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 - Stream Events for ETL Pipeline (Priority: P1) 🎯 MVP
+
+**Goal**: Enable data engineers to stream events directly from Mixpanel API without local storage
+
+**Independent Test**: Call `ws.stream_events(from_date="...", to_date="...")` and iterate over results. Verify events are yielded and no database files are created.
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Implement stream_events() method in src/mixpanel_data/workspace.py with signature: `stream_events(*, from_date: str, to_date: str, events: list[str] | None = None, where: str | None = None, raw: bool = False) -> Iterator[dict[str, Any]]`
+- [X] T004 [US1] Add docstring with Args, Yields, Raises, and Example sections per contract in contracts/workspace-streaming.md
+- [X] T005 [US1] Import _transform_event from fetcher.py and apply when raw=False
+- [X] T006 [US1] Write unit tests for stream_events() in tests/test_workspace_streaming.py covering: basic streaming, event name filter, where filter, raw=True, raw=False
+
+**Checkpoint**: User Story 1 complete - stream_events() works independently with both normalized and raw output
+
+---
+
+## Phase 4: User Story 3 - Stream User Profiles (Priority: P2)
+
+**Goal**: Enable streaming of user profiles without local storage
+
+**Independent Test**: Call `ws.stream_profiles()` and iterate over results. Verify profiles are yielded and no database files are created.
+
+**Note**: Can be implemented in parallel with User Story 1 (different method, no dependencies)
+
+### Implementation for User Story 3
+
+- [X] T007 [P] [US3] Implement stream_profiles() method in src/mixpanel_data/workspace.py with signature: `stream_profiles(*, where: str | None = None, raw: bool = False) -> Iterator[dict[str, Any]]`
+- [X] T008 [US3] Add docstring with Args, Yields, Raises, and Example sections per contract
+- [X] T009 [US3] Import _transform_profile from fetcher.py and apply when raw=False
+- [X] T010 [US3] Write unit tests for stream_profiles() in tests/test_workspace_streaming.py covering: basic streaming, where filter, raw=True, raw=False
+
+**Checkpoint**: User Story 3 complete - stream_profiles() works independently
+
+---
+
+## Phase 5: User Story 2 - CLI Export to Standard Output (Priority: P1)
+
+**Goal**: Enable CLI users to stream data to stdout for piping to other tools
+
+**Independent Test**: Run `mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout` and pipe to `jq`. Verify valid JSONL output.
+
+**Dependencies**: Requires stream_events() and stream_profiles() from US1 and US3
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Add --stdout option to fetch_events command in src/mixpanel_data/cli/commands/fetch.py
+- [X] T012 [US2] Add --raw option to fetch_events command (only valid with --stdout)
+- [X] T013 [US2] Make NAME argument optional when --stdout is set (use `typer.Argument(default=None)`)
+- [X] T014 [US2] Implement stdout streaming logic: iterate over ws.stream_events(), print each dict as JSON line using json.dumps with default=str for datetime serialization
+- [X] T015 [US2] Send progress to stderr using err_console when --stdout is set
+- [X] T016 [US2] Add --stdout and --raw options to fetch_profiles command in src/mixpanel_data/cli/commands/fetch.py
+- [X] T017 [US2] Implement stdout streaming logic for profiles: iterate over ws.stream_profiles(), print JSONL
+- [X] T018 [US2] Write CLI tests in tests/integration/cli/test_fetch_streaming.py covering: --stdout output is valid JSONL, --raw changes output format, progress goes to stderr
+
+**Checkpoint**: User Story 2 complete - CLI streaming works for both events and profiles
+
+---
+
+## Phase 6: User Story 4 - Choose Output Format (Priority: P2)
+
+**Goal**: Support both normalized and raw API formats for integration flexibility
+
+**Independent Test**: Stream with `raw=True` and verify output matches Mixpanel API format. Stream with `raw=False` (default) and verify normalized format.
+
+**Note**: Core implementation is complete in US1 and US3. This phase adds edge case testing and documentation.
+
+### Verification for User Story 4
+
+- [X] T019 [US4] Add test case verifying normalized event format matches data-model.md structure in tests/unit/test_workspace_streaming.py
+- [X] T020 [US4] Add test case verifying raw event format matches Mixpanel API structure (event + properties with time as Unix timestamp)
+- [X] T021 [US4] Add test case verifying normalized profile format matches data-model.md structure
+- [X] T022 [US4] Add test case verifying raw profile format matches Mixpanel API structure ($distinct_id + $properties)
+- [X] T023 [US4] Add CLI test verifying --raw flag produces raw format output
+
+**Checkpoint**: User Story 4 complete - both output formats verified
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality checks and validation
+
+- [X] T024 Run `ruff check src/mixpanel_data/workspace.py src/mixpanel_data/cli/commands/fetch.py`
+- [X] T025 Run `ruff format src/mixpanel_data/workspace.py src/mixpanel_data/cli/commands/fetch.py`
+- [X] T026 Run `mypy --strict src/mixpanel_data/workspace.py src/mixpanel_data/cli/commands/fetch.py`
+- [X] T027 Run full test suite with `pytest tests/`
+- [X] T028 Validate quickstart.md examples work as documented (via tests)
+- [X] T029 Verify backward compatibility: existing fetch commands still work without --stdout (via TestBackwardCompatibility)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1: Setup ──────────────────────────────┐
+                                             │
+Phase 2: Foundational (none needed) ─────────┤
+                                             ▼
+        ┌────────────────────────────────────┴───────────────────────────────┐
+        │                                                                    │
+        ▼                                                                    ▼
+Phase 3: US1 - stream_events()                           Phase 4: US3 - stream_profiles()
+        │                                                                    │
+        └────────────────────────┬───────────────────────────────────────────┘
+                                 ▼
+                    Phase 5: US2 - CLI --stdout/--raw
+                                 │
+                                 ▼
+                    Phase 6: US4 - Output Format Verification
+                                 │
+                                 ▼
+                    Phase 7: Polish
+```
+
+### User Story Dependencies
+
+| Story | Depends On | Can Parallel With |
+|-------|------------|-------------------|
+| US1 (stream_events) | Setup only | US3 |
+| US3 (stream_profiles) | Setup only | US1 |
+| US2 (CLI --stdout) | US1, US3 | - |
+| US4 (Output Format) | US1, US3, US2 | - |
+
+### Parallel Opportunities
+
+**Within Phase 3 & 4 (can run simultaneously):**
+- T003-T006 (US1: stream_events)
+- T007-T010 (US3: stream_profiles)
+
+**Within Phase 5:**
+- T011-T015 (events CLI) can partially parallel with T016-T017 (profiles CLI)
+
+---
+
+## Parallel Example: US1 and US3 Together
+
+```bash
+# These can run in parallel (different methods in same file):
+Task: "T003 Implement stream_events() method in src/mixpanel_data/workspace.py"
+Task: "T007 Implement stream_profiles() method in src/mixpanel_data/workspace.py"
+
+# Note: If same developer, do sequentially to avoid merge conflicts in workspace.py
+# If different developers, use feature branches and merge carefully
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 3: User Story 1 (T003-T006)
+3. **STOP and VALIDATE**: Test `ws.stream_events()` independently
+4. This alone enables ETL pipeline use case
+
+### Full Feature (All Stories)
+
+1. Complete Setup
+2. Implement US1 and US3 in parallel (library methods)
+3. Implement US2 (CLI depends on library)
+4. Verify US4 (output formats)
+5. Polish and validate
+
+### Estimated Scope
+
+| Phase | Tasks | Effort |
+|-------|-------|--------|
+| Setup | 2 | Minimal (verification only) |
+| US1 | 4 | ~30 lines of code + tests |
+| US3 | 4 | ~20 lines of code + tests |
+| US2 | 8 | ~50 lines of code + tests |
+| US4 | 5 | Tests only |
+| Polish | 6 | Validation |
+| **Total** | **29** | Small feature |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1 and US3 can be implemented in parallel by different developers
+- US2 (CLI) must wait for US1 and US3 to complete
+- US4 is verification of functionality built into US1-US3
+- Commit after each task or logical group
+- Run `just check` after each phase to verify quality gates

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -3,12 +3,17 @@
 This module provides commands for fetching data from Mixpanel:
 - events: Fetch events into local storage
 - profiles: Fetch user profiles into local storage
+
+Both commands support streaming to stdout with --stdout flag, which bypasses
+local storage and outputs JSONL directly for piping to other tools.
 """
 
 from __future__ import annotations
 
 import contextlib
-from typing import Annotated
+import json
+import sys
+from typing import Annotated, Any
 
 import typer
 
@@ -28,14 +33,22 @@ fetch_app = typer.Typer(
 )
 
 
+def _json_serializer(obj: Any) -> str:
+    """JSON serializer for objects not serializable by default json code."""
+    if hasattr(obj, "isoformat"):
+        result: str = obj.isoformat()
+        return result
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
 @fetch_app.command("events")
 @handle_errors
 def fetch_events(
     ctx: typer.Context,
     name: Annotated[
-        str,
-        typer.Argument(help="Table name for storing events."),
-    ] = "events",
+        str | None,
+        typer.Argument(help="Table name for storing events. Ignored with --stdout."),
+    ] = None,
     from_date: Annotated[
         str,
         typer.Option("--from", help="Start date (YYYY-MM-DD).", show_default=False),
@@ -60,6 +73,14 @@ def fetch_events(
         bool,
         typer.Option("--no-progress", help="Hide progress bar."),
     ] = False,
+    stdout: Annotated[
+        bool,
+        typer.Option("--stdout", help="Stream to stdout as JSONL instead of storing."),
+    ] = False,
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Output raw API format (only with --stdout)."),
+    ] = False,
     format: FormatOption = "json",
 ) -> None:
     """Fetch events from Mixpanel into local storage.
@@ -69,6 +90,8 @@ def fetch_events(
 
     Use --events to filter by event name (comma-separated list).
     Use --where for Mixpanel expression filters (e.g., 'properties["country"]=="US"').
+    Use --stdout to stream JSONL to stdout instead of storing locally.
+    Use --raw with --stdout to output raw Mixpanel API format.
 
     Output shows table name, row count, duration, and date range.
 
@@ -77,6 +100,8 @@ def fetch_events(
       mp fetch events signups --from 2025-01-01 --to 2025-01-31 --events "Sign Up"
       mp fetch events --from 2025-01-01 --to 2025-01-31 --where 'properties["country"]=="US"'
       mp fetch events --from 2025-01-01 --to 2025-01-31 --replace
+      mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout
+      mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout --raw | jq '.event'
     """
     # Validate required options
     if not from_date:
@@ -86,21 +111,50 @@ def fetch_events(
         err_console.print("[red]Error:[/red] --to is required")
         raise typer.Exit(3)
 
+    # Validate --raw only with --stdout
+    if raw and not stdout:
+        err_console.print("[red]Error:[/red] --raw requires --stdout")
+        raise typer.Exit(3)
+
     # Parse events filter
     events_list = [e.strip() for e in events.split(",")] if events else None
 
     workspace = get_workspace(ctx)
 
+    # Streaming mode: output JSONL to stdout
+    if stdout:
+        quiet = ctx.obj.get("quiet", False)
+        count = 0
+
+        for event in workspace.stream_events(
+            from_date=from_date,
+            to_date=to_date,
+            events=events_list,
+            where=where,
+            raw=raw,
+        ):
+            print(json.dumps(event, default=_json_serializer), file=sys.stdout)
+            count += 1
+            if not quiet and count % 1000 == 0:
+                err_console.print(f"Streaming events... {count} rows", highlight=False)
+
+        if not quiet:
+            err_console.print(f"Streamed {count} events", highlight=False)
+        return
+
+    # Storage mode: fetch into local database
+    table_name = name if name else "events"
+
     # Drop table if replace is set
     if replace:
         with contextlib.suppress(Exception):
-            workspace.drop(name)
+            workspace.drop(table_name)
 
     quiet = ctx.obj.get("quiet", False)
     show_progress = not quiet and not no_progress
 
     result = workspace.fetch_events(
-        name=name,
+        name=table_name,
         from_date=from_date,
         to_date=to_date,
         events=events_list,
@@ -116,9 +170,9 @@ def fetch_events(
 def fetch_profiles(
     ctx: typer.Context,
     name: Annotated[
-        str,
-        typer.Argument(help="Table name for storing profiles."),
-    ] = "profiles",
+        str | None,
+        typer.Argument(help="Table name for storing profiles. Ignored with --stdout."),
+    ] = None,
     where: Annotated[
         str | None,
         typer.Option("--where", "-w", help="Mixpanel filter expression."),
@@ -131,6 +185,14 @@ def fetch_profiles(
         bool,
         typer.Option("--no-progress", help="Hide progress bar."),
     ] = False,
+    stdout: Annotated[
+        bool,
+        typer.Option("--stdout", help="Stream to stdout as JSONL instead of storing."),
+    ] = False,
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Output raw API format (only with --stdout)."),
+    ] = False,
     format: FormatOption = "json",
 ) -> None:
     """Fetch user profiles from Mixpanel into local storage.
@@ -139,6 +201,8 @@ def fetch_profiles(
     shows fetch progress (disable with --no-progress or --quiet).
 
     Use --where for Mixpanel expression filters on profile properties.
+    Use --stdout to stream JSONL to stdout instead of storing locally.
+    Use --raw with --stdout to output raw Mixpanel API format.
 
     Output shows table name, row count, and fetch duration.
 
@@ -146,19 +210,46 @@ def fetch_profiles(
       mp fetch profiles
       mp fetch profiles users --replace
       mp fetch profiles --where 'properties["plan"]=="premium"'
+      mp fetch profiles --stdout
+      mp fetch profiles --stdout --raw
     """
+    # Validate --raw only with --stdout
+    if raw and not stdout:
+        err_console.print("[red]Error:[/red] --raw requires --stdout")
+        raise typer.Exit(3)
+
     workspace = get_workspace(ctx)
+
+    # Streaming mode: output JSONL to stdout
+    if stdout:
+        quiet = ctx.obj.get("quiet", False)
+        count = 0
+
+        for profile in workspace.stream_profiles(where=where, raw=raw):
+            print(json.dumps(profile, default=_json_serializer), file=sys.stdout)
+            count += 1
+            if not quiet and count % 1000 == 0:
+                err_console.print(
+                    f"Streaming profiles... {count} rows", highlight=False
+                )
+
+        if not quiet:
+            err_console.print(f"Streamed {count} profiles", highlight=False)
+        return
+
+    # Storage mode: fetch into local database
+    table_name = name if name else "profiles"
 
     # Drop table if replace is set
     if replace:
         with contextlib.suppress(Exception):
-            workspace.drop(name)
+            workspace.drop(table_name)
 
     quiet = ctx.obj.get("quiet", False)
     show_progress = not quiet and not no_progress
 
     result = workspace.fetch_profiles(
-        name=name,
+        name=table_name,
         where=where,
         progress=show_progress,
     )

--- a/tests/integration/cli/test_fetch_streaming.py
+++ b/tests/integration/cli/test_fetch_streaming.py
@@ -1,0 +1,551 @@
+"""Unit tests for CLI fetch streaming commands (--stdout, --raw)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import app
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing commands."""
+    return CliRunner()
+
+
+def raw_event(
+    name: str = "PageView",
+    distinct_id: str = "user_123",
+    timestamp: int = 1705328400,
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a raw event in Mixpanel API format."""
+    props = {
+        "distinct_id": distinct_id,
+        "time": timestamp,
+        "$insert_id": f"evt_{timestamp}",
+        **extra_props,
+    }
+    return {"event": name, "properties": props}
+
+
+def normalized_event(
+    name: str = "PageView",
+    distinct_id: str = "user_123",
+    timestamp: datetime | None = None,
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a normalized event."""
+    if timestamp is None:
+        timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+    return {
+        "event_name": name,
+        "distinct_id": distinct_id,
+        "event_time": timestamp,
+        "insert_id": f"evt_{int(timestamp.timestamp())}",
+        "properties": extra_props,
+    }
+
+
+def raw_profile(
+    distinct_id: str = "user_123",
+    last_seen: str | None = "2024-01-15T14:30:00",
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a raw profile in Mixpanel API format."""
+    props = {**extra_props}
+    if last_seen:
+        props["$last_seen"] = last_seen
+    return {"$distinct_id": distinct_id, "$properties": props}
+
+
+def normalized_profile(
+    distinct_id: str = "user_123",
+    last_seen: str | None = "2024-01-15T14:30:00",
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a normalized profile."""
+    return {
+        "distinct_id": distinct_id,
+        "last_seen": last_seen,
+        "properties": extra_props,
+    }
+
+
+# =============================================================================
+# Phase 5: User Story 2 - CLI Stream Events Tests (T011-T015)
+# =============================================================================
+
+
+class TestFetchEventsStdout:
+    """Tests for mp fetch events --stdout command."""
+
+    def test_stdout_outputs_jsonl(self, cli_runner: CliRunner) -> None:
+        """T018: Test --stdout output is valid JSONL."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter(
+            [
+                normalized_event("PageView", "user_1", page="/home"),
+                normalized_event("Click", "user_2", button="signup"),
+            ]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--stdout",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # Parse each line as JSON
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert len(lines) == 2
+
+        for line in lines:
+            parsed = json.loads(line)
+            assert "event_name" in parsed
+            assert "distinct_id" in parsed
+
+    def test_stdout_with_raw_flag(self, cli_runner: CliRunner) -> None:
+        """T018: Test --raw changes output format."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter(
+            [raw_event("PageView", "user_1", 1705328400, page="/home")]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--stdout",
+                    "--raw",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # Parse output
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert len(lines) == 1
+
+        parsed = json.loads(lines[0])
+        # Raw format has "event" key, not "event_name"
+        assert "event" in parsed
+        assert "properties" in parsed
+        assert parsed["properties"]["time"] == 1705328400
+
+        # Verify stream_events was called with raw=True
+        mock_workspace.stream_events.assert_called_once()
+        call_kwargs = mock_workspace.stream_events.call_args[1]
+        assert call_kwargs["raw"] is True
+
+    def test_raw_without_stdout_fails(self, cli_runner: CliRunner) -> None:
+        """T012: Test --raw without --stdout returns error."""
+        result = cli_runner.invoke(
+            app,
+            ["fetch", "events", "--from", "2024-01-01", "--to", "2024-01-31", "--raw"],
+        )
+
+        assert result.exit_code == 3
+        assert (
+            "--raw requires --stdout" in result.stderr
+            or "--raw requires --stdout" in result.output
+        )
+
+    def test_stdout_ignores_table_name(self, cli_runner: CliRunner) -> None:
+        """T013: Test table name is ignored when --stdout is set."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter([])
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "my_table_name",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--stdout",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        # stream_events should be called, not fetch_events
+        mock_workspace.stream_events.assert_called_once()
+        mock_workspace.fetch_events.assert_not_called()
+
+    def test_stdout_progress_to_stderr(self, cli_runner: CliRunner) -> None:
+        """T015: Test progress goes to stderr when --stdout is set."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter(
+            [normalized_event("Event", f"user_{i}") for i in range(5)]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            # Run without -q to get progress output
+            result = cli_runner.invoke(
+                app,
+                [
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--stdout",
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # stdout should only have JSONL (5 lines)
+        stdout_lines = [
+            line for line in result.stdout.strip().split("\n") if line.startswith("{")
+        ]
+        assert len(stdout_lines) == 5
+
+    def test_stdout_with_event_filter(self, cli_runner: CliRunner) -> None:
+        """Test --stdout with --events filter passes filter to stream_events."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter([])
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--events",
+                    "Purchase,Signup",
+                    "--stdout",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        mock_workspace.stream_events.assert_called_once()
+        call_kwargs = mock_workspace.stream_events.call_args[1]
+        assert call_kwargs["events"] == ["Purchase", "Signup"]
+
+    def test_stdout_with_where_filter(self, cli_runner: CliRunner) -> None:
+        """Test --stdout with --where filter passes filter to stream_events."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter([])
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--where",
+                    'properties["country"]=="US"',
+                    "--stdout",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        mock_workspace.stream_events.assert_called_once()
+        call_kwargs = mock_workspace.stream_events.call_args[1]
+        assert call_kwargs["where"] == 'properties["country"]=="US"'
+
+
+# =============================================================================
+# Phase 5: User Story 2 - CLI Stream Profiles Tests (T016-T017)
+# =============================================================================
+
+
+class TestFetchProfilesStdout:
+    """Tests for mp fetch profiles --stdout command."""
+
+    def test_stdout_outputs_jsonl(self, cli_runner: CliRunner) -> None:
+        """T018: Test --stdout output is valid JSONL for profiles."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_profiles.return_value = iter(
+            [
+                normalized_profile("user_1", name="Alice"),
+                normalized_profile("user_2", name="Bob"),
+            ]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                ["-q", "fetch", "profiles", "--stdout"],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # Parse each line as JSON
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert len(lines) == 2
+
+        for line in lines:
+            parsed = json.loads(line)
+            assert "distinct_id" in parsed
+            assert "properties" in parsed
+
+    def test_stdout_with_raw_flag(self, cli_runner: CliRunner) -> None:
+        """T018: Test --raw changes output format for profiles."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_profiles.return_value = iter(
+            [raw_profile("user_1", "2024-01-15T10:00:00", name="Alice")]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                ["-q", "fetch", "profiles", "--stdout", "--raw"],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # Parse output
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert len(lines) == 1
+
+        parsed = json.loads(lines[0])
+        # Raw format has "$distinct_id" key
+        assert "$distinct_id" in parsed
+        assert "$properties" in parsed
+
+        # Verify stream_profiles was called with raw=True
+        mock_workspace.stream_profiles.assert_called_once()
+        call_kwargs = mock_workspace.stream_profiles.call_args[1]
+        assert call_kwargs["raw"] is True
+
+    def test_raw_without_stdout_fails_profiles(self, cli_runner: CliRunner) -> None:
+        """Test --raw without --stdout returns error for profiles."""
+        result = cli_runner.invoke(
+            app,
+            ["fetch", "profiles", "--raw"],
+        )
+
+        assert result.exit_code == 3
+        assert (
+            "--raw requires --stdout" in result.stderr
+            or "--raw requires --stdout" in result.output
+        )
+
+    def test_stdout_with_where_filter(self, cli_runner: CliRunner) -> None:
+        """Test --stdout with --where filter for profiles."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_profiles.return_value = iter([])
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "profiles",
+                    "--where",
+                    'properties["plan"]=="premium"',
+                    "--stdout",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        mock_workspace.stream_profiles.assert_called_once()
+        call_kwargs = mock_workspace.stream_profiles.call_args[1]
+        assert call_kwargs["where"] == 'properties["plan"]=="premium"'
+
+
+# =============================================================================
+# Phase 6: User Story 4 - CLI Raw Format Verification (T023)
+# =============================================================================
+
+
+class TestCliRawFormat:
+    """T023: Tests verifying --raw flag produces raw format output."""
+
+    def test_events_raw_format_structure(self, cli_runner: CliRunner) -> None:
+        """Verify --raw produces Mixpanel API format for events."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_events.return_value = iter(
+            [
+                {
+                    "event": "Purchase",
+                    "properties": {
+                        "distinct_id": "user_abc",
+                        "time": 1705328400,
+                        "$insert_id": "evt_123",
+                        "amount": 99.99,
+                    },
+                }
+            ]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                [
+                    "-q",
+                    "fetch",
+                    "events",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--stdout",
+                    "--raw",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        parsed = json.loads(result.stdout.strip())
+
+        # Verify raw API structure
+        assert parsed["event"] == "Purchase"
+        assert parsed["properties"]["distinct_id"] == "user_abc"
+        assert parsed["properties"]["time"] == 1705328400
+        assert parsed["properties"]["$insert_id"] == "evt_123"
+
+    def test_profiles_raw_format_structure(self, cli_runner: CliRunner) -> None:
+        """Verify --raw produces Mixpanel API format for profiles."""
+        mock_workspace = MagicMock()
+        mock_workspace.stream_profiles.return_value = iter(
+            [
+                {
+                    "$distinct_id": "user_abc",
+                    "$properties": {
+                        "$last_seen": "2024-01-15T14:30:00",
+                        "name": "Alice",
+                        "plan": "premium",
+                    },
+                }
+            ]
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                ["-q", "fetch", "profiles", "--stdout", "--raw"],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        parsed = json.loads(result.stdout.strip())
+
+        # Verify raw API structure with $ prefixes
+        assert parsed["$distinct_id"] == "user_abc"
+        assert "$properties" in parsed
+        assert parsed["$properties"]["$last_seen"] == "2024-01-15T14:30:00"
+
+
+# =============================================================================
+# Backward Compatibility Tests (T029)
+# =============================================================================
+
+
+class TestBackwardCompatibility:
+    """T029: Tests verifying existing fetch commands still work without --stdout."""
+
+    def test_fetch_events_without_stdout_stores_locally(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Verify fetch events without --stdout uses fetch_events (storage mode)."""
+        mock_workspace = MagicMock()
+        mock_workspace.fetch_events.return_value = MagicMock(
+            to_dict=lambda: {
+                "table": "events",
+                "rows": 100,
+                "from_date": "2024-01-01",
+                "to_date": "2024-01-31",
+            }
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                ["-q", "fetch", "events", "--from", "2024-01-01", "--to", "2024-01-31"],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        # fetch_events should be called, not stream_events
+        mock_workspace.fetch_events.assert_called_once()
+        mock_workspace.stream_events.assert_not_called()
+
+    def test_fetch_profiles_without_stdout_stores_locally(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Verify fetch profiles without --stdout uses fetch_profiles (storage mode)."""
+        mock_workspace = MagicMock()
+        mock_workspace.fetch_profiles.return_value = MagicMock(
+            to_dict=lambda: {"table": "profiles", "rows": 50}
+        )
+
+        with patch("mixpanel_data.cli.commands.fetch.get_workspace") as mock_get_ws:
+            mock_get_ws.return_value = mock_workspace
+
+            result = cli_runner.invoke(
+                app,
+                ["-q", "fetch", "profiles"],
+            )
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        # fetch_profiles should be called, not stream_profiles
+        mock_workspace.fetch_profiles.assert_called_once()
+        mock_workspace.stream_profiles.assert_not_called()

--- a/tests/unit/test_workspace_streaming.py
+++ b/tests/unit/test_workspace_streaming.py
@@ -1,0 +1,662 @@
+"""Unit tests for Workspace streaming methods.
+
+Tests for stream_events() and stream_profiles() methods that
+stream data directly from Mixpanel API without local storage.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import ConfigError, Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data._internal.storage import StorageEngine
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_credentials() -> Credentials:
+    """Create mock credentials for testing."""
+    return Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id="12345",
+        region="us",
+    )
+
+
+@pytest.fixture
+def mock_config_manager(mock_credentials: Credentials) -> MagicMock:
+    """Create mock ConfigManager that returns credentials."""
+    manager = MagicMock(spec=ConfigManager)
+    manager.resolve_credentials.return_value = mock_credentials
+    return manager
+
+
+@pytest.fixture
+def mock_storage() -> StorageEngine:
+    """Create ephemeral storage for testing."""
+    return StorageEngine.ephemeral()
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create mock API client for testing."""
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+    client = MagicMock(spec=MixpanelAPIClient)
+    client.close = MagicMock()
+    return client
+
+
+@pytest.fixture
+def workspace_factory(
+    mock_config_manager: MagicMock,
+    mock_storage: StorageEngine,
+    mock_api_client: MagicMock,
+) -> Callable[..., Workspace]:
+    """Factory for creating Workspace instances with mocked dependencies."""
+
+    def factory(**kwargs: Any) -> Workspace:
+        defaults = {
+            "_config_manager": mock_config_manager,
+            "_storage": mock_storage,
+            "_api_client": mock_api_client,
+        }
+        defaults.update(kwargs)
+        return Workspace(**defaults)
+
+    return factory
+
+
+# =============================================================================
+# Sample Data
+# =============================================================================
+
+
+def raw_event(
+    name: str = "PageView",
+    distinct_id: str = "user_123",
+    timestamp: int = 1705328400,
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a raw event in Mixpanel API format."""
+    props = {
+        "distinct_id": distinct_id,
+        "time": timestamp,
+        "$insert_id": f"evt_{timestamp}",
+        **extra_props,
+    }
+    return {"event": name, "properties": props}
+
+
+def raw_profile(
+    distinct_id: str = "user_123",
+    last_seen: str | None = "2024-01-15T14:30:00",
+    **extra_props: Any,
+) -> dict[str, Any]:
+    """Create a raw profile in Mixpanel API format."""
+    props = {**extra_props}
+    if last_seen:
+        props["$last_seen"] = last_seen
+    return {"$distinct_id": distinct_id, "$properties": props}
+
+
+# =============================================================================
+# Phase 3: User Story 1 - Stream Events Tests (T003-T006)
+# =============================================================================
+
+
+class TestStreamEvents:
+    """Tests for stream_events() method."""
+
+    def test_stream_events_basic(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T006: Test basic streaming of events with default (normalized) format."""
+        ws = workspace_factory()
+        try:
+            # Set up mock to return raw events
+            mock_api_client.export_events.return_value = iter(
+                [
+                    raw_event("PageView", "user_1", 1705328400, page="/home"),
+                    raw_event("Click", "user_2", 1705328500, button="signup"),
+                ]
+            )
+
+            events = list(
+                ws.stream_events(from_date="2024-01-15", to_date="2024-01-15")
+            )
+
+            assert len(events) == 2
+
+            # Verify normalized format
+            assert events[0]["event_name"] == "PageView"
+            assert events[0]["distinct_id"] == "user_1"
+            assert isinstance(events[0]["event_time"], datetime)
+            assert events[0]["properties"]["page"] == "/home"
+
+            assert events[1]["event_name"] == "Click"
+            assert events[1]["distinct_id"] == "user_2"
+
+            # Verify API client was called correctly
+            mock_api_client.export_events.assert_called_once_with(
+                from_date="2024-01-15",
+                to_date="2024-01-15",
+                events=None,
+                where=None,
+            )
+        finally:
+            ws.close()
+
+    def test_stream_events_with_event_filter(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T006: Test streaming events with event name filter."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("Purchase", "user_1", 1705328400, amount=99.99)]
+            )
+
+            events = list(
+                ws.stream_events(
+                    from_date="2024-01-15",
+                    to_date="2024-01-15",
+                    events=["Purchase", "Signup"],
+                )
+            )
+
+            assert len(events) == 1
+            assert events[0]["event_name"] == "Purchase"
+
+            mock_api_client.export_events.assert_called_once_with(
+                from_date="2024-01-15",
+                to_date="2024-01-15",
+                events=["Purchase", "Signup"],
+                where=None,
+            )
+        finally:
+            ws.close()
+
+    def test_stream_events_with_where_filter(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T006: Test streaming events with WHERE filter."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("PageView", "user_1", 1705328400, country="US")]
+            )
+
+            where_clause = 'properties["country"]=="US"'
+            events = list(
+                ws.stream_events(
+                    from_date="2024-01-15",
+                    to_date="2024-01-15",
+                    where=where_clause,
+                )
+            )
+
+            assert len(events) == 1
+            assert events[0]["properties"]["country"] == "US"
+
+            mock_api_client.export_events.assert_called_once_with(
+                from_date="2024-01-15",
+                to_date="2024-01-15",
+                events=None,
+                where=where_clause,
+            )
+        finally:
+            ws.close()
+
+    def test_stream_events_raw_true(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T006: Test streaming events with raw=True returns Mixpanel API format."""
+        ws = workspace_factory()
+        try:
+            raw_events = [
+                raw_event("PageView", "user_1", 1705328400, page="/home"),
+                raw_event("Click", "user_2", 1705328500, button="signup"),
+            ]
+            mock_api_client.export_events.return_value = iter(raw_events)
+
+            events = list(
+                ws.stream_events(from_date="2024-01-15", to_date="2024-01-15", raw=True)
+            )
+
+            assert len(events) == 2
+
+            # Verify raw format (Mixpanel API structure)
+            assert events[0]["event"] == "PageView"
+            assert "properties" in events[0]
+            assert events[0]["properties"]["distinct_id"] == "user_1"
+            assert events[0]["properties"]["time"] == 1705328400  # Unix timestamp
+            assert events[0]["properties"]["$insert_id"] == "evt_1705328400"
+        finally:
+            ws.close()
+
+    def test_stream_events_raw_false_transforms(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T006: Test streaming events with raw=False (default) transforms data."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("Purchase", "user_123", 1705328400, amount=49.99)]
+            )
+
+            events = list(
+                ws.stream_events(
+                    from_date="2024-01-15", to_date="2024-01-15", raw=False
+                )
+            )
+
+            assert len(events) == 1
+            event = events[0]
+
+            # Verify normalized format
+            assert event["event_name"] == "Purchase"
+            assert event["distinct_id"] == "user_123"
+            assert isinstance(event["event_time"], datetime)
+            assert event["event_time"].tzinfo == UTC
+            assert event["insert_id"] == "evt_1705328400"
+
+            # Properties should NOT include distinct_id, time, $insert_id
+            assert "distinct_id" not in event["properties"]
+            assert "time" not in event["properties"]
+            assert "$insert_id" not in event["properties"]
+            assert event["properties"]["amount"] == 49.99
+        finally:
+            ws.close()
+
+    def test_stream_events_empty_result(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Test streaming events returns empty iterator when no events."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter([])
+
+            events = list(
+                ws.stream_events(from_date="2024-01-15", to_date="2024-01-15")
+            )
+
+            assert events == []
+        finally:
+            ws.close()
+
+    def test_stream_events_is_lazy_iterator(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Test stream_events returns a lazy iterator."""
+        ws = workspace_factory()
+        try:
+            call_count = 0
+
+            def mock_iterator() -> Any:
+                nonlocal call_count
+                for i in range(3):
+                    call_count += 1
+                    yield raw_event("Event", f"user_{i}", 1705328400 + i)
+
+            mock_api_client.export_events.return_value = mock_iterator()
+
+            # Get iterator but don't consume it
+            iterator = ws.stream_events(from_date="2024-01-15", to_date="2024-01-15")
+
+            # No events should have been yielded yet (lazy evaluation)
+            assert call_count == 0
+
+            # Consume first event
+            next(iterator)
+            assert call_count == 1
+
+            # Consume remaining
+            list(iterator)
+            assert call_count == 3
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# Phase 4: User Story 3 - Stream Profiles Tests (T007-T010)
+# =============================================================================
+
+
+class TestStreamProfiles:
+    """Tests for stream_profiles() method."""
+
+    def test_stream_profiles_basic(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T010: Test basic streaming of profiles with default (normalized) format."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter(
+                [
+                    raw_profile("user_1", "2024-01-15T10:00:00", name="Alice"),
+                    raw_profile("user_2", "2024-01-15T11:00:00", name="Bob"),
+                ]
+            )
+
+            profiles = list(ws.stream_profiles())
+
+            assert len(profiles) == 2
+
+            # Verify normalized format
+            assert profiles[0]["distinct_id"] == "user_1"
+            assert profiles[0]["last_seen"] == "2024-01-15T10:00:00"
+            assert profiles[0]["properties"]["name"] == "Alice"
+
+            assert profiles[1]["distinct_id"] == "user_2"
+            assert profiles[1]["properties"]["name"] == "Bob"
+
+            mock_api_client.export_profiles.assert_called_once_with(where=None)
+        finally:
+            ws.close()
+
+    def test_stream_profiles_with_where_filter(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T010: Test streaming profiles with WHERE filter."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter(
+                [raw_profile("user_1", plan="premium")]
+            )
+
+            where_clause = 'properties["plan"]=="premium"'
+            profiles = list(ws.stream_profiles(where=where_clause))
+
+            assert len(profiles) == 1
+            assert profiles[0]["properties"]["plan"] == "premium"
+
+            mock_api_client.export_profiles.assert_called_once_with(where=where_clause)
+        finally:
+            ws.close()
+
+    def test_stream_profiles_raw_true(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T010: Test streaming profiles with raw=True returns Mixpanel API format."""
+        ws = workspace_factory()
+        try:
+            raw_profiles = [
+                raw_profile("user_1", "2024-01-15T10:00:00", name="Alice"),
+                raw_profile("user_2", None, name="Bob"),
+            ]
+            mock_api_client.export_profiles.return_value = iter(raw_profiles)
+
+            profiles = list(ws.stream_profiles(raw=True))
+
+            assert len(profiles) == 2
+
+            # Verify raw format (Mixpanel API structure with $ prefixes)
+            assert profiles[0]["$distinct_id"] == "user_1"
+            assert "$properties" in profiles[0]
+            assert profiles[0]["$properties"]["$last_seen"] == "2024-01-15T10:00:00"
+            assert profiles[0]["$properties"]["name"] == "Alice"
+
+            # Second profile has no $last_seen
+            assert "$last_seen" not in profiles[1]["$properties"]
+        finally:
+            ws.close()
+
+    def test_stream_profiles_raw_false_transforms(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T010: Test streaming profiles with raw=False (default) transforms data."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter(
+                [
+                    raw_profile(
+                        "user_abc", "2024-01-15T14:30:00", email="test@example.com"
+                    )
+                ]
+            )
+
+            profiles = list(ws.stream_profiles(raw=False))
+
+            assert len(profiles) == 1
+            profile = profiles[0]
+
+            # Verify normalized format
+            assert profile["distinct_id"] == "user_abc"
+            assert profile["last_seen"] == "2024-01-15T14:30:00"
+            assert profile["properties"]["email"] == "test@example.com"
+
+            # Properties should NOT include $last_seen
+            assert "$last_seen" not in profile["properties"]
+        finally:
+            ws.close()
+
+    def test_stream_profiles_empty_result(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Test streaming profiles returns empty iterator when no profiles."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter([])
+
+            profiles = list(ws.stream_profiles())
+
+            assert profiles == []
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# ConfigError Tests (Query-Only Mode)
+# =============================================================================
+
+
+class TestStreamingConfigError:
+    """Tests for ConfigError when streaming without credentials."""
+
+    def test_stream_events_raises_config_error_in_query_only_mode(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """Test stream_events raises ConfigError when opened without credentials."""
+        # Create a database file
+        db_path = temp_dir / "test.db"
+        storage = StorageEngine(path=db_path)
+        storage.close()
+
+        ws = Workspace.open(db_path)
+        try:
+            with pytest.raises(ConfigError) as exc_info:
+                list(ws.stream_events(from_date="2024-01-01", to_date="2024-01-31"))
+
+            assert "API access requires credentials" in str(exc_info.value)
+        finally:
+            ws.close()
+
+    def test_stream_profiles_raises_config_error_in_query_only_mode(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """Test stream_profiles raises ConfigError when opened without credentials."""
+        # Create a database file
+        db_path = temp_dir / "test.db"
+        storage = StorageEngine(path=db_path)
+        storage.close()
+
+        ws = Workspace.open(db_path)
+        try:
+            with pytest.raises(ConfigError) as exc_info:
+                list(ws.stream_profiles())
+
+            assert "API access requires credentials" in str(exc_info.value)
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# Phase 6: User Story 4 - Output Format Verification Tests (T019-T022)
+# =============================================================================
+
+
+class TestNormalizedEventFormat:
+    """T019: Tests verifying normalized event format matches data-model.md."""
+
+    def test_normalized_event_has_required_fields(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Verify normalized events have all required fields from data-model.md."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("Purchase", "user_abc123", 1705328400, amount=99.99)]
+            )
+
+            events = list(
+                ws.stream_events(from_date="2024-01-15", to_date="2024-01-15")
+            )
+
+            event = events[0]
+            # Required fields per data-model.md
+            assert "event_name" in event
+            assert "event_time" in event
+            assert "distinct_id" in event
+            assert "insert_id" in event
+            assert "properties" in event
+
+            # Type checks
+            assert isinstance(event["event_name"], str)
+            assert isinstance(event["event_time"], datetime)
+            assert isinstance(event["distinct_id"], str)
+            assert isinstance(event["insert_id"], str)
+            assert isinstance(event["properties"], dict)
+        finally:
+            ws.close()
+
+
+class TestRawEventFormat:
+    """T020: Tests verifying raw event format matches Mixpanel API structure."""
+
+    def test_raw_event_has_api_structure(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Verify raw events have Mixpanel API structure with Unix timestamp."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("Purchase", "user_abc123", 1705328400, amount=99.99)]
+            )
+
+            events = list(
+                ws.stream_events(from_date="2024-01-15", to_date="2024-01-15", raw=True)
+            )
+
+            event = events[0]
+            # Raw format per data-model.md
+            assert "event" in event
+            assert "properties" in event
+            assert event["properties"]["time"] == 1705328400  # Unix timestamp
+            assert event["properties"]["distinct_id"] == "user_abc123"
+            assert "$insert_id" in event["properties"]
+        finally:
+            ws.close()
+
+
+class TestNormalizedProfileFormat:
+    """T021: Tests verifying normalized profile format matches data-model.md."""
+
+    def test_normalized_profile_has_required_fields(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Verify normalized profiles have all required fields from data-model.md."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter(
+                [raw_profile("user_abc123", "2024-01-15T14:30:00", name="Alice")]
+            )
+
+            profiles = list(ws.stream_profiles())
+
+            profile = profiles[0]
+            # Required fields per data-model.md
+            assert "distinct_id" in profile
+            assert "last_seen" in profile
+            assert "properties" in profile
+
+            # Type checks
+            assert isinstance(profile["distinct_id"], str)
+            assert isinstance(profile["last_seen"], str | type(None))
+            assert isinstance(profile["properties"], dict)
+        finally:
+            ws.close()
+
+
+class TestRawProfileFormat:
+    """T022: Tests verifying raw profile format matches Mixpanel API structure."""
+
+    def test_raw_profile_has_api_structure(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Verify raw profiles have Mixpanel API structure with $ prefixes."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_profiles.return_value = iter(
+                [raw_profile("user_abc123", "2024-01-15T14:30:00", name="Alice")]
+            )
+
+            profiles = list(ws.stream_profiles(raw=True))
+
+            profile = profiles[0]
+            # Raw format per data-model.md
+            assert "$distinct_id" in profile
+            assert "$properties" in profile
+            assert profile["$distinct_id"] == "user_abc123"
+            assert profile["$properties"]["$last_seen"] == "2024-01-15T14:30:00"
+        finally:
+            ws.close()


### PR DESCRIPTION
## Summary

- Add `stream_events()` and `stream_profiles()` methods to Workspace for direct data streaming without local storage
- Add `--stdout` and `--raw` CLI flags for Unix pipeline integration
- Comprehensive documentation across README, user guide, and API reference

## Features

### Python API
- `stream_events(from_date, to_date, events, where, raw)` → `Iterator[dict]`
- `stream_profiles(where, raw)` → `Iterator[dict]`
- Supports normalized (default) and raw Mixpanel API formats

### CLI
- `mp fetch events --stdout`: Stream events as JSONL
- `mp fetch profiles --stdout`: Stream profiles as JSONL  
- `--raw` flag for raw Mixpanel API format

### Use Cases
- ETL pipelines to external systems
- One-time processing without disk usage
- Memory-constrained environments
- Unix pipeline integration (jq, grep, etc.)

## Test Plan

- [x] Unit tests for `stream_events()` and `stream_profiles()` (18 tests)
- [x] Integration tests for CLI `--stdout` and `--raw` flags (15 tests)
- [x] Backward compatibility tests for existing fetch commands
- [x] All quality gates pass: ruff, mypy --strict, pytest (751 passed)

## Documentation

- New streaming guide: `docs/guide/streaming.md`
- Updated: README, quickstart, CLI reference, API reference, architecture docs