### PR TITLE
Add db_path property to Workspace

### DIFF
--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -92,4 +92,5 @@ Duplicate events (by `insert_id`) and profiles (by `distinct_id`) are automatica
         - property_keys
         - column_stats
         - connection
+        - db_path
         - api

--- a/docs/guide/sql-queries.md
+++ b/docs/guide/sql-queries.md
@@ -248,6 +248,22 @@ conn.execute("SET threads TO 4")
 result = conn.execute("EXPLAIN ANALYZE SELECT * FROM events").fetchall()
 ```
 
+### Database Path
+
+Get the path to the underlying database file:
+
+```python
+# Get the database file path
+path = ws.db_path
+print(f"Data stored at: {path}")
+
+# Useful for reopening the same database later
+ws.close()
+ws = mp.Workspace.open(path)
+```
+
+Note: `db_path` returns `None` for in-memory workspaces created with `Workspace.memory()`.
+
 ## Performance Tips
 
 ### Use Appropriate Data Types

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -2388,6 +2388,30 @@ class Workspace:
         return self.storage.connection
 
     @property
+    def db_path(self) -> Path | None:
+        """Path to the DuckDB database file.
+
+        Returns the filesystem path where data is stored. Useful for:
+        - Knowing where your data lives
+        - Opening the same database later with ``Workspace.open(path)``
+        - Debugging and logging
+
+        Returns:
+            The database file path, or None for in-memory workspaces.
+
+        Example:
+            Save the path for later use::
+
+                ws = mp.Workspace()
+                path = ws.db_path
+                ws.close()
+
+                # Later, reopen the same database
+                ws = mp.Workspace.open(path)
+        """
+        return self.storage.path
+
+    @property
     def api(self) -> MixpanelAPIClient:
         """Direct access to the Mixpanel API client.
 

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1321,6 +1321,34 @@ class TestEscapeHatches:
         finally:
             ws.close()
 
+    def test_db_path_property_returns_path(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """T103: Test db_path property returning database path."""
+        ws = workspace_factory()
+        try:
+            path = ws.db_path
+
+            # Should be a Path object
+            assert isinstance(path, Path)
+            # Should match the storage path
+            assert path == ws.storage.path
+        finally:
+            ws.close()
+
+    def test_db_path_property_returns_none_for_memory(
+        self,
+        mock_config_manager: MagicMock,
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T104: Test db_path property returns None for memory workspaces."""
+        with Workspace.memory(
+            _config_manager=mock_config_manager,
+            _api_client=mock_api_client,
+        ) as ws:
+            assert ws.db_path is None
+
 
 # =============================================================================
 # Context Manager Tests


### PR DESCRIPTION
## Summary

- Add `db_path` property to Workspace class for accessing the database file path
- Follows the existing escape hatch pattern (`connection`, `api`)
- Returns `None` for in-memory workspaces

## Changes

- **workspace.py**: Add `db_path` property with docstring and example
- **test_workspace.py**: Add tests T103, T104 for path and memory workspace cases
- **sql-queries.md**: Document usage in "Direct DuckDB Access" section
- **workspace.md**: Add to API reference members list

## Test plan

- [x] `just check` passes (lint, typecheck, tests)
- [x] New tests verify Path returned for file-based workspaces
- [x] New tests verify None returned for memory workspaces