### PR TITLE
feat: add public request() method for arbitrary API calls

### DIFF
--- a/docs/guide/live-analytics.md
+++ b/docs/guide/live-analytics.md
@@ -392,6 +392,45 @@ result = ws.segmentation_average(
 # Average purchase amount per time period
 ```
 
+## API Escape Hatch
+
+For Mixpanel APIs not covered by the Workspace class, use the `api` property to make authenticated requests directly:
+
+=== "Python"
+
+    ```python
+    import mixpanel_data as mp
+    from urllib.parse import quote
+
+    ws = mp.Workspace()
+    client = ws.api
+
+    # Example: Fetch event schema from the Lexicon Schemas API
+    # Many Mixpanel APIs require the project ID in the URL path
+    event_name = quote("Added To Cart", safe="")
+    url = f"https://mixpanel.com/api/app/projects/{client.project_id}/schemas/event/{event_name}"
+
+    schema = client.request("GET", url)
+    print(schema)
+    ```
+
+### Request Parameters
+
+```python
+client.request(
+    "POST",
+    "https://mixpanel.com/api/some/endpoint",
+    params={"key": "value"},           # Query parameters
+    json_body={"data": "payload"},     # JSON request body
+    headers={"X-Custom": "header"},    # Additional headers
+    timeout=60.0                       # Request timeout in seconds
+)
+```
+
+Authentication is handled automatically — the client adds the proper `Authorization` header to all requests.
+
+The client also exposes `project_id` and `region` properties, which are useful when constructing URLs for APIs that require these values in the path.
+
 ## Next Steps
 
 - [Data Discovery](discovery.md) — Explore your event schema

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1383,12 +1383,36 @@ class Workspace:
     def api(self) -> MixpanelAPIClient:
         """Direct access to the Mixpanel API client.
 
-        Use this for API operations not covered by the Workspace API.
+        Use this escape hatch for Mixpanel API operations not covered by the
+        Workspace class. The client handles authentication automatically.
+
+        The client provides:
+            - ``request(method, url, **kwargs)``: Make authenticated requests
+              to any Mixpanel API endpoint.
+            - ``project_id``: The configured project ID for constructing URLs.
+            - ``region``: The configured region ('us', 'eu', or 'in').
 
         Returns:
             The underlying MixpanelAPIClient.
 
         Raises:
             ConfigError: If API credentials not available.
+
+        Example:
+            Fetch event schema from the Lexicon Schemas API::
+
+                import mixpanel_data as mp
+                from urllib.parse import quote
+
+                ws = mp.Workspace()
+                client = ws.api
+
+                # Build the URL with proper encoding
+                event_name = quote("Added To Cart", safe="")
+                url = f"https://mixpanel.com/api/app/projects/{client.project_id}/schemas/event/{event_name}"
+
+                # Make the authenticated request
+                schema = client.request("GET", url)
+                print(schema)
         """
         return self._require_api_client()


### PR DESCRIPTION
## Summary

- Add `request(method, url, **kwargs)` method to `MixpanelAPIClient` as an escape hatch for calling Mixpanel APIs not covered by the Workspace class
- Add `project_id` and `region` properties for convenient URL construction
- Refactor internal request methods to eliminate code duplication via `_execute_with_retry()`
- Document usage in `Workspace.api` docstring and live-analytics guide

## Motivation

Users need a way to call new, undocumented, or specialized Mixpanel APIs (like the Lexicon Schemas API) without waiting for library updates. The `api` property now provides a clean escape hatch with automatic authentication handling.

## Example Usage

```python
import mixpanel_data as mp
from urllib.parse import quote

ws = mp.Workspace()
client = ws.api

# Fetch event schema from the Lexicon Schemas API
event_name = quote("Added To Cart", safe="")
url = f"https://mixpanel.com/api/app/projects/{client.project_id}/schemas/event/{event_name}"

schema = client.request("GET", url)
```

## Test plan

- [x] Unit tests for `request()` method (auth, params, JSON body, custom headers, error handling, rate limiting)
- [x] Unit tests for `project_id` and `region` properties
- [x] All existing tests pass (791 tests)
- [x] Type checking passes (`mypy --strict`)
- [x] Linting passes (`ruff check`)