### PR TITLE
feat: add append mode, configurable batch_size, and memory optimizations

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -95,6 +95,15 @@ except mp.MixpanelDataError as e:
 
 ## Storage Exceptions
 
+Storage exceptions are raised during fetch and table operations:
+
+| Exception | Raised When |
+|-----------|-------------|
+| `TableExistsError` | Fetching to an existing table without `append=True` or `--replace` |
+| `TableNotFoundError` | Using `append=True` on a non-existent table |
+| `DatabaseLockedError` | Another process has the database locked |
+| `DatabaseNotFoundError` | Database file not found in read-only mode |
+
 ::: mixpanel_data.TableExistsError
     options:
       show_root_heading: true

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -11,6 +11,28 @@ Workspace orchestrates four internal services:
 - **LiveQueryService** — Real-time analytics queries
 - **StorageEngine** — Local SQL query execution
 
+## Key Features
+
+### Append Mode
+
+The `fetch_events()` and `fetch_profiles()` methods support an `append` parameter for incremental data loading:
+
+```python
+# Initial fetch
+ws.fetch_events(name="events", from_date="2024-01-01", to_date="2024-01-31")
+
+# Append more data (duplicates are automatically skipped)
+ws.fetch_events(name="events", from_date="2024-02-01", to_date="2024-02-28", append=True)
+```
+
+This is useful for:
+
+- **Incremental loading**: Fetch data in chunks without creating multiple tables
+- **Crash recovery**: Resume a failed fetch from the last successful point
+- **Extending date ranges**: Add more historical or recent data to an existing table
+
+Duplicate events (by `insert_id`) and profiles (by `distinct_id`) are automatically skipped via `INSERT OR IGNORE`.
+
 ## Class Reference
 
 ::: mixpanel_data.Workspace

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -50,6 +50,14 @@ Fetch data from Mixpanel into local storage, or stream directly to stdout.
 | `mp fetch events` | Fetch events to local DuckDB |
 | `mp fetch profiles` | Fetch user profiles to local DuckDB |
 
+**Table Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--replace` | Drop and recreate existing table |
+| `--append` | Add data to existing table (duplicates skipped) |
+| `--batch-size` | Rows per commit (100-100000, default: 1000) |
+
 **Streaming Options:**
 
 | Option | Description |
@@ -167,6 +175,23 @@ mp query sql "SELECT event_name, COUNT(*) FROM jan GROUP BY 1" --format table
 
 # 5. Run live queries
 mp query segmentation --event Purchase --from 2024-01-01 --to 2024-01-31 --format table
+```
+
+### Incremental Fetching
+
+```bash
+# Fetch initial data
+mp fetch events events --from 2024-01-01 --to 2024-01-31
+
+# Append more data later
+mp fetch events events --from 2024-02-01 --to 2024-02-28 --append
+
+# Resume after a crash (overlapping dates are safe)
+mp query sql "SELECT MAX(event_time) FROM events"
+mp fetch events events --from 2024-02-15 --to 2024-02-28 --append
+
+# Replace with fresh data
+mp fetch events events --from 2024-01-01 --to 2024-02-28 --replace
 ```
 
 ### Piping and Scripting

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -65,6 +65,14 @@ Fetch data from Mixpanel into local storage, or stream directly to stdout.
 | `--stdout` | Stream data as JSONL to stdout instead of storing |
 | `--raw` | Output raw Mixpanel API format (requires `--stdout`) |
 
+**Event Filter Options (fetch events only):**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--events` | `-e` | Comma-separated event names to filter |
+| `--where` | `-w` | Mixpanel filter expression |
+| `--limit` | `-l` | Maximum events to return (max 100000) |
+
 **Profile Filter Options (fetch profiles only):**
 
 | Option | Short | Description |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -65,6 +65,14 @@ Fetch data from Mixpanel into local storage, or stream directly to stdout.
 | `--stdout` | Stream data as JSONL to stdout instead of storing |
 | `--raw` | Output raw Mixpanel API format (requires `--stdout`) |
 
+**Profile Filter Options (fetch profiles only):**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--cohort` | `-c` | Filter by cohort ID |
+| `--output-properties` | `-o` | Comma-separated properties to include |
+| `--where` | `-w` | Mixpanel filter expression |
+
 ### query — Query Operations
 
 Execute queries against local or remote data.
@@ -218,6 +226,12 @@ mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout
 
 # Stream profiles
 mp fetch profiles --stdout
+
+# Stream profiles filtered by cohort
+mp fetch profiles --stdout --cohort 12345
+
+# Stream specific profile properties only
+mp fetch profiles --stdout --output-properties '$email,$name,plan'
 
 # Pipe to jq for filtering
 mp fetch events --from 2024-01-01 --to 2024-01-31 --stdout \

--- a/docs/guide/fetching.md
+++ b/docs/guide/fetching.md
@@ -161,6 +161,68 @@ Use Mixpanel expression syntax:
         --where 'properties["plan"] == "premium"'
     ```
 
+### Filtering by Cohort
+
+Fetch only profiles that are members of a specific cohort:
+
+=== "Python"
+
+    ```python
+    result = ws.fetch_profiles(
+        name="power_users",
+        cohort_id="12345"
+    )
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch profiles power_users --cohort 12345
+    ```
+
+### Selecting Specific Properties
+
+Reduce bandwidth and memory by fetching only the properties you need:
+
+=== "Python"
+
+    ```python
+    result = ws.fetch_profiles(
+        name="user_emails",
+        output_properties=["$email", "$name", "plan"]
+    )
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch profiles user_emails --output-properties '$email,$name,plan'
+    ```
+
+### Combining Filters
+
+Filters can be combined for precise data selection:
+
+=== "Python"
+
+    ```python
+    result = ws.fetch_profiles(
+        name="premium_emails",
+        cohort_id="premium_cohort",
+        output_properties=["$email", "$name"],
+        where='properties["country"] == "US"'
+    )
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch profiles premium_emails \
+        --cohort premium_cohort \
+        --output-properties '$email,$name' \
+        --where 'properties["country"] == "US"'
+    ```
+
 ## Table Naming
 
 Tables are stored with the name you provide:

--- a/docs/guide/fetching.md
+++ b/docs/guide/fetching.md
@@ -74,6 +74,30 @@ Filter with Mixpanel expression syntax:
         --where 'properties["plan"] == "premium"'
     ```
 
+### Limiting Results
+
+Cap the number of events returned (max 100,000):
+
+=== "Python"
+
+    ```python
+    result = ws.fetch_events(
+        name="sample_events",
+        from_date="2024-01-01",
+        to_date="2024-01-31",
+        limit=10000
+    )
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp fetch events sample_events --from 2024-01-01 --to 2024-01-31 \
+        --limit 10000
+    ```
+
+This is useful for testing queries or sampling data before a full fetch.
+
 ### Progress Tracking
 
 Monitor fetch progress with a callback:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,6 @@ pytest_add_cli_args_test_selection = ["tests/"]
 dev = [
     "click-man>=0.5.1",
     "pre-commit>=4.5.1",
+    "psutil>=7.2.0",
+    "types-psutil>=7.2.0.20251228",
 ]

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -617,6 +617,7 @@ class MixpanelAPIClient:
         *,
         events: list[str] | None = None,
         where: str | None = None,
+        limit: int | None = None,
         on_batch: Callable[[int], None] | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Stream events from the Export API.
@@ -629,6 +630,7 @@ class MixpanelAPIClient:
             to_date: End date (YYYY-MM-DD, inclusive).
             events: Optional list of event names to filter.
             where: Optional filter expression.
+            limit: Optional maximum number of events to return (max 100000).
             on_batch: Optional callback invoked with cumulative count every
                 1000 events, and once at the end for any remaining events.
 
@@ -653,6 +655,8 @@ class MixpanelAPIClient:
             params["event"] = json.dumps(events)
         if where:
             params["where"] = where
+        if limit is not None:
+            params["limit"] = limit
 
         client = self._ensure_client()
         headers = {

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -752,6 +752,8 @@ class MixpanelAPIClient:
         self,
         *,
         where: str | None = None,
+        cohort_id: str | None = None,
+        output_properties: list[str] | None = None,
         on_batch: Callable[[int], None] | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Stream profiles from the Engage API.
@@ -761,6 +763,10 @@ class MixpanelAPIClient:
 
         Args:
             where: Optional filter expression.
+            cohort_id: Optional cohort ID to filter by. Only profiles that are
+                members of this cohort will be returned.
+            output_properties: Optional list of property names to include in
+                the response. If None, all properties are returned.
             on_batch: Optional callback invoked with cumulative count after
                 each page is processed.
 
@@ -787,6 +793,10 @@ class MixpanelAPIClient:
                 params["session_id"] = session_id
             if where:
                 params["where"] = where
+            if cohort_id:
+                params["filter_by_cohort"] = cohort_id
+            if output_properties:
+                params["output_properties"] = json.dumps(output_properties)
 
             response = self._request("POST", url, data=params)
 

--- a/src/mixpanel_data/_internal/expressions.py
+++ b/src/mixpanel_data/_internal/expressions.py
@@ -27,7 +27,8 @@ def normalize_on_expression(on: str) -> str:
 
     Returns:
         The normalized expression. Bare names are wrapped in properties["..."],
-        while existing expressions pass through unchanged.
+        while existing expressions pass through unchanged. Double quotes and
+        backslashes in bare property names are escaped to produce valid syntax.
 
     Examples:
         >>> normalize_on_expression("Source")
@@ -36,7 +37,12 @@ def normalize_on_expression(on: str) -> str:
         'properties["Source"]'
         >>> normalize_on_expression('properties["Type"] == "Event"')
         'properties["Type"] == "Event"'
+        >>> normalize_on_expression('my"property')
+        'properties["my\\\\"property"]'
     """
     if any(accessor in on for accessor in _FILTER_EXPR_ACCESSORS):
         return on
-    return f'properties["{on}"]'
+    # Escape backslashes first, then double quotes, to produce valid syntax.
+    # Order matters: escaping quotes first would double-escape the backslash.
+    escaped = on.replace("\\", "\\\\").replace('"', '\\"')
+    return f'properties["{escaped}"]'

--- a/src/mixpanel_data/_internal/expressions.py
+++ b/src/mixpanel_data/_internal/expressions.py
@@ -1,0 +1,42 @@
+"""Expression normalization utilities for Mixpanel filter expressions.
+
+This module provides functions to normalize user input into valid
+Mixpanel filter expression syntax. Filter expressions use property
+accessor syntax (properties["name"], user["name"], event["name"])
+and are distinct from JQL (JavaScript Query Language).
+"""
+
+from __future__ import annotations
+
+# Accessor patterns that indicate a full filter expression.
+# These are the three accessor types supported by Mixpanel's filter expression syntax.
+_FILTER_EXPR_ACCESSORS = ('properties["', 'user["', 'event["')
+
+
+def normalize_on_expression(on: str) -> str:
+    """Wrap bare property names in properties[] accessor syntax.
+
+    The Mixpanel segmentation API requires property references to use
+    filter expression syntax (e.g., properties["Source"]). This function
+    normalizes bare property names by wrapping them, while passing through
+    expressions that already use accessor syntax.
+
+    Args:
+        on: The segmentation property expression. Can be a bare property name
+            (e.g., "Source") or a full expression (e.g., 'properties["Source"]').
+
+    Returns:
+        The normalized expression. Bare names are wrapped in properties["..."],
+        while existing expressions pass through unchanged.
+
+    Examples:
+        >>> normalize_on_expression("Source")
+        'properties["Source"]'
+        >>> normalize_on_expression('properties["Source"]')
+        'properties["Source"]'
+        >>> normalize_on_expression('properties["Type"] == "Event"')
+        'properties["Type"] == "Event"'
+    """
+    if any(accessor in on for accessor in _FILTER_EXPR_ACCESSORS):
+        return on
+    return f'properties["{on}"]'

--- a/src/mixpanel_data/_internal/services/fetcher.py
+++ b/src/mixpanel_data/_internal/services/fetcher.py
@@ -278,6 +278,8 @@ class FetcherService:
         name: str,
         *,
         where: str | None = None,
+        cohort_id: str | None = None,
+        output_properties: list[str] | None = None,
         progress_callback: Callable[[int], None] | None = None,
         append: bool = False,
         batch_size: int = 1000,
@@ -287,6 +289,10 @@ class FetcherService:
         Args:
             name: Table name to create or append to.
             where: Optional filter expression.
+            cohort_id: Optional cohort ID to filter by. Only profiles that are
+                members of this cohort will be returned.
+            output_properties: Optional list of property names to include in
+                the response. If None, all properties are returned.
             progress_callback: Optional callback invoked with row count during fetch.
             append: If True, append to existing table. If False (default), create new.
             batch_size: Number of rows per INSERT/COMMIT cycle. Controls the
@@ -315,6 +321,8 @@ class FetcherService:
         # Stream profiles from API
         profiles_iter = self._api_client.export_profiles(
             where=where,
+            cohort_id=cohort_id,
+            output_properties=output_properties,
             on_batch=on_api_batch,
         )
 
@@ -332,6 +340,8 @@ class FetcherService:
             to_date=None,
             filter_events=None,
             filter_where=where,
+            filter_cohort_id=cohort_id,
+            filter_output_properties=output_properties,
         )
 
         # Store in database (handles TableExistsError/TableNotFoundError, transactions)

--- a/src/mixpanel_data/_internal/services/fetcher.py
+++ b/src/mixpanel_data/_internal/services/fetcher.py
@@ -178,6 +178,7 @@ class FetcherService:
         *,
         events: list[str] | None = None,
         where: str | None = None,
+        limit: int | None = None,
         progress_callback: Callable[[int], None] | None = None,
         append: bool = False,
         batch_size: int = 1000,
@@ -190,6 +191,7 @@ class FetcherService:
             to_date: End date (YYYY-MM-DD, inclusive).
             events: Optional list of event names to filter.
             where: Optional filter expression.
+            limit: Optional maximum number of events to return (max 100000).
             progress_callback: Optional callback invoked with row count during fetch.
             append: If True, append to existing table. If False (default), create new.
             batch_size: Number of rows per INSERT/COMMIT cycle. Controls the
@@ -225,6 +227,7 @@ class FetcherService:
             to_date=to_date,
             events=events,
             where=where,
+            limit=limit,
             on_batch=on_api_batch,
         )
 

--- a/src/mixpanel_data/_internal/services/live_query.py
+++ b/src/mixpanel_data/_internal/services/live_query.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
+from mixpanel_data._internal.expressions import normalize_on_expression
 from mixpanel_data._literal_types import CountType, HourDayUnit, TimeUnit
 from mixpanel_data.types import (
     ActivityFeedResult,
@@ -281,11 +282,14 @@ class LiveQueryService:
             print(result.df.head())
             ```
         """
+        # Normalize bare property names to filter expression syntax
+        normalized_on = normalize_on_expression(on) if on else None
+
         raw = self._api_client.segmentation(
             event=event,
             from_date=from_date,
             to_date=to_date,
-            on=on,
+            on=normalized_on,
             unit=unit,
             where=where,
         )
@@ -778,11 +782,14 @@ class LiveQueryService:
                 print(f"{bucket}: {sum(series.values())} events")
             ```
         """
+        # Normalize bare property names to filter expression syntax
+        normalized_on = normalize_on_expression(on)
+
         raw = self._api_client.segmentation_numeric(
             event=event,
             from_date=from_date,
             to_date=to_date,
-            on=on,
+            on=normalized_on,
             unit=unit,
             where=where,
             type=type,
@@ -832,11 +839,14 @@ class LiveQueryService:
             print(f"Total revenue: ${total:,.2f}")
             ```
         """
+        # Normalize bare property names to filter expression syntax
+        normalized_on = normalize_on_expression(on)
+
         raw = self._api_client.segmentation_sum(
             event=event,
             from_date=from_date,
             to_date=to_date,
-            on=on,
+            on=normalized_on,
             unit=unit,
             where=where,
         )
@@ -885,11 +895,14 @@ class LiveQueryService:
             print(f"Average order value: ${avg:.2f}")
             ```
         """
+        # Normalize bare property names to filter expression syntax
+        normalized_on = normalize_on_expression(on)
+
         raw = self._api_client.segmentation_average(
             event=event,
             from_date=from_date,
             to_date=to_date,
-            on=on,
+            on=normalized_on,
             unit=unit,
             where=where,
         )

--- a/src/mixpanel_data/_internal/storage.py
+++ b/src/mixpanel_data/_internal/storage.py
@@ -882,7 +882,7 @@ class StorageEngine:
 
         Raises:
             TableNotFoundError: If table does not exist.
-            ValueError: If data is malformed.
+            ValueError: If data is malformed or table is not an events table.
         """
         # Validate table name
         self._validate_table_name(name)
@@ -890,6 +890,13 @@ class StorageEngine:
         # Check if table exists
         if not self.table_exists(name):
             raise TableNotFoundError(f"Table '{name}' does not exist")
+
+        # Verify table is an events table (not profiles)
+        existing_metadata = self.get_metadata(name)
+        if existing_metadata.type != "events":
+            raise ValueError(
+                f"Cannot append events to {existing_metadata.type} table '{name}'"
+            )
 
         # Start transaction
         self.connection.execute("BEGIN TRANSACTION")
@@ -939,7 +946,7 @@ class StorageEngine:
 
         Raises:
             TableNotFoundError: If table does not exist.
-            ValueError: If data is malformed.
+            ValueError: If data is malformed or table is not a profiles table.
         """
         # Validate table name
         self._validate_table_name(name)
@@ -947,6 +954,13 @@ class StorageEngine:
         # Check if table exists
         if not self.table_exists(name):
             raise TableNotFoundError(f"Table '{name}' does not exist")
+
+        # Verify table is a profiles table (not events)
+        existing_metadata = self.get_metadata(name)
+        if existing_metadata.type != "profiles":
+            raise ValueError(
+                f"Cannot append profiles to {existing_metadata.type} table '{name}'"
+            )
 
         # Start transaction
         self.connection.execute("BEGIN TRANSACTION")

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -67,7 +67,13 @@ def fetch_events(
     ] = None,
     limit: Annotated[
         int | None,
-        typer.Option("--limit", "-l", help="Maximum events to return (max 100000)."),
+        typer.Option(
+            "--limit",
+            "-l",
+            help="Maximum events to return (max 100000).",
+            min=1,
+            max=100000,
+        ),
     ] = None,
     replace: Annotated[
         bool,

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -101,6 +101,9 @@ def fetch_events(
     Events are stored in a DuckDB table for SQL querying. A progress bar
     shows fetch progress (disable with --no-progress or --quiet).
 
+    **Note:** This is a long-running operation. For large date ranges, chunk
+    into smaller ranges with --append, or run in the background.
+
     Use --events to filter by event name (comma-separated list).
     Use --where for Mixpanel expression filters (e.g., 'properties["country"]=="US"').
     Use --replace to drop and recreate an existing table.
@@ -238,6 +241,9 @@ def fetch_profiles(
 
     Profiles are stored in a DuckDB table for SQL querying. A progress bar
     shows fetch progress (disable with --no-progress or --quiet).
+
+    **Note:** This is a long-running operation. For large profile sets,
+    consider running in the background.
 
     Use --where for Mixpanel expression filters on profile properties.
     Use --replace to drop and recreate an existing table.

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -65,6 +65,10 @@ def fetch_events(
         str | None,
         typer.Option("--where", "-w", help="Mixpanel filter expression."),
     ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", "-l", help="Maximum events to return (max 100000)."),
+    ] = None,
     replace: Annotated[
         bool,
         typer.Option("--replace", help="Replace existing table."),
@@ -106,6 +110,7 @@ def fetch_events(
 
     Use --events to filter by event name (comma-separated list).
     Use --where for Mixpanel expression filters (e.g., 'properties["country"]=="US"').
+    Use --limit to cap the number of events returned (max 100000).
     Use --replace to drop and recreate an existing table.
     Use --append to add data to an existing table.
     Use --stdout to stream JSONL to stdout instead of storing locally.
@@ -118,6 +123,7 @@ def fetch_events(
         mp fetch events --from 2025-01-01 --to 2025-01-31
         mp fetch events signups --from 2025-01-01 --to 2025-01-31 --events "Sign Up"
         mp fetch events --from 2025-01-01 --to 2025-01-31 --where 'properties["country"]=="US"'
+        mp fetch events --from 2025-01-01 --to 2025-01-31 --limit 10000
         mp fetch events --from 2025-01-01 --to 2025-01-31 --replace
         mp fetch events --from 2025-01-01 --to 2025-01-31 --append
         mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout
@@ -158,6 +164,7 @@ def fetch_events(
             to_date=to_date,
             events=events_list,
             where=where,
+            limit=limit,
             raw=raw,
         ):
             print(json.dumps(event, default=_json_serializer), file=sys.stdout)
@@ -186,6 +193,7 @@ def fetch_events(
         to_date=to_date,
         events=events_list,
         where=where,
+        limit=limit,
         progress=show_progress,
         append=append,
         batch_size=batch_size,

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -132,7 +132,11 @@ def query_segmentation(
     ],
     on: Annotated[
         str | None,
-        typer.Option("--on", "-o", help="Property to segment by."),
+        typer.Option(
+            "--on",
+            "-o",
+            help="Property to segment by (bare name or expression).",
+        ),
     ] = None,
     unit: Annotated[
         str,
@@ -149,6 +153,9 @@ def query_segmentation(
     Returns time-series event counts, optionally segmented by a property.
     Without --on, returns total counts per time period. With --on, breaks
     down counts by property values (e.g., --on country shows counts per country).
+
+    The --on parameter accepts bare property names (e.g., 'country') or full
+    filter expressions (e.g., 'properties["country"] == "US"').
 
     Output includes event name, date range, total count, time unit, and
     a series dict mapping dates to counts (or segments to date/count dicts).
@@ -709,7 +716,11 @@ def query_segmentation_numeric(
     ],
     on: Annotated[
         str,
-        typer.Option("--on", "-o", help="Numeric property to bucket."),
+        typer.Option(
+            "--on",
+            "-o",
+            help="Numeric property to bucket (bare name or expression).",
+        ),
     ],
     from_date: Annotated[
         str,
@@ -782,7 +793,11 @@ def query_segmentation_sum(
     ],
     on: Annotated[
         str,
-        typer.Option("--on", "-o", help="Numeric property to sum."),
+        typer.Option(
+            "--on",
+            "-o",
+            help="Numeric property to sum (bare name or expression).",
+        ),
     ],
     from_date: Annotated[
         str,
@@ -844,7 +859,11 @@ def query_segmentation_average(
     ],
     on: Annotated[
         str,
-        typer.Option("--on", "-o", help="Numeric property to average."),
+        typer.Option(
+            "--on",
+            "-o",
+            help="Numeric property to average (bare name or expression).",
+        ),
     ],
     from_date: Annotated[
         str,

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -1307,6 +1307,12 @@ class TableMetadata:
     filter_where: str | None = None
     """WHERE clause filter (if applicable)."""
 
+    filter_cohort_id: str | None = None
+    """Cohort ID filter for profiles (if applicable)."""
+
+    filter_output_properties: list[str] | None = None
+    """Property names to include in output (if applicable)."""
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize for JSON output."""
         return {
@@ -1316,6 +1322,8 @@ class TableMetadata:
             "to_date": self.to_date,
             "filter_events": self.filter_events,
             "filter_where": self.filter_where,
+            "filter_cohort_id": self.filter_cohort_id,
+            "filter_output_properties": self.filter_output_properties,
         }
 
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -804,6 +804,11 @@ class Workspace:
     ) -> FetchResult:
         """Fetch events from Mixpanel and store in local database.
 
+        Note:
+            This is a potentially long-running operation that streams data from
+            Mixpanel's Export API. For large date ranges, consider chunking into
+            smaller ranges with ``append=True``, or running in a background process.
+
         Args:
             name: Table name to create or append to (default: "events").
             from_date: Start date (YYYY-MM-DD).
@@ -879,6 +884,11 @@ class Workspace:
         batch_size: int = 1000,
     ) -> FetchResult:
         """Fetch user profiles from Mixpanel and store in local database.
+
+        Note:
+            This is a potentially long-running operation that streams data from
+            Mixpanel's Engage API. For large profile sets, consider running in a
+            background process.
 
         Args:
             name: Table name to create or append to (default: "profiles").

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -91,6 +91,25 @@ _MIN_BATCH_SIZE = 100
 _MAX_BATCH_SIZE = 100_000
 
 
+def _validate_batch_size(batch_size: int) -> None:
+    """Validate batch_size is within the allowed range.
+
+    Args:
+        batch_size: Number of rows per commit.
+
+    Raises:
+        ValueError: If batch_size is outside the valid range.
+    """
+    if batch_size < _MIN_BATCH_SIZE:
+        raise ValueError(
+            f"batch_size must be at least {_MIN_BATCH_SIZE}, got {batch_size}"
+        )
+    if batch_size > _MAX_BATCH_SIZE:
+        raise ValueError(
+            f"batch_size must be at most {_MAX_BATCH_SIZE}, got {batch_size}"
+        )
+
+
 class Workspace:
     """Unified entry point for Mixpanel data operations.
 
@@ -809,14 +828,7 @@ class Workspace:
             ValueError: If batch_size is outside valid range (100-100000).
         """
         # Validate batch_size
-        if batch_size < _MIN_BATCH_SIZE:
-            raise ValueError(
-                f"batch_size must be at least {_MIN_BATCH_SIZE}, got {batch_size}"
-            )
-        if batch_size > _MAX_BATCH_SIZE:
-            raise ValueError(
-                f"batch_size must be at most {_MAX_BATCH_SIZE}, got {batch_size}"
-            )
+        _validate_batch_size(batch_size)
         # Create progress callback if requested (only for interactive terminals)
         progress_callback = None
         pbar = None
@@ -888,14 +900,7 @@ class Workspace:
             ValueError: If batch_size is outside valid range (100-100000).
         """
         # Validate batch_size
-        if batch_size < _MIN_BATCH_SIZE:
-            raise ValueError(
-                f"batch_size must be at least {_MIN_BATCH_SIZE}, got {batch_size}"
-            )
-        if batch_size > _MAX_BATCH_SIZE:
-            raise ValueError(
-                f"batch_size must be at most {_MAX_BATCH_SIZE}, got {batch_size}"
-            )
+        _validate_batch_size(batch_size)
 
         # Create progress callback if requested (only for interactive terminals)
         progress_callback = None

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -798,6 +798,7 @@ class Workspace:
         to_date: str,
         events: list[str] | None = None,
         where: str | None = None,
+        limit: int | None = None,
         progress: bool = True,
         append: bool = False,
         batch_size: int = 1000,
@@ -815,6 +816,7 @@ class Workspace:
             to_date: End date (YYYY-MM-DD).
             events: Optional list of event names to filter.
             where: Optional WHERE clause for filtering.
+            limit: Optional maximum number of events to return (max 100000).
             progress: Show progress bar (default: True).
             append: If True, append to existing table. If False (default), create new.
             batch_size: Number of rows per INSERT/COMMIT cycle. Controls the
@@ -864,6 +866,7 @@ class Workspace:
                 to_date=to_date,
                 events=events,
                 where=where,
+                limit=limit,
                 progress_callback=progress_callback,
                 append=append,
                 batch_size=batch_size,
@@ -968,6 +971,7 @@ class Workspace:
         to_date: str,
         events: list[str] | None = None,
         where: str | None = None,
+        limit: int | None = None,
         raw: bool = False,
     ) -> Iterator[dict[str, Any]]:
         """Stream events directly from Mixpanel API without storing.
@@ -980,6 +984,7 @@ class Workspace:
             to_date: End date inclusive (YYYY-MM-DD format).
             events: Optional list of event names to filter. If None, all events returned.
             where: Optional Mixpanel filter expression (e.g., 'properties["country"]=="US"').
+            limit: Optional maximum number of events to return (max 100000).
             raw: If True, return events in raw Mixpanel API format.
                  If False (default), return normalized format with datetime objects.
 
@@ -1015,6 +1020,7 @@ class Workspace:
             to_date=to_date,
             events=events,
             where=where,
+            limit=limit,
         )
 
         if raw:

--- a/tests/integration/cli/test_fetch_streaming.py
+++ b/tests/integration/cli/test_fetch_streaming.py
@@ -706,3 +706,71 @@ class TestBackwardCompatibility:
         assert result.exit_code == 0, f"Failed with: {result.output}"
         call_kwargs = mock_workspace.stream_events.call_args.kwargs
         assert call_kwargs.get("limit") == 1000
+
+
+class TestFetchEventsLimitValidation:
+    """Tests for CLI limit parameter validation."""
+
+    def test_fetch_events_rejects_limit_over_100000(
+        self,
+        cli_runner: CliRunner,
+    ) -> None:
+        """fetch events should reject limit > 100000 at CLI level."""
+        result = cli_runner.invoke(
+            app,
+            [
+                "fetch",
+                "events",
+                "--from",
+                "2024-01-01",
+                "--to",
+                "2024-01-31",
+                "--limit",
+                "100001",
+            ],
+        )
+
+        assert result.exit_code == 2  # Typer validation error
+        assert "100000" in result.output or "Invalid value" in result.output
+
+    def test_fetch_events_rejects_limit_zero(
+        self,
+        cli_runner: CliRunner,
+    ) -> None:
+        """fetch events should reject limit = 0 at CLI level."""
+        result = cli_runner.invoke(
+            app,
+            [
+                "fetch",
+                "events",
+                "--from",
+                "2024-01-01",
+                "--to",
+                "2024-01-31",
+                "--limit",
+                "0",
+            ],
+        )
+
+        assert result.exit_code == 2  # Typer validation error
+
+    def test_fetch_events_rejects_negative_limit(
+        self,
+        cli_runner: CliRunner,
+    ) -> None:
+        """fetch events should reject negative limit at CLI level."""
+        result = cli_runner.invoke(
+            app,
+            [
+                "fetch",
+                "events",
+                "--from",
+                "2024-01-01",
+                "--to",
+                "2024-01-31",
+                "--limit",
+                "-5",
+            ],
+        )
+
+        assert result.exit_code == 2  # Typer validation error

--- a/tests/unit/_internal/test_expressions.py
+++ b/tests/unit/_internal/test_expressions.py
@@ -74,6 +74,30 @@ class TestNormalizeOnExpression:
         assert normalize_on_expression("日本語") == 'properties["日本語"]'
         assert normalize_on_expression("émoji🎉") == 'properties["émoji🎉"]'
 
+    # Category 5: Special character escaping
+
+    @pytest.mark.parametrize(
+        ("name_with_quotes", "expected"),
+        [
+            ('my"property', 'properties["my\\"property"]'),
+            ('"quoted"', 'properties["\\"quoted\\""]'),
+            ('a"b"c', 'properties["a\\"b\\"c"]'),
+            ('say "hello"', 'properties["say \\"hello\\""]'),
+        ],
+    )
+    def test_escapes_double_quotes_in_property_names(
+        self, name_with_quotes: str, expected: str
+    ) -> None:
+        """Property names containing double quotes should be escaped."""
+        assert normalize_on_expression(name_with_quotes) == expected
+
+    def test_backslash_before_quote_escaping(self) -> None:
+        """Backslash before quote should be handled correctly."""
+        # A property name ending with backslash followed by quote
+        result = normalize_on_expression('path\\to\\"file')
+        # The quote should be escaped, and existing backslashes preserved
+        assert result == 'properties["path\\\\to\\\\\\"file"]'
+
     # Category 4: Idempotency
 
     def test_idempotent_for_bare_names(self) -> None:

--- a/tests/unit/_internal/test_expressions.py
+++ b/tests/unit/_internal/test_expressions.py
@@ -1,0 +1,90 @@
+"""Unit tests for expression normalization utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from mixpanel_data._internal.expressions import normalize_on_expression
+
+
+class TestNormalizeOnExpression:
+    """Tests for normalize_on_expression function."""
+
+    # Category 1: Bare property names that need wrapping
+
+    @pytest.mark.parametrize(
+        ("bare_name", "expected"),
+        [
+            ("Source", 'properties["Source"]'),
+            ("Screen Name", 'properties["Screen Name"]'),
+            ("$os", 'properties["$os"]'),
+            ("$browser", 'properties["$browser"]'),
+        ],
+    )
+    def test_wraps_bare_property_names(self, bare_name: str, expected: str) -> None:
+        """Bare property names should be wrapped in properties[] accessor."""
+        assert normalize_on_expression(bare_name) == expected
+
+    @pytest.mark.parametrize(
+        "tricky_name",
+        [
+            "foo[0]",  # Contains [ but not an accessor
+            "properties_count",  # Starts with "properties" but isn't accessor
+            "user_id",  # Contains "user" but isn't accessor
+            "event_type",  # Contains "event" but isn't accessor
+        ],
+    )
+    def test_wraps_names_with_misleading_substrings(self, tricky_name: str) -> None:
+        """Property names containing accessor-like substrings should still be wrapped."""
+        result = normalize_on_expression(tricky_name)
+        assert result == f'properties["{tricky_name}"]'
+
+    # Category 2: Already-valid expressions (pass through unchanged)
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            'properties["Source"]',
+            'user["email"]',
+            'event["name"]',
+            'properties["Screen"] == "Home"',
+            'properties["Type"] + " from " + properties["Source"]',
+            'properties["Screen"] in ["Home", "Events"]',
+            'defined(properties["Type"])',
+            'if(properties["x"], "yes", "no")',
+            'properties["x"] + user["y"]',  # Mixed accessors
+        ],
+    )
+    def test_passes_through_valid_expressions(self, expression: str) -> None:
+        """Expressions containing accessor syntax should pass through unchanged."""
+        assert normalize_on_expression(expression) == expression
+
+    # Category 3: Edge cases
+
+    def test_empty_string_wrapped(self) -> None:
+        """Empty string should be wrapped (API will handle the error)."""
+        assert normalize_on_expression("") == 'properties[""]'
+
+    def test_whitespace_only_wrapped(self) -> None:
+        """Whitespace-only string should be wrapped (API will handle the error)."""
+        assert normalize_on_expression("  ") == 'properties["  "]'
+
+    def test_unicode_property_names(self) -> None:
+        """Unicode property names should be wrapped correctly."""
+        assert normalize_on_expression("日本語") == 'properties["日本語"]'
+        assert normalize_on_expression("émoji🎉") == 'properties["émoji🎉"]'
+
+    # Category 4: Idempotency
+
+    def test_idempotent_for_bare_names(self) -> None:
+        """Applying twice to a bare name should give same result."""
+        once = normalize_on_expression("Source")
+        twice = normalize_on_expression(once)
+        assert once == twice == 'properties["Source"]'
+
+    def test_idempotent_for_expressions(self) -> None:
+        """Applying twice to an expression should give same result."""
+        expr = 'properties["Type"] == "Event"'
+        once = normalize_on_expression(expr)
+        twice = normalize_on_expression(once)
+        assert once == twice == expr

--- a/tests/unit/_internal/test_expressions_pbt.py
+++ b/tests/unit/_internal/test_expressions_pbt.py
@@ -31,13 +31,22 @@ class TestNormalizeOnExpressionProperties:
     def test_bare_names_get_wrapped(self, name: str) -> None:
         """Any bare property name should be wrapped in properties[] accessor.
 
-        Invariant: If input contains no accessor patterns, output wraps it.
+        Invariant: If input contains no accessor patterns, output wraps it
+        with proper escaping of special characters.
 
         Args:
             name: A string that does not contain any filter expression accessors.
         """
         result = normalize_on_expression(name)
-        assert result == f'properties["{name}"]'
+
+        # The result should be wrapped in properties["..."]
+        assert result.startswith('properties["')
+        assert result.endswith('"]')
+
+        # Extract and unescape the inner content to verify it matches the input
+        inner = result[len('properties["') : -len('"]')]
+        unescaped = inner.replace('\\"', '"').replace("\\\\", "\\")
+        assert unescaped == name
 
     @given(expr=valid_expressions)
     def test_expressions_pass_through(self, expr: str) -> None:
@@ -75,3 +84,60 @@ class TestNormalizeOnExpressionProperties:
         result = normalize_on_expression(name)
         accessors = ('properties["', 'user["', 'event["')
         assert any(accessor in result for accessor in accessors)
+
+    @given(name=bare_property_names)
+    def test_wrapped_output_has_valid_syntax(self, name: str) -> None:
+        """Wrapped output should have properly escaped quotes for valid syntax.
+
+        Invariant: For bare property names, the output should be a valid
+        properties["..."] accessor where any double quotes in the property
+        name are escaped with backslash.
+
+        Args:
+            name: A bare property name (no accessor patterns).
+        """
+        result = normalize_on_expression(name)
+
+        # The result should start with properties[" and end with "]
+        assert result.startswith('properties["')
+        assert result.endswith('"]')
+
+        # Extract the content between properties[" and "]
+        inner = result[len('properties["') : -len('"]')]
+
+        # Unescape the inner content: replace \" with " and \\ with \
+        # This reverses the escaping that should have been applied
+        unescaped = inner.replace('\\"', '"').replace("\\\\", "\\")
+
+        # The unescaped content should equal the original input
+        assert unescaped == name
+
+    @given(
+        prefix=st.text(max_size=20),
+        suffix=st.text(max_size=20),
+    )
+    def test_quotes_in_names_are_escaped(self, prefix: str, suffix: str) -> None:
+        """Property names containing quotes should have them escaped.
+
+        Invariant: Any double quote in a bare property name must be escaped
+        in the output to prevent syntax errors.
+
+        Args:
+            prefix: Text before the embedded quote.
+            suffix: Text after the embedded quote.
+        """
+        # Construct a property name with an embedded quote
+        name = f'{prefix}"{suffix}'
+
+        # Skip if accidentally contains accessor pattern
+        if 'properties["' in name or 'user["' in name or 'event["' in name:
+            return
+
+        result = normalize_on_expression(name)
+
+        # Extract the inner content and verify it unescapes to the original
+        assert result.startswith('properties["')
+        assert result.endswith('"]')
+        inner = result[len('properties["') : -len('"]')]
+        unescaped = inner.replace('\\"', '"').replace("\\\\", "\\")
+        assert unescaped == name

--- a/tests/unit/_internal/test_expressions_pbt.py
+++ b/tests/unit/_internal/test_expressions_pbt.py
@@ -1,0 +1,77 @@
+"""Property-based tests for expression normalization using Hypothesis."""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from mixpanel_data._internal.expressions import normalize_on_expression
+
+# Strategy for bare property names (no accessor patterns)
+bare_property_names = st.text(min_size=1).filter(
+    lambda s: 'properties["' not in s and 'user["' not in s and 'event["' not in s
+)
+
+# Strategy for valid expressions (contain at least one accessor)
+valid_expressions = st.sampled_from(
+    [
+        'properties["Source"]',
+        'user["email"]',
+        'event["name"]',
+        'properties["x"] == "y"',
+        'defined(properties["z"])',
+    ]
+)
+
+
+class TestNormalizeOnExpressionProperties:
+    """Property-based tests for normalize_on_expression."""
+
+    @given(name=bare_property_names)
+    def test_bare_names_get_wrapped(self, name: str) -> None:
+        """Any bare property name should be wrapped in properties[] accessor.
+
+        Invariant: If input contains no accessor patterns, output wraps it.
+
+        Args:
+            name: A string that does not contain any filter expression accessors.
+        """
+        result = normalize_on_expression(name)
+        assert result == f'properties["{name}"]'
+
+    @given(expr=valid_expressions)
+    def test_expressions_pass_through(self, expr: str) -> None:
+        """Expressions with accessor patterns should pass through unchanged.
+
+        Invariant: If input contains accessor pattern, output equals input.
+
+        Args:
+            expr: A valid filter expression containing at least one accessor.
+        """
+        assert normalize_on_expression(expr) == expr
+
+    @given(name=st.text())
+    def test_idempotent(self, name: str) -> None:
+        """Normalizing twice should equal normalizing once.
+
+        Invariant: normalize(normalize(x)) == normalize(x)
+
+        Args:
+            name: Any string input (bare name or expression).
+        """
+        once = normalize_on_expression(name)
+        twice = normalize_on_expression(once)
+        assert once == twice
+
+    @given(name=st.text())
+    def test_output_always_has_accessor(self, name: str) -> None:
+        """Output should always contain at least one accessor pattern.
+
+        Invariant: Every normalized expression contains a valid accessor.
+
+        Args:
+            name: Any string input (bare name or expression).
+        """
+        result = normalize_on_expression(name)
+        accessors = ('properties["', 'user["', 'event["')
+        assert any(accessor in result for accessor in accessors)

--- a/tests/unit/test_fetcher_service.py
+++ b/tests/unit/test_fetcher_service.py
@@ -513,6 +513,82 @@ class TestFetchProfiles:
         call_kwargs = mock_api_client.export_profiles.call_args.kwargs
         assert call_kwargs["where"] == 'user["plan"] == "premium"'
 
+    def test_fetch_profiles_passes_cohort_id_to_api_client(self) -> None:
+        """fetch_profiles should pass cohort_id to API client."""
+        mock_api_client = MagicMock()
+        mock_storage = MagicMock()
+
+        mock_api_client.export_profiles.return_value = iter([])
+        mock_storage.create_profiles_table.return_value = 0
+
+        fetcher = FetcherService(mock_api_client, mock_storage)
+
+        fetcher.fetch_profiles(
+            name="cohort_profiles",
+            cohort_id="cohort_12345",
+        )
+
+        call_kwargs = mock_api_client.export_profiles.call_args.kwargs
+        assert call_kwargs["cohort_id"] == "cohort_12345"
+
+    def test_fetch_profiles_passes_output_properties_to_api_client(self) -> None:
+        """fetch_profiles should pass output_properties to API client."""
+        mock_api_client = MagicMock()
+        mock_storage = MagicMock()
+
+        mock_api_client.export_profiles.return_value = iter([])
+        mock_storage.create_profiles_table.return_value = 0
+
+        fetcher = FetcherService(mock_api_client, mock_storage)
+
+        fetcher.fetch_profiles(
+            name="limited_profiles",
+            output_properties=["$email", "$name", "plan"],
+        )
+
+        call_kwargs = mock_api_client.export_profiles.call_args.kwargs
+        assert call_kwargs["output_properties"] == ["$email", "$name", "plan"]
+
+    def test_fetch_profiles_metadata_includes_cohort_id(self) -> None:
+        """fetch_profiles should include cohort_id in metadata."""
+        mock_api_client = MagicMock()
+        mock_storage = MagicMock()
+
+        mock_api_client.export_profiles.return_value = iter([])
+        mock_storage.create_profiles_table.return_value = 0
+
+        fetcher = FetcherService(mock_api_client, mock_storage)
+
+        fetcher.fetch_profiles(
+            name="profiles",
+            cohort_id="cohort_abc",
+        )
+
+        # Get the metadata passed to storage
+        call_kwargs = mock_storage.create_profiles_table.call_args.kwargs
+        metadata = call_kwargs["metadata"]
+        assert metadata.filter_cohort_id == "cohort_abc"
+
+    def test_fetch_profiles_metadata_includes_output_properties(self) -> None:
+        """fetch_profiles should include output_properties in metadata."""
+        mock_api_client = MagicMock()
+        mock_storage = MagicMock()
+
+        mock_api_client.export_profiles.return_value = iter([])
+        mock_storage.create_profiles_table.return_value = 0
+
+        fetcher = FetcherService(mock_api_client, mock_storage)
+
+        fetcher.fetch_profiles(
+            name="profiles",
+            output_properties=["$email"],
+        )
+
+        # Get the metadata passed to storage
+        call_kwargs = mock_storage.create_profiles_table.call_args.kwargs
+        metadata = call_kwargs["metadata"]
+        assert metadata.filter_output_properties == ["$email"]
+
     def test_fetch_profiles_table_exists_error(self) -> None:
         """fetch_profiles should propagate TableExistsError from storage."""
         mock_api_client = MagicMock()

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1941,3 +1941,219 @@ class TestReadOnlyMode:
             assert count == 2
         finally:
             ws.close()
+
+
+# =============================================================================
+# Batch Size Parameter Tests
+# =============================================================================
+
+
+class TestBatchSizeParameter:
+    """Tests for batch_size parameter in fetch_events and fetch_profiles."""
+
+    def test_fetch_events_passes_batch_size_to_fetcher(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_events should pass batch_size to FetcherService."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_events.return_value = FetchResult(
+                table="events",
+                rows=100,
+                type="events",
+                duration_seconds=1.5,
+                date_range=("2024-01-01", "2024-01-31"),
+                fetched_at=MagicMock(),
+            )
+            ws._fetcher = mock_fetcher
+
+            ws.fetch_events(
+                "events",
+                from_date="2024-01-01",
+                to_date="2024-01-31",
+                progress=False,
+                batch_size=500,
+            )
+
+            # Verify batch_size was passed to fetcher
+            call_kwargs = mock_fetcher.fetch_events.call_args.kwargs
+            assert call_kwargs.get("batch_size") == 500
+        finally:
+            ws.close()
+
+    def test_fetch_profiles_passes_batch_size_to_fetcher(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_profiles should pass batch_size to FetcherService."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_profiles.return_value = FetchResult(
+                table="profiles",
+                rows=50,
+                type="profiles",
+                duration_seconds=0.5,
+                date_range=None,
+                fetched_at=MagicMock(),
+            )
+            ws._fetcher = mock_fetcher
+
+            ws.fetch_profiles(
+                "profiles",
+                progress=False,
+                batch_size=250,
+            )
+
+            # Verify batch_size was passed to fetcher
+            call_kwargs = mock_fetcher.fetch_profiles.call_args.kwargs
+            assert call_kwargs.get("batch_size") == 250
+        finally:
+            ws.close()
+
+    def test_fetch_events_validates_batch_size_minimum(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_events should reject batch_size below 100."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            with pytest.raises(ValueError, match="batch_size must be at least 100"):
+                ws.fetch_events(
+                    "events",
+                    from_date="2024-01-01",
+                    to_date="2024-01-31",
+                    batch_size=50,
+                )
+        finally:
+            ws.close()
+
+    def test_fetch_events_validates_batch_size_maximum(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_events should reject batch_size above 100000."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            with pytest.raises(ValueError, match="batch_size must be at most 100000"):
+                ws.fetch_events(
+                    "events",
+                    from_date="2024-01-01",
+                    to_date="2024-01-31",
+                    batch_size=200000,
+                )
+        finally:
+            ws.close()
+
+    def test_fetch_profiles_validates_batch_size_minimum(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_profiles should reject batch_size below 100."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            with pytest.raises(ValueError, match="batch_size must be at least 100"):
+                ws.fetch_profiles(
+                    "profiles",
+                    batch_size=99,
+                )
+        finally:
+            ws.close()
+
+    def test_fetch_profiles_validates_batch_size_maximum(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_profiles should reject batch_size above 100000."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            with pytest.raises(ValueError, match="batch_size must be at most 100000"):
+                ws.fetch_profiles(
+                    "profiles",
+                    batch_size=100001,
+                )
+        finally:
+            ws.close()
+
+    def test_fetch_events_default_batch_size(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_events should use default batch_size of 1000."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_events.return_value = FetchResult(
+                table="events",
+                rows=100,
+                type="events",
+                duration_seconds=1.5,
+                date_range=("2024-01-01", "2024-01-31"),
+                fetched_at=MagicMock(),
+            )
+            ws._fetcher = mock_fetcher
+
+            # Don't specify batch_size - should use default
+            ws.fetch_events(
+                "events",
+                from_date="2024-01-01",
+                to_date="2024-01-31",
+                progress=False,
+            )
+
+            # Verify default batch_size of 1000
+            call_kwargs = mock_fetcher.fetch_events.call_args.kwargs
+            assert call_kwargs.get("batch_size") == 1000
+        finally:
+            ws.close()

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -2027,6 +2027,80 @@ class TestBatchSizeParameter:
         finally:
             ws.close()
 
+    def test_fetch_profiles_passes_cohort_id_to_fetcher(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_profiles should pass cohort_id to FetcherService."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_profiles.return_value = FetchResult(
+                table="profiles",
+                rows=50,
+                type="profiles",
+                duration_seconds=0.5,
+                date_range=None,
+                fetched_at=MagicMock(),
+            )
+            ws._fetcher = mock_fetcher
+
+            ws.fetch_profiles(
+                "cohort_profiles",
+                cohort_id="cohort_12345",
+                progress=False,
+            )
+
+            # Verify cohort_id was passed to fetcher
+            call_kwargs = mock_fetcher.fetch_profiles.call_args.kwargs
+            assert call_kwargs.get("cohort_id") == "cohort_12345"
+        finally:
+            ws.close()
+
+    def test_fetch_profiles_passes_output_properties_to_fetcher(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """fetch_profiles should pass output_properties to FetcherService."""
+        db_path = tmp_path / "test.db"
+        ws = Workspace(
+            path=db_path,
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        )
+        try:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_profiles.return_value = FetchResult(
+                table="profiles",
+                rows=50,
+                type="profiles",
+                duration_seconds=0.5,
+                date_range=None,
+                fetched_at=MagicMock(),
+            )
+            ws._fetcher = mock_fetcher
+
+            ws.fetch_profiles(
+                "limited_profiles",
+                output_properties=["$email", "$name", "plan"],
+                progress=False,
+            )
+
+            # Verify output_properties was passed to fetcher
+            call_kwargs = mock_fetcher.fetch_profiles.call_args.kwargs
+            assert call_kwargs.get("output_properties") == ["$email", "$name", "plan"]
+        finally:
+            ws.close()
+
     def test_fetch_events_validates_batch_size_minimum(
         self,
         mock_config_manager: MagicMock,

--- a/tests/unit/test_workspace_streaming.py
+++ b/tests/unit/test_workspace_streaming.py
@@ -160,6 +160,7 @@ class TestStreamEvents:
                 to_date="2024-01-15",
                 events=None,
                 where=None,
+                limit=None,
             )
         finally:
             ws.close()
@@ -192,6 +193,7 @@ class TestStreamEvents:
                 to_date="2024-01-15",
                 events=["Purchase", "Signup"],
                 where=None,
+                limit=None,
             )
         finally:
             ws.close()
@@ -225,6 +227,7 @@ class TestStreamEvents:
                 to_date="2024-01-15",
                 events=None,
                 where=where_clause,
+                limit=None,
             )
         finally:
             ws.close()
@@ -343,6 +346,34 @@ class TestStreamEvents:
             # Consume remaining
             list(iterator)
             assert call_count == 3
+        finally:
+            ws.close()
+
+    def test_stream_events_with_limit(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Test streaming events with limit parameter."""
+        ws = workspace_factory()
+        try:
+            mock_api_client.export_events.return_value = iter(
+                [raw_event("Event", "user_1", 1705328400)]
+            )
+
+            list(
+                ws.stream_events(
+                    from_date="2024-01-15", to_date="2024-01-15", limit=5000
+                )
+            )
+
+            mock_api_client.export_events.assert_called_once_with(
+                from_date="2024-01-15",
+                to_date="2024-01-15",
+                events=None,
+                where=None,
+                limit=5000,
+            )
         finally:
             ws.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -779,6 +779,8 @@ docs = [
 dev = [
     { name = "click-man" },
     { name = "pre-commit" },
+    { name = "psutil" },
+    { name = "types-psutil" },
 ]
 
 [package.metadata]
@@ -808,6 +810,8 @@ provides-extras = ["dev", "docs"]
 dev = [
     { name = "click-man", specifier = ">=0.5.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "psutil", specifier = ">=7.2.0" },
+    { name = "types-psutil", specifier = ">=7.2.0.20251228" },
 ]
 
 [[package]]
@@ -1223,6 +1227,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/7c/31d1c3ceb1260301f87565f50689dc6da3db427ece1e1e012af22abca54e/psutil-7.2.0.tar.gz", hash = "sha256:2e4f8e1552f77d14dc96fb0f6240c5b34a37081c0889f0853b3b29a496e5ef64", size = 489863, upload-time = "2025-12-23T20:26:24.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/8e/b35aae6ed19bc4e2286cac4832e4d522fcf00571867b0a85a3f77ef96a80/psutil-7.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c31e927555539132a00380c971816ea43d089bf4bd5f3e918ed8c16776d68474", size = 129593, upload-time = "2025-12-23T20:26:28.019Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a2/773d17d74e122bbffe08b97f73f2d4a01ef53fb03b98e61b8e4f64a9c6b9/psutil-7.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:db8e44e766cef86dea47d9a1fa535d38dc76449e5878a92f33683b7dba5bfcb2", size = 130104, upload-time = "2025-12-23T20:26:30.27Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/e3/d3a9b3f4bd231abbd70a988beb2e3edd15306051bccbfc4472bd34a56e01/psutil-7.2.0-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85ef849ac92169dedc59a7ac2fb565f47b3468fbe1524bf748746bc21afb94c7", size = 180579, upload-time = "2025-12-23T20:26:32.628Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f8/6c73044424aabe1b7824d4d4504029d406648286d8fe7ba8c4682e0d3042/psutil-7.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26782bdbae2f5c14ce9ebe8ad2411dc2ca870495e0cd90f8910ede7fa5e27117", size = 183171, upload-time = "2025-12-23T20:26:34.972Z" },
+    { url = "https://files.pythonhosted.org/packages/48/7d/76d7a863340885d41826562225a566683e653ee6c9ba03c9f3856afa7d80/psutil-7.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b7665f612d3b38a583391b95969667a53aaf6c5706dc27a602c9a4874fbf09e4", size = 139055, upload-time = "2025-12-23T20:26:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/48/200054ada0ae4872c8a71db54f3eb6a9af4101680ee6830d373b7fda526b/psutil-7.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:4413373c174520ae28a24a8974ad8ce6b21f060d27dde94e25f8c73a7effe57a", size = 134737, upload-time = "2025-12-23T20:26:38.784Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/98da45dff471b93ef5ce5bcaefa00e3038295a7880a77cf74018243d37fb/psutil-7.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2f2f53fd114e7946dfba3afb98c9b7c7f376009447360ca15bfb73f2066f84c7", size = 129692, upload-time = "2025-12-23T20:26:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/10eae91ba4ad071c92db3c178ba861f30406342de9f0ddbe6d51fd741236/psutil-7.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e65c41d7e60068f60ce43b31a3a7fc90deb0dfd34ffc824a2574c2e5279b377e", size = 130110, upload-time = "2025-12-23T20:26:42.569Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/2b2897443d56fedbbc34ac68a0dc7d55faa05d555372a2f989109052f86d/psutil-7.2.0-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc66d21366850a4261412ce994ae9976bba9852dafb4f2fa60db68ed17ff5281", size = 181487, upload-time = "2025-12-23T20:26:44.633Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/44308428f7333db42c5ea7390c52af1b38f59b80b80c437291f58b5dfdad/psutil-7.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e025d67b42b8f22b096d5d20f5171de0e0fefb2f0ce983a13c5a1b5ed9872706", size = 184320, upload-time = "2025-12-23T20:26:46.83Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/d2feadc7f18e501c5ce687c377db7dca924585418fd694272b8e488ea99f/psutil-7.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:45f6b91f7ad63414d6454fd609e5e3556d0e1038d5d9c75a1368513bdf763f57", size = 140372, upload-time = "2025-12-23T20:26:49.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/48381f5fd0425aa054c4ee3de24f50de3d6c347019f3aec75f357377d447/psutil-7.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87b18a19574139d60a546e88b5f5b9cbad598e26cdc790d204ab95d7024f03ee", size = 135400, upload-time = "2025-12-23T20:26:51.585Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c5/a49160bf3e165b7b93a60579a353cf5d939d7f878fe5fd369110f1d18043/psutil-7.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:977a2fcd132d15cb05b32b2d85b98d087cad039b0ce435731670ba74da9e6133", size = 128116, upload-time = "2025-12-23T20:26:53.516Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a1/c75feb480f60cd768fb6ed00ac362a16a33e5076ec8475a22d8162fb2659/psutil-7.2.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:24151011c21fadd94214d7139d7c6c54569290d7e553989bdf0eab73b13beb8c", size = 128925, upload-time = "2025-12-23T20:26:55.573Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91f211ba9279e7c61d9d8f84b713cfc38fa161cb0597d5cb3f1ca742f6848254", size = 154666, upload-time = "2025-12-23T20:26:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/dd/4c2de9c3827c892599d277a69d2224136800870a8a88a80981de905de28d/psutil-7.2.0-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f37415188b7ea98faf90fed51131181646c59098b077550246e2e092e127418b", size = 156109, upload-time = "2025-12-23T20:26:58.851Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3f/090943c682d3629968dd0b04826ddcbc760ee1379021dbe316e2ddfcd01b/psutil-7.2.0-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0d12c7ce6ed1128cd81fd54606afa054ac7dbb9773469ebb58cf2f171c49f2ac", size = 148081, upload-time = "2025-12-23T20:27:01.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/88/c39648ebb8ec182d0364af53cdefe6eddb5f3872ba718b5855a8ff65d6d4/psutil-7.2.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ca0faef7976530940dcd39bc5382d0d0d5eb023b186a4901ca341bd8d8684151", size = 147376, upload-time = "2025-12-23T20:27:03.347Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a2/5b39e08bd9b27476bc7cce7e21c71a481ad60b81ffac49baf02687a50d7f/psutil-7.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:abdb74137ca232d20250e9ad471f58d500e7743bc8253ba0bfbf26e570c0e437", size = 136910, upload-time = "2025-12-23T20:27:05.289Z" },
+    { url = "https://files.pythonhosted.org/packages/59/54/53839db1258c1eaeb4ded57ff202144ebc75b23facc05a74fd98d338b0c6/psutil-7.2.0-cp37-abi3-win_arm64.whl", hash = "sha256:284e71038b3139e7ab3834b63b3eb5aa5565fcd61a681ec746ef9a0a8c457fd2", size = 133807, upload-time = "2025-12-23T20:27:06.825Z" },
 ]
 
 [[package]]
@@ -1750,6 +1782,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/c1/933d30fd7a123ed981e2a1eedafceab63cb379db0402e438a13bc51bbb15/typer-0.20.1.tar.gz", hash = "sha256:68585eb1b01203689c4199bc440d6be616f0851e9f0eb41e4a778845c5a0fd5b", size = 105968, upload-time = "2025-12-19T16:48:56.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl", hash = "sha256:4b3bde918a67c8e03d861aa02deca90a95bbac572e71b1b9be56ff49affdb5a8", size = 47381, upload-time = "2025-12-19T16:48:53.679Z" },
+]
+
+[[package]]
+name = "types-psutil"
+version = "7.2.0.20251228"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/b1/4a1b95bf267c32abffc7feadb8160a7d8639e2185f7ff2125e217556e8e2/types_psutil-7.2.0.20251228.tar.gz", hash = "sha256:dde992ac5b22512724a82ed21a43b03971592dff6cd271e2bd42a8750b30929b", size = 25400, upload-time = "2025-12-28T03:28:20.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cb/ffb612d5f744da7861bce043b25aa567fd0cd8e726f465a09be1826dd76a/types_psutil-7.2.0.20251228-py3-none-any.whl", hash = "sha256:fbef94469c5067449ce3330acfe3f525b91f2762f8351a84266ac9b745a3290d", size = 32426, upload-time = "2025-12-28T03:28:18.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Append mode**: Add data to existing tables with automatic deduplication
- **Configurable batch_size**: Control memory/IO tradeoff (100-100000, default: 1000)
- **Memory optimizations**: Per-batch commits keep memory constant for large datasets

## Changes

### Storage Layer
- Per-batch commits to bound memory usage
- `append_events_table` and `append_profiles_table` methods
- INSERT OR IGNORE for automatic deduplication by insert_id/distinct_id
- `batch_size` parameter on all create/append methods

### Workspace API
- `append` parameter on `fetch_events()` and `fetch_profiles()`
- `batch_size` parameter with validation (100-100000)
- Metadata merging for expanded date ranges

### CLI
- `--append` flag for incremental data loading
- `--batch-size` option for tuning performance

### Documentation
- Batch Size section in fetching guide
- Append mode usage and crash recovery examples
- CLI reference updates

## Test plan

- [x] Unit tests for StorageEngine batch_size and append methods
- [x] Unit tests for FetcherService batch_size pass-through
- [x] Unit tests for Workspace batch_size validation and append
- [x] Integration tests for CLI --batch-size and --append options
- [x] Memory usage integration test (1M events stays constant)
- [x] All 1222 tests pass