### PR TITLE
feat: add error handling improvements and fix PBT strategy

### DIFF
--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -14,6 +14,8 @@ from mixpanel_data.exceptions import (
     ConfigError,
     DatabaseLockedError,
     DatabaseNotFoundError,
+    DateRangeTooLargeError,
+    EventNotFoundError,
     JQLSyntaxError,
     MixpanelDataError,
     QueryError,
@@ -89,6 +91,8 @@ __all__ = [
     "TableNotFoundError",
     "DatabaseLockedError",
     "DatabaseNotFoundError",
+    "EventNotFoundError",
+    "DateRangeTooLargeError",
     # Result types
     "FetchResult",
     "SegmentationResult",

--- a/src/mixpanel_data/_internal/services/fetcher.py
+++ b/src/mixpanel_data/_internal/services/fetcher.py
@@ -25,6 +25,10 @@ _logger = logging.getLogger(__name__)
 # These are standard Mixpanel fields that become top-level columns in storage.
 _RESERVED_EVENT_KEYS = frozenset({"distinct_id", "time", "$insert_id"})
 
+# Reserved keys that _transform_profile extracts from properties.
+# These are standard Mixpanel fields that become top-level columns in storage.
+_RESERVED_PROFILE_KEYS = frozenset({"$last_seen"})
+
 
 def _transform_event(event: dict[str, Any]) -> dict[str, Any]:
     """Transform API event to storage format.

--- a/src/mixpanel_data/_internal/services/fetcher.py
+++ b/src/mixpanel_data/_internal/services/fetcher.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# Reserved keys that _transform_event extracts from properties.
+# These are standard Mixpanel fields that become top-level columns in storage.
+_RESERVED_EVENT_KEYS = frozenset({"distinct_id", "time", "$insert_id"})
+
 
 def _transform_event(event: dict[str, Any]) -> dict[str, Any]:
     """Transform API event to storage format.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -33,6 +33,7 @@ Example:
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -794,10 +795,10 @@ class Workspace:
             ConfigError: If API credentials not available.
             AuthenticationError: If credentials are invalid.
         """
-        # Create progress callback if requested
+        # Create progress callback if requested (only for interactive terminals)
         progress_callback = None
         pbar = None
-        if progress:
+        if progress and sys.stderr.isatty():
             try:
                 from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -853,10 +854,10 @@ class Workspace:
             TableExistsError: If table already exists.
             ConfigError: If API credentials not available.
         """
-        # Create progress callback if requested
+        # Create progress callback if requested (only for interactive terminals)
         progress_callback = None
         pbar = None
-        if progress:
+        if progress and sys.stderr.isatty():
             try:
                 from rich.progress import Progress, SpinnerColumn, TextColumn
 

--- a/tests/unit/test_fetcher_service_pbt.py
+++ b/tests/unit/test_fetcher_service_pbt.py
@@ -46,9 +46,18 @@ json_values: st.SearchStrategy[Any] = st.recursive(
     max_leaves=15,
 )
 
+# Reserved keys that _transform_event extracts from properties
+# These should not be randomly generated in property dicts
+_RESERVED_EVENT_KEYS = frozenset({"distinct_id", "time", "$insert_id"})
+
+# Strategy for event property keys (excluding reserved keys)
+event_property_keys = st.text().filter(lambda k: k not in _RESERVED_EVENT_KEYS)
+
 # Strategy for event properties dict
 # These are properties that might come from Mixpanel's Export API
-event_properties = st.dictionaries(st.text(), json_values, max_size=10)
+# Reserved keys (distinct_id, time, $insert_id) are excluded since they're
+# handled separately as standard fields in _transform_event
+event_properties = st.dictionaries(event_property_keys, json_values, max_size=10)
 
 # Strategy for Unix timestamps (valid range for Mixpanel events)
 # Mixpanel uses seconds since epoch

--- a/tests/unit/test_fetcher_service_pbt.py
+++ b/tests/unit/test_fetcher_service_pbt.py
@@ -19,6 +19,7 @@ from hypothesis import strategies as st
 
 from mixpanel_data._internal.services.fetcher import (
     _RESERVED_EVENT_KEYS,
+    _RESERVED_PROFILE_KEYS,
     _transform_event,
     _transform_profile,
 )
@@ -55,6 +56,14 @@ event_property_keys = st.text().filter(lambda k: k not in _RESERVED_EVENT_KEYS)
 # Reserved keys (distinct_id, time, $insert_id) are excluded since they're
 # handled separately as standard fields in _transform_event
 event_properties = st.dictionaries(event_property_keys, json_values, max_size=10)
+
+# Strategy for profile property keys (excluding reserved keys)
+profile_property_keys = st.text().filter(lambda k: k not in _RESERVED_PROFILE_KEYS)
+
+# Strategy for profile properties dict
+# Reserved keys ($last_seen) are excluded since they're handled separately
+# as standard fields in _transform_profile
+profile_properties = st.dictionaries(profile_property_keys, json_values, max_size=10)
 
 # Strategy for Unix timestamps (valid range for Mixpanel events)
 # Mixpanel uses seconds since epoch
@@ -138,7 +147,7 @@ def api_profiles(draw: st.DrawFn) -> dict[str, Any]:
     )
 
     # Build properties with optional $last_seen
-    properties: dict[str, Any] = draw(event_properties)
+    properties: dict[str, Any] = draw(profile_properties)
     if last_seen is not None:
         properties["$last_seen"] = last_seen
 

--- a/tests/unit/test_fetcher_service_pbt.py
+++ b/tests/unit/test_fetcher_service_pbt.py
@@ -18,6 +18,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from mixpanel_data._internal.services.fetcher import (
+    _RESERVED_EVENT_KEYS,
     _transform_event,
     _transform_profile,
 )
@@ -45,10 +46,6 @@ json_values: st.SearchStrategy[Any] = st.recursive(
     ),
     max_leaves=15,
 )
-
-# Reserved keys that _transform_event extracts from properties
-# These should not be randomly generated in property dicts
-_RESERVED_EVENT_KEYS = frozenset({"distinct_id", "time", "$insert_id"})
 
 # Strategy for event property keys (excluding reserved keys)
 event_property_keys = st.text().filter(lambda k: k not in _RESERVED_EVENT_KEYS)


### PR DESCRIPTION
## Summary

- Fixed PBT test failure where `event_properties` strategy could generate reserved keys (`time`, `distinct_id`, `$insert_id`) with `None` values
- Added `_RESERVED_EVENT_KEYS` constant to `fetcher.py` as single source of truth for reserved event keys
- Added `_RESERVED_PROFILE_KEYS` constant to `fetcher.py` for reserved profile keys (`$last_seen`)
- Created `profile_property_keys` and `profile_properties` strategies for profile tests
- Added `EventNotFoundError` exception with similar event name suggestions using case-insensitive and substring matching
- Added `DateRangeTooLargeError` exception for validating 100-day API limit
- Updated `DiscoveryService.list_properties` to raise `EventNotFoundError` with helpful suggestions when event not found
- Added date range validation to `FetcherService`
- Added `validate_date_range` helper to CLI utils
- Exported new exceptions from public API

## Test plan

- [x] `pytest tests/unit/test_fetcher_service_pbt.py` - all 11 PBT tests pass
- [x] `pytest tests/unit/test_exceptions.py` - new exception tests pass
- [x] `pytest tests/unit/test_discovery.py` - discovery tests pass
- [x] `pytest tests/unit/test_fetcher_service.py` - fetcher tests pass
- [x] `just lint` - passes
- [x] `just typecheck` - passes