### PR TITLE
Add normalized table output for query results

### DIFF
--- a/.claude/hooks/validate-python-commands.sh
+++ b/.claude/hooks/validate-python-commands.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+# Read hook input from stdin
+input=$(cat)
+
+# Extract the command from the tool input
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Check if command contains bare python or python3
+if echo "$command" | grep -qE '(^|[;&|]\s*)(python3?)\b' && ! echo "$command" | grep -q 'uv run python'; then
+  # Deny the command
+  cat >&2 <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny"
+  },
+  "systemMessage": "🚫 **Bare python command blocked**\n\nThis project uses uv for dependency management. Please use 'uv run python' instead of bare 'python' or 'python3' commands.\n\n**Examples:**\n- ❌ python script.py → ✅ uv run python script.py\n- ❌ python3 -m pytest → ✅ uv run python -m pytest\n- ❌ python -c 'code' → ✅ uv run python -c 'code'\n\n**Why?** Bare python/python3 won't have access to project dependencies installed via uv."
+}
+EOF
+  exit 2
+fi
+
+# Check if command contains bare pytest
+if echo "$command" | grep -qE '(^|[;&|]\s*)(pytest)\b' && ! echo "$command" | grep -qE 'uv run (python -m )?pytest'; then
+  # Deny the command
+  cat >&2 <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny"
+  },
+  "systemMessage": "🚫 **Bare pytest command blocked**\n\nThis project uses uv for dependency management. Please use 'uv run pytest' instead of bare 'pytest' commands.\n\n**Examples:**\n- ❌ pytest → ✅ uv run pytest\n- ❌ pytest tests/ → ✅ uv run pytest tests/\n- ❌ pytest -k test_name → ✅ uv run pytest -k test_name\n\n**Why?** Bare pytest won't have access to project dependencies installed via uv."
+}
+EOF
+  exit 2
+fi
+
+# Approve the command
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-python-commands.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ man/
 
 # Jupyter
 .ipynb_checkpoints/
+
+# Demo
+demo/

--- a/context/implementation-plans/bookmark_id_guide.md
+++ b/context/implementation-plans/bookmark_id_guide.md
@@ -190,7 +190,7 @@ class MixpanelBookmarkAPI:
         self.client = httpx.Client(
             auth=(username, secret),
             base_url=base_url,
-            timeout=30.0
+            timeout=120.0
         )
     
     def get_insights_bookmarks(self, project_id: int) -> List[Dict[str, Any]]:

--- a/specs/002-api-client/contracts/api_client.py
+++ b/specs/002-api-client/contracts/api_client.py
@@ -25,8 +25,8 @@ class MixpanelAPIClientProtocol(Protocol):
         self,
         credentials: Credentials,
         *,
-        timeout: float = 30.0,
-        export_timeout: float = 300.0,
+        timeout: float = 120.0,
+        export_timeout: float = 600.0,
         max_retries: int = 3,
     ) -> None:
         """Initialize the API client.

--- a/specs/002-api-client/quickstart.md
+++ b/specs/002-api-client/quickstart.md
@@ -176,8 +176,8 @@ def test_export_events():
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `timeout` | 30.0 | Request timeout (seconds) |
-| `export_timeout` | 300.0 | Export request timeout (seconds) |
+| `timeout` | 120.0 | Request timeout (seconds) |
+| `export_timeout` | 600.0 | Export request timeout (seconds) |
 | `max_retries` | 3 | Max retries for rate limits |
 
 ```python

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -85,8 +85,8 @@ class MixpanelAPIClient:
         self,
         credentials: Credentials,
         *,
-        timeout: float = 30.0,
-        export_timeout: float = 300.0,
+        timeout: float = 120.0,
+        export_timeout: float = 600.0,
         max_retries: int = 3,
         _transport: httpx.BaseTransport | None = None,
     ) -> None:

--- a/src/mixpanel_data/_internal/expressions.py
+++ b/src/mixpanel_data/_internal/expressions.py
@@ -31,14 +31,19 @@ def normalize_on_expression(on: str) -> str:
         backslashes in bare property names are escaped to produce valid syntax.
 
     Examples:
-        >>> normalize_on_expression("Source")
-        'properties["Source"]'
-        >>> normalize_on_expression('properties["Source"]')
-        'properties["Source"]'
-        >>> normalize_on_expression('properties["Type"] == "Event"')
-        'properties["Type"] == "Event"'
-        >>> normalize_on_expression('my"property')
-        'properties["my\\\\"property"]'
+        ```python
+        normalize_on_expression("Source")
+        # 'properties["Source"]'
+
+        normalize_on_expression('properties["Source"]')
+        # 'properties["Source"]'
+
+        normalize_on_expression('properties["Type"] == "Event"')
+        # 'properties["Type"] == "Event"'
+
+        normalize_on_expression('my"property')
+        # 'properties["my\\\\"property"]'
+        ```
     """
     if any(accessor in on for accessor in _FILTER_EXPR_ACCESSORS):
         return on

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -31,6 +31,7 @@ from mixpanel_data.cli.utils import (
     get_workspace,
     handle_errors,
     output_result,
+    present_result,
     status_spinner,
 )
 from mixpanel_data.cli.validators import (
@@ -180,9 +181,7 @@ def query_segmentation(
             where=where,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("funnel")
@@ -236,9 +235,7 @@ def query_funnel(
             on=on,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("retention")
@@ -324,9 +321,7 @@ def query_retention(
             unit=validated_unit,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("jql")
@@ -389,9 +384,7 @@ def query_jql(
             params=params if params else None,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("event-counts")
@@ -456,9 +449,7 @@ def query_event_counts(
             unit=validated_unit,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("property-counts")
@@ -532,9 +523,7 @@ def query_property_counts(
             limit=limit,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("activity-feed")
@@ -584,9 +573,7 @@ def query_activity_feed(
             to_date=to_date,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("saved-report")
@@ -651,9 +638,7 @@ def query_flows(
     with status_spinner(ctx, "Querying flows report..."):
         result = workspace.query_flows(bookmark_id=bookmark_id)
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("frequency")
@@ -720,9 +705,7 @@ def query_frequency(
             where=where,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("segmentation-numeric")
@@ -799,9 +782,7 @@ def query_segmentation_numeric(
             where=where,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("segmentation-sum")
@@ -867,9 +848,7 @@ def query_segmentation_sum(
             where=where,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)
 
 
 @query_app.command("segmentation-average")
@@ -935,6 +914,4 @@ def query_segmentation_average(
             where=where,
         )
 
-    # Use normalized format for tables, nested dict for other formats
-    data = result.to_table_dict() if format == "table" else result.to_dict()
-    output_result(ctx, data, format=format)
+    present_result(ctx, result, format)

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -180,7 +180,9 @@ def query_segmentation(
             where=where,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("funnel")
@@ -234,7 +236,9 @@ def query_funnel(
             on=on,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("retention")
@@ -320,7 +324,9 @@ def query_retention(
             unit=validated_unit,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("jql")
@@ -383,7 +389,9 @@ def query_jql(
             params=params if params else None,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("event-counts")
@@ -448,7 +456,9 @@ def query_event_counts(
             unit=validated_unit,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("property-counts")
@@ -522,7 +532,9 @@ def query_property_counts(
             limit=limit,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("activity-feed")
@@ -572,7 +584,9 @@ def query_activity_feed(
             to_date=to_date,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("saved-report")
@@ -637,7 +651,9 @@ def query_flows(
     with status_spinner(ctx, "Querying flows report..."):
         result = workspace.query_flows(bookmark_id=bookmark_id)
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("frequency")
@@ -704,7 +720,9 @@ def query_frequency(
             where=where,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("segmentation-numeric")
@@ -781,7 +799,9 @@ def query_segmentation_numeric(
             where=where,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("segmentation-sum")
@@ -847,7 +867,9 @@ def query_segmentation_sum(
             where=where,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)
 
 
 @query_app.command("segmentation-average")
@@ -913,4 +935,6 @@ def query_segmentation_average(
             where=where,
         )
 
-    output_result(ctx, result.to_dict(), format=format)
+    # Use normalized format for tables, nested dict for other formats
+    data = result.to_table_dict() if format == "table" else result.to_dict()
+    output_result(ctx, data, format=format)

--- a/tests/integration/cli/test_query_commands.py
+++ b/tests/integration/cli/test_query_commands.py
@@ -12,7 +12,9 @@ from typer.testing import CliRunner
 from mixpanel_data.cli.main import app
 from mixpanel_data.types import (
     ActivityFeedResult,
+    CohortInfo,
     EventCountsResult,
+    FlowsResult,
     FrequencyResult,
     FunnelResult,
     FunnelStep,
@@ -208,6 +210,142 @@ class TestQuerySegmentation:
         call_kwargs = mock_workspace.segmentation.call_args.kwargs
         assert call_kwargs["on"] == "country"
 
+    def test_segmentation_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/segment/count columns."""
+        mock_workspace.segmentation.return_value = SegmentationResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            segment_property="country",
+            total=375,
+            series={
+                "US": {"2024-01-01": 100, "2024-01-02": 150},
+                "EU": {"2024-01-01": 50, "2024-01-02": 75},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation",
+                    "--event",
+                    "Purchase",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--on",
+                    "country",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "SEGMENT" in result.stdout
+        assert "COUNT" in result.stdout
+        # Should NOT contain the nested series JSON structure
+        assert "series" not in result.stdout.lower()
+
+    def test_segmentation_json_format_unchanged(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """JSON format should still use nested series structure."""
+        mock_workspace.segmentation.return_value = SegmentationResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            segment_property="country",
+            total=375,
+            series={
+                "US": {"2024-01-01": 100, "2024-01-02": 150},
+                "EU": {"2024-01-01": 50, "2024-01-02": 75},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation",
+                    "--event",
+                    "Purchase",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--on",
+                    "country",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        # JSON format should have nested series structure
+        assert "series" in data
+        assert isinstance(data["series"], dict)
+        assert "US" in data["series"]
+        assert "2024-01-01" in data["series"]["US"]
+
+    def test_segmentation_table_without_segments(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should work without segmentation (unsegmented query)."""
+        mock_workspace.segmentation.return_value = SegmentationResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            segment_property=None,
+            total=250,
+            series={
+                "total": {"2024-01-01": 100, "2024-01-02": 150},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation",
+                    "--event",
+                    "Purchase",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Should still have normalized columns
+        assert "DATE" in result.stdout
+        assert "SEGMENT" in result.stdout
+        assert "COUNT" in result.stdout
+
 
 class TestQueryFunnel:
     """Tests for mp query funnel command."""
@@ -260,6 +398,50 @@ class TestQueryFunnel:
         assert data["funnel_id"] == 123
         assert len(data["steps"]) == 2
 
+    def test_funnel_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with step/event/count/conversion_rate columns."""
+        mock_workspace.funnel.return_value = FunnelResult(
+            funnel_id=123,
+            funnel_name="Signup Funnel",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            conversion_rate=0.5,
+            steps=[
+                FunnelStep(event="View Page", count=1000, conversion_rate=1.0),
+                FunnelStep(event="Sign Up", count=500, conversion_rate=0.5),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "funnel",
+                    "123",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "STEP" in result.stdout
+        assert "EVENT" in result.stdout
+        assert "COUNT" in result.stdout
+        assert "CONVERSION_RATE" in result.stdout or "CONVERSION RATE" in result.stdout
+        # Should NOT contain the nested steps JSON structure
+        assert "steps" not in result.stdout.lower()
+
 
 class TestQueryRetention:
     """Tests for mp query retention command."""
@@ -303,6 +485,54 @@ class TestQueryRetention:
         data = json.loads(result.stdout)
         assert data["born_event"] == "Signup"
         assert data["return_event"] == "Login"
+
+    def test_retention_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with cohort_date/cohort_size/period_N columns."""
+        mock_workspace.retention.return_value = RetentionResult(
+            born_event="Signup",
+            return_event="Login",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="day",
+            cohorts=[
+                CohortInfo(date="2024-01-01", size=100, retention=[1.0, 0.8, 0.6]),
+                CohortInfo(date="2024-01-02", size=150, retention=[1.0, 0.7, 0.5]),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "retention",
+                    "--born",
+                    "Signup",
+                    "--return",
+                    "Login",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "COHORT_DATE" in result.stdout or "COHORT DATE" in result.stdout
+        assert "COHORT_SIZE" in result.stdout or "COHORT SIZE" in result.stdout
+        assert (
+            "PERIOD " in result.stdout
+        )  # period_0, period_1, etc. (Rich formats period_0 as PERIOD 0)
+        # Should NOT contain the nested cohorts JSON structure
+        assert "cohorts" not in result.stdout.lower()
 
 
 class TestQueryJql:
@@ -415,6 +645,105 @@ class TestQueryJql:
         assert result.exit_code == 3
         assert "Invalid parameter format" in result.output
 
+    def test_jql_table_format_groupby_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data for groupBy results."""
+        # Simulate groupBy result: Events.groupBy(['country'], reducer.count())
+        mock_workspace.jql.return_value = JQLResult(
+            _raw=[
+                {"key": ["US"], "value": 1000},
+                {"key": ["EU"], "value": 500},
+                {"key": ["Asia"], "value": 300},
+            ]
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "jql",
+                    "--script",
+                    "function main() { return []; }",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain normalized columns from groupBy expansion
+        assert "KEY_0" in result.stdout or "KEY 0" in result.stdout
+        assert "VALUE" in result.stdout
+        # Should NOT contain the nested raw JSON structure
+        assert '"key"' not in result.stdout.lower()
+
+    def test_jql_table_format_simple_dicts(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should handle simple list of dicts."""
+        # Simulate simple dict result from .map()
+        mock_workspace.jql.return_value = JQLResult(
+            _raw=[
+                {"event": "Login", "count": 100},
+                {"event": "Signup", "count": 50},
+            ]
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "jql",
+                    "--script",
+                    "function main() { return []; }",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain columns from dict keys
+        assert "EVENT" in result.stdout
+        assert "COUNT" in result.stdout
+
+    def test_jql_json_format_unchanged(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """JSON format should still use nested raw structure."""
+        mock_workspace.jql.return_value = JQLResult(
+            _raw=[{"key": ["US"], "value": 1000}]
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "jql",
+                    "--script",
+                    "function main() { return []; }",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        # JSON format should preserve raw structure
+        assert "raw" in data
+        assert data["raw"] == [{"key": ["US"], "value": 1000}]
+
 
 class TestQueryEventCounts:
     """Tests for mp query event-counts command."""
@@ -455,6 +784,50 @@ class TestQueryEventCounts:
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["events"] == ["Signup", "Login"]
+
+    def test_event_counts_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/event/count columns."""
+        mock_workspace.event_counts.return_value = EventCountsResult(
+            events=["Login", "Purchase"],
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            type="general",
+            series={
+                "Login": {"2024-01-01": 100, "2024-01-02": 150},
+                "Purchase": {"2024-01-01": 50, "2024-01-02": 75},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "event-counts",
+                    "--events",
+                    "Login,Purchase",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "EVENT" in result.stdout
+        assert "COUNT" in result.stdout
+        # Should NOT contain the nested series JSON structure
+        assert "series" not in result.stdout.lower()
 
 
 class TestQueryPropertyCounts:
@@ -501,6 +874,53 @@ class TestQueryPropertyCounts:
         assert data["event"] == "Signup"
         assert data["property_name"] == "country"
 
+    def test_property_counts_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/value/count columns."""
+        mock_workspace.property_counts.return_value = PropertyCountsResult(
+            event="Purchase",
+            property_name="country",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            type="general",
+            series={
+                "US": {"2024-01-01": 100, "2024-01-02": 150},
+                "EU": {"2024-01-01": 50, "2024-01-02": 75},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "property-counts",
+                    "--event",
+                    "Purchase",
+                    "--property",
+                    "country",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "VALUE" in result.stdout
+        assert "COUNT" in result.stdout
+        # Should NOT contain the nested series JSON structure
+        assert "series" not in result.stdout.lower()
+
 
 class TestQueryActivityFeed:
     """Tests for mp query activity-feed command."""
@@ -539,6 +959,56 @@ class TestQueryActivityFeed:
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["distinct_ids"] == ["user1", "user2"]
+
+    def test_activity_feed_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with event/time/distinct_id columns."""
+        mock_workspace.activity_feed.return_value = ActivityFeedResult(
+            distinct_ids=["user1"],
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            events=[
+                UserEvent(
+                    event="Login",
+                    time=datetime(2024, 1, 1, 10, 0, 0),
+                    properties={"$distinct_id": "user1", "city": "SF"},
+                ),
+                UserEvent(
+                    event="Purchase",
+                    time=datetime(2024, 1, 2, 11, 0, 0),
+                    properties={"$distinct_id": "user1", "amount": 50},
+                ),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "activity-feed",
+                    "--users",
+                    "user1",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "EVENT" in result.stdout
+        assert "TIME" in result.stdout
+        assert "DISTINCT_ID" in result.stdout or "DISTINCT ID" in result.stdout
+        # Should NOT contain the nested events JSON structure
+        assert '"events"' not in result.stdout.lower()
 
 
 class TestQuerySavedReport:
@@ -609,6 +1079,51 @@ class TestQueryFrequency:
         data = json.loads(result.stdout)
         assert "data" in data
 
+    def test_frequency_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/period_N columns."""
+        mock_workspace.frequency.return_value = FrequencyResult(
+            event="Login",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            unit="day",
+            addiction_unit="hour",
+            data={
+                "2024-01-01": [100, 50, 25],
+                "2024-01-02": [120, 60, 30],
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "frequency",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--event",
+                    "Login",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert (
+            "PERIOD " in result.stdout
+        )  # PERIOD 1, PERIOD 2, etc. (Rich formats period_1 as PERIOD 1)
+        # Should NOT contain the nested data JSON structure
+        assert '"data"' not in result.stdout.lower()
+
 
 class TestQuerySegmentationNumeric:
     """Tests for mp query segmentation-numeric command."""
@@ -652,6 +1167,52 @@ class TestQuerySegmentationNumeric:
         data = json.loads(result.stdout)
         assert data["event"] == "Purchase"
         assert data["property_expr"] == "price"
+
+    def test_segmentation_numeric_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/bucket/count columns."""
+        mock_workspace.segmentation_numeric.return_value = NumericBucketResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-02",
+            property_expr="price",
+            unit="day",
+            series={
+                "0-10": {"2024-01-01": 100, "2024-01-02": 150},
+                "10-20": {"2024-01-01": 50, "2024-01-02": 75},
+            },
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-numeric",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "price",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-02",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "BUCKET" in result.stdout
+        assert "COUNT" in result.stdout
+        # Should NOT contain the nested series JSON structure
+        assert "series" not in result.stdout.lower()
 
 
 class TestQuerySegmentationSum:
@@ -697,6 +1258,48 @@ class TestQuerySegmentationSum:
         assert data["event"] == "Purchase"
         assert data["property_expr"] == "revenue"
 
+    def test_segmentation_sum_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/sum columns."""
+        mock_workspace.segmentation_sum.return_value = NumericSumResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr="revenue",
+            unit="day",
+            results={"2024-01-01": 500.25, "2024-01-02": 600.50},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-sum",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "revenue",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "SUM" in result.stdout
+        # Should NOT contain the nested results JSON structure
+        assert "results" not in result.stdout.lower()
+
 
 class TestQuerySegmentationAverage:
     """Tests for mp query segmentation-average command."""
@@ -740,3 +1343,105 @@ class TestQuerySegmentationAverage:
         data = json.loads(result.stdout)
         assert data["event"] == "Purchase"
         assert data["property_expr"] == "price"
+
+    def test_segmentation_average_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data with date/average columns."""
+        mock_workspace.segmentation_average.return_value = NumericAverageResult(
+            event="Purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            property_expr="price",
+            unit="day",
+            results={"2024-01-01": 45.50, "2024-01-02": 52.25},
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "segmentation-average",
+                    "--event",
+                    "Purchase",
+                    "--on",
+                    "price",
+                    "--from",
+                    "2024-01-01",
+                    "--to",
+                    "2024-01-31",
+                    "--format",
+                    "table",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers for normalized data
+        assert "DATE" in result.stdout
+        assert "AVERAGE" in result.stdout
+        # Should NOT contain the nested results JSON structure
+        assert "results" not in result.stdout.lower()
+
+
+class TestQueryFlows:
+    """Tests for mp query flows command."""
+
+    def test_flows_happy_path(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test flows query with bookmark ID."""
+        mock_workspace.query_flows.return_value = FlowsResult(
+            bookmark_id=12345,
+            computed_at="2024-02-01T00:00:00Z",
+            steps=[{"event": "View Page", "count": 1000}],
+            breakdowns=[],
+            overall_conversion_rate=0.5,
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["query", "flows", "12345", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["bookmark_id"] == 12345
+
+    def test_flows_table_format_normalized(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Table format should use normalized data from steps."""
+        mock_workspace.query_flows.return_value = FlowsResult(
+            bookmark_id=12345,
+            computed_at="2024-02-01T00:00:00Z",
+            steps=[
+                {"event": "View Page", "count": 1000},
+                {"event": "Sign Up", "count": 500},
+            ],
+            breakdowns=[],
+            overall_conversion_rate=0.5,
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["query", "flows", "12345", "--format", "table"],
+            )
+
+        assert result.exit_code == 0
+        # Table output should contain column headers from steps data
+        assert "EVENT" in result.stdout
+        assert "COUNT" in result.stdout
+        # Should NOT contain the nested steps/breakdowns JSON structure
+        assert "steps" not in result.stdout.lower()

--- a/tests/unit/cli/test_formatters.py
+++ b/tests/unit/cli/test_formatters.py
@@ -205,6 +205,22 @@ class TestFormatTable:
         assert isinstance(table, Table)
         assert table.row_count == 1
 
+    def test_format_normalized_segmentation_data(self) -> None:
+        """Test formatting normalized segmentation data with date/segment/count."""
+        # This is the format returned by SegmentationResult.to_table_dict()
+        data = [
+            {"date": "2024-01-01", "segment": "US", "count": 100},
+            {"date": "2024-01-01", "segment": "EU", "count": 50},
+            {"date": "2024-01-02", "segment": "US", "count": 150},
+            {"date": "2024-01-02", "segment": "EU", "count": 75},
+        ]
+        table = format_table(data)
+
+        assert isinstance(table, Table)
+        assert table.row_count == 4
+        # Verify columns are properly detected from first item
+        assert len(table.columns) == 3
+
 
 class TestFormatCsv:
     """Tests for format_csv function."""

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -17,9 +17,11 @@ Usage:
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from datetime import datetime
 
+import pandas as pd
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -124,9 +126,6 @@ class TestResultWithDataFrameProperties:
         self, num_rows: int, num_cols: int
     ) -> None:
         """to_table_dict() should always return a list, never None or other type."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -151,9 +150,6 @@ class TestResultWithDataFrameProperties:
     )
     def test_all_elements_are_dicts(self, num_rows: int, num_cols: int) -> None:
         """Every element in to_table_dict() output should be a dict."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -169,9 +165,6 @@ class TestResultWithDataFrameProperties:
 
     def test_empty_dataframe_returns_empty_list(self) -> None:
         """to_table_dict() should return empty list for empty DataFrame."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class EmptyResult(ResultWithDataFrame):
@@ -191,9 +184,6 @@ class TestResultWithDataFrameProperties:
     )
     def test_row_count_matches_dataframe(self, num_rows: int, num_cols: int) -> None:
         """Length of to_table_dict() should equal number of DataFrame rows."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -225,9 +215,6 @@ class TestResultWithDataFrameProperties:
         self, num_rows: int, col_names: list[str]
     ) -> None:
         """All DataFrame column names should appear as keys in output dicts."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -249,9 +236,6 @@ class TestResultWithDataFrameProperties:
     )
     def test_output_is_json_serializable(self, num_rows: int, num_cols: int) -> None:
         """to_table_dict() output should always be JSON-serializable."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -278,9 +262,6 @@ class TestResultWithDataFrameProperties:
     )
     def test_deterministic_conversion(self, num_rows: int, num_cols: int) -> None:
         """Same DataFrame should always produce identical output."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -319,9 +300,6 @@ class TestResultWithDataFrameProperties:
     )
     def test_handles_various_data_types(self, values: list[object]) -> None:
         """Should handle DataFrames with various column types."""
-        import dataclasses
-
-        import pandas as pd
 
         @dataclasses.dataclass(frozen=True)
         class TestResult(ResultWithDataFrame):
@@ -783,8 +761,6 @@ class TestJQLResultProperties:
         not relying on dictionary ordering, hash randomness, or other
         non-deterministic factors.
         """
-        import pandas as pd
-
         # Create two separate JQLResult objects with same data
         result1 = JQLResult(_raw=raw_data)
         result2 = JQLResult(_raw=raw_data)
@@ -826,8 +802,6 @@ class TestJQLResultProperties:
         df = result.df
 
         # Should always return a DataFrame
-        import pandas as pd
-
         assert isinstance(df, pd.DataFrame)
 
         # Row count should match input length (or flattened length for nested)
@@ -2103,8 +2077,6 @@ class TestPropertyValueCountProperties:
     def test_immutable(self, count: int, percentage: float) -> None:
         """PropertyValueCount should be immutable (frozen dataclass)."""
         result = PropertyValueCount(value="test", count=count, percentage=percentage)
-
-        import dataclasses
 
         import pytest
 

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -52,6 +52,7 @@ from mixpanel_data.types import (
     PropertyCoverageResult,
     PropertyDistributionResult,
     PropertyValueCount,
+    ResultWithDataFrame,
     RetentionResult,
     SavedCohort,
     SavedReportResult,
@@ -101,6 +102,241 @@ datetimes = st.datetimes(
     min_value=datetime(2020, 1, 1),
     max_value=datetime(2030, 12, 31),
 )
+
+
+# =============================================================================
+# ResultWithDataFrame Property Tests
+# =============================================================================
+
+
+class TestResultWithDataFrameProperties:
+    """Property-based tests for ResultWithDataFrame base class.
+
+    These tests verify invariants that should hold for all types inheriting from
+    ResultWithDataFrame, ensuring the base class implementation is robust.
+    """
+
+    @given(
+        num_rows=st.integers(min_value=0, max_value=50),
+        num_cols=st.integers(min_value=1, max_value=10),
+    )
+    def test_to_table_dict_always_returns_list(
+        self, num_rows: int, num_cols: int
+    ) -> None:
+        """to_table_dict() should always return a list, never None or other type."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                if self._df_cache is not None:
+                    return self._df_cache
+
+                data = {f"col_{i}": list(range(num_rows)) for i in range(num_cols)}
+                result_df = pd.DataFrame(data)
+                object.__setattr__(self, "_df_cache", result_df)
+                return result_df
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        assert isinstance(table_dict, list)
+
+    @given(
+        num_rows=st.integers(min_value=1, max_value=50),
+        num_cols=st.integers(min_value=1, max_value=10),
+    )
+    def test_all_elements_are_dicts(self, num_rows: int, num_cols: int) -> None:
+        """Every element in to_table_dict() output should be a dict."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                data = {f"col_{i}": list(range(num_rows)) for i in range(num_cols)}
+                return pd.DataFrame(data)
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        assert all(isinstance(row, dict) for row in table_dict)
+
+    def test_empty_dataframe_returns_empty_list(self) -> None:
+        """to_table_dict() should return empty list for empty DataFrame."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class EmptyResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                return pd.DataFrame()
+
+        result = EmptyResult()
+        table_dict = result.to_table_dict()
+
+        assert table_dict == []
+        assert isinstance(table_dict, list)
+
+    @given(
+        num_rows=st.integers(min_value=0, max_value=50),
+        num_cols=st.integers(min_value=1, max_value=10),
+    )
+    def test_row_count_matches_dataframe(self, num_rows: int, num_cols: int) -> None:
+        """Length of to_table_dict() should equal number of DataFrame rows."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                data = {f"col_{i}": list(range(num_rows)) for i in range(num_cols)}
+                return pd.DataFrame(data)
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        assert len(table_dict) == num_rows
+        assert len(table_dict) == len(result.df)
+
+    @given(
+        num_rows=st.integers(min_value=1, max_value=20),
+        col_names=st.lists(
+            st.text(
+                alphabet=st.characters(categories=("L", "N")),
+                min_size=1,
+                max_size=15,
+            ).filter(lambda s: s and s[0].isalpha()),
+            min_size=1,
+            max_size=8,
+            unique=True,
+        ),
+    )
+    def test_column_names_become_dict_keys(
+        self, num_rows: int, col_names: list[str]
+    ) -> None:
+        """All DataFrame column names should appear as keys in output dicts."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                data = {col: list(range(num_rows)) for col in col_names}
+                return pd.DataFrame(data)
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        if table_dict:  # Only check if non-empty
+            for row in table_dict:
+                assert set(row.keys()) == set(col_names)
+
+    @given(
+        num_rows=st.integers(min_value=0, max_value=30),
+        num_cols=st.integers(min_value=1, max_value=8),
+    )
+    def test_output_is_json_serializable(self, num_rows: int, num_cols: int) -> None:
+        """to_table_dict() output should always be JSON-serializable."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                data = {f"col_{i}": list(range(num_rows)) for i in range(num_cols)}
+                return pd.DataFrame(data)
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        # Should not raise
+        json_str = json.dumps(table_dict)
+        assert isinstance(json_str, str)
+
+        # Should round-trip correctly
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, list)
+        assert len(parsed) == num_rows
+
+    @given(
+        num_rows=st.integers(min_value=1, max_value=20),
+        num_cols=st.integers(min_value=1, max_value=5),
+    )
+    def test_deterministic_conversion(self, num_rows: int, num_cols: int) -> None:
+        """Same DataFrame should always produce identical output."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            data: dict[str, list[int]] = dataclasses.field(default_factory=dict)
+
+            @property
+            def df(self) -> pd.DataFrame:
+                if self._df_cache is not None:
+                    return self._df_cache
+
+                result_df = pd.DataFrame(self.data)
+                object.__setattr__(self, "_df_cache", result_df)
+                return result_df
+
+        data = {f"col_{i}": list(range(num_rows)) for i in range(num_cols)}
+
+        result1 = TestResult(data=data)
+        result2 = TestResult(data=data)
+
+        table_dict1 = result1.to_table_dict()
+        table_dict2 = result2.to_table_dict()
+
+        assert table_dict1 == table_dict2
+
+    @given(
+        values=st.lists(
+            st.one_of(
+                st.integers(min_value=-1000, max_value=1000),
+                st.floats(min_value=-1e6, max_value=1e6, allow_nan=False),
+                st.text(max_size=20),
+                st.booleans(),
+            ),
+            min_size=0,
+            max_size=20,
+        )
+    )
+    def test_handles_various_data_types(self, values: list[object]) -> None:
+        """Should handle DataFrames with various column types."""
+        import dataclasses
+
+        import pandas as pd
+
+        @dataclasses.dataclass(frozen=True)
+        class TestResult(ResultWithDataFrame):
+            @property
+            def df(self) -> pd.DataFrame:
+                if not values:
+                    return pd.DataFrame()
+                return pd.DataFrame({"value": values})
+
+        result = TestResult()
+        table_dict = result.to_table_dict()
+
+        assert len(table_dict) == len(values)
+        # Should still be JSON-serializable
+        json.dumps(table_dict)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Introduces `ResultWithDataFrame` base class providing normalized table output for all query result types
- Updates CLI commands to use `to_table_dict()` for `--format table`, preserving nested structure for other formats
- Increases API client timeout defaults for better reliability with large queries
- Adds PreToolUse hook for Python command validation

## Changes

### Core improvements
- **ResultWithDataFrame base class**: Provides `to_table_dict()` method that converts nested data structures to flat, readable table rows
- **CLI query commands**: All query commands now use normalized output for table format (date/segment/count columns instead of nested JSON blobs)
- **Result type updates**: All result types (SegmentationResult, FunnelResult, RetentionResult, etc.) now inherit from ResultWithDataFrame

### Configuration changes
- API client timeout increased: 30s → 120s
- Export timeout increased: 300s → 600s
- Added demo/ directory to .gitignore
- Added PreToolUse hook for validating Python commands

### Documentation
- Updated docstrings to use code blocks instead of >>> format in expressions.py
- Updated timeout documentation in specs and contracts

## Test plan

- [x] Unit tests for to_table_dict() method across all result types
- [x] Integration tests verifying table format uses normalized output
- [x] Integration tests verifying JSON format preserves nested structure
- [x] Property-based tests for edge cases
- [x] All existing tests pass