### PR TITLE
docs: add llms.txt plugins for LLM-optimized documentation

### DIFF
--- a/.claude/skills/mixpanel-data/SKILL.md
+++ b/.claude/skills/mixpanel-data/SKILL.md
@@ -7,6 +7,41 @@ description: Analyze Mixpanel analytics data using the mixpanel_data Python libr
 
 Fetch Mixpanel data once into local DuckDB, then query repeatedly with SQL—preserving context for reasoning rather than consuming it with raw API responses.
 
+## Documentation Access
+
+Full documentation is hosted at **https://discohead.github.io/mixpanel_data/** with LLM-optimized access:
+
+| Resource | URL | Use Case |
+|----------|-----|----------|
+| **llms.txt** | `https://discohead.github.io/mixpanel_data/llms.txt` | Index of all docs with descriptions |
+| **llms-full.txt** | `https://discohead.github.io/mixpanel_data/llms-full.txt` | Complete documentation (~400KB) |
+| **Individual pages** | `https://discohead.github.io/mixpanel_data/{path}/index.md` | Specific topic deep-dive |
+
+### When to Fetch Documentation
+
+- **Use this skill** for quick patterns, common examples, and API summaries
+- **Fetch llms.txt** to discover what documentation exists
+- **Fetch llms-full.txt** when you need comprehensive reference (API signatures, all parameters, edge cases)
+- **Fetch individual .md** for focused deep-dives (e.g., `/api/workspace/index.md` for Workspace class details)
+
+### Documentation Structure
+
+| Path | Content |
+|------|---------|
+| `/getting-started/installation/index.md` | Installation options |
+| `/getting-started/quickstart/index.md` | 5-minute tutorial |
+| `/getting-started/configuration/index.md` | Credentials and config |
+| `/guide/fetching/index.md` | Fetching events/profiles |
+| `/guide/streaming/index.md` | Streaming without storage |
+| `/guide/sql-queries/index.md` | DuckDB SQL patterns |
+| `/guide/live-analytics/index.md` | Segmentation, funnels, retention |
+| `/guide/discovery/index.md` | Schema exploration |
+| `/api/workspace/index.md` | Workspace class reference |
+| `/api/auth/index.md` | Authentication module |
+| `/api/exceptions/index.md` | Exception hierarchy |
+| `/api/types/index.md` | Result types |
+| `/cli/commands/index.md` | CLI command reference |
+
 ## When to Use
 
 ### Python Library (`mixpanel_data`)
@@ -312,6 +347,7 @@ For complete method signatures, see [references/library-api.md](references/libra
 For CLI commands, see [references/cli-commands.md](references/cli-commands.md).
 For filter expressions and JQL, see [references/query-expressions.md](references/query-expressions.md).
 For pandas/jq integration patterns, see [references/patterns.md](references/patterns.md).
+For documentation access and URLs, see [references/documentation.md](references/documentation.md).
 
 ## Common Errors
 

--- a/.claude/skills/mixpanel-data/references/documentation.md
+++ b/.claude/skills/mixpanel-data/references/documentation.md
@@ -1,0 +1,149 @@
+# Documentation Reference
+
+Complete guide to accessing mixpanel_data documentation programmatically.
+
+## Base URL
+
+```
+https://discohead.github.io/mixpanel_data/
+```
+
+## LLM-Optimized Endpoints
+
+### llms.txt (Index)
+
+```
+https://discohead.github.io/mixpanel_data/llms.txt
+```
+
+A structured index file (~3KB) containing:
+- Project name and description
+- Section headers (Getting Started, User Guide, API Reference, CLI Reference, Architecture)
+- Links to each documentation page with descriptions
+- URLs point to markdown files for direct LLM consumption
+
+**When to fetch:** To discover what documentation exists or find the right page for a topic.
+
+### llms-full.txt (Complete Documentation)
+
+```
+https://discohead.github.io/mixpanel_data/llms-full.txt
+```
+
+Complete documentation (~400KB, ~15,000 lines) containing:
+- All user guide content
+- Full API reference with method signatures and docstrings
+- CLI command documentation with all options
+- Architecture documentation
+
+**When to fetch:** When you need comprehensive information about multiple topics or want to search across all documentation.
+
+## Individual Markdown Pages
+
+Each HTML page has a corresponding `.md` file at the same path:
+
+```
+HTML: https://discohead.github.io/mixpanel_data/guide/fetching/
+MD:   https://discohead.github.io/mixpanel_data/guide/fetching/index.md
+```
+
+### Complete Page List
+
+#### Getting Started
+| Page | URL | Content |
+|------|-----|---------|
+| Home | `/index.md` | Project overview, key concepts |
+| Installation | `/getting-started/installation/index.md` | pip/uv installation, optional dependencies |
+| Quick Start | `/getting-started/quickstart/index.md` | First queries in 5 minutes |
+| Configuration | `/getting-started/configuration/index.md` | Credentials, environment variables, config files |
+
+#### User Guide
+| Page | URL | Content |
+|------|-----|---------|
+| Fetching Data | `/guide/fetching/index.md` | fetch_events, fetch_profiles, options |
+| Streaming Data | `/guide/streaming/index.md` | stream_events, stream_profiles, pipelines |
+| Local SQL Queries | `/guide/sql-queries/index.md` | DuckDB SQL, JSON operators, patterns |
+| Live Analytics | `/guide/live-analytics/index.md` | Segmentation, funnels, retention, JQL |
+| Data Discovery | `/guide/discovery/index.md` | Schema exploration, events, properties |
+
+#### API Reference
+| Page | URL | Content |
+|------|-----|---------|
+| Overview | `/api/index.md` | Import patterns, public API |
+| Workspace | `/api/workspace/index.md` | Full Workspace class reference |
+| Auth | `/api/auth/index.md` | Authentication, ConfigManager |
+| Exceptions | `/api/exceptions/index.md` | Exception hierarchy, error handling |
+| Result Types | `/api/types/index.md` | FetchResult, SegmentationResult, etc. |
+
+#### CLI Reference
+| Page | URL | Content |
+|------|-----|---------|
+| Overview | `/cli/index.md` | CLI structure, global options |
+| Commands | `/cli/commands/index.md` | Complete command reference |
+
+#### Architecture
+| Page | URL | Content |
+|------|-----|---------|
+| Design | `/architecture/design/index.md` | Layered architecture, services |
+| Data Model | `/architecture/data-model/index.md` | Event/profile schema |
+| Storage Engine | `/architecture/storage/index.md` | DuckDB storage details |
+
+## Fetch Strategy
+
+### Quick Questions
+Use the skill's quick reference for:
+- Common code patterns
+- Basic API method signatures
+- CLI command examples
+- Error solutions
+
+### Detailed Implementation
+Fetch individual `.md` pages for:
+- Full method signatures with all parameters
+- Edge case handling
+- Complete option descriptions
+- Detailed examples
+
+### Comprehensive Search
+Fetch `llms-full.txt` when:
+- Searching for specific functionality across the library
+- Need complete context for complex implementation
+- Debugging obscure issues
+- Understanding the full API surface
+
+## Example: Fetching Documentation
+
+Using WebFetch tool:
+
+```
+# Get the index to find relevant pages
+WebFetch(url="https://discohead.github.io/mixpanel_data/llms.txt",
+         prompt="Find pages related to funnel analysis")
+
+# Get specific page for details
+WebFetch(url="https://discohead.github.io/mixpanel_data/guide/live-analytics/index.md",
+         prompt="Extract the funnel() method signature and all parameters")
+
+# Get complete docs for comprehensive search
+WebFetch(url="https://discohead.github.io/mixpanel_data/llms-full.txt",
+         prompt="Find all methods that accept a where parameter")
+```
+
+## Documentation Content Types
+
+### User Guide Pages
+- Conceptual explanations
+- Step-by-step tutorials
+- Code examples with context
+- Best practices
+
+### API Reference Pages
+- Complete method signatures extracted from source
+- Docstrings with Args, Returns, Raises sections
+- Type annotations
+- Source code links
+
+### CLI Reference
+- Auto-generated from Typer CLI app
+- All commands with options
+- Output format examples

--- a/docs/javascripts/copy-markdown.js
+++ b/docs/javascripts/copy-markdown.js
@@ -1,0 +1,156 @@
+/**
+ * Copy Markdown Button Handler
+ *
+ * Pre-fetches markdown content on page load so copy is synchronous.
+ * This is necessary because Safari's Clipboard API requires the copy to happen
+ * synchronously within the user gesture - any async operation breaks the gesture chain.
+ */
+(function() {
+    'use strict';
+
+    // Constants
+    const FEEDBACK_DURATION_MS = 2000;
+    const IOS_MAX_SELECTION = 999999;
+
+    // Module state
+    let cachedMarkdown = null;
+    let fetchError = null;
+
+    // Fetch markdown immediately when page loads
+    (function prefetchMarkdown() {
+        const currentPath = window.location.pathname;
+        const mdPath = currentPath.endsWith('/')
+            ? currentPath + 'index.md'
+            : currentPath.replace(/\.html$/, '.md');
+
+        fetch(mdPath)
+            .then(response => {
+                if (!response.ok) throw new Error('Not found');
+                return response.text();
+            })
+            .then(text => {
+                // Strip any trailing "Copy Markdown" button text that the plugin may have added
+                cachedMarkdown = text
+                    .replace(/[\r\n]*Copy Markdown[\r\n\s]*$/i, '')
+                    .replace(/\s+$/, '');
+            })
+            .catch(err => {
+                fetchError = err;
+                console.warn('Could not prefetch markdown:', err);
+                // Hide the button if markdown is unavailable
+                hideButton();
+            });
+    })();
+
+    /**
+     * Hides the copy button when markdown content is unavailable.
+     */
+    function hideButton() {
+        const button = document.getElementById('llms-copy-button');
+        if (button) {
+            button.style.display = 'none';
+        }
+    }
+
+    /**
+     * Copies text to clipboard using execCommand.
+     *
+     * Note: We use execCommand instead of navigator.clipboard.writeText() because
+     * Safari's Clipboard API requires operations to be synchronous within the user
+     * gesture. Even with prefetched content, calling an async function (await) breaks
+     * the gesture chain. By using the synchronous execCommand, we ensure reliable
+     * cross-browser clipboard access including Safari/iOS.
+     *
+     * @param {string} text - Text to copy to clipboard
+     * @returns {boolean} Whether the copy succeeded
+     */
+    function copyToClipboard(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+
+        // Style it to be invisible but present in the DOM
+        textarea.style.cssText = 'position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;';
+
+        document.body.appendChild(textarea);
+
+        // Handle iOS Safari which requires special selection handling
+        if (/ipad|iphone/i.test(navigator.userAgent)) {
+            textarea.contentEditable = true;
+            textarea.readOnly = false;
+
+            const range = document.createRange();
+            range.selectNodeContents(textarea);
+
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            textarea.setSelectionRange(0, IOS_MAX_SELECTION);
+        } else {
+            textarea.focus();
+            textarea.select();
+        }
+
+        let success = false;
+        try {
+            success = document.execCommand('copy');
+        } catch (err) {
+            console.error('execCommand error:', err);
+        }
+
+        document.body.removeChild(textarea);
+        return success;
+    }
+
+    /**
+     * Shows success feedback on the button.
+     * @param {HTMLElement} button - The button element
+     */
+    function showSuccess(button) {
+        const originalHTML = button.innerHTML;
+        button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><polyline points="20 6 9 17 4 12"></polyline></svg>Copied!';
+        button.classList.add('success');
+        setTimeout(() => {
+            button.innerHTML = originalHTML;
+            button.classList.remove('success');
+        }, FEEDBACK_DURATION_MS);
+    }
+
+    /**
+     * Shows error feedback on the button.
+     * @param {HTMLElement} button - The button element
+     * @param {string} message - Error message to log
+     */
+    function showError(button, message) {
+        console.error('Copy failed:', message);
+        const originalHTML = button.innerHTML;
+        button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>Failed';
+        button.classList.add('error');
+        setTimeout(() => {
+            button.innerHTML = originalHTML;
+            button.classList.remove('error');
+        }, FEEDBACK_DURATION_MS);
+    }
+
+    // Expose the copy function to window (called by plugin's onclick handler)
+    window.copyMarkdownToClipboard = function() {
+        const button = document.querySelector('#llms-copy-button button');
+        if (!button) {
+            console.warn('Copy button not found');
+            return;
+        }
+
+        if (fetchError || !cachedMarkdown) {
+            showError(button, 'Markdown not available');
+            return;
+        }
+
+        // Synchronous copy - no async operations to preserve user gesture
+        const success = copyToClipboard(cachedMarkdown);
+
+        if (success) {
+            showSuccess(button);
+        } else {
+            showError(button, 'Copy failed');
+        }
+    };
+})();

--- a/docs/stylesheets/mixpanel.css
+++ b/docs/stylesheets/mixpanel.css
@@ -301,3 +301,97 @@
 .md-typeset table:not([class]) th {
   background-color: rgba(120, 86, 255, 0.1);
 }
+
+/*
+ * LLMs.txt copy button - Anthropic-style outlined button with icon
+ * Note: !important is required throughout to override inline styles
+ * injected by the mkdocs-llmstxt-md plugin
+ */
+#llms-copy-button {
+  position: fixed !important;
+  top: 85px !important;
+  right: 24px !important;
+}
+
+#llms-copy-button button {
+  display: inline-flex !important;
+  align-items: center !important;
+  background: transparent !important;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  border-radius: 6px !important;
+  padding: 6px 12px !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  color: rgba(255, 255, 255, 0.7) !important;
+  cursor: pointer !important;
+  transition: all 0.15s ease !important;
+}
+
+#llms-copy-button button::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 6px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.7)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='9' y='9' width='13' height='13' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'%3E%3C/path%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  flex-shrink: 0;
+}
+
+#llms-copy-button button:hover {
+  background: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.3) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+#llms-copy-button button:hover::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.9)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='9' y='9' width='13' height='13' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'%3E%3C/path%3E%3C/svg%3E");
+}
+
+/* Light mode adjustments */
+[data-md-color-scheme="default"] #llms-copy-button button {
+  border-color: rgba(0, 0, 0, 0.15) !important;
+  color: rgba(0, 0, 0, 0.6) !important;
+}
+
+[data-md-color-scheme="default"] #llms-copy-button button::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='rgba(0,0,0,0.6)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='9' y='9' width='13' height='13' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'%3E%3C/path%3E%3C/svg%3E");
+}
+
+[data-md-color-scheme="default"] #llms-copy-button button:hover {
+  background: rgba(0, 0, 0, 0.05) !important;
+  border-color: rgba(0, 0, 0, 0.25) !important;
+  color: rgba(0, 0, 0, 0.8) !important;
+}
+
+[data-md-color-scheme="default"] #llms-copy-button button:hover::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='rgba(0,0,0,0.8)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='9' y='9' width='13' height='13' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'%3E%3C/path%3E%3C/svg%3E");
+}
+
+/* Copy button success state (works in both light and dark modes) */
+#llms-copy-button button.success {
+  border-color: #219464 !important;
+  color: #219464 !important;
+}
+
+#llms-copy-button button.success::before {
+  display: none;
+}
+
+/* Copy button error state (works in both light and dark modes) */
+#llms-copy-button button.error {
+  border-color: #e34f2f !important;
+  color: #e34f2f !important;
+}
+
+#llms-copy-button button.error::before {
+  display: none;
+}
+
+/* Keyboard focus styles for accessibility */
+#llms-copy-button button:focus-visible {
+  outline: 2px solid var(--md-primary-fg-color) !important;
+  outline-offset: 2px !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,55 @@ theme:
 extra_css:
   - stylesheets/mixpanel.css
 
+extra_javascript:
+  - javascripts/copy-markdown.js
+
 plugins:
   - search
+  - llmstxt-md:
+      # noklam's plugin - markdown URLs and copy buttons (llms.txt generation disabled)
+      enable_markdown_urls: true
+      enable_copy_button: true
+      enable_llms_txt: false
+      enable_llms_full: false
+      copy_button_text: "Copy markdown"
+      copy_button_position:
+        top: "85px"
+        right: "24px"
+      copy_button_style:
+        background: "transparent"
+        color: "rgba(255, 255, 255, 0.7)"
+        border: "1px solid rgba(255, 255, 255, 0.2)"
+        padding: "6px 12px"
+        border_radius: "6px"
+        font_size: "13px"
+        font_weight: "400"
+        font_family: "inherit"
+      sections:
+        Getting Started:
+          - index.md
+          - getting-started/installation.md
+          - getting-started/quickstart.md
+          - getting-started/configuration.md
+        User Guide:
+          - guide/fetching.md
+          - guide/streaming.md
+          - guide/sql-queries.md
+          - guide/live-analytics.md
+          - guide/discovery.md
+        API Reference:
+          - api/index.md
+          - api/workspace.md
+          - api/auth.md
+          - api/exceptions.md
+          - api/types.md
+        CLI Reference:
+          - cli/index.md
+          - cli/commands.md
+        Architecture:
+          - architecture/design.md
+          - architecture/data-model.md
+          - architecture/storage.md
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -67,6 +114,39 @@ plugins:
             separate_signature: true
             line_length: 80
             members_order: source
+  - llmstxt:
+      # pawamoy's plugin - handles all llms.txt generation from HTML
+      full_output: llms-full.txt
+      markdown_description: |
+        mixpanel_data is a complete programmable interface to Mixpanel analytics.
+        Python library and CLI for discovery, querying, and data extraction.
+        Discover your schema, run live analytics (segmentation, funnels, retention),
+        execute JQL, and analyze locally with SQL via DuckDB.
+      sections:
+        Getting Started:
+          - index.md: "Project overview and key concepts"
+          - getting-started/installation.md: "Install with pip or uv"
+          - getting-started/quickstart.md: "First queries in 5 minutes"
+          - getting-started/configuration.md: "Accounts, env vars, config files"
+        User Guide:
+          - guide/fetching.md: "Fetch events and profiles to DuckDB"
+          - guide/streaming.md: "Stream data without storage for ETL"
+          - guide/sql-queries.md: "Query with DuckDB SQL and JSON operators"
+          - guide/live-analytics.md: "Segmentation, funnels, retention, JQL"
+          - guide/discovery.md: "Explore schema, events, properties, cohorts"
+        API Reference:
+          - api/index.md: "Python API overview"
+          - api/workspace.md: "Workspace class - main entry point"
+          - api/auth.md: "Authentication and credentials"
+          - api/exceptions.md: "Exception hierarchy"
+          - api/types.md: "Result types (SegmentationResult, etc.)"
+        CLI Reference:
+          - cli/index.md: "CLI overview and output formats"
+          - cli/commands.md: "Complete command reference"
+        Architecture:
+          - architecture/design.md: "Layered architecture and services"
+          - architecture/data-model.md: "Event and profile data model"
+          - architecture/storage.md: "DuckDB storage engine"
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.24",
     "mkdocs-typer>=0.0.3",
+    "mkdocs-llmstxt>=0.2.0",
+    "mkdocs-llmstxt-md>=0.1.0",
 ]
 notebook = [
     "jupyterlab>=4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1199,19 +1199,32 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [package.optional-dependencies]
 linkify = [
     { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
 ]
 
 [[package]]
@@ -1301,6 +1314,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,6 +1403,8 @@ dev = [
 ]
 docs = [
     { name = "mkdocs" },
+    { name = "mkdocs-llmstxt" },
+    { name = "mkdocs-llmstxt-md" },
     { name = "mkdocs-material" },
     { name = "mkdocs-typer" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1388,6 +1428,8 @@ requires-dist = [
     { name = "hypothesis", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5" },
+    { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2.0" },
+    { name = "mkdocs-llmstxt-md", marker = "extra == 'docs'", specifier = ">=0.1.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocs-typer", marker = "extra == 'docs'", specifier = ">=0.0.3" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24" },
@@ -1463,6 +1505,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt-md"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "ruff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/86/a899ef021e44e358544b31fd3e34aa566ff876650e7dbede3e677053a492/mkdocs_llmstxt_md-0.2.0.tar.gz", hash = "sha256:c42c86fc316c5e96920b403abfffda7615fe519baca9cdb716e9ff77b703570f", size = 8780, upload-time = "2025-08-01T14:14:10.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/96/519526b02a4429262b0e8728765a0bda8a987d1fd4e6ac7655f26ce2a245/mkdocs_llmstxt_md-0.2.0-py3-none-any.whl", hash = "sha256:ce836a6e7bc7f7d0987c8ac0703f04b51f1d7d0096a5700b042161fbbaea5175", size = 7551, upload-time = "2025-08-01T14:14:09.558Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds two complementary MkDocs plugins for llms.txt generation following the [llms.txt specification](https://llmstxt.org/):

- **mkdocs-llmstxt** (pawamoy): Generates `/llms.txt` and `/llms-full.txt` from built HTML
- **mkdocs-llmstxt-md** (noklam): Serves raw `.md` files at URLs and adds copy-to-markdown buttons

### Why Both Plugins?

| Feature | pawamoy's | noklam's |
|---------|-----------|----------|
| `/llms.txt` generation | ✅ (from HTML) | Disabled |
| `/llms-full.txt` generation | ✅ | Disabled |
| Captures mkdocstrings output | ✅ | ❌ |
| Captures mkdocs-typer output | ✅ | ❌ |
| Serve raw `.md` at URLs | ❌ | ✅ |
| Copy-to-markdown buttons | ❌ | ✅ |

The HTML-parsing approach is essential because this project uses mkdocstrings and mkdocs-typer for dynamic content generation.

### Additional Changes

- Custom JavaScript for Safari-compatible clipboard copy (prefetch pattern to preserve user gesture)
- Anthropic-style outlined button with copy icon
- Light/dark mode support for button styling
- Enhanced mixpanel-data skill with documentation access URLs
- New `references/documentation.md` with complete URL structure for LLM fetching

## Test Plan

- [ ] Build docs locally: `just docs`
- [ ] Verify `/llms.txt` and `/llms-full.txt` are generated in `site/`
- [ ] Test copy button works in Safari and Chrome
- [ ] Test `.md` URLs resolve (e.g., `/getting-started/installation/index.md`)
- [ ] Verify button styling in both light and dark modes