### PR TITLE
feat: add mp inspect drop-all command

### DIFF
--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -5,7 +5,7 @@ Designed for AI coding agents. Fetch data once into a local DuckDB database,
 then query it repeatedly with SQL.
 """
 
-from mixpanel_data._literal_types import CountType, HourDayUnit, TimeUnit
+from mixpanel_data._literal_types import CountType, HourDayUnit, TableType, TimeUnit
 from mixpanel_data.exceptions import (
     AccountExistsError,
     AccountNotFoundError,
@@ -76,6 +76,7 @@ __all__ = [
     # Type aliases
     "CountType",
     "HourDayUnit",
+    "TableType",
     "TimeUnit",
     # Exceptions
     "MixpanelDataError",

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -25,4 +25,7 @@ HourDayUnit = Literal["hour", "day"]
 # Count/aggregation methods
 CountType = Literal["general", "unique", "average"]
 
-__all__ = ["TimeUnit", "HourDayUnit", "CountType"]
+# Table types for filtering (events vs profiles)
+TableType = Literal["events", "profiles"]
+
+__all__ = ["TimeUnit", "HourDayUnit", "CountType", "TableType"]

--- a/src/mixpanel_data/cli/commands/inspect.py
+++ b/src/mixpanel_data/cli/commands/inspect.py
@@ -28,7 +28,7 @@ Local (uses DuckDB):
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal, cast
 
 import typer
 
@@ -451,8 +451,6 @@ def inspect_drop_all(
             raise typer.Exit(2)
 
     # Cast type_ to Literal for type safety
-    from typing import Literal, cast
-
     type_literal = cast(Literal["events", "profiles"] | None, type_)
 
     workspace.drop_all(type=type_literal)

--- a/src/mixpanel_data/cli/validators.py
+++ b/src/mixpanel_data/cli/validators.py
@@ -10,7 +10,7 @@ from typing import Any, TypeVar, cast, get_args
 
 import typer
 
-from mixpanel_data._literal_types import CountType, HourDayUnit, TimeUnit
+from mixpanel_data._literal_types import CountType, HourDayUnit, TableType, TimeUnit
 from mixpanel_data.cli.utils import ExitCode, err_console
 from mixpanel_data.types import EntityType
 
@@ -107,3 +107,20 @@ def validate_entity_type(value: str, param_name: str = "--type") -> EntityType:
     """
     validate_literal(value, EntityType, param_name)
     return cast(EntityType, value)
+
+
+def validate_table_type(value: str, param_name: str = "--type") -> TableType:
+    """Validate table type for filtering.
+
+    Args:
+        value: String value from CLI. Valid types: "events", "profiles".
+        param_name: Parameter name for error message. Default: "--type".
+
+    Returns:
+        Validated value as TableType literal type.
+
+    Raises:
+        typer.Exit: With code 3 (INVALID_ARGS) if value is invalid.
+    """
+    validate_literal(value, TableType, param_name)
+    return cast(TableType, value)

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -53,6 +53,7 @@ from mixpanel_data._internal.services.fetcher import (
 )
 from mixpanel_data._internal.services.live_query import LiveQueryService
 from mixpanel_data._internal.storage import StorageEngine
+from mixpanel_data._literal_types import TableType
 from mixpanel_data.exceptions import ConfigError, QueryError
 from mixpanel_data.types import (
     ActivityFeedResult,
@@ -2104,11 +2105,35 @@ class Workspace:
         for name in names:
             self.storage.drop_table(name)
 
-    def drop_all(self, type: Literal["events", "profiles"] | None = None) -> None:
-        """Drop all tables, optionally filtered by type.
+    def drop_all(self, type: TableType | None = None) -> None:
+        """Drop all tables from the workspace, optionally filtered by type.
+
+        Permanently removes all tables and their data. When used with the type
+        parameter, only tables matching the specified type are dropped.
 
         Args:
-            type: If specified, only drop tables of this type.
+            type: Optional table type filter. Valid values: "events", "profiles".
+                  If None, all tables are dropped regardless of type.
+
+        Raises:
+            TableNotFoundError: If a table cannot be dropped (rare in practice).
+
+        Example:
+            Drop all event tables:
+
+            ```python
+            ws = Workspace()
+            ws.drop_all(type="events")  # Only drops event tables
+            ws.close()
+            ```
+
+            Drop all tables:
+
+            ```python
+            ws = Workspace()
+            ws.drop_all()  # Drops everything
+            ws.close()
+            ```
         """
         tables = self.storage.list_tables()
         for table in tables:

--- a/tests/integration/cli/test_inspect_commands.py
+++ b/tests/integration/cli/test_inspect_commands.py
@@ -541,6 +541,22 @@ class TestInspectDropAll:
         data = json.loads(result.stdout)
         assert data["dropped_count"] == 0
 
+    def test_drop_all_invalid_type(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test dropping all tables with invalid type returns error."""
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "drop-all", "--type", "invalid", "--force"],
+            )
+
+        assert result.exit_code == 3  # INVALID_ARGS
+        mock_workspace.drop_all.assert_not_called()
+
 
 class TestInspectLexiconSchemas:
     """Tests for mp inspect lexicon-schemas command."""

--- a/tests/integration/cli/test_inspect_commands.py
+++ b/tests/integration/cli/test_inspect_commands.py
@@ -435,7 +435,7 @@ class TestInspectDropAll:
         mock_table1.name = "events1"
         mock_table2 = MagicMock()
         mock_table2.name = "profiles1"
-        mock_workspace.storage.list_tables.return_value = [mock_table1, mock_table2]
+        mock_workspace.tables.return_value = [mock_table1, mock_table2]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -458,7 +458,7 @@ class TestInspectDropAll:
         mock_table = MagicMock()
         mock_table.name = "events1"
         mock_table.type = "events"
-        mock_workspace.storage.list_tables.return_value = [mock_table]
+        mock_workspace.tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -488,7 +488,7 @@ class TestInspectDropAll:
         mock_workspace.drop_all.return_value = None
         mock_table = MagicMock()
         mock_table.name = "events1"
-        mock_workspace.storage.list_tables.return_value = [mock_table]
+        mock_workspace.tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -508,7 +508,7 @@ class TestInspectDropAll:
         """Test dropping all tables cancelled when user declines."""
         mock_table = MagicMock()
         mock_table.name = "events1"
-        mock_workspace.storage.list_tables.return_value = [mock_table]
+        mock_workspace.tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -527,7 +527,7 @@ class TestInspectDropAll:
     ) -> None:
         """Test dropping all tables when no tables exist."""
         mock_workspace.drop_all.return_value = None
-        mock_workspace.storage.list_tables.return_value = []
+        mock_workspace.tables.return_value = []
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,

--- a/tests/integration/cli/test_inspect_commands.py
+++ b/tests/integration/cli/test_inspect_commands.py
@@ -431,10 +431,11 @@ class TestInspectDropAll:
     ) -> None:
         """Test dropping all tables with --force flag skips confirmation."""
         mock_workspace.drop_all.return_value = None
-        mock_workspace.storage.list_tables.return_value = [
-            MagicMock(name="events1"),
-            MagicMock(name="profiles1"),
-        ]
+        mock_table1 = MagicMock()
+        mock_table1.name = "events1"
+        mock_table2 = MagicMock()
+        mock_table2.name = "profiles1"
+        mock_workspace.storage.list_tables.return_value = [mock_table1, mock_table2]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -454,9 +455,10 @@ class TestInspectDropAll:
     ) -> None:
         """Test dropping all tables with type filter."""
         mock_workspace.drop_all.return_value = None
-        mock_workspace.storage.list_tables.return_value = [
-            MagicMock(name="events1", type="events"),
-        ]
+        mock_table = MagicMock()
+        mock_table.name = "events1"
+        mock_table.type = "events"
+        mock_workspace.storage.list_tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -484,9 +486,9 @@ class TestInspectDropAll:
     ) -> None:
         """Test dropping all tables prompts for confirmation."""
         mock_workspace.drop_all.return_value = None
-        mock_workspace.storage.list_tables.return_value = [
-            MagicMock(name="events1"),
-        ]
+        mock_table = MagicMock()
+        mock_table.name = "events1"
+        mock_workspace.storage.list_tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,
@@ -504,9 +506,9 @@ class TestInspectDropAll:
         self, cli_runner: CliRunner, mock_workspace: MagicMock
     ) -> None:
         """Test dropping all tables cancelled when user declines."""
-        mock_workspace.storage.list_tables.return_value = [
-            MagicMock(name="events1"),
-        ]
+        mock_table = MagicMock()
+        mock_table.name = "events1"
+        mock_workspace.storage.list_tables.return_value = [mock_table]
         with patch(
             "mixpanel_data.cli.commands.inspect.get_workspace",
             return_value=mock_workspace,

--- a/tests/unit/test_config_pbt.py
+++ b/tests/unit/test_config_pbt.py
@@ -29,8 +29,18 @@ from mixpanel_data._internal.config import ConfigManager, Credentials
 _FIXED_USERNAME = "test_user"
 _FIXED_PROJECT_ID = "12345"
 _FIXED_REGION = "us"
-# Include "Credentials" to avoid false positives where secret is substring of class name
-_FIXED_VALUES = {_FIXED_USERNAME, _FIXED_PROJECT_ID, _FIXED_REGION, "Credentials"}
+# Include class name and field names to avoid false positives where secret
+# is a substring of repr output structure (not an actual security leak)
+_REPR_STRUCTURAL_STRINGS = {
+    _FIXED_USERNAME,
+    _FIXED_PROJECT_ID,
+    _FIXED_REGION,
+    "Credentials",  # Class name
+    "username",  # Field name
+    "secret",  # Field name
+    "project_id",  # Field name
+    "region",  # Field name
+}
 
 # Strategy for valid UTF-8 text (excludes surrogates which can't be encoded)
 _valid_utf8_text = st.text(
@@ -40,14 +50,14 @@ _valid_utf8_text = st.text(
 )
 
 # Strategy for secrets that are long enough to not match by coincidence,
-# don't contain the redaction placeholder, and aren't substrings of fixed field values
+# don't contain the redaction placeholder, and aren't substrings of repr structural elements
 secrets = _valid_utf8_text.filter(
     lambda s: (
         len(s) >= 4
         and "***" not in s
         and s.strip()
-        and s not in _FIXED_VALUES
-        and not any(s in v for v in _FIXED_VALUES)  # Not a substring of fixed values
+        and s not in _REPR_STRUCTURAL_STRINGS
+        and not any(s in v for v in _REPR_STRUCTURAL_STRINGS)  # Not a substring
     )
 )
 


### PR DESCRIPTION
## Summary

- Add new `mp inspect drop-all` CLI command that exposes `Workspace.drop_all()`
- Support `--type/-t` filter to drop only events or profiles tables
- Require `--force` flag or interactive confirmation before dropping
- Return JSON with `dropped_count` and optional `type_filter`

Also includes:
- Fix for flaky property-based test in secret redaction (unrelated)

## Test Plan

- [x] 6 new tests for drop-all command
- [x] All 1319 tests pass
- [x] Coverage at 92.46% (above 90% threshold)
- [x] mypy --strict passes
- [x] ruff check passes

## GitHub Copilot Summary

This pull request introduces a new `drop-all` command to the CLI for removing all tables from the local database, along with comprehensive tests for this functionality. It also refines the property-based tests for configuration redaction to avoid false positives by expanding the set of structural strings excluded from secret matching.

**New CLI Feature: Drop All Tables**
- Added a new `drop-all` command to the CLI, allowing users to drop all tables from the local database, with optional filtering by table type (`events` or `profiles`) and a `--force` flag to skip confirmation. The command validates input, confirms destructive actions unless forced, and reports the number of tables dropped. [[1]](diffhunk://#diff-e148318379f7d7b97c2959db6195a0359a50ec08f704b718ff01211cbbe9fb68R21) [[2]](diffhunk://#diff-e148318379f7d7b97c2959db6195a0359a50ec08f704b718ff01211cbbe9fb68L52-R53) [[3]](diffhunk://#diff-e148318379f7d7b97c2959db6195a0359a50ec08f704b718ff01211cbbe9fb68R404-R464)

**Testing:**
- Added a comprehensive test class for the new `drop-all` command, covering scenarios including force flag usage, type filtering, user confirmation/cancellation, empty table lists, and invalid type arguments.

**Test Improvements:**
- Refined property-based tests for configuration redaction by expanding the set of structural strings (`_REPR_STRUCTURAL_STRINGS`) excluded from secret matching, reducing the risk of false positives due to substrings in class or field names. [[1]](diffhunk://#diff-a10c67d720fcbeda44d055144efc41bb437219b4034453caf3f3827d31545d12L32-R43) [[2]](diffhunk://#diff-a10c67d720fcbeda44d055144efc41bb437219b4034453caf3f3827d31545d12L43-R60)

**Dependency Update:**
- Updated imports in `inspect.py` to include `Literal` and `cast` for improved type safety in the new command implementation.