### PR TITLE
fix: make invalid path test environment-independent

### DIFF
--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -54,10 +54,13 @@ def test_init_can_reopen_existing_database(tmp_path: Path) -> None:
         assert storage.connection is not None
 
 
-def test_init_with_invalid_path_raises_error() -> None:
+def test_init_with_invalid_path_raises_error(tmp_path: Path) -> None:
     """Test that StorageEngine raises error for invalid paths."""
-    # Try to create database in root directory (should fail on permissions)
-    invalid_path = Path("/root/cannot_write_here.db")
+    # Create a file, then try to create a database "inside" it
+    # This reliably fails on all systems (not permission-dependent)
+    blocker_file = tmp_path / "blocker.txt"
+    blocker_file.write_text("I am a file, not a directory")
+    invalid_path = blocker_file / "subdir" / "test.db"
 
     with pytest.raises(OSError):
         StorageEngine(path=invalid_path)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -59,8 +59,8 @@ def test_init_with_invalid_path_raises_error(tmp_path: Path) -> None:
     # Create a file, then try to create a database "inside" it
     # This reliably fails on all systems (not permission-dependent)
     blocker_file = tmp_path / "blocker.txt"
-    blocker_file.write_text("I am a file, not a directory")
-    invalid_path = blocker_file / "subdir" / "test.db"
+    blocker_file.touch()
+    invalid_path = blocker_file / "test.db"
 
     with pytest.raises(OSError):
         StorageEngine(path=invalid_path)


### PR DESCRIPTION
The test previously relied on permission-based failure when writing to
/root/, which doesn't work in containerized environments running as root.

Changed approach: create a file, then attempt to create a database
"inside" that file (treating a file as a directory). This reliably
triggers an OSError on all systems regardless of user permissions.