### PR TITLE
feat: add DuckDB concurrent access handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.14.10
     hooks:
       - id: ruff
         args: [--fix]

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -17,7 +17,8 @@ MixpanelDataError
 │   └── JQLSyntaxError
 ├── TableExistsError
 ├── TableNotFoundError
-└── DatabaseLockedError
+├── DatabaseLockedError
+└── DatabaseNotFoundError
 ```
 
 ## Catching Errors
@@ -105,6 +106,11 @@ except mp.MixpanelDataError as e:
       show_root_toc_entry: true
 
 ::: mixpanel_data.DatabaseLockedError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.DatabaseNotFoundError
     options:
       show_root_heading: true
       show_root_toc_entry: true

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -16,7 +16,8 @@ MixpanelDataError
 │   ├── ServerError
 │   └── JQLSyntaxError
 ├── TableExistsError
-└── TableNotFoundError
+├── TableNotFoundError
+└── DatabaseLockedError
 ```
 
 ## Catching Errors
@@ -99,6 +100,11 @@ except mp.MixpanelDataError as e:
       show_root_toc_entry: true
 
 ::: mixpanel_data.TableNotFoundError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.DatabaseLockedError
     options:
       show_root_heading: true
       show_root_toc_entry: true

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -61,6 +61,17 @@ Database locked: /home/user/.mp/data/12345.db
 Another mp command may be running. Try again shortly.
 ```
 
+## Database Not Found
+
+When opening a database in read-only mode, the file must already exist. If you run a read command (like `mp query` or `mp inspect tables`) before fetching any data, you'll get a `DatabaseNotFoundError`:
+
+```
+No data yet: /home/user/.mp/data/12345.db
+Run 'mp fetch events' or 'mp fetch profiles' to create the database.
+```
+
+This is different from write mode, which creates the database file automatically.
+
 ### Common Causes
 
 1. **Long-running fetch** — Large date ranges take time; other commands must wait

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -49,7 +49,7 @@ This differs from client-server databases (PostgreSQL, MySQL) where a server pro
 | One `mp fetch` command | Works normally |
 | Two `mp fetch` commands to same database | Second command gets `DatabaseLockedError` |
 | `mp fetch` + `mp query` to same database | Query command gets `DatabaseLockedError` |
-| Two `mp query` commands to same database | Both work (concurrent reads allowed) |
+| Two `mp query` commands to same database | Both work (when no write lock is held) |
 | Two `mp inspect` commands (API-only) | Both work (no database access) |
 
 ## Lock Conflicts

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,0 +1,180 @@
+# Storage Engine
+
+How mixpanel_data uses DuckDB for local data storage.
+
+## Overview
+
+The `StorageEngine` class wraps DuckDB to provide persistent local storage for fetched Mixpanel data. Understanding DuckDB's concurrency model helps avoid conflicts when running multiple `mp` commands.
+
+## Storage Modes
+
+Three storage modes are available:
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| **Persistent** | Database file on disk (default) | Production use, data preservation |
+| **Ephemeral** | Temp file deleted on close | Testing, one-off analysis |
+| **In-Memory** | No file, RAM only | Quick scripts, no persistence needed |
+
+### Mode Selection
+
+```python
+# Persistent (default) - stored at ~/.mp/data/{project_id}.db
+ws = Workspace()
+
+# Custom path
+ws = Workspace(path="/path/to/my.db")
+
+# Ephemeral - temp file, deleted on close
+ws = Workspace(ephemeral=True)
+
+# In-memory - no file at all
+ws = Workspace(in_memory=True)
+```
+
+## DuckDB Concurrency Model
+
+DuckDB uses a **single-writer, multiple-reader** concurrency model:
+
+- **One write connection** can be active at a time per database file
+- **Multiple read connections** can coexist with each other
+- Read and write connections **cannot coexist** on the same file
+
+This differs from client-server databases (PostgreSQL, MySQL) where a server process mediates all access.
+
+### What This Means in Practice
+
+| Scenario | Result |
+|----------|--------|
+| One `mp fetch` command | Works normally |
+| Two `mp fetch` commands to same database | Second command gets `DatabaseLockedError` |
+| `mp fetch` + `mp query` to same database | Query command gets `DatabaseLockedError` |
+| Two `mp query` commands to same database | Both work (concurrent reads allowed) |
+| Two `mp inspect` commands (API-only) | Both work (no database access) |
+
+## Lock Conflicts
+
+When a second process tries to open a database that's already locked for writing, DuckDB raises an error. mixpanel_data catches this and raises a `DatabaseLockedError`:
+
+```
+Database locked: /home/user/.mp/data/12345.db
+Another mp command may be running. Try again shortly.
+```
+
+### Common Causes
+
+1. **Long-running fetch** — Large date ranges take time; other commands must wait
+2. **Background processes** — A previous command didn't exit cleanly
+3. **Multiple terminals** — Different shells running concurrent `mp` commands
+
+### Resolution
+
+1. **Wait** — Let the first operation complete
+2. **Check for stuck processes** — `ps aux | grep mp` to find orphaned commands
+3. **Use separate databases** — Specify different `--path` for concurrent work
+
+## Lazy Storage Initialization
+
+To avoid unnecessary lock conflicts, `Workspace` initializes storage **lazily**:
+
+```python
+# These DON'T open the database:
+ws = Workspace()
+ws.events()           # API call, no storage
+ws.segmentation(...)  # API call, no storage
+ws.funnels(...)       # API call, no storage
+
+# These DO open the database (on first access):
+ws.fetch_events(...)  # Writes to storage
+ws.sql(...)           # Reads from storage
+ws.tables()           # Reads metadata
+```
+
+This means API-only commands like `mp inspect events` never conflict with fetch operations, even when targeting the same project.
+
+## Avoiding Conflicts
+
+### Use Ephemeral Mode for Testing
+
+```bash
+# Won't conflict with your main database
+mp fetch events --from 2024-01-01 --to 2024-01-07 --ephemeral
+```
+
+### Use Separate Paths for Parallel Work
+
+```bash
+# Terminal 1
+mp fetch events --from 2024-01-01 --to 2024-06-30 --path ./h1.db
+
+# Terminal 2 (parallel)
+mp fetch events --from 2024-07-01 --to 2024-12-31 --path ./h2.db
+```
+
+### Combine into Single Commands
+
+```bash
+# Instead of two fetches, use date range in one command
+mp fetch events --from 2024-01-01 --to 2024-12-31
+```
+
+### Stream Instead of Store
+
+If you don't need to query the data repeatedly:
+
+```bash
+# No database, no locks
+mp fetch events --from 2024-01-01 --stdout | process_events.py
+```
+
+## Connection Lifecycle
+
+The `StorageEngine` manages its DuckDB connection:
+
+```python
+# Workspace as context manager ensures cleanup
+with Workspace() as ws:
+    ws.fetch_events(from_date="2024-01-01", to_date="2024-01-31")
+    df = ws.sql("SELECT * FROM events LIMIT 10")
+# Connection closed, lock released
+
+# Or explicit close
+ws = Workspace()
+try:
+    ws.fetch_events(...)
+finally:
+    ws.close()
+```
+
+CLI commands handle this automatically.
+
+## Technical Details
+
+### Lock File
+
+DuckDB creates a `.wal` (write-ahead log) file alongside the database during write operations. The lock is held for the duration of the connection.
+
+### Process Isolation
+
+Within a single Python process, multiple `Workspace` instances can share the same database file (DuckDB handles internal locking). Lock conflicts occur between **separate processes**.
+
+### Read-Only Mode
+
+`StorageEngine` supports read-only connections for future optimization:
+
+```python
+# Internal API - not currently exposed via Workspace
+storage = StorageEngine(path=db_path, read_only=True)
+```
+
+Read-only connections:
+
+- Allow concurrent reads while a write lock is held (by another process)
+- Cannot execute INSERT, UPDATE, DELETE, or DDL statements
+- Useful for query-only workflows
+
+## See Also
+
+- [Design](design.md) — Overall architecture
+- [Data Model](data-model.md) — Table schemas and query patterns
+- [DuckDB Documentation](https://duckdb.org/docs/) — Full DuckDB reference

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -183,14 +183,16 @@ ws = Workspace(path="data.db", read_only=True)
 
 Read-only connections:
 
-- Allow concurrent reads while a write lock is held (by another process)
+- Allow multiple reader processes to access the database concurrently (when no write lock is held)
 - Cannot execute INSERT, UPDATE, DELETE, or DDL statements
-- Useful for query-only workflows
+- Still blocked by an active write lock (DuckDB write locks are exclusive)
 
 The CLI uses this automatically:
 
 - **Read commands** (`mp query`, `mp inspect tables`, etc.) use `read_only=True`
 - **Write commands** (`mp fetch`, `mp inspect drop`) use `read_only=False`
+
+**Note:** If a `mp fetch` is running, other commands will still be blocked until it completes. The benefit of read-only mode is enabling multiple concurrent read operations (e.g., two `mp query` commands).
 
 ## See Also
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -160,11 +160,14 @@ Within a single Python process, multiple `Workspace` instances can share the sam
 
 ### Read-Only Mode
 
-`StorageEngine` supports read-only connections for future optimization:
+Both `StorageEngine` and `Workspace` support a `read_only` parameter:
 
 ```python
-# Internal API - not currently exposed via Workspace
-storage = StorageEngine(path=db_path, read_only=True)
+# Default: write access (matches DuckDB's native behavior)
+ws = Workspace()  # read_only=False
+
+# Explicit read-only for concurrent access
+ws = Workspace(path="data.db", read_only=True)
 ```
 
 Read-only connections:
@@ -172,6 +175,11 @@ Read-only connections:
 - Allow concurrent reads while a write lock is held (by another process)
 - Cannot execute INSERT, UPDATE, DELETE, or DDL statements
 - Useful for query-only workflows
+
+The CLI uses this automatically:
+
+- **Read commands** (`mp query`, `mp inspect tables`, etc.) use `read_only=True`
+- **Write commands** (`mp fetch`, `mp inspect drop`) use `read_only=False`
 
 ## See Also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Architecture:
       - Design: architecture/design.md
       - Data Model: architecture/data-model.md
+      - Storage Engine: architecture/storage.md
 
 extra:
   social:

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -12,6 +12,7 @@ from mixpanel_data.exceptions import (
     APIError,
     AuthenticationError,
     ConfigError,
+    DatabaseLockedError,
     JQLSyntaxError,
     MixpanelDataError,
     QueryError,
@@ -85,6 +86,7 @@ __all__ = [
     "ServerError",
     "TableExistsError",
     "TableNotFoundError",
+    "DatabaseLockedError",
     # Result types
     "FetchResult",
     "SegmentationResult",

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -13,6 +13,7 @@ from mixpanel_data.exceptions import (
     AuthenticationError,
     ConfigError,
     DatabaseLockedError,
+    DatabaseNotFoundError,
     JQLSyntaxError,
     MixpanelDataError,
     QueryError,
@@ -87,6 +88,7 @@ __all__ = [
     "TableExistsError",
     "TableNotFoundError",
     "DatabaseLockedError",
+    "DatabaseNotFoundError",
     # Result types
     "FetchResult",
     "SegmentationResult",

--- a/src/mixpanel_data/_internal/storage.py
+++ b/src/mixpanel_data/_internal/storage.py
@@ -78,7 +78,7 @@ class StorageEngine:
         self,
         path: Path | None = None,
         *,
-        read_only: bool = True,
+        read_only: bool = False,
         _ephemeral: bool = False,
         _in_memory: bool = False,
     ) -> None:

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -120,7 +120,7 @@ def fetch_events(
     # Parse events filter
     events_list = [e.strip() for e in events.split(",")] if events else None
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=False)
 
     # Streaming mode: output JSONL to stdout
     if stdout:
@@ -220,7 +220,7 @@ def fetch_profiles(
         err_console.print("[red]Error:[/red] --raw requires --stdout")
         raise typer.Exit(3)
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=False)
 
     # Streaming mode: output JSONL to stdout
     if stdout:

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -120,7 +120,7 @@ def fetch_events(
     # Parse events filter
     events_list = [e.strip() for e in events.split(",")] if events else None
 
-    workspace = get_workspace(ctx, read_only=False)
+    workspace = get_workspace(ctx)
 
     # Streaming mode: output JSONL to stdout
     if stdout:
@@ -220,7 +220,7 @@ def fetch_profiles(
         err_console.print("[red]Error:[/red] --raw requires --stdout")
         raise typer.Exit(3)
 
-    workspace = get_workspace(ctx, read_only=False)
+    workspace = get_workspace(ctx)
 
     # Streaming mode: output JSONL to stdout
     if stdout:

--- a/src/mixpanel_data/cli/commands/inspect.py
+++ b/src/mixpanel_data/cli/commands/inspect.py
@@ -382,7 +382,7 @@ def inspect_drop(
             err_console.print("[yellow]Cancelled[/yellow]")
             raise typer.Exit(2)
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=False)
     workspace.drop(table)
 
     output_result(ctx, {"dropped": table}, format=format)

--- a/src/mixpanel_data/cli/commands/inspect.py
+++ b/src/mixpanel_data/cli/commands/inspect.py
@@ -56,7 +56,7 @@ def inspect_events(ctx: typer.Context, format: FormatOption = "json") -> None:
         mp inspect events
         mp inspect events --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching events..."):
         events = workspace.events()
     output_result(ctx, events, format=format)
@@ -82,7 +82,7 @@ def inspect_properties(
         mp inspect properties -e "Sign Up"
         mp inspect properties -e "Purchase" --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching properties..."):
         properties = workspace.properties(event)
     output_result(ctx, properties, format=format)
@@ -117,7 +117,7 @@ def inspect_values(
         mp inspect values -p country -e "Sign Up" --limit 20
         mp inspect values -p browser --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching values..."):
         values = workspace.property_values(
             property_name=property_name,
@@ -140,7 +140,7 @@ def inspect_funnels(ctx: typer.Context, format: FormatOption = "json") -> None:
         mp inspect funnels
         mp inspect funnels --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching funnels..."):
         funnels = workspace.funnels()
     data = [{"funnel_id": f.funnel_id, "name": f.name} for f in funnels]
@@ -160,7 +160,7 @@ def inspect_cohorts(ctx: typer.Context, format: FormatOption = "json") -> None:
         mp inspect cohorts
         mp inspect cohorts --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching cohorts..."):
         cohorts = workspace.cohorts()
     data = [
@@ -203,7 +203,7 @@ def inspect_top_events(
         mp inspect top-events --type unique
     """
     validated_type = validate_count_type(type_)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching top events..."):
         events = workspace.top_events(type=validated_type, limit=limit)
     data = [
@@ -244,7 +244,7 @@ def inspect_bookmarks(
         mp inspect bookmarks --type insights
         mp inspect bookmarks --type funnels --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Fetching bookmarks..."):
         bookmarks = workspace.list_bookmarks(bookmark_type=type_)  # type: ignore[arg-type]
@@ -273,7 +273,7 @@ def inspect_info(ctx: typer.Context, format: FormatOption = "json") -> None:
         mp inspect info
         mp inspect info --format json
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     info = workspace.info()
     output_result(ctx, info.to_dict(), format=format)
 
@@ -291,7 +291,7 @@ def inspect_tables(ctx: typer.Context, format: FormatOption = "json") -> None:
         mp inspect tables
         mp inspect tables --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     tables = workspace.tables()
     data = [
         {
@@ -334,7 +334,7 @@ def inspect_schema(
         mp inspect schema -t events --format table
     """
     # Note: _sample is reserved for future implementation
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     schema = workspace.table_schema(table)
 
     data = {
@@ -382,7 +382,7 @@ def inspect_drop(
             err_console.print("[yellow]Cancelled[/yellow]")
             raise typer.Exit(2)
 
-    workspace = get_workspace(ctx, read_only=False)
+    workspace = get_workspace(ctx)  # write access needed for drop
     workspace.drop(table)
 
     output_result(ctx, {"dropped": table}, format=format)
@@ -412,7 +412,7 @@ def inspect_lexicon_schemas(
         mp inspect lexicon-schemas --type profile --format table
     """
     validated_type = validate_entity_type(type_) if type_ is not None else None
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching schemas..."):
         schemas = workspace.lexicon_schemas(entity_type=validated_type)
     data = [
@@ -460,7 +460,7 @@ def inspect_lexicon_schema(
         mp inspect lexicon-schema -t profile -n "Plan Type" --format json
     """
     validated_type = validate_entity_type(type_)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     with status_spinner(ctx, "Fetching schema..."):
         schema = workspace.lexicon_schema(validated_type, name)
     output_result(ctx, schema.to_dict(), format=format)
@@ -490,7 +490,7 @@ def inspect_sample(
         mp inspect sample -t events
         mp inspect sample -t events -n 5 --format json
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     df = workspace.sample(table, n=rows)
     # Convert DataFrame to list of dicts for output
     data = df.to_dict(orient="records")
@@ -517,7 +517,7 @@ def inspect_summarize(
         mp inspect summarize -t events
         mp inspect summarize -t events --format json
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     result = workspace.summarize(table)
     output_result(ctx, result.to_dict(), format=format)
 
@@ -542,7 +542,7 @@ def inspect_breakdown(
         mp inspect breakdown -t events
         mp inspect breakdown -t events --format json
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     result = workspace.event_breakdown(table)
     output_result(ctx, result.to_dict(), format=format)
 
@@ -572,7 +572,7 @@ def inspect_keys(
         mp inspect keys -t events -e "Purchase"
         mp inspect keys -t events --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     keys = workspace.property_keys(table, event=event)
     output_result(ctx, keys, format=format)
 
@@ -607,6 +607,6 @@ def inspect_column(
         mp inspect column -t events -c "properties->>'$.country'"
         mp inspect column -t events -c distinct_id --top 20
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
     result = workspace.column_stats(table, column, top_n=top)
     output_result(ctx, result.to_dict(), format=format)

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -100,7 +100,7 @@ def query_sql(
     else:
         sql_query = query  # type: ignore[assignment]
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     if scalar:
         result = workspace.sql_scalar(sql_query)
@@ -160,7 +160,7 @@ def query_segmentation(
         mp query segmentation -e "Login" --from 2025-01-01 --to 2025-01-07 --unit week
     """
     validated_unit = validate_time_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running segmentation query..."):
         result = workspace.segmentation(
@@ -215,7 +215,7 @@ def query_funnel(
         mp query funnel 12345 --from 2025-01-01 --to 2025-01-31 --unit week
         mp query funnel 12345 --from 2025-01-01 --to 2025-01-31 --on country
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running funnel query..."):
         result = workspace.funnel(
@@ -293,7 +293,7 @@ def query_retention(
         mp query retention --born "Sign Up" --return "Login" --from 2025-01-01 --to 2025-01-31 --intervals 7
     """
     validated_unit = validate_time_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     # Use defaults if not provided
     actual_interval = interval if interval is not None else 1
@@ -367,7 +367,7 @@ def query_jql(
             key, value = p.split("=", 1)
             params[key] = value
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running JQL query..."):
         result = workspace.jql(
@@ -429,7 +429,7 @@ def query_event_counts(
     # Parse events
     events_list = [e.strip() for e in events.split(",")]
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running event counts query..."):
         result = workspace.event_counts(
@@ -501,7 +501,7 @@ def query_property_counts(
     """
     validated_type = validate_count_type(type_)
     validated_unit = validate_time_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running property counts query..."):
         result = workspace.property_counts(
@@ -555,7 +555,7 @@ def query_activity_feed(
     # Parse users
     user_list = [u.strip() for u in users.split(",")]
 
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Fetching activity feed..."):
         result = workspace.activity_feed(
@@ -592,7 +592,7 @@ def query_saved_report(
         mp query saved-report 12345
         mp query saved-report 12345 --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Querying saved report..."):
         result = workspace.query_saved_report(bookmark_id=bookmark_id)
@@ -624,7 +624,7 @@ def query_flows(
         mp query flows 12345
         mp query flows 12345 --format table
     """
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Querying flows report..."):
         result = workspace.query_flows(bookmark_id=bookmark_id)
@@ -684,7 +684,7 @@ def query_frequency(
     validated_addiction_unit = validate_hour_day_unit(
         addiction_unit, "--addiction-unit"
     )
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running frequency query..."):
         result = workspace.frequency(
@@ -756,7 +756,7 @@ def query_segmentation_numeric(
     """
     validated_type = validate_count_type(type_)
     validated_unit = validate_hour_day_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running numeric segmentation..."):
         result = workspace.segmentation_numeric(
@@ -819,7 +819,7 @@ def query_segmentation_sum(
         mp query segmentation-sum -e "Purchase" --on quantity --from 2025-01-01 --to 2025-01-31 --unit hour
     """
     validated_unit = validate_hour_day_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running sum query..."):
         result = workspace.segmentation_sum(
@@ -881,7 +881,7 @@ def query_segmentation_average(
         mp query segmentation-average -e "Session" --on duration --from 2025-01-01 --to 2025-01-31 --unit hour
     """
     validated_unit = validate_hour_day_unit(unit)
-    workspace = get_workspace(ctx)
+    workspace = get_workspace(ctx, read_only=True)
 
     with status_spinner(ctx, "Running average query..."):
         result = workspace.segmentation_average(

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -25,6 +25,7 @@ from mixpanel_data.exceptions import (
     AccountNotFoundError,
     AuthenticationError,
     ConfigError,
+    DatabaseLockedError,
     MixpanelDataError,
     QueryError,
     RateLimitError,
@@ -101,6 +102,10 @@ def handle_errors(func: F) -> F:
         except TableNotFoundError as e:
             err_console.print(f"[red]Table not found:[/red] {e.table_name}")
             raise typer.Exit(ExitCode.NOT_FOUND) from None
+        except DatabaseLockedError as e:
+            err_console.print(f"[yellow]Database locked:[/yellow] {e.db_path}")
+            err_console.print("Another mp command may be running. Try again shortly.")
+            raise typer.Exit(ExitCode.GENERAL_ERROR) from None
         except RateLimitError as e:
             err_console.print(f"[yellow]Rate limited:[/yellow] {e.message}")
             if e.retry_after:

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -139,7 +139,9 @@ def get_workspace(ctx: typer.Context, *, read_only: bool = False) -> Workspace:
 
     Note: The read_only parameter only applies when creating a new workspace.
     If a workspace already exists in context, that instance is returned
-    regardless of the read_only parameter.
+    regardless of the read_only parameter. This is safe because each CLI
+    command runs in a separate process, so caching within a single command
+    invocation doesn't cause read_only mismatches across commands.
 
     Args:
         ctx: Typer context with global options in obj dict.

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -124,14 +124,21 @@ def handle_errors(func: F) -> F:
     return wrapper  # type: ignore[return-value]
 
 
-def get_workspace(ctx: typer.Context) -> Workspace:
+def get_workspace(ctx: typer.Context, *, read_only: bool = True) -> Workspace:
     """Get or create workspace from context.
 
     Lazily initializes a Workspace instance, respecting the --account
     global option. The workspace is cached in the context for reuse.
 
+    Note: The read_only parameter only applies when creating a new workspace.
+    If a workspace already exists in context, that instance is returned
+    regardless of the read_only parameter.
+
     Args:
         ctx: Typer context with global options in obj dict.
+        read_only: If True (default), open database in read-only mode
+            allowing concurrent reads. Pass False for commands that
+            modify the database (fetch, drop).
 
     Returns:
         Configured Workspace instance.
@@ -144,7 +151,7 @@ def get_workspace(ctx: typer.Context) -> Workspace:
 
     if "workspace" not in ctx.obj or ctx.obj["workspace"] is None:
         account = ctx.obj.get("account")
-        ctx.obj["workspace"] = Workspace(account=account)
+        ctx.obj["workspace"] = Workspace(account=account, read_only=read_only)
     workspace: Workspace = ctx.obj["workspace"]
     return workspace
 

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -26,6 +26,7 @@ from mixpanel_data.exceptions import (
     AuthenticationError,
     ConfigError,
     DatabaseLockedError,
+    DatabaseNotFoundError,
     MixpanelDataError,
     QueryError,
     RateLimitError,
@@ -106,6 +107,12 @@ def handle_errors(func: F) -> F:
             err_console.print(f"[yellow]Database locked:[/yellow] {e.db_path}")
             err_console.print("Another mp command may be running. Try again shortly.")
             raise typer.Exit(ExitCode.GENERAL_ERROR) from None
+        except DatabaseNotFoundError as e:
+            err_console.print(f"[yellow]No data yet:[/yellow] {e.db_path}")
+            err_console.print(
+                "Run 'mp fetch events' or 'mp fetch profiles' to create the database."
+            )
+            raise typer.Exit(ExitCode.NOT_FOUND) from None
         except RateLimitError as e:
             err_console.print(f"[yellow]Rate limited:[/yellow] {e.message}")
             if e.retry_after:

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -124,7 +124,7 @@ def handle_errors(func: F) -> F:
     return wrapper  # type: ignore[return-value]
 
 
-def get_workspace(ctx: typer.Context, *, read_only: bool = True) -> Workspace:
+def get_workspace(ctx: typer.Context, *, read_only: bool = False) -> Workspace:
     """Get or create workspace from context.
 
     Lazily initializes a Workspace instance, respecting the --account
@@ -136,9 +136,10 @@ def get_workspace(ctx: typer.Context, *, read_only: bool = True) -> Workspace:
 
     Args:
         ctx: Typer context with global options in obj dict.
-        read_only: If True (default), open database in read-only mode
-            allowing concurrent reads. Pass False for commands that
-            modify the database (fetch, drop).
+        read_only: If True, open database in read-only mode allowing
+            concurrent reads. Defaults to False (write access) matching
+            DuckDB's native behavior. Pass True for read-only commands
+            (query, inspect) to enable concurrent access.
 
     Returns:
         Configured Workspace instance.

--- a/src/mixpanel_data/exceptions.py
+++ b/src/mixpanel_data/exceptions.py
@@ -614,6 +614,49 @@ class DatabaseLockedError(MixpanelDataError):
         return int(pid) if pid is not None else None
 
 
+class DatabaseNotFoundError(MixpanelDataError):
+    """Database file does not exist.
+
+    Raised when attempting to open a non-existent database file in read-only
+    mode. DuckDB cannot create a new database file when opened read-only.
+
+    This typically happens when running read-only commands (like `mp query`
+    or `mp inspect tables`) before any data has been fetched.
+
+    Example:
+        ```python
+        try:
+            ws = Workspace(read_only=True)
+        except DatabaseNotFoundError as e:
+            print(f"No data yet: {e.db_path}")
+            print("Run 'mp fetch events' first to create the database.")
+        ```
+    """
+
+    def __init__(self, db_path: str) -> None:
+        """Initialize DatabaseNotFoundError.
+
+        Args:
+            db_path: Path to the database file that doesn't exist.
+        """
+        message = (
+            f"Database '{db_path}' does not exist. "
+            "Run 'mp fetch events' first to create it."
+        )
+
+        details: dict[str, str] = {
+            "db_path": db_path,
+            "suggestion": "Run 'mp fetch events' or 'mp fetch profiles' to create the database.",
+        }
+
+        super().__init__(message, code="DATABASE_NOT_FOUND", details=details)
+
+    @property
+    def db_path(self) -> str:
+        """Path to the database file that doesn't exist."""
+        return str(self._details.get("db_path", ""))
+
+
 # JQL Exceptions
 
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -182,19 +182,24 @@ class Workspace:
                 region=cast(RegionType, resolved_region),
             )
 
-        # Initialize storage
+        # Initialize storage lazily
+        # Store path for lazy initialization, or use injected storage directly
+        self._db_path: Path | None = None
+        self._storage: StorageEngine | None = None
+
         if _storage is not None:
+            # Injected storage - use directly
             self._storage = _storage
         else:
-            # Determine database path
+            # Determine database path for lazy initialization
             if path is not None:
-                db_path = Path(path) if isinstance(path, str) else path
+                self._db_path = Path(path) if isinstance(path, str) else path
             else:
                 # Default path: ~/.mp/data/{project_id}.db
-                db_path = (
+                self._db_path = (
                     Path.home() / ".mp" / "data" / f"{self._credentials.project_id}.db"
                 )
-            self._storage = StorageEngine(path=db_path)
+            # NOTE: StorageEngine is NOT created here - see storage property
 
         # Lazy-initialized services (None until first use)
         self._api_client: MixpanelAPIClient | None = _api_client
@@ -505,12 +510,33 @@ class Workspace:
         return self._discovery
 
     @property
+    def storage(self) -> StorageEngine:
+        """Get or create storage engine (lazy initialization).
+
+        Only connects to database when first accessed. API-only operations
+        (discovery, live queries, streaming) don't touch the database.
+
+        Returns:
+            StorageEngine instance.
+
+        Raises:
+            DatabaseLockedError: If database is locked by another process.
+            RuntimeError: If no database path configured (shouldn't happen
+                in normal use).
+        """
+        if self._storage is None:
+            if self._db_path is None:
+                raise RuntimeError("No database path configured")
+            self._storage = StorageEngine(path=self._db_path)
+        return self._storage
+
+    @property
     def _fetcher_service(self) -> FetcherService:
         """Get or create fetcher service (lazy initialization)."""
         if self._fetcher is None:
             self._fetcher = FetcherService(
                 self._require_api_client(),
-                self._storage,
+                self.storage,  # Uses lazy storage property
             )
         return self._fetcher
 
@@ -982,7 +1008,7 @@ class Workspace:
         Raises:
             QueryError: If query is invalid.
         """
-        return self._storage.execute_df(query)
+        return self.storage.execute_df(query)
 
     def sql_scalar(self, query: str) -> Any:
         """Execute SQL query and return single scalar value.
@@ -996,7 +1022,7 @@ class Workspace:
         Raises:
             QueryError: If query is invalid or returns multiple values.
         """
-        return self._storage.execute_scalar(query)
+        return self.storage.execute_scalar(query)
 
     def sql_rows(self, query: str) -> list[tuple[Any, ...]]:
         """Execute SQL query and return results as list of tuples.
@@ -1010,7 +1036,7 @@ class Workspace:
         Raises:
             QueryError: If query is invalid.
         """
-        return self._storage.execute_rows(query)
+        return self.storage.execute_rows(query)
 
     # =========================================================================
     # LIVE QUERY METHODS
@@ -1431,8 +1457,8 @@ class Workspace:
         Returns:
             WorkspaceInfo with path, project_id, region, account, tables, size.
         """
-        path = self._storage.path
-        tables = [t.name for t in self._storage.list_tables()]
+        path = self.storage.path
+        tables = [t.name for t in self.storage.list_tables()]
 
         # Calculate database size and creation time
         size_mb = 0.0
@@ -1462,7 +1488,7 @@ class Workspace:
         Returns:
             List of TableInfo objects (name, type, row_count, fetched_at).
         """
-        return self._storage.list_tables()
+        return self.storage.list_tables()
 
     def table_schema(self, table: str) -> TableSchema:
         """Get schema for a table in the local database.
@@ -1476,7 +1502,7 @@ class Workspace:
         Raises:
             TableNotFoundError: If table doesn't exist.
         """
-        return self._storage.get_schema(table)
+        return self.storage.get_schema(table)
 
     def sample(self, table: str, n: int = 10) -> pd.DataFrame:
         """Return random sample rows from a table.
@@ -1503,11 +1529,11 @@ class Workspace:
             ```
         """
         # Validate table exists
-        self._storage.get_schema(table)
+        self.storage.get_schema(table)
 
         # Use DuckDB's reservoir sampling
         sql = f'SELECT * FROM "{table}" USING SAMPLE {n}'
-        return self._storage.execute_df(sql)
+        return self.storage.execute_df(sql)
 
     def summarize(self, table: str) -> SummaryResult:
         """Get statistical summary of all columns in a table.
@@ -1533,13 +1559,13 @@ class Workspace:
             ```
         """
         # Validate table exists
-        self._storage.get_schema(table)
+        self.storage.get_schema(table)
 
         # Get row count
-        row_count = self._storage.execute_scalar(f'SELECT COUNT(*) FROM "{table}"')
+        row_count = self.storage.execute_scalar(f'SELECT COUNT(*) FROM "{table}"')
 
         # Get column statistics using SUMMARIZE
-        summary_df = self._storage.execute_df(f'SUMMARIZE "{table}"')
+        summary_df = self.storage.execute_df(f'SUMMARIZE "{table}"')
 
         # Convert to ColumnSummary objects (to_dict is more efficient than iterrows)
         columns: list[ColumnSummary] = []
@@ -1595,7 +1621,7 @@ class Workspace:
             ```
         """
         # Validate table exists and get schema
-        schema = self._storage.get_schema(table)
+        schema = self.storage.get_schema(table)
         column_names = {col.name for col in schema.columns}
 
         # Check for required columns
@@ -1617,7 +1643,7 @@ class Workspace:
                 MAX(event_time) as max_time
             FROM "{table}"
         """
-        agg_result = self._storage.execute_rows(agg_sql)
+        agg_result = self.storage.execute_rows(agg_sql)
         total_events, total_users, min_time, max_time = agg_result[0]
 
         # Handle empty table
@@ -1643,7 +1669,7 @@ class Workspace:
             GROUP BY event_name
             ORDER BY count DESC
         """
-        breakdown_rows = self._storage.execute_rows(breakdown_sql)
+        breakdown_rows = self.storage.execute_rows(breakdown_sql)
 
         events: list[EventStats] = []
         for row in breakdown_rows:
@@ -1717,7 +1743,7 @@ class Workspace:
             ```
         """
         # Validate table exists and get schema
-        schema = self._storage.get_schema(table)
+        schema = self.storage.get_schema(table)
         column_names = {col.name for col in schema.columns}
 
         # Check for required column
@@ -1742,14 +1768,14 @@ class Workspace:
                 WHERE event_name = ?
                 ORDER BY key
             """
-            rows = self._storage.connection.execute(sql, [event]).fetchall()
+            rows = self.storage.connection.execute(sql, [event]).fetchall()
         else:
             sql = f"""
                 SELECT DISTINCT unnest(json_keys(properties)) as key
                 FROM "{table}"
                 ORDER BY key
             """
-            rows = self._storage.execute_rows(sql)
+            rows = self.storage.execute_rows(sql)
 
         return [str(row[0]) for row in rows]
 
@@ -1803,10 +1829,10 @@ class Workspace:
             developers or AI coding agents. Do not pass untrusted user input.
         """
         # Validate table exists
-        self._storage.get_schema(table)
+        self.storage.get_schema(table)
 
         # Get total row count
-        total_rows = self._storage.execute_scalar(f'SELECT COUNT(*) FROM "{table}"')
+        total_rows = self.storage.execute_scalar(f'SELECT COUNT(*) FROM "{table}"')
 
         # Get basic stats: count, null_count, approx unique
         stats_sql = f"""
@@ -1817,7 +1843,7 @@ class Workspace:
             FROM "{table}"
         """
         try:
-            stats_result = self._storage.execute_rows(stats_sql)
+            stats_result = self.storage.execute_rows(stats_sql)
         except Exception as e:
             raise QueryError(
                 f"Invalid column expression: {column}. Error: {e}",
@@ -1839,7 +1865,7 @@ class Workspace:
             ORDER BY cnt DESC
             LIMIT {top_n}
         """
-        top_rows = self._storage.execute_rows(top_sql)
+        top_rows = self.storage.execute_rows(top_sql)
         top_values: list[tuple[Any, int]] = [(row[0], int(row[1])) for row in top_rows]
 
         # Detect column type to determine if numeric stats apply
@@ -1847,7 +1873,7 @@ class Workspace:
             f'SELECT typeof({column}) FROM "{table}" WHERE {column} IS NOT NULL LIMIT 1'
         )
         try:
-            type_result = self._storage.execute_rows(type_sql)
+            type_result = self.storage.execute_rows(type_sql)
             dtype = str(type_result[0][0]) if type_result else "UNKNOWN"
         except Exception:
             dtype = "UNKNOWN"
@@ -1882,7 +1908,7 @@ class Workspace:
                 FROM "{table}"
             """
             try:
-                numeric_result = self._storage.execute_rows(numeric_sql)
+                numeric_result = self.storage.execute_rows(numeric_sql)
                 if numeric_result:
                     min_val = (
                         float(numeric_result[0][0])
@@ -1938,7 +1964,7 @@ class Workspace:
             TableNotFoundError: If any table doesn't exist.
         """
         for name in names:
-            self._storage.drop_table(name)
+            self.storage.drop_table(name)
 
     def drop_all(self, type: Literal["events", "profiles"] | None = None) -> None:
         """Drop all tables, optionally filtered by type.
@@ -1946,10 +1972,10 @@ class Workspace:
         Args:
             type: If specified, only drop tables of this type.
         """
-        tables = self._storage.list_tables()
+        tables = self.storage.list_tables()
         for table in tables:
             if type is None or table.type == type:
-                self._storage.drop_table(table.name)
+                self.storage.drop_table(table.name)
 
     # =========================================================================
     # ESCAPE HATCHES
@@ -1964,7 +1990,7 @@ class Workspace:
         Returns:
             The underlying DuckDB connection.
         """
-        return self._storage.connection
+        return self.storage.connection
 
     @property
     def api(self) -> MixpanelAPIClient:

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -149,8 +149,8 @@ class Workspace:
             project_id: Override project ID from credentials.
             region: Override region from credentials (us, eu, in).
             path: Path to database file. If None, uses default location.
-            read_only: If True (default), open database in read-only mode
-                allowing concurrent reads. Set to False for write access.
+            read_only: If True, open database in read-only mode allowing
+                concurrent reads. Defaults to False (write access).
             _config_manager: Injected ConfigManager for testing.
             _api_client: Injected MixpanelAPIClient for testing.
             _storage: Injected StorageEngine for testing.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -131,7 +131,7 @@ class Workspace:
         project_id: str | None = None,
         region: str | None = None,
         path: str | Path | None = None,
-        read_only: bool = True,
+        read_only: bool = False,
         # Dependency injection for testing
         _config_manager: ConfigManager | None = None,
         _api_client: MixpanelAPIClient | None = None,

--- a/tests/integration/test_fetch_service.py
+++ b/tests/integration/test_fetch_service.py
@@ -69,7 +69,7 @@ def test_fetch_events_with_real_duckdb(tmp_path: Path) -> None:
 
     mock_api_client.export_events.return_value = mock_export_events()
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         # Fetch events
@@ -140,7 +140,7 @@ def test_fetch_events_json_properties_queryable(tmp_path: Path) -> None:
 
     mock_api_client.export_events.return_value = mock_export_events()
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
         fetcher.fetch_events(
             name="purchases",
@@ -182,7 +182,7 @@ def test_fetch_events_table_exists_error_with_real_storage(tmp_path: Path) -> No
         ]
     )
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         # First fetch should succeed
@@ -235,7 +235,7 @@ def test_fetch_events_progress_callback_integration(tmp_path: Path) -> None:
 
     mock_api_client.export_events.side_effect = mock_export_events
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         progress_values: list[int] = []
@@ -303,7 +303,7 @@ def test_fetch_profiles_with_real_duckdb(tmp_path: Path) -> None:
 
     mock_api_client.export_profiles.return_value = mock_export_profiles()
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         # Fetch profiles
@@ -360,7 +360,7 @@ def test_fetch_profiles_json_properties_queryable(tmp_path: Path) -> None:
 
     mock_api_client.export_profiles.return_value = mock_export_profiles()
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
         fetcher.fetch_profiles(name="users")
 
@@ -395,7 +395,7 @@ def test_fetch_profiles_table_exists_error_with_real_storage(tmp_path: Path) -> 
         ]
     )
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         # First fetch should succeed
@@ -455,7 +455,7 @@ def test_events_and_profiles_can_be_joined(tmp_path: Path) -> None:
             },
         }
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         fetcher = FetcherService(mock_api_client, storage)
 
         # Fetch events

--- a/tests/integration/test_workspace_integration.py
+++ b/tests/integration/test_workspace_integration.py
@@ -214,7 +214,7 @@ class TestEphemeralWorkflow:
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            db_path = ws._storage.path
+            db_path = ws.storage.path
             assert db_path is not None
             assert db_path.exists()
 

--- a/tests/integration/test_workspace_integration.py
+++ b/tests/integration/test_workspace_integration.py
@@ -96,7 +96,7 @@ class TestFetchQueryWorkflow:
         mock_api_client.export_events.return_value = iter(events)
 
         db_path = temp_dir / "test_workflow.db"
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
 
         with Workspace(
             _config_manager=mock_config_manager,
@@ -151,7 +151,7 @@ class TestFetchQueryWorkflow:
         ]
         mock_api_client.export_events.return_value = iter(events)
 
-        storage1 = StorageEngine(path=db_path)
+        storage1 = StorageEngine(path=db_path, read_only=False)
         ws1 = Workspace(
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
@@ -253,7 +253,7 @@ class TestQueryOnlyIntegration:
         db_path = temp_dir / "existing.db"
 
         # Create database with data
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
         storage.connection.execute("CREATE TABLE test_data (id INTEGER, value VARCHAR)")
         storage.connection.execute(
             "INSERT INTO test_data VALUES (1, 'one'), (2, 'two')"
@@ -291,7 +291,7 @@ class TestTableManagementIntegration:
         create, list, get schema, and drop tables.
         """
         db_path = temp_dir / "management.db"
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
 
         # Create events using the storage directly (simulating fetch)
         events = [
@@ -359,7 +359,7 @@ class TestWorkspaceInfoIntegration:
     ) -> None:
         """Test info() returns complete workspace metadata."""
         db_path = temp_dir / "info_test.db"
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
 
         # Create a table
         storage.connection.execute("CREATE TABLE test (id INTEGER)")

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -197,7 +197,7 @@ class TestGetWorkspace:
 
             result = get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account=None)
+            MockWorkspace.assert_called_once_with(account=None, read_only=True)
             assert result == mock_ws
             assert ctx.obj["workspace"] == mock_ws
 
@@ -221,7 +221,7 @@ class TestGetWorkspace:
         with patch("mixpanel_data.workspace.Workspace") as MockWorkspace:
             get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account="staging")
+            MockWorkspace.assert_called_once_with(account="staging", read_only=True)
 
 
 class TestGetConfig:

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -197,7 +197,7 @@ class TestGetWorkspace:
 
             result = get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account=None, read_only=True)
+            MockWorkspace.assert_called_once_with(account=None, read_only=False)
             assert result == mock_ws
             assert ctx.obj["workspace"] == mock_ws
 
@@ -221,7 +221,7 @@ class TestGetWorkspace:
         with patch("mixpanel_data.workspace.Workspace") as MockWorkspace:
             get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account="staging", read_only=True)
+            MockWorkspace.assert_called_once_with(account="staging", read_only=False)
 
 
 class TestGetConfig:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -226,8 +226,6 @@ class TestStorageExceptions:
         assert result["details"]["holding_pid"] == 99999
 
         # Verify JSON serializable
-        import json
-
         json_str = json.dumps(result)
         assert "DATABASE_LOCKED" in json_str
         assert "99999" in json_str

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -19,7 +19,7 @@ from mixpanel_data._internal.storage import StorageEngine
 def test_init_with_explicit_path_creates_database_file(tmp_path: Path) -> None:
     """Test that StorageEngine creates database file at specified path."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Database file should exist
         assert db_path.exists()
         assert db_path.is_file()
@@ -34,7 +34,7 @@ def test_init_with_explicit_path_creates_database_file(tmp_path: Path) -> None:
 def test_init_creates_parent_directories_if_needed(tmp_path: Path) -> None:
     """Test that StorageEngine creates parent directories automatically."""
     db_path = tmp_path / "subdir" / "nested" / "test.db"
-    with StorageEngine(path=db_path):
+    with StorageEngine(path=db_path, read_only=False):
         # Parent directories should be created
         assert db_path.parent.exists()
         assert db_path.exists()
@@ -45,11 +45,11 @@ def test_init_can_reopen_existing_database(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
 
     # Create database
-    with StorageEngine(path=db_path):
+    with StorageEngine(path=db_path, read_only=False):
         pass
 
     # Reopen same database
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         assert storage.path == db_path
         assert storage.connection is not None
 
@@ -107,7 +107,7 @@ def test_context_manager_enters_and_exits(tmp_path: Path) -> None:
     """Test that StorageEngine works as context manager."""
     db_path = tmp_path / "test.db"
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Inside context, storage should be usable
         assert storage.connection is not None
         assert storage.path == db_path
@@ -120,7 +120,10 @@ def test_context_manager_closes_on_exception(tmp_path: Path) -> None:
     """Test that context manager closes connection even on exception."""
     db_path = tmp_path / "test.db"
 
-    with pytest.raises(ValueError), StorageEngine(path=db_path) as storage:
+    with (
+        pytest.raises(ValueError),
+        StorageEngine(path=db_path, read_only=False) as storage,
+    ):
         assert storage.connection is not None
         # Raise exception to test cleanup
         raise ValueError("test exception")
@@ -132,7 +135,7 @@ def test_context_manager_returns_self(tmp_path: Path) -> None:
     """Test that __enter__ returns self."""
     db_path = tmp_path / "test.db"
 
-    storage = StorageEngine(path=db_path)
+    storage = StorageEngine(path=db_path, read_only=False)
     try:
         result = storage.__enter__()
         assert result is storage
@@ -154,7 +157,7 @@ def test_context_manager_returns_self(tmp_path: Path) -> None:
 def test_close_can_be_called_multiple_times(tmp_path: Path) -> None:
     """Test that close() is idempotent."""
     db_path = tmp_path / "test.db"
-    storage = StorageEngine(path=db_path)
+    storage = StorageEngine(path=db_path, read_only=False)
 
     # Should be safe to call multiple times
     storage.close()
@@ -165,7 +168,7 @@ def test_close_can_be_called_multiple_times(tmp_path: Path) -> None:
 def test_path_property_returns_path(tmp_path: Path) -> None:
     """Test that path property returns the database path."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         assert storage.path == db_path
 
 
@@ -174,14 +177,14 @@ def test_connection_property_returns_duckdb_connection(tmp_path: Path) -> None:
     import duckdb
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         assert isinstance(storage.connection, duckdb.DuckDBPyConnection)
 
 
 def test_cleanup_is_alias_for_close(tmp_path: Path) -> None:
     """Test that cleanup() calls close()."""
     db_path = tmp_path / "test.db"
-    storage = StorageEngine(path=db_path)
+    storage = StorageEngine(path=db_path, read_only=False)
 
     # cleanup() should work just like close()
     storage.cleanup()
@@ -200,7 +203,7 @@ def test_create_events_table_inserts_all_records(tmp_path: Path) -> None:
     from datetime import datetime
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create sample events
         events = [
             {
@@ -252,7 +255,7 @@ def test_create_events_table_handles_large_batches(tmp_path: Path) -> None:
     from datetime import datetime
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create 2100 events to test batching (batch size is 2000, so this
         # creates 2 batches - enough to verify batching works correctly)
         def event_generator() -> Iterator[dict[str, Any]]:
@@ -297,7 +300,7 @@ def test_create_events_table_raises_error_if_table_exists(tmp_path: Path) -> Non
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         events = [
             {
                 "event_name": "Event",
@@ -328,7 +331,7 @@ def test_create_events_table_validates_table_name(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         events = [
             {
                 "event_name": "Event",
@@ -368,7 +371,7 @@ def test_create_events_table_validates_required_fields(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         metadata = TableMetadata(
             type="events",
             fetched_at=datetime.now(UTC),
@@ -471,7 +474,7 @@ def test_create_profiles_table_inserts_all_records(tmp_path: Path) -> None:
     from datetime import datetime
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create sample profiles
         profiles = [
             {
@@ -521,7 +524,7 @@ def test_create_profiles_table_validates_required_fields(tmp_path: Path) -> None
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         metadata = TableMetadata(
             type="profiles",
             fetched_at=datetime.now(UTC),
@@ -577,7 +580,7 @@ def test_create_events_table_invokes_progress_callback(tmp_path: Path) -> None:
     from datetime import datetime
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events generator (2100 events = 2 batches with batch_size=2000)
         def event_generator() -> Iterator[dict[str, Any]]:
             for i in range(2100):
@@ -623,7 +626,7 @@ def test_create_profiles_table_invokes_progress_callback(tmp_path: Path) -> None
     from datetime import datetime
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create profiles generator (500 is enough to verify callback works)
         def profile_generator() -> Iterator[dict[str, Any]]:
             for i in range(500):
@@ -768,7 +771,7 @@ def test_cleanup_removes_wal_files_if_present() -> None:
 def test_cleanup_does_nothing_for_persistent_database(tmp_path: Path) -> None:
     """Test that cleanup() doesn't delete persistent databases."""
     db_path = tmp_path / "persistent.db"
-    storage = StorageEngine(path=db_path)
+    storage = StorageEngine(path=db_path, read_only=False)
 
     # Before cleanup, file should exist
     assert db_path.exists()
@@ -793,7 +796,7 @@ def test_open_existing_opens_existing_database(tmp_path: Path) -> None:
     db_path = tmp_path / "existing.db"
 
     # Create database first
-    with StorageEngine(path=db_path) as storage1:
+    with StorageEngine(path=db_path, read_only=False) as storage1:
         storage1.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage1.connection.execute("INSERT INTO test VALUES (1, 'data')")
 
@@ -820,7 +823,7 @@ def test_open_existing_raises_error_if_file_missing(tmp_path: Path) -> None:
 def test_list_tables_returns_empty_list_for_new_database(tmp_path: Path) -> None:
     """Test that list_tables() returns empty list for new database."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # New database should have no user tables
         tables = storage.list_tables()
         assert tables == []
@@ -833,7 +836,7 @@ def test_list_tables_returns_all_user_tables(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create multiple tables
         events = [
             {
@@ -893,7 +896,7 @@ def test_list_tables_excludes_internal_metadata_table(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create one user table
         events = [
             {
@@ -936,7 +939,7 @@ def test_get_schema_returns_events_table_schema(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events table
         events = [
             {
@@ -980,7 +983,7 @@ def test_get_schema_returns_profiles_table_schema(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create profiles table
         profiles = [
             {
@@ -1027,7 +1030,7 @@ def test_get_metadata_returns_table_metadata(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events table with specific metadata
         events = [
             {
@@ -1064,7 +1067,7 @@ def test_get_metadata_returns_profiles_metadata(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create profiles table
         profiles = [
             {
@@ -1101,7 +1104,7 @@ def test_get_schema_raises_error_for_missing_table(tmp_path: Path) -> None:
 
     db_path = tmp_path / "test.db"
     with (
-        StorageEngine(path=db_path) as storage,
+        StorageEngine(path=db_path, read_only=False) as storage,
         pytest.raises(TableNotFoundError, match="nonexistent_table"),
     ):
         storage.get_schema("nonexistent_table")
@@ -1113,7 +1116,7 @@ def test_get_metadata_raises_error_for_missing_table(tmp_path: Path) -> None:
 
     db_path = tmp_path / "test.db"
     with (
-        StorageEngine(path=db_path) as storage,
+        StorageEngine(path=db_path, read_only=False) as storage,
         pytest.raises(TableNotFoundError, match="nonexistent_table"),
     ):
         storage.get_metadata("nonexistent_table")
@@ -1131,7 +1134,7 @@ def test_table_exists_returns_true_for_existing_table(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a table
         events = [
             {
@@ -1157,7 +1160,7 @@ def test_table_exists_returns_true_for_existing_table(tmp_path: Path) -> None:
 def test_table_exists_returns_false_for_nonexistent_table(tmp_path: Path) -> None:
     """Test that table_exists() returns False for nonexistent tables."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Check for table that doesn't exist
         assert storage.table_exists("nonexistent_table") is False
 
@@ -1169,7 +1172,7 @@ def test_table_exists_returns_false_for_metadata_table(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a table to trigger _metadata table creation
         events = [
             {
@@ -1204,7 +1207,7 @@ def test_drop_table_removes_table_from_database(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a table
         events = [
             {
@@ -1240,7 +1243,7 @@ def test_drop_table_removes_metadata_entry(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a table
         events = [
             {
@@ -1292,7 +1295,7 @@ def test_create_events_table_raises_table_exists_error_on_duplicate(
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         events = [
             {
                 "event_name": "Event",
@@ -1326,7 +1329,7 @@ def test_create_profiles_table_raises_table_exists_error_on_duplicate(
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         profiles = [
             {
                 "distinct_id": "user_1",
@@ -1361,7 +1364,7 @@ def test_drop_table_raises_table_not_found_error_for_missing_table(
 
     db_path = tmp_path / "test.db"
     with (
-        StorageEngine(path=db_path) as storage,
+        StorageEngine(path=db_path, read_only=False) as storage,
         pytest.raises(TableNotFoundError, match="nonexistent_table"),
     ):
         # Try to drop table that doesn't exist
@@ -1376,7 +1379,7 @@ def test_drop_table_raises_table_not_found_error_after_drop(tmp_path: Path) -> N
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a table
         events = [
             {
@@ -1413,7 +1416,7 @@ def test_execute_returns_duckdb_relation(tmp_path: Path) -> None:
     import duckdb
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create a test table
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute("INSERT INTO test VALUES (1, 'hello'), (2, 'world')")
@@ -1434,7 +1437,7 @@ def test_execute_can_be_chained(tmp_path: Path) -> None:
     import duckdb
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute(
@@ -1463,7 +1466,7 @@ def test_execute_df_returns_dataframe(tmp_path: Path) -> None:
     import pandas as pd
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute("INSERT INTO test VALUES (1, 'hello'), (2, 'world')")
@@ -1486,7 +1489,7 @@ def test_execute_df_returns_empty_dataframe_for_empty_result(tmp_path: Path) -> 
     import pandas as pd
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create empty table
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
 
@@ -1506,7 +1509,7 @@ def test_execute_df_handles_json_columns(tmp_path: Path) -> None:
     import pandas as pd
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events table with JSON properties
         from mixpanel_data.types import TableMetadata
 
@@ -1544,7 +1547,7 @@ def test_execute_df_handles_json_columns(tmp_path: Path) -> None:
 def test_execute_scalar_returns_single_value(tmp_path: Path) -> None:
     """Test that execute_scalar() returns a single scalar value."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute("INSERT INTO test VALUES (1, 'hello'), (2, 'world')")
@@ -1560,7 +1563,7 @@ def test_execute_scalar_returns_single_value(tmp_path: Path) -> None:
 def test_execute_scalar_returns_different_types(tmp_path: Path) -> None:
     """Test that execute_scalar() returns correct types for different queries."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute(
             "CREATE TABLE test (id INTEGER, price DECIMAL, name VARCHAR)"
@@ -1585,7 +1588,7 @@ def test_execute_scalar_returns_different_types(tmp_path: Path) -> None:
 def test_execute_scalar_returns_none_for_null(tmp_path: Path) -> None:
     """Test that execute_scalar() returns None for NULL values."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data with NULL
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute("INSERT INTO test VALUES (1, NULL)")
@@ -1605,7 +1608,7 @@ def test_execute_scalar_returns_none_for_null(tmp_path: Path) -> None:
 def test_execute_rows_returns_list_of_tuples(tmp_path: Path) -> None:
     """Test that execute_rows() returns a list of tuples."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute(
@@ -1629,7 +1632,7 @@ def test_execute_rows_returns_list_of_tuples(tmp_path: Path) -> None:
 def test_execute_rows_returns_empty_list_for_empty_result(tmp_path: Path) -> None:
     """Test that execute_rows() returns empty list for empty result."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create empty table
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
 
@@ -1644,7 +1647,7 @@ def test_execute_rows_returns_empty_list_for_empty_result(tmp_path: Path) -> Non
 def test_execute_rows_handles_single_column(tmp_path: Path) -> None:
     """Test that execute_rows() handles single column queries."""
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create test data
         storage.connection.execute("CREATE TABLE test (id INTEGER, value VARCHAR)")
         storage.connection.execute("INSERT INTO test VALUES (1, 'a'), (2, 'b')")
@@ -1669,7 +1672,7 @@ def test_execute_wraps_sql_errors_in_query_error(tmp_path: Path) -> None:
     from mixpanel_data.exceptions import QueryError
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Execute invalid SQL
         with pytest.raises(QueryError) as exc_info:
             storage.execute("SELECT * FROM nonexistent_table")
@@ -1689,7 +1692,7 @@ def test_execute_df_wraps_sql_errors_in_query_error(tmp_path: Path) -> None:
     from mixpanel_data.exceptions import QueryError
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Execute invalid SQL
         with pytest.raises(QueryError) as exc_info:
             storage.execute_df("INVALID SQL SYNTAX")
@@ -1704,7 +1707,7 @@ def test_execute_scalar_wraps_sql_errors_in_query_error(tmp_path: Path) -> None:
     from mixpanel_data.exceptions import QueryError
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Execute invalid SQL
         with pytest.raises(QueryError) as exc_info:
             storage.execute_scalar("SELECT * FROM missing_table")
@@ -1719,7 +1722,7 @@ def test_execute_rows_wraps_sql_errors_in_query_error(tmp_path: Path) -> None:
     from mixpanel_data.exceptions import QueryError
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Execute invalid SQL
         with pytest.raises(QueryError) as exc_info:
             storage.execute_rows("GARBAGE SQL")
@@ -1734,7 +1737,7 @@ def test_query_error_includes_query_text(tmp_path: Path) -> None:
     from mixpanel_data.exceptions import QueryError
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         bad_query = "SELECT * FROM table_does_not_exist"
 
         # Execute invalid SQL
@@ -1766,7 +1769,7 @@ def test_create_events_table_skips_duplicate_insert_ids(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events with duplicate insert_ids (simulating raw export data)
         events = [
             {
@@ -1821,7 +1824,7 @@ def test_create_events_table_keeps_first_duplicate(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create events with same insert_id but different properties
         events = [
             {
@@ -1871,7 +1874,7 @@ def test_create_profiles_table_skips_duplicate_distinct_ids(tmp_path: Path) -> N
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create profiles with duplicate distinct_ids
         profiles = [
             {
@@ -1918,7 +1921,7 @@ def test_create_profiles_table_keeps_first_duplicate(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create profiles with same distinct_id but different properties
         profiles = [
             {
@@ -1962,7 +1965,7 @@ def test_create_events_table_handles_many_duplicates(tmp_path: Path) -> None:
     from mixpanel_data.types import TableMetadata
 
     db_path = tmp_path / "test.db"
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         # Create 100 events where each insert_id appears 3 times
         # (simulating the ai_demo project's ~65% duplicate rate)
         events = []
@@ -2023,7 +2026,7 @@ def test_create_events_table_rolls_back_on_failure(tmp_path: Path) -> None:
         }
         raise ValueError("Simulated failure during iteration")
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         metadata = TableMetadata(
             type="events",
             fetched_at=datetime.now(UTC),
@@ -2060,7 +2063,7 @@ def test_create_profiles_table_rolls_back_on_failure(tmp_path: Path) -> None:
         }
         raise RuntimeError("Simulated database error")
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         metadata = TableMetadata(
             type="profiles",
             fetched_at=datetime.now(UTC),
@@ -2101,7 +2104,7 @@ def test_rollback_allows_retry_without_table_exists_error(tmp_path: Path) -> Non
             raise ValueError("First attempt fails")
         # Second attempt succeeds
 
-    with StorageEngine(path=db_path) as storage:
+    with StorageEngine(path=db_path, read_only=False) as storage:
         metadata = TableMetadata(
             type="events",
             fetched_at=datetime.now(UTC),
@@ -2355,7 +2358,7 @@ class TestDatabaseLocking:
 
         # Should raise DatabaseLockedError
         with pytest.raises(DatabaseLockedError) as exc_info:
-            StorageEngine(path=db_path)
+            StorageEngine(path=db_path, read_only=False)
 
         # Error should contain the database path
         assert str(db_path) in str(exc_info.value.message)
@@ -2380,7 +2383,7 @@ class TestDatabaseLocking:
         monkeypatch.setattr(duckdb, "connect", mock_connect)
 
         with pytest.raises(DatabaseLockedError) as exc_info:
-            StorageEngine(path=db_path)
+            StorageEngine(path=db_path, read_only=False)
 
         assert exc_info.value.details["db_path"] == str(db_path)
         assert exc_info.value.holding_pid == 99999
@@ -2404,7 +2407,7 @@ class TestDatabaseLocking:
         monkeypatch.setattr(duckdb, "connect", mock_connect)
 
         with pytest.raises(DatabaseLockedError) as exc_info:
-            StorageEngine(path=db_path)
+            StorageEngine(path=db_path, read_only=False)
 
         assert exc_info.value.holding_pid is None
 
@@ -2422,18 +2425,18 @@ class TestDatabaseLocking:
         monkeypatch.setattr(duckdb, "connect", mock_connect)
 
         with pytest.raises(OSError, match="Failed to create database"):
-            StorageEngine(path=db_path)
+            StorageEngine(path=db_path, read_only=False)
 
     def test_lock_released_after_close(self, tmp_path: Path) -> None:
         """Database can be opened after previous connection is closed."""
         db_path = tmp_path / "test.db"
 
         # Open and close first connection
-        storage1 = StorageEngine(path=db_path)
+        storage1 = StorageEngine(path=db_path, read_only=False)
         storage1.close()
 
         # Second connection should succeed
-        storage2 = StorageEngine(path=db_path)
+        storage2 = StorageEngine(path=db_path, read_only=False)
         try:
             assert storage2.connection is not None
         finally:
@@ -2444,11 +2447,11 @@ class TestDatabaseLocking:
         db_path = tmp_path / "test.db"
 
         # Use context manager
-        with StorageEngine(path=db_path):
+        with StorageEngine(path=db_path, read_only=False):
             pass  # Lock held during context
 
         # After context exits, should be able to open
-        with StorageEngine(path=db_path) as storage:
+        with StorageEngine(path=db_path, read_only=False) as storage:
             assert storage.connection is not None
 
     def test_memory_databases_dont_conflict(self) -> None:
@@ -2478,7 +2481,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database with write connection
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
             writer.connection.execute("INSERT INTO test VALUES (1), (2), (3)")
 
@@ -2495,7 +2498,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
 
         # Try to insert via read-only connection
@@ -2512,7 +2515,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database with data
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
             writer.connection.execute("INSERT INTO test VALUES (1)")
 
@@ -2530,7 +2533,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database with data
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
             writer.connection.execute("INSERT INTO test VALUES (1)")
 
@@ -2548,7 +2551,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create empty database
-        with StorageEngine(path=db_path):
+        with StorageEngine(path=db_path, read_only=False):
             pass
 
         # Try to create table via read-only connection
@@ -2563,7 +2566,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database with data
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
             writer.connection.execute("INSERT INTO test VALUES (1), (2)")
 
@@ -2593,7 +2596,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database with data
-        with StorageEngine(path=db_path) as writer:
+        with StorageEngine(path=db_path, read_only=False) as writer:
             writer.connection.execute("CREATE TABLE test (id INTEGER)")
             writer.connection.execute("INSERT INTO test VALUES (1)")
 
@@ -2608,7 +2611,7 @@ class TestReadOnlyMode:
         db_path = tmp_path / "test.db"
 
         # Create database
-        with StorageEngine(path=db_path):
+        with StorageEngine(path=db_path, read_only=False):
             pass
 
         # Check property on both modes
@@ -2622,5 +2625,5 @@ class TestReadOnlyMode:
         """Default read_only value is False."""
         db_path = tmp_path / "test.db"
 
-        with StorageEngine(path=db_path) as storage:
+        with StorageEngine(path=db_path, read_only=False) as storage:
             assert storage.read_only is False

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -334,10 +334,10 @@ class TestBasicWorkflow:
         ws = workspace_factory()
         try:
             # Create a test table
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 "CREATE TABLE test_table (id INTEGER, name VARCHAR)"
             )
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 "INSERT INTO test_table VALUES (1, 'Alice'), (2, 'Bob')"
             )
 
@@ -357,8 +357,8 @@ class TestBasicWorkflow:
         ws = workspace_factory()
         try:
             # Create a test table
-            ws._storage.connection.execute("CREATE TABLE count_table (id INTEGER)")
-            ws._storage.connection.execute(
+            ws.storage.connection.execute("CREATE TABLE count_table (id INTEGER)")
+            ws.storage.connection.execute(
                 "INSERT INTO count_table VALUES (1), (2), (3)"
             )
 
@@ -376,10 +376,10 @@ class TestBasicWorkflow:
         ws = workspace_factory()
         try:
             # Create a test table
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 "CREATE TABLE rows_table (id INTEGER, name VARCHAR)"
             )
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 "INSERT INTO rows_table VALUES (1, 'A'), (2, 'B')"
             )
 
@@ -411,9 +411,8 @@ class TestEphemeralWorkspace:
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            assert ws._storage is not None
-            # Ephemeral storage should exist
-            assert ws._storage._is_ephemeral is True
+            # Ephemeral storage should exist and be marked ephemeral
+            assert ws.storage._is_ephemeral is True
 
     def test_ephemeral_cleanup_on_normal_exit(
         self,
@@ -425,7 +424,7 @@ class TestEphemeralWorkspace:
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            path = ws._storage.path
+            path = ws.storage.path
             assert path is not None
             assert path.exists()
 
@@ -444,7 +443,7 @@ class TestEphemeralWorkspace:
                 _config_manager=mock_config_manager,
                 _api_client=mock_api_client,
             ) as ws:
-                path = ws._storage.path
+                path = ws.storage.path
                 assert path is not None
                 assert path.exists()
                 raise ValueError("Test exception")
@@ -1170,7 +1169,7 @@ class TestIntrospection:
         ws = workspace_factory()
         try:
             # Create a table
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 "CREATE TABLE test_schema (id INTEGER, name VARCHAR)"
             )
 
@@ -1190,8 +1189,8 @@ class TestIntrospection:
         ws = workspace_factory()
         try:
             # Create and then drop a table (need metadata table for drop)
-            ws._storage.connection.execute("CREATE TABLE drop_test (id INTEGER)")
-            ws._storage.connection.execute(
+            ws.storage.connection.execute("CREATE TABLE drop_test (id INTEGER)")
+            ws.storage.connection.execute(
                 """CREATE TABLE IF NOT EXISTS _metadata (
                     table_name VARCHAR PRIMARY KEY,
                     type VARCHAR NOT NULL,
@@ -1201,14 +1200,14 @@ class TestIntrospection:
                     row_count INTEGER NOT NULL
                 )"""
             )
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 """INSERT INTO _metadata VALUES
                 ('drop_test', 'events', CURRENT_TIMESTAMP, NULL, NULL, 0)"""
             )
 
             ws.drop("drop_test")
 
-            assert not ws._storage.table_exists("drop_test")
+            assert not ws.storage.table_exists("drop_test")
         finally:
             ws.close()
 
@@ -1220,9 +1219,9 @@ class TestIntrospection:
         ws = workspace_factory()
         try:
             # Create tables with metadata
-            ws._storage.connection.execute("CREATE TABLE events1 (id INTEGER)")
-            ws._storage.connection.execute("CREATE TABLE profiles1 (id INTEGER)")
-            ws._storage.connection.execute(
+            ws.storage.connection.execute("CREATE TABLE events1 (id INTEGER)")
+            ws.storage.connection.execute("CREATE TABLE profiles1 (id INTEGER)")
+            ws.storage.connection.execute(
                 """CREATE TABLE IF NOT EXISTS _metadata (
                     table_name VARCHAR PRIMARY KEY,
                     type VARCHAR NOT NULL,
@@ -1232,7 +1231,7 @@ class TestIntrospection:
                     row_count INTEGER NOT NULL
                 )"""
             )
-            ws._storage.connection.execute(
+            ws.storage.connection.execute(
                 """INSERT INTO _metadata VALUES
                 ('events1', 'events', CURRENT_TIMESTAMP, NULL, NULL, 0),
                 ('profiles1', 'profiles', CURRENT_TIMESTAMP, NULL, NULL, 0)"""
@@ -1241,8 +1240,8 @@ class TestIntrospection:
             ws.drop_all(type="events")
 
             # events1 should be dropped, profiles1 should remain
-            assert not ws._storage.table_exists("events1")
-            assert ws._storage.table_exists("profiles1")
+            assert not ws.storage.table_exists("events1")
+            assert ws.storage.table_exists("profiles1")
         finally:
             ws.close()
 
@@ -1342,7 +1341,7 @@ class TestContextManager:
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            path = ws._storage.path
+            path = ws.storage.path
             assert path is not None
             assert path.exists()
 
@@ -1501,8 +1500,8 @@ class TestMemoryWorkspace:
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            assert ws._storage._is_in_memory is True
-            assert ws._storage.path is None
+            assert ws.storage._is_in_memory is True
+            assert ws.storage.path is None
 
     def test_memory_info_reflects_in_memory(
         self,
@@ -1549,10 +1548,13 @@ class TestMemoryWorkspace:
         ) as ws:
             ws_ref = ws
             # Connection should be active
-            assert ws._storage._conn is not None
+            assert ws.storage._conn is not None
 
-        # After exit, connection should be closed
-        assert ws_ref._storage._conn is None
+        # After exit, connection should be closed (storage accessed before close)
+        assert ws_ref is not None
+        storage = ws_ref._storage
+        assert storage is not None
+        assert storage._conn is None
 
     def test_memory_with_account_parameter(
         self,
@@ -1577,7 +1579,7 @@ class TestMemoryWorkspace:
             _api_client=mock_api_client,
         ) as ws:
             assert ws._account_name == "test_account"
-            assert ws._storage._is_in_memory is True
+            assert ws.storage._is_in_memory is True
 
     def test_memory_with_project_override(
         self,
@@ -1592,7 +1594,7 @@ class TestMemoryWorkspace:
         ) as ws:
             assert ws._credentials is not None
             assert ws._credentials.project_id == "override_project"
-            assert ws._storage._is_in_memory is True
+            assert ws.storage._is_in_memory is True
 
     def test_memory_tables_method_works(
         self,
@@ -1613,4 +1615,199 @@ class TestMemoryWorkspace:
 
             # tables() won't show it because it uses _metadata table
             # But this confirms the introspection methods work
-            assert ws._storage.list_tables() == []
+            assert ws.storage.list_tables() == []
+
+
+class TestLazyStorageInitialization:
+    """Tests for lazy storage initialization (Phase 2).
+
+    Verify that storage is not created until actually needed,
+    allowing API-only commands to run without touching the database.
+    """
+
+    def test_storage_not_initialized_at_construction(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Storage should be None after construction when not injected."""
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            # Storage should not be created yet
+            assert ws._storage is None
+            # Database file should not exist yet
+            assert not (tmp_path / "test.db").exists()
+        finally:
+            ws.close()
+
+    def test_api_only_method_does_not_initialize_storage(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Calling API-only methods should not create storage connection."""
+        from mixpanel_data._internal.services.discovery import DiscoveryService
+
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            # Mock the discovery service
+            mock_discovery = MagicMock(spec=DiscoveryService)
+            mock_discovery.list_events.return_value = ["Event1", "Event2"]
+            ws._discovery = mock_discovery
+
+            # Call API-only method
+            result = ws.events()
+
+            # Storage should still be None
+            assert ws._storage is None
+            assert result == ["Event1", "Event2"]
+        finally:
+            ws.close()
+
+    def test_storage_method_initializes_storage_lazily(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Calling storage method should initialize storage on first access."""
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            # Storage should not exist yet
+            assert ws._storage is None
+
+            # Access storage via property
+            storage = ws.storage
+
+            # Now storage should exist
+            assert ws._storage is not None
+            assert storage is ws._storage
+            # Database file should now exist
+            assert (tmp_path / "test.db").exists()
+        finally:
+            ws.close()
+
+    def test_storage_property_returns_same_instance(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Storage property should return same instance on repeated access."""
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            storage1 = ws.storage
+            storage2 = ws.storage
+
+            assert storage1 is storage2
+        finally:
+            ws.close()
+
+    def test_injected_storage_used_directly(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Injected storage should be used directly without lazy initialization."""
+        injected_storage = StorageEngine.ephemeral()
+        try:
+            ws = Workspace(
+                _config_manager=mock_config_manager,
+                _storage=injected_storage,
+                _api_client=mock_api_client,
+            )
+            try:
+                # Storage should be the injected instance
+                assert ws._storage is injected_storage
+                assert ws.storage is injected_storage
+            finally:
+                ws.close()
+        finally:
+            injected_storage.close()
+
+    def test_close_handles_uninitialized_storage(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """close() should work when storage was never initialized."""
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+
+        # Storage never accessed
+        assert ws._storage is None
+
+        # close() should not raise
+        ws.close()
+
+    def test_multiple_api_calls_never_touch_storage(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Multiple API-only calls should never initialize storage."""
+        from mixpanel_data._internal.services.discovery import DiscoveryService
+        from mixpanel_data._internal.services.live_query import LiveQueryService
+
+        ws = Workspace(
+            path=tmp_path / "test.db",
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            # Mock services
+            mock_discovery = MagicMock(spec=DiscoveryService)
+            mock_discovery.list_events.return_value = ["Event1"]
+            mock_discovery.list_properties.return_value = ["prop1"]
+            mock_discovery.list_funnels.return_value = []
+            mock_discovery.list_cohorts.return_value = []
+            ws._discovery = mock_discovery
+
+            mock_live = MagicMock(spec=LiveQueryService)
+            mock_live.segmentation.return_value = SegmentationResult(
+                event="Event1",
+                from_date="2024-01-01",
+                to_date="2024-01-02",
+                unit="day",
+                segment_property=None,
+                total=100,
+                series={"2024-01-01": {"Event1": 100}},
+            )
+            ws._live_query = mock_live
+
+            # Call multiple API-only methods
+            ws.events()
+            ws.properties("event")
+            ws.funnels()
+            ws.cohorts()
+            ws.segmentation(
+                event="Event1", from_date="2024-01-01", to_date="2024-01-02"
+            )
+
+            # Storage should still be None
+            assert ws._storage is None
+        finally:
+            ws.close()

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1541,20 +1541,18 @@ class TestMemoryWorkspace:
         mock_api_client: MagicMock,
     ) -> None:
         """Test memory() context manager closes resources on exit."""
-        ws_ref = None
+        storage_ref = None
         with Workspace.memory(
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         ) as ws:
-            ws_ref = ws
-            # Connection should be active
-            assert ws.storage._conn is not None
+            # Capture storage reference while connection is active
+            storage_ref = ws.storage
+            assert storage_ref._conn is not None
 
-        # After exit, connection should be closed (storage accessed before close)
-        assert ws_ref is not None
-        storage = ws_ref._storage
-        assert storage is not None
-        assert storage._conn is None
+        # After exit, connection should be closed
+        assert storage_ref is not None
+        assert storage_ref._conn is None
 
     def test_memory_with_account_parameter(
         self,

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1839,20 +1839,20 @@ class TestReadOnlyMode:
         finally:
             ws.close()
 
-    def test_workspace_default_is_read_only(
+    def test_workspace_default_is_not_read_only(
         self,
         mock_config_manager: MagicMock,
         mock_api_client: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Workspace should default to read-only for concurrent read access."""
+        """Workspace should default to write access matching DuckDB behavior."""
         ws = Workspace(
             path=tmp_path / "test.db",
             _config_manager=mock_config_manager,
             _api_client=mock_api_client,
         )
         try:
-            assert ws._read_only is True
+            assert ws._read_only is False
         finally:
             ws.close()
 

--- a/tests/unit/test_workspace_streaming.py
+++ b/tests/unit/test_workspace_streaming.py
@@ -500,7 +500,7 @@ class TestStreamingConfigError:
         """Test stream_events raises ConfigError when opened without credentials."""
         # Create a database file
         db_path = temp_dir / "test.db"
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
         storage.close()
 
         ws = Workspace.open(db_path)
@@ -519,7 +519,7 @@ class TestStreamingConfigError:
         """Test stream_profiles raises ConfigError when opened without credentials."""
         # Create a database file
         db_path = temp_dir / "test.db"
-        storage = StorageEngine(path=db_path)
+        storage = StorageEngine(path=db_path, read_only=False)
         storage.close()
 
         ws = Workspace.open(db_path)


### PR DESCRIPTION
## Summary

- Add `DatabaseLockedError` exception for graceful lock conflict handling
- Implement lazy storage initialization in `Workspace` to avoid database access for API-only commands
- Add `read_only` parameter to `StorageEngine` for read-only database connections
- Add CLI handler to display user-friendly error messages for lock conflicts

## Problem

Multiple `mp` CLI processes crash with DuckDB lock errors because `Workspace.__init__` eagerly created `StorageEngine` with write access for ALL commands, even API-only ones that never touch the database.

## Solution

This prevents crashes when multiple mp commands run concurrently by:

1. **Deferring database initialization** until actually needed (lazy `storage` property)
2. **Showing helpful error messages** when lock conflicts occur instead of cryptic tracebacks
3. **Enabling read-only access mode** for concurrent read operations from different processes

## Test plan

- [x] All 1011 tests pass
- [x] `just check` passes (lint, typecheck, test)
- [x] New tests for `DatabaseLockedError` exception
- [x] New tests for lazy storage initialization
- [x] New tests for read-only mode