### PR TITLE
Add --jq option for client-side JSON filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ just test-pbt-dev
 - Python 3.11+ with full type hints (mypy --strict compliant)
 - Typer (CLI) + Rich (output formatting)
 - DuckDB (embedded analytical database)
+- jq (JSON filtering via `--jq` option for CLI commands)
 - httpx (HTTP client), Pydantic (validation)
 - Hypothesis (property-based testing), mutmut (mutation testing)
 - uv (package manager), just (command runner)
@@ -219,10 +220,3 @@ Design documents in `context/`:
 - [mixpanel_data-design.md](context/mixpanel_data-design.md) — Architecture and public API
 - [mp-cli-project-spec.md](context/mp-cli-project-spec.md) — CLI specification
 - [mixpanel-http-api-specification.md](context/mixpanel-http-api-specification.md) — Mixpanel API reference
-
-## Active Technologies
-- Python 3.11+ + jq>=1.9.0 (new), typer, rich, pydantic (016-jq-filter-support)
-- N/A (output filtering only) (016-jq-filter-support)
-
-## Recent Changes
-- 016-jq-filter-support: Added Python 3.11+ + jq>=1.9.0 (new), typer, rich, pydantic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,26 @@ Required docstring sections:
 - **Raises**: All exceptions that may be raised
 - **Example**: Usage example where behavior isn't immediately obvious
 
+**Example format**: Use markdown fenced code blocks with language hints, not doctest-style `>>>` operators:
+
+```python
+# CORRECT - markdown code fence with language hint
+"""
+Example:
+    ```python
+    result = my_function("input")
+    # ["output"]
+    ```
+"""
+
+# WRONG - doctest style (DO NOT USE)
+"""
+Example:
+    >>> my_function("input")
+    ["output"]
+"""
+```
+
 Undocumented code will not pass code review.
 
 ## Test-Driven Development (STRICT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,3 +219,10 @@ Design documents in `context/`:
 - [mixpanel_data-design.md](context/mixpanel_data-design.md) — Architecture and public API
 - [mp-cli-project-spec.md](context/mp-cli-project-spec.md) — CLI specification
 - [mixpanel-http-api-specification.md](context/mixpanel-http-api-specification.md) — Mixpanel API reference
+
+## Active Technologies
+- Python 3.11+ + jq>=1.9.0 (new), typer, rich, pydantic (016-jq-filter-support)
+- N/A (output filtering only) (016-jq-filter-support)
+
+## Recent Changes
+- 016-jq-filter-support: Added Python 3.11+ + jq>=1.9.0 (new), typer, rich, pydantic

--- a/README.md
+++ b/README.md
@@ -167,6 +167,23 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 All commands support `--format` (`json`, `jsonl`, `table`, `csv`, `plain`) and `--help`.
 
+### Filtering with --jq
+
+Commands that output JSON support `--jq` for client-side filtering:
+
+```bash
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Extract total from segmentation
+mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 \
+    --format json --jq '.total'
+
+# Filter SQL results
+mp query sql "SELECT * FROM events LIMIT 100" --format json \
+    --jq '.[] | select(.event_name == "Purchase")'
+```
+
 See [CLI Reference](https://jaredmcfarland.github.io/mixpanel_data/cli/) for complete documentation.
 
 ## DuckDB JSON Queries
@@ -204,7 +221,7 @@ Key design features:
 
 - **Discoverable schema**: `list_events()`, `list_properties()`, `list_funnels()`, `list_cohorts()`, `list_bookmarks()` reveal what's in your project before you query
 - **Consistent interfaces**: Same operations available as Python methods and CLI commands
-- **Structured output**: All CLI commands support `--format json` for machine-readable responses
+- **Structured output**: All CLI commands support `--format json` for machine-readable responses, plus `--jq` for inline filtering
 - **Local SQL iteration**: Fetch once, query repeatedly—no re-fetching needed
 - **Typed exceptions**: Error codes and context for programmatic handling
 

--- a/context/implementation-plans/jq-filter-support-plan.md
+++ b/context/implementation-plans/jq-filter-support-plan.md
@@ -1,0 +1,616 @@
+# JQ Filter Support for CLI Output - TDD Implementation Plan
+
+## Overview
+
+Add `--jq` option to CLI commands for client-side JSON filtering using jq syntax. This enables power users to filter and transform JSON output without piping to external tools, following modern CLI patterns (gh, kubectl).
+
+## Motivation
+
+**Current workflow:**
+```bash
+mp inspect events --format json | jq '.[] | select(.event == "signup")'
+```
+
+**Problems:**
+- Requires jq installed on system (platform-specific install)
+- Extra shell plumbing
+- No consistency across platforms (especially Windows)
+- Breaks integration with non-shell environments
+
+**With --jq support:**
+```bash
+mp inspect events --format json --jq '.[] | select(.event == "signup")'
+```
+
+**Benefits:**
+- Native jq syntax with zero external dependencies
+- Consistent experience across all platforms (Windows, macOS, Linux)
+- Better integration with automation tools and AI agents
+- Progressive disclosure: simple cases use `--format`, advanced cases use `--jq`
+
+## Research Summary
+
+**Library Selection: jq.py (PyPI: `jq`)**
+
+| Criteria | Status |
+|----------|--------|
+| Maintenance | ✅ Active (v1.10.0, July 2025) |
+| GitHub | ✅ 434 stars, 10 contributors |
+| Dependents | ✅ 220 packages depend on it |
+| Python support | ✅ 3.8-3.13 |
+
+**Pre-built Wheels (no compilation needed):**
+- ✅ Linux (x86, x86-64, arm64)
+- ✅ macOS (Intel, Apple Silicon)
+- ✅ Windows (x86, x86-64)
+
+**Decision: Required Dependency**
+
+jq.py is added as a **required** dependency, not optional. Rationale:
+1. Pre-built wheels exist for all major platforms
+2. Package already includes heavy native deps (pandas, duckdb)
+3. Better UX - `--jq` works out of the box
+4. No "gotcha" moment for users discovering the feature
+5. Simpler documentation
+
+## Scope
+
+### In Scope
+- `--jq` option on all commands that support `--format json/jsonl`
+- Integration with existing formatter pipeline
+- Unit tests for jq filtering logic
+- Integration tests for CLI commands with --jq
+- Property-based tests for jq filter edge cases
+- Error messages for jq syntax errors
+- Error messages for incompatible format combinations
+- Documentation updates
+
+### Out of Scope
+- jq support for non-JSON formats (table, csv, plain)
+- Custom jq functions or modules
+
+## Design Decisions
+
+### 1. Integration Point: Post-Formatter Pipeline
+
+**Current flow:**
+```
+data → formatter (json/jsonl/table/csv/plain) → console.print()
+```
+
+**New flow:**
+```
+data → formatter → apply_jq_filter() → console.print()
+                        ↑
+                  (only for json/jsonl)
+```
+
+**Location:** Add `_apply_jq_filter()` helper in `cli/utils.py`
+
+### 2. Format Compatibility
+
+Only allow `--jq` with `--format json` or `--format jsonl`.
+
+```bash
+mp inspect events --format table --jq '.[]'  # ERROR: --jq requires json/jsonl
+mp inspect events --format json --jq '.[]'   # OK
+```
+
+### 3. Error Handling
+
+**Two error cases:**
+
+A. Invalid jq syntax:
+```
+jq filter error: compile error: syntax error...
+```
+
+B. jq runtime error:
+```
+jq filter error: Cannot index string with number
+```
+
+**Exit Code:** `ExitCode.INVALID_ARGS` (3) for all jq errors
+
+### 4. Output Format
+
+Always pretty-print jq results as JSON:
+- Single result → pretty-printed value
+- Multiple results → pretty-printed array
+- No results → `[]`
+
+### 5. Per-Command Option
+
+Add `--jq` to individual commands (not global), mirroring `--format` pattern.
+
+## Architecture Changes
+
+### Files Modified
+
+```
+pyproject.toml                    # Add jq>=1.9.0 to dependencies
+src/mixpanel_data/cli/
+├── options.py                    # Add JqOption type
+├── utils.py                      # Add _apply_jq_filter(), update output_result()
+└── commands/
+    ├── inspect.py                # Add jq_filter param to commands
+    ├── query.py                  # Add jq_filter param to commands
+    └── fetch.py                  # Add jq_filter param to commands
+
+tests/unit/cli/
+├── test_utils.py                 # Tests for _apply_jq_filter()
+├── test_jq_integration.py        # NEW: Integration tests
+└── test_jq_pbt.py                # NEW: Property-based tests
+```
+
+### Type Definitions
+
+**cli/options.py:**
+```python
+JqOption = Annotated[
+    str | None,
+    typer.Option(
+        "--jq",
+        help="Apply jq filter to JSON output.",
+    ),
+]
+```
+
+**cli/utils.py signature:**
+```python
+def output_result(
+    ctx: typer.Context,
+    data: dict[str, Any] | list[Any],
+    columns: list[str] | None = None,
+    *,
+    format: str | None = None,
+    jq_filter: str | None = None,  # NEW
+) -> None:
+```
+
+## TDD Implementation Steps
+
+### Phase 1: Add Dependency
+
+**File:** `pyproject.toml`
+
+```toml
+dependencies = [
+    # ... existing deps ...
+    "jq>=1.9.0",
+]
+```
+
+### Phase 2: Core jq Filtering Logic (TDD)
+
+**Test File:** `tests/unit/cli/test_utils.py`
+
+#### Test 2.1: Simple filter on dict
+```python
+def test_apply_jq_filter_simple_dict() -> None:
+    """Test applying a simple jq filter to a dictionary."""
+    json_str = '{"name": "Alice", "age": 30}'
+    result = _apply_jq_filter(json_str, ".name")
+    assert result == '"Alice"'
+```
+
+#### Test 2.2: Filter on list
+```python
+def test_apply_jq_filter_list() -> None:
+    """Test applying jq filter to extract from list."""
+    json_str = '[{"event": "Signup"}, {"event": "Purchase"}]'
+    result = _apply_jq_filter(json_str, ".[] | .event")
+    assert json.loads(result) == ["Signup", "Purchase"]
+```
+
+#### Test 2.3: Select filter
+```python
+def test_apply_jq_filter_select() -> None:
+    """Test applying jq select filter."""
+    json_str = '[{"event": "Signup", "count": 100}, {"event": "Login", "count": 50}]'
+    result = _apply_jq_filter(json_str, '.[] | select(.count > 75)')
+    parsed = json.loads(result)
+    assert len(parsed) == 1
+    assert parsed[0]["event"] == "Signup"
+```
+
+#### Test 2.4: Invalid jq syntax
+```python
+def test_apply_jq_filter_invalid_syntax() -> None:
+    """Test error handling for invalid jq syntax."""
+    json_str = '{"name": "test"}'
+    with pytest.raises(typer.Exit) as exc_info:
+        _apply_jq_filter(json_str, ".name |")  # Incomplete
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 2.5: jq runtime error
+```python
+def test_apply_jq_filter_runtime_error() -> None:
+    """Test error handling for jq runtime errors."""
+    json_str = '{"name": "test"}'
+    with pytest.raises(typer.Exit) as exc_info:
+        _apply_jq_filter(json_str, ".[0]")  # Index dict as array
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 2.6: Empty results
+```python
+def test_apply_jq_filter_empty_results() -> None:
+    """Test jq filter that returns no results."""
+    json_str = '[{"count": 10}, {"count": 20}]'
+    result = _apply_jq_filter(json_str, '.[] | select(.count > 100)')
+    assert json.loads(result) == []
+```
+
+#### Test 2.7: Single vs multiple results
+```python
+def test_apply_jq_filter_single_result() -> None:
+    """Test jq filter returning a single scalar."""
+    json_str = '{"data": [1, 2, 3]}'
+    result = _apply_jq_filter(json_str, '.data | length')
+    assert result == "3"
+
+def test_apply_jq_filter_multiple_results() -> None:
+    """Test jq filter returning multiple results."""
+    json_str = '[{"x": 1}, {"x": 2}]'
+    result = _apply_jq_filter(json_str, '.[].x')
+    assert json.loads(result) == [1, 2]
+```
+
+**Implementation:**
+```python
+def _apply_jq_filter(json_str: str, filter_expr: str) -> str:
+    """Apply jq filter to JSON string.
+
+    Args:
+        json_str: JSON string to filter.
+        filter_expr: jq filter expression.
+
+    Returns:
+        Filtered JSON string (pretty-printed).
+
+    Raises:
+        typer.Exit: If filter syntax invalid or runtime error occurs.
+    """
+    import jq
+
+    try:
+        data = json.loads(json_str)
+        compiled = jq.compile(filter_expr)
+        results = list(compiled.input(data).all())
+
+        if len(results) == 0:
+            return "[]"
+        elif len(results) == 1:
+            return json.dumps(results[0], indent=2, default=_json_serializer, ensure_ascii=False)
+        else:
+            return json.dumps(results, indent=2, default=_json_serializer, ensure_ascii=False)
+
+    except ValueError as e:
+        # jq compile/runtime errors
+        err_console.print(f"[red]jq filter error:[/red] {e}")
+        raise typer.Exit(ExitCode.INVALID_ARGS) from None
+    except json.JSONDecodeError as e:
+        err_console.print(f"[red]Invalid JSON:[/red] {e}")
+        raise typer.Exit(ExitCode.GENERAL_ERROR) from None
+```
+
+### Phase 3: Integration with output_result() (TDD)
+
+**Test File:** `tests/unit/cli/test_utils.py`
+
+#### Test 3.1: output_result with jq filter
+```python
+def test_output_result_with_jq_filter_json(mock_context, capsys) -> None:
+    """Test output_result applies jq filter for JSON format."""
+    data = [{"event": "Signup", "count": 100}, {"event": "Login", "count": 50}]
+    output_result(mock_context, data, format="json", jq_filter=".[] | select(.count > 75)")
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert len(result) == 1
+    assert result[0]["event"] == "Signup"
+```
+
+#### Test 3.2: Reject jq with table format
+```python
+def test_output_result_rejects_jq_with_table_format(mock_context) -> None:
+    """Test that jq filter is rejected for table format."""
+    data = [{"event": "Signup"}]
+    with pytest.raises(typer.Exit) as exc_info:
+        output_result(mock_context, data, format="table", jq_filter=".[]")
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 3.3: Reject jq with csv format
+```python
+def test_output_result_rejects_jq_with_csv_format(mock_context) -> None:
+    """Test that jq filter is rejected for csv format."""
+    data = [{"event": "Signup"}]
+    with pytest.raises(typer.Exit) as exc_info:
+        output_result(mock_context, data, format="csv", jq_filter=".[]")
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 3.4: Reject jq with plain format
+```python
+def test_output_result_rejects_jq_with_plain_format(mock_context) -> None:
+    """Test that jq filter is rejected for plain format."""
+    data = [{"event": "Signup"}]
+    with pytest.raises(typer.Exit) as exc_info:
+        output_result(mock_context, data, format="plain", jq_filter=".[]")
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 3.5: No jq filter works normally
+```python
+def test_output_result_without_jq_filter(mock_context, capsys) -> None:
+    """Test that output_result works normally without jq filter."""
+    data = {"event": "Signup", "count": 100}
+    output_result(mock_context, data, format="json")
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == data
+```
+
+### Phase 4: Add JqOption (TDD)
+
+**Test File:** `tests/unit/cli/test_options.py` (NEW)
+
+```python
+def test_jq_option_type() -> None:
+    """Test that JqOption has correct type annotation."""
+    from mixpanel_data.cli.options import JqOption
+    import typing
+    actual_type = typing.get_args(JqOption)[0]
+    assert actual_type == str | None
+```
+
+### Phase 5: Command Integration (TDD)
+
+**Test File:** `tests/unit/cli/test_jq_integration.py` (NEW)
+
+#### Test 5.1: inspect events with --jq
+```python
+def test_inspect_events_with_jq_filter(cli_runner, mock_workspace) -> None:
+    """Test inspect events command with --jq filter."""
+    mock_workspace.events.return_value = ["Signup", "Login", "Purchase"]
+    with patch("mixpanel_data.cli.commands.inspect.get_workspace", return_value=mock_workspace):
+        result = cli_runner.invoke(
+            app,
+            ["inspect", "events", "--format", "json", "--jq", '.[0]']
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == "Signup"
+```
+
+#### Test 5.2: inspect events --jq with incompatible format
+```python
+def test_inspect_events_jq_with_table_fails(cli_runner, mock_workspace) -> None:
+    """Test that --jq fails with --format table."""
+    mock_workspace.events.return_value = ["Signup"]
+    with patch("mixpanel_data.cli.commands.inspect.get_workspace", return_value=mock_workspace):
+        result = cli_runner.invoke(
+            app,
+            ["inspect", "events", "--format", "table", "--jq", ".[]"]
+        )
+    assert result.exit_code == ExitCode.INVALID_ARGS
+```
+
+#### Test 5.3: query sql with --jq
+```python
+def test_query_sql_with_jq_filter(cli_runner, mock_workspace) -> None:
+    """Test query sql command with --jq filter."""
+    mock_workspace.sql_rows.return_value = [
+        {"event": "Signup", "count": 100},
+        {"event": "Login", "count": 50}
+    ]
+    with patch("mixpanel_data.cli.commands.query.get_workspace", return_value=mock_workspace):
+        result = cli_runner.invoke(
+            app,
+            ["query", "sql", "SELECT * FROM events", "--format", "json", "--jq", ".[] | select(.count > 75)"]
+        )
+    assert result.exit_code == 0
+    output = json.loads(result.stdout)
+    assert len(output) == 1
+    assert output[0]["event"] == "Signup"
+```
+
+### Phase 6: Property-Based Tests (TDD)
+
+**Test File:** `tests/unit/cli/test_jq_pbt.py` (NEW)
+
+```python
+from hypothesis import given, strategies as st
+
+@given(st.builds(dict, name=st.text(min_size=1), count=st.integers()))
+def test_jq_identity_preserves_structure(data: dict) -> None:
+    """Test that identity filter '.' preserves JSON structure."""
+    json_str = json.dumps(data)
+    result = _apply_jq_filter(json_str, ".")
+    assert json.loads(result) == data
+
+@given(st.lists(st.builds(dict, x=st.integers()), min_size=1, max_size=20))
+def test_jq_length_returns_correct_count(data: list) -> None:
+    """Test that 'length' filter returns correct list length."""
+    json_str = json.dumps(data)
+    result = _apply_jq_filter(json_str, "length")
+    assert int(result) == len(data)
+
+@given(st.lists(st.builds(dict, count=st.integers(0, 100)), min_size=1, max_size=20))
+def test_jq_select_never_increases_size(data: list) -> None:
+    """Test that select filter never increases list size."""
+    json_str = json.dumps(data)
+    result = _apply_jq_filter(json_str, ".[] | select(.count > 50)")
+    parsed = json.loads(result) if result != "[]" else []
+    assert len(parsed) <= len(data)
+```
+
+### Phase 7: Update Commands
+
+Add `jq_filter: JqOption = None` parameter to all commands with `--format`:
+
+**inspect.py commands:**
+- events, properties, values, funnels, cohorts, top_events, bookmarks
+- lexicon_schemas, lexicon_schema
+- distribution, numeric, daily, engagement, coverage
+- info, tables, schema, sample, summarize, breakdown, keys, column
+
+**query.py commands:**
+- sql, segmentation, funnel, retention, jql
+
+**fetch.py commands:**
+- events, profiles
+
+Example update:
+```python
+@inspect_app.command("events")
+@handle_errors
+def inspect_events(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """List all event names from Mixpanel project.
+
+    Examples:
+        mp inspect events
+        mp inspect events --format json --jq '.[0:5]'
+    """
+    workspace = get_workspace(ctx, read_only=True)
+    with status_spinner(ctx, "Fetching events..."):
+        events = workspace.events()
+    output_result(ctx, events, format=format, jq_filter=jq_filter)
+```
+
+### Phase 8: Update Documentation (`docs/`)
+
+Review and update all documentation files to include `--jq` option where relevant.
+
+**Files to review:**
+
+| File | Updates Needed |
+|------|----------------|
+| `docs/cli/commands.md` | Add `--jq` to command reference, examples |
+| `docs/cli/index.md` | Mention `--jq` in CLI overview |
+| `docs/getting-started/quickstart.md` | Add `--jq` example in quick start |
+| `docs/guide/discovery.md` | Add `--jq` examples for filtering discovery results |
+| `docs/guide/live-analytics.md` | Add `--jq` examples for filtering query results |
+| `docs/guide/sql-queries.md` | Add `--jq` examples for post-processing SQL output |
+
+**Documentation pattern:**
+```markdown
+## Filtering Output with jq
+
+All commands that support `--format json` also support `--jq` for client-side filtering:
+
+```bash
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Filter segmentation results
+mp query segmentation --event Signup --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.series.total | to_entries | map({date: .key, count: .value})'
+
+# Extract specific fields from SQL results
+mp query sql "SELECT * FROM events LIMIT 100" \
+  --format json --jq '.[] | {event, time: .properties.time}'
+```
+
+See the [jq manual](https://jqlang.org/manual/) for filter syntax.
+```
+
+### Phase 9: Update Plugin (`mixpanel-plugin/`)
+
+Review and update all plugin files to include `--jq` option where relevant.
+
+**Files to review:**
+
+| File | Updates Needed |
+|------|----------------|
+| `mixpanel-plugin/commands/mp-inspect.md` | Add `--jq` examples |
+| `mixpanel-plugin/commands/mp-query.md` | Add `--jq` examples |
+| `mixpanel-plugin/commands/mp-fetch.md` | Add `--jq` examples |
+| `mixpanel-plugin/skills/mixpanel-data/SKILL.md` | Mention `--jq` capability |
+| `mixpanel-plugin/skills/mixpanel-data/references/cli-commands.md` | Document `--jq` option |
+| `mixpanel-plugin/skills/mixpanel-data/references/patterns.md` | Add `--jq` patterns |
+| `mixpanel-plugin/agents/mixpanel-analyst.md` | Include `--jq` in agent context |
+| `mixpanel-plugin/agents/jql-expert.md` | Include `--jq` for post-processing |
+| `mixpanel-plugin/agents/funnel-optimizer.md` | Include `--jq` for result filtering |
+| `mixpanel-plugin/agents/retention-specialist.md` | Include `--jq` for result filtering |
+
+**Plugin documentation pattern:**
+```markdown
+## Output Filtering
+
+Use `--jq` to filter JSON output without external tools:
+
+```bash
+# Filter events by name pattern
+mp inspect events --format json --jq '.[] | select(startswith("User"))'
+
+# Extract funnel conversion rates
+mp query funnel --funnel-id 12345 --format json \
+  --jq '.steps | map({step: .step, rate: .conversion_rate})'
+```
+```
+
+**Validation:**
+After updates, run plugin validation:
+```bash
+cd mixpanel-plugin && ./scripts/validate.sh
+```
+
+## Testing Checklist
+
+- [ ] All unit tests pass for `_apply_jq_filter()`
+- [ ] All integration tests pass for commands with `--jq`
+- [ ] Property-based tests pass
+- [ ] Coverage remains ≥90%
+- [ ] `just check` passes (lint, typecheck, test)
+- [ ] Manual testing on local machine
+
+## Acceptance Criteria
+
+### Core Implementation
+- [ ] `jq>=1.9.0` added to required dependencies
+- [ ] All commands with `--format` support `--jq` parameter
+- [ ] `--jq` only works with `--format json/jsonl` (clear error otherwise)
+- [ ] Invalid jq syntax shows clear error with exit code 3
+- [ ] jq runtime errors show clear error with exit code 3
+- [ ] All tests pass (unit, integration, property-based)
+- [ ] Test coverage remains ≥90%
+- [ ] Type checking passes (`mypy --strict`)
+- [ ] Linting passes (`ruff check`, `ruff format`)
+- [ ] Docstrings updated with `--jq` examples
+
+### Documentation (`docs/`)
+- [ ] `docs/cli/commands.md` updated with `--jq` reference
+- [ ] `docs/cli/index.md` mentions `--jq` capability
+- [ ] `docs/getting-started/quickstart.md` includes `--jq` example
+- [ ] `docs/guide/discovery.md` has `--jq` filtering examples
+- [ ] `docs/guide/live-analytics.md` has `--jq` filtering examples
+- [ ] `docs/guide/sql-queries.md` has `--jq` filtering examples
+
+### Plugin (`mixpanel-plugin/`)
+- [ ] `mixpanel-plugin/commands/mp-*.md` files updated with `--jq` examples
+- [ ] `mixpanel-plugin/skills/mixpanel-data/SKILL.md` mentions `--jq`
+- [ ] `mixpanel-plugin/skills/mixpanel-data/references/cli-commands.md` documents `--jq`
+- [ ] `mixpanel-plugin/skills/mixpanel-data/references/patterns.md` has `--jq` patterns
+- [ ] `mixpanel-plugin/agents/*.md` files include `--jq` context
+- [ ] Plugin validation passes (`./scripts/validate.sh`)
+
+## Implementation Estimate
+
+**Complexity:** Low-Medium
+**Lines of Code:** ~50-100 (implementation) + tests + documentation updates
+**Estimated Time:** 6-8 hours total
+- Phases 1-7 (Core): 4-5 hours
+- Phase 8 (docs/): 1 hour
+- Phase 9 (mixpanel-plugin/): 1-2 hours
+
+## References
+
+- [jq.py on PyPI](https://pypi.org/project/jq/)
+- [jq.py GitHub](https://github.com/mwilliamson/jq.py)
+- [jq Manual](https://jqlang.org/manual/)
+- [gh CLI --jq reference](https://cli.github.com/manual/gh_help_formatting)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -268,6 +268,10 @@ For real-time analytics, query Mixpanel directly:
 
     ```bash
     mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 --format table
+
+    # Filter results with built-in jq support
+    mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 \
+        --format json --jq '.total'
     ```
 
 === "Python"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -298,11 +298,12 @@ For ETL pipelines or one-time processing, stream data directly without storing:
 === "CLI"
 
     ```bash
-    # Stream events as JSONL
-    mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout
+    # Stream events as JSONL (memory-efficient for large datasets)
+    mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout > events.jsonl
 
-    # Pipe to other tools
-    mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout | jq '.event_name'
+    # Count unique users via Unix pipeline
+    mp fetch events --from 2025-01-01 --to 2025-01-31 --stdout \
+      | jq -r '.distinct_id' | sort -u | wc -l
     ```
 
 === "Python"

--- a/docs/guide/discovery.md
+++ b/docs/guide/discovery.md
@@ -21,6 +21,12 @@ Get all event names in your project:
 
     ```bash
     mp inspect events
+
+    # Filter with jq - get first 5 events
+    mp inspect events --format json --jq '.[:5]'
+
+    # Find events containing "User"
+    mp inspect events --format json --jq '.[] | select(contains("User"))'
     ```
 
 Events are returned sorted alphabetically.

--- a/docs/guide/live-analytics.md
+++ b/docs/guide/live-analytics.md
@@ -67,6 +67,14 @@ Time-series event counts with optional property segmentation:
     # With property breakdown
     mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 \
         --on country --format table
+
+    # Filter with jq to get just the total
+    mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 \
+        --format json --jq '.total'
+
+    # Get top 3 days by volume
+    mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 \
+        --format json --jq '.series | to_entries | sort_by(.value) | reverse | .[:3]'
     ```
 
 ### SegmentationResult

--- a/docs/guide/sql-queries.md
+++ b/docs/guide/sql-queries.md
@@ -233,6 +233,14 @@ mp query sql "SELECT * FROM events" --format csv > events.csv
 
 # JSONL for streaming
 mp query sql "SELECT * FROM events" --format jsonl > events.jsonl
+
+# Filter with built-in jq support
+mp query sql "SELECT * FROM events LIMIT 100" --format json \
+    --jq '.[] | select(.event_name == "Purchase")'
+
+# Extract specific fields with jq
+mp query sql "SELECT event_name, COUNT(*) as cnt FROM events GROUP BY 1" \
+    --format json --jq 'map({name: .event_name, count: .cnt})'
 ```
 
 ## Direct DuckDB Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,10 +113,12 @@ mp inspect schema jan_events
 mp inspect sample jan_events
 mp inspect summarize jan_events
 
-# Compose with Unix tools
-mp query segmentation "Purchase" --from 2025-01-01 --format json \
-    | jq '.data'
-mp fetch events --stream --from 2025-01-01 | wc -l
+# Filter with built-in jq
+mp query segmentation "Purchase" --from 2025-01-01 --format json --jq '.total'
+
+# Stream to Unix tools (memory-efficient for large datasets)
+mp fetch events --stdout --from 2025-01-01 --to 2025-01-31 \
+    | jq -r '.distinct_id' | sort -u | wc -l
 ```
 
 ## Capabilities

--- a/mixpanel-plugin/agents/funnel-optimizer.md
+++ b/mixpanel-plugin/agents/funnel-optimizer.md
@@ -51,6 +51,10 @@ mp query funnel \
 ```bash
 # If user has a saved funnel in Mixpanel
 mp query funnel --funnel-id 12345 --from 2024-01-01 --to 2024-01-31
+
+# Filter output with --jq (e.g., get just step names and rates)
+mp query funnel 12345 --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.steps | map({step: .event, rate: .conversion_rate})'
 ```
 
 **Option C: SQL-Based Funnel (for local data)**

--- a/mixpanel-plugin/agents/jql-expert.md
+++ b/mixpanel-plugin/agents/jql-expert.md
@@ -24,6 +24,13 @@ You are a JQL (JavaScript Query Language) expert specializing in advanced Mixpan
 - Standard GROUP BY, JOIN, WHERE operations
 - Performance is critical (SQL on DuckDB is faster)
 
+**Use --jq for:** Filtering JQL/query output on the command line without external tools:
+```bash
+mp query jql script.js --format json --jq '.[:5]'
+mp query segmentation -e Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
+```
+
 ## JQL Core Concepts
 
 ### 1. Events() and People() Functions

--- a/mixpanel-plugin/agents/mixpanel-analyst.md
+++ b/mixpanel-plugin/agents/mixpanel-analyst.md
@@ -216,6 +216,11 @@ mp query segmentation --event Purchase --from 2024-01-01 --to 2024-01-31
 
 # Funnel
 mp query funnel --events "Signup,Purchase" --from 2024-01-01 --to 2024-01-31
+
+# Filter output with --jq
+mp inspect events --format json --jq '.[:5]'
+mp query segmentation -e Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
 ```
 
 ## Best Practices

--- a/mixpanel-plugin/agents/retention-specialist.md
+++ b/mixpanel-plugin/agents/retention-specialist.md
@@ -42,6 +42,11 @@ mp query retention \
   --unit day \
   --born-where 'properties["plan"] == "premium"' \
   --retention-type first_time  # or recurring
+
+# Filter output with --jq
+mp query retention --born "Signup" --return "Login" \
+  --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.cohorts | map(select(.retention_rate > 0.3))'
 ```
 
 **Retention types:**

--- a/mixpanel-plugin/commands/mp-inspect.md
+++ b/mixpanel-plugin/commands/mp-inspect.md
@@ -61,6 +61,18 @@ Discover all event names tracked in your Mixpanel project.
 
 **Output**: List of all event names alphabetically sorted.
 
+**Filter with jq** (JSON format only):
+```bash
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Find events containing "User"
+mp inspect events --format json --jq '.[] | select(contains("User"))'
+
+# Count total events
+mp inspect events --format json --jq 'length'
+```
+
 **Chain suggestions:**
 - Pick an interesting event → Run `/mp-inspect properties <event-name>` to see its properties
 - Ready to fetch specific events? → Run `/mp-fetch` with filtered event list

--- a/mixpanel-plugin/commands/mp-query.md
+++ b/mixpanel-plugin/commands/mp-query.md
@@ -106,6 +106,17 @@ mp query sql "<query>" --format table
 - `--format json` - Machine processing
 - `--format csv` - Export to spreadsheet
 
+**Filter JSON output with --jq**:
+```bash
+# Filter results with jq
+mp query sql "SELECT * FROM events LIMIT 100" --format json \
+  --jq '.[] | select(.event_name == "Purchase")'
+
+# Extract specific fields
+mp query sql "SELECT event_name, COUNT(*) as cnt FROM events GROUP BY 1" \
+  --format json --jq 'map({name: .event_name, count: .cnt})'
+```
+
 **Next steps after query**:
 - Deep column analysis → Run `/mp-inspect column -t <table> -c <column>` for statistics
 - Explore workflow analysis → Run `/mp-funnel` or `/mp-retention` for specialized analytics
@@ -217,6 +228,19 @@ mp query segmentation -e "Purchase" \
   --to 2024-01-31 \
   --on country \
   --format table
+```
+
+**Filter with --jq**:
+```bash
+# Get just the total count
+mp query segmentation -e "Purchase" \
+  --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
+
+# Get top days by volume
+mp query segmentation -e "Purchase" \
+  --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.series | to_entries | sort_by(.value) | reverse | .[:5]'
 ```
 
 **With filter**:

--- a/mixpanel-plugin/skills/mixpanel-data/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-data/SKILL.md
@@ -223,6 +223,27 @@ Full schema and query patterns in [references/patterns.md](references/patterns.m
 
 `--format json` (default), `jsonl`, `table`, `csv`, `plain`
 
+### Filtering with --jq
+
+Commands that output JSON also support the `--jq` option for client-side filtering using jq syntax:
+
+```bash
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Filter by name pattern
+mp inspect events --format json --jq '.[] | select(contains("User"))'
+
+# Extract fields from query results
+mp query segmentation -e Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
+
+# Filter SQL results
+mp query sql "SELECT * FROM events" --format json --jq '.[] | select(.event_name == "Purchase")'
+```
+
+Note: `--jq` only works with `--format json` or `--format jsonl`.
+
 ## API Overview
 
 The Workspace class provides three main capability areas:

--- a/mixpanel-plugin/skills/mixpanel-data/references/cli-commands.md
+++ b/mixpanel-plugin/skills/mixpanel-data/references/cli-commands.md
@@ -17,7 +17,33 @@ Complete reference for the `mp` CLI application.
 | `--quiet, -q` | Suppress progress output |
 | `--verbose, -v` | Enable debug output |
 | `--format` | Output format: json, jsonl, table, csv, plain |
+| `--jq` | Apply jq filter to JSON output (requires --format json/jsonl) |
 | `--version` | Show version and exit |
+
+## Output Filtering with --jq
+
+Commands that support `--format json` or `--format jsonl` also support the `--jq` option for client-side filtering using jq syntax:
+
+```bash
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Filter by name pattern
+mp inspect events --format json --jq '.[] | select(contains("User"))'
+
+# Count results
+mp inspect events --format json --jq 'length'
+
+# Extract fields from query results
+mp query segmentation -e Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
+
+# Filter SQL results
+mp query sql "SELECT * FROM events LIMIT 100" --format json \
+  --jq '.[] | select(.event_name == "Purchase")'
+```
+
+Note: `--jq` only works with JSON formats. Using it with other formats produces an error.
 
 ## Filter Expression Syntax
 

--- a/mixpanel-plugin/skills/mixpanel-data/references/patterns.md
+++ b/mixpanel-plugin/skills/mixpanel-data/references/patterns.md
@@ -168,7 +168,28 @@ df = ws.sql("""
 
 ## jq Processing
 
-### Extract Fields
+### Built-in --jq Option
+
+The CLI has built-in jq support via the `--jq` option, eliminating the need for external tools:
+
+```bash
+# Filter events inline
+mp inspect events --format json --jq '.[:5]'
+mp inspect events --format json --jq '.[] | select(contains("User"))'
+
+# Filter query results
+mp query segmentation -e Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.total'
+
+# Filter SQL results
+mp query sql "SELECT * FROM events LIMIT 100" --format json \
+  --jq '.[] | select(.event_name == "Purchase")'
+```
+
+### External jq with Streaming
+
+For streaming data, pipe to external jq:
+
 ```bash
 # Single field
 mp fetch events --from 2024-01-01 --to 2024-01-01 --stdout | jq '.event'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "httpx>=0.27",
     "typer>=0.12",
     "rich>=13.0",
+    "jq>=1.9.0",
 ]
 
 [project.optional-dependencies]

--- a/specs/016-jq-filter-support/checklists/requirements.md
+++ b/specs/016-jq-filter-support/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: JQ Filter Support for CLI Output
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The implementation plan in `context/implementation-plans/jq-filter-support-plan.md` provides technical details for the planning phase

--- a/specs/016-jq-filter-support/data-model.md
+++ b/specs/016-jq-filter-support/data-model.md
@@ -1,0 +1,175 @@
+# Data Model: JQ Filter Support
+
+**Feature**: 016-jq-filter-support
+**Date**: 2026-01-04
+
+## Type Definitions
+
+### New Types
+
+```python
+# cli/options.py
+
+JqOption = Annotated[
+    str | None,
+    typer.Option(
+        "--jq",
+        help="Apply jq filter to JSON output (requires --format json or jsonl).",
+    ),
+]
+```
+
+### Modified Function Signatures
+
+```python
+# cli/utils.py
+
+def _apply_jq_filter(json_str: str, filter_expr: str) -> str:
+    """Apply jq filter to JSON string.
+
+    Args:
+        json_str: JSON string to filter.
+        filter_expr: jq filter expression.
+
+    Returns:
+        Filtered JSON string (pretty-printed).
+
+    Raises:
+        typer.Exit: If filter syntax invalid or runtime error occurs.
+    """
+    ...
+
+def output_result(
+    ctx: typer.Context,
+    data: dict[str, Any] | list[Any],
+    columns: list[str] | None = None,
+    *,
+    format: str | None = None,
+    jq_filter: str | None = None,  # NEW PARAMETER
+) -> None:
+    """Output data in the requested format.
+
+    Args:
+        ctx: Typer context with global options in obj dict.
+        data: Data to output (dict or list).
+        columns: Column names for table/csv format (auto-detected if None).
+        format: Output format. If None, falls back to ctx.obj["format"] or "json".
+        jq_filter: Optional jq filter expression. Only valid with json/jsonl format.
+
+    Raises:
+        typer.Exit: If jq_filter used with incompatible format.
+    """
+    ...
+
+def present_result(
+    ctx: typer.Context,
+    result: ResultWithTableAndDict,
+    format: str,
+    *,
+    jq_filter: str | None = None,  # NEW PARAMETER
+) -> None:
+    """Select appropriate dict format and output the result.
+
+    Args:
+        ctx: Typer context with global options in obj dict.
+        result: Result object with to_table_dict() and to_dict() methods.
+        format: Output format (e.g., "table", "json", "jsonl", "csv", "plain").
+        jq_filter: Optional jq filter expression.
+    """
+    ...
+```
+
+## Data Flow
+
+```
+Command invocation
+    │
+    ▼
+get_workspace() / execute query
+    │
+    ▼
+result data (dict | list)
+    │
+    ▼
+output_result(data, format=format, jq_filter=jq_filter)
+    │
+    ├─► format != json/jsonl AND jq_filter?
+    │       └─► ERROR: Exit(INVALID_ARGS)
+    │
+    ├─► format_json(data) or format_jsonl(data)
+    │       │
+    │       ▼
+    │   json_str (formatted JSON)
+    │       │
+    │       ▼
+    │   jq_filter provided?
+    │       ├─► NO: print(json_str)
+    │       └─► YES: _apply_jq_filter(json_str, jq_filter)
+    │               │
+    │               ├─► SUCCESS: print(filtered_result)
+    │               └─► ERROR: Exit(INVALID_ARGS)
+    │
+    └─► other formats: proceed as before
+```
+
+## Error States
+
+| State | Condition | Exit Code | Error Message |
+|-------|-----------|-----------|---------------|
+| Incompatible format | `--jq` with `--format table/csv/plain` | 3 | "jq filter requires --format json or jsonl" |
+| Invalid syntax | jq.compile() fails | 3 | "jq filter error: {error}" |
+| Runtime error | jq.input() fails | 3 | "jq filter error: {error}" |
+
+## Result Handling
+
+| jq Result | Output |
+|-----------|--------|
+| Zero items | `[]` |
+| One item (scalar) | Scalar value (e.g., `42`, `"text"`) |
+| One item (object/array) | Pretty-printed object/array |
+| Multiple items | Pretty-printed array of items |
+
+## Command Parameters
+
+All commands with `format: FormatOption` gain:
+
+```python
+jq_filter: JqOption = None
+```
+
+### Commands to Update
+
+**inspect.py**:
+- `events`, `properties`, `values`, `funnels`, `cohorts`
+- `top_events`, `bookmarks`
+- `lexicon_schemas`, `lexicon_schema`
+- `distribution`, `numeric`, `daily`, `engagement`, `coverage`
+- `info`, `tables`, `schema`, `sample`, `summarize`, `breakdown`, `keys`, `column`
+
+**query.py**:
+- `sql`, `segmentation`, `funnel`, `retention`, `jql`
+
+**fetch.py**:
+- `events`, `profiles`
+
+### Example Command Signature
+
+```python
+@inspect_app.command("events")
+@handle_errors
+def inspect_events(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,  # NEW
+) -> None:
+    """List all event names from Mixpanel project.
+
+    Examples:
+        mp inspect events
+        mp inspect events --format json --jq '.[0:5]'
+    """
+    workspace = get_workspace(ctx, read_only=True)
+    with status_spinner(ctx, "Fetching events..."):
+        events = workspace.events()
+    output_result(ctx, events, format=format, jq_filter=jq_filter)
+```

--- a/specs/016-jq-filter-support/plan.md
+++ b/specs/016-jq-filter-support/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: JQ Filter Support for CLI Output
+
+**Branch**: `016-jq-filter-support` | **Date**: 2026-01-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/016-jq-filter-support/spec.md`
+
+## Summary
+
+Add `--jq` option to all CLI commands that support `--format json/jsonl`, enabling client-side JSON filtering using jq syntax. Uses jq.py library for cross-platform compatibility with pre-built wheels (no compilation needed). Integration at post-formatter pipeline in `cli/utils.py`.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: jq>=1.9.0 (new), typer, rich, pydantic
+**Storage**: N/A (output filtering only)
+**Testing**: pytest, hypothesis
+**Target Platform**: Linux, macOS, Windows (pre-built wheels for all)
+**Project Type**: Single library with CLI
+**Performance Goals**: Negligible overhead for typical output sizes
+**Constraints**: Must work without external jq binary; no interactive prompts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | ✅ Pass | `_apply_jq_filter()` is a library function; CLI wraps it |
+| II. Agent-Native Design | ✅ Pass | No interactive prompts; structured JSON output; meaningful exit codes |
+| III. Context Window Efficiency | ✅ Pass | Enables precise output filtering, reducing tokens |
+| IV. Two Data Paths | ✅ Pass | Works with both live queries and local SQL output |
+| V. Explicit Over Implicit | ✅ Pass | User explicitly provides `--jq` filter; no magic |
+| VI. Unix Philosophy | ✅ Pass | Extends composability without requiring external jq binary |
+| VII. Secure by Default | ✅ Pass | No credential exposure; jq sandbox is read-only |
+
+**Quality Gates**:
+- [ ] All public functions have type hints
+- [ ] All public functions have docstrings (Google style)
+- [ ] All new code passes `ruff check` and `ruff format`
+- [ ] All new code passes `mypy --strict`
+- [ ] Tests exist for new functionality (pytest)
+- [ ] CLI commands have `--help` with examples
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-jq-filter-support/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (library selection)
+├── data-model.md        # Phase 1 output (type definitions)
+├── quickstart.md        # Phase 1 output (usage examples)
+├── contracts/           # N/A for this feature (no API changes)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/cli/
+├── options.py           # Add JqOption type alias
+├── utils.py             # Add _apply_jq_filter(), update output_result()
+└── commands/
+    ├── inspect.py       # Add jq_filter param to commands
+    ├── query.py         # Add jq_filter param to commands
+    └── fetch.py         # Add jq_filter param to commands
+
+tests/unit/cli/
+├── test_utils.py        # Tests for _apply_jq_filter()
+├── test_jq_integration.py  # NEW: CLI integration tests
+└── test_jq_pbt.py       # NEW: Property-based tests
+```
+
+**Structure Decision**: Single project structure. Changes are localized to CLI layer (`src/mixpanel_data/cli/`). No new modules needed—extending existing `utils.py` and `options.py`.
+
+## Complexity Tracking
+
+> No Constitution violations. All changes align with existing patterns.
+
+| Item | Decision | Rationale |
+|------|----------|-----------|
+| Required dependency | jq.py as required (not optional) | Pre-built wheels for all platforms; already have heavy native deps (pandas, duckdb); better UX |
+| Post-formatter integration | Filter applied after JSON formatting | Simpler than modifying formatters; consistent behavior |
+| Exit code | INVALID_ARGS (3) for all jq errors | Consistent with other syntax errors (JQL, date validation) |

--- a/specs/016-jq-filter-support/quickstart.md
+++ b/specs/016-jq-filter-support/quickstart.md
@@ -1,0 +1,122 @@
+# Quickstart: JQ Filter Support
+
+**Feature**: 016-jq-filter-support
+**Date**: 2026-01-04
+
+## Basic Usage
+
+The `--jq` option applies a jq filter to JSON output. It works with any command that supports `--format json` or `--format jsonl`.
+
+```bash
+# Basic field extraction
+mp inspect events --format json --jq '.[0]'
+
+# Get first 5 events
+mp inspect events --format json --jq '.[:5]'
+
+# Count events
+mp inspect events --format json --jq 'length'
+```
+
+## Filtering Results
+
+Use `select()` to filter results based on conditions:
+
+```bash
+# Filter events starting with "User"
+mp inspect events --format json --jq '.[] | select(startswith("User"))'
+
+# Filter segmentation results by count
+mp query segmentation --event Signup --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '.series.total | to_entries | map(select(.value > 100))'
+
+# Filter SQL results
+mp query sql "SELECT * FROM events" --format json \
+  --jq '.[] | select(.properties.country == "US")'
+```
+
+## Transforming Data
+
+Reshape output using jq transformations:
+
+```bash
+# Extract specific fields from funnel
+mp query funnel --funnel-id 12345 --format json \
+  --jq '.steps | map({step: .step_label, rate: .conversion_rate})'
+
+# Flatten nested structures
+mp inspect properties --event Signup --format json \
+  --jq '.[] | {name, type: .property_type}'
+
+# Create summary object
+mp query segmentation --event Purchase --from 2024-01-01 --to 2024-01-31 \
+  --format json --jq '{total: .series.total | add, days: .series.total | length}'
+```
+
+## Common Patterns
+
+### Get First/Last N Items
+
+```bash
+mp inspect events --format json --jq '.[:10]'    # First 10
+mp inspect events --format json --jq '.[-5:]'    # Last 5
+mp inspect events --format json --jq '.[10:20]'  # Items 10-19
+```
+
+### Count and Aggregate
+
+```bash
+mp inspect events --format json --jq 'length'                    # Count items
+mp query sql "SELECT * FROM events" --format json --jq 'group_by(.event) | map({event: .[0].event, count: length})'
+```
+
+### Check for Existence
+
+```bash
+# Check if any events match
+mp inspect events --format json --jq 'map(select(contains("signup"))) | length > 0'
+
+# Find events containing substring
+mp inspect events --format json --jq '.[] | select(contains("User"))'
+```
+
+## Error Handling
+
+### Invalid jq Syntax
+
+```bash
+$ mp inspect events --format json --jq '.name |'
+jq filter error: compile error: syntax error, unexpected end of file
+```
+
+### Runtime Errors
+
+```bash
+$ mp inspect events --format json --jq '.[0].nonexistent.field'
+jq filter error: Cannot index string with string "nonexistent"
+```
+
+### Incompatible Format
+
+```bash
+$ mp inspect events --format table --jq '.[0]'
+Error: --jq requires --format json or jsonl
+```
+
+## jq Reference
+
+For full jq syntax, see the [jq manual](https://jqlang.org/manual/).
+
+Common operators:
+- `.field` - access field
+- `.[]` - iterate array
+- `| ` - pipe to next filter
+- `select(condition)` - filter items
+- `map(expr)` - transform each item
+- `length` - array/string length
+- `keys` - object keys
+- `to_entries` - `{k:v}` → `[{key:k, value:v}]`
+- `group_by(.field)` - group by field value
+- `sort_by(.field)` - sort by field value
+- `unique` - deduplicate
+- `first`, `last` - first/last item

--- a/specs/016-jq-filter-support/research.md
+++ b/specs/016-jq-filter-support/research.md
@@ -1,0 +1,102 @@
+# Research: JQ Filter Support
+
+**Feature**: 016-jq-filter-support
+**Date**: 2026-01-04
+
+## Library Selection
+
+### Decision: jq.py (PyPI: `jq>=1.9.0`)
+
+Selected jq.py as the Python binding for jq functionality.
+
+### Rationale
+
+1. **Maintenance**: Active development (v1.10.0, July 2025)
+2. **Community**: 434 GitHub stars, 10 contributors, 220 dependent packages
+3. **Python support**: 3.8-3.13 (covers project requirement of 3.11+)
+4. **Pre-built wheels**: Available for all target platforms without compilation
+
+### Alternatives Considered
+
+| Library | Why Rejected |
+|---------|--------------|
+| pyjq | Abandoned (last release 2020), Python 2.7 era code |
+| jmespath | Different query syntax (not jq-compatible), less powerful |
+| jsonpath-ng | Different query syntax (JSONPath), no jq compatibility |
+| Subprocess jq | Requires external binary install, platform-specific |
+
+### Platform Support
+
+Pre-built wheels eliminate compilation requirements:
+
+| Platform | Architecture | Wheel Available |
+|----------|--------------|-----------------|
+| Linux | x86, x86-64, arm64 | ✅ |
+| macOS | Intel (x86-64), Apple Silicon (arm64) | ✅ |
+| Windows | x86, x86-64 | ✅ |
+
+## Dependency Strategy
+
+### Decision: Required Dependency (not optional)
+
+Add `jq>=1.9.0` to main dependencies in `pyproject.toml`.
+
+### Rationale
+
+1. **Pre-built wheels**: No compilation needed on any platform
+2. **Existing precedent**: Project already includes heavy native deps (pandas, duckdb)
+3. **Better UX**: `--jq` works out of the box with `pip install mixpanel_data`
+4. **Simpler docs**: No conditional installation instructions
+
+### Alternatives Considered
+
+| Approach | Why Rejected |
+|----------|--------------|
+| Optional dependency | Extra install step creates "gotcha" moment; documentation complexity |
+| Vendored jq binary | Distribution complexity; platform-specific bundling |
+| Pure Python parser | No complete jq parser exists; would need maintenance |
+
+## Integration Design
+
+### Decision: Post-Formatter Pipeline
+
+Apply jq filter after JSON formatting, before console output.
+
+### Rationale
+
+1. **Simpler implementation**: Single integration point in `output_result()`
+2. **Consistent behavior**: Works identically for all commands
+3. **No formatter changes**: Existing formatters remain unchanged
+4. **Clear data flow**: `data → format_json() → _apply_jq_filter() → print()`
+
+### Error Handling
+
+| Error Type | Exit Code | Example |
+|------------|-----------|---------|
+| Invalid jq syntax | 3 (INVALID_ARGS) | `.name |` (incomplete) |
+| jq runtime error | 3 (INVALID_ARGS) | `.[0]` on object |
+| Incompatible format | 3 (INVALID_ARGS) | `--format table --jq '.'` |
+
+Exit code 3 matches existing patterns for JQL syntax errors and date validation errors.
+
+## Output Format
+
+### Decision: Pretty-Print JSON Results
+
+Always output jq results as formatted JSON:
+- Single result → pretty-printed value
+- Multiple results → pretty-printed array
+- No results → `[]`
+
+### Rationale
+
+1. **Consistency**: Output remains valid JSON for further piping
+2. **Readability**: Indentation helps human inspection
+3. **Composability**: Can pipe to external jq or other tools if needed
+
+## References
+
+- [jq.py on PyPI](https://pypi.org/project/jq/)
+- [jq.py GitHub](https://github.com/mwilliamson/jq.py)
+- [jq Manual](https://jqlang.org/manual/)
+- [gh CLI --jq reference](https://cli.github.com/manual/gh_help_formatting)

--- a/specs/016-jq-filter-support/spec.md
+++ b/specs/016-jq-filter-support/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: JQ Filter Support for CLI Output
+
+**Feature Branch**: `016-jq-filter-support`
+**Created**: 2026-01-04
+**Status**: Draft
+**Input**: User description: "Add --jq option to CLI commands for client-side JSON filtering using jq syntax, enabling power users to filter and transform JSON output without piping to external tools"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter JSON Output with jq Expression (Priority: P1)
+
+As a power user, I want to filter and transform JSON output from CLI commands using jq syntax so that I can extract exactly the data I need without piping to external tools.
+
+**Why this priority**: This is the core functionality that delivers the primary value proposition—native jq filtering without external dependencies.
+
+**Independent Test**: Can be fully tested by running any command with `--format json --jq '<expression>'` and verifying the output matches the expected filtered result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command returns JSON data, **When** I add `--jq '.field'` to extract a single field, **Then** only that field's value is returned
+2. **Given** a command returns a JSON array, **When** I add `--jq '.[] | select(.count > 50)'` to filter items, **Then** only items matching the condition are returned
+3. **Given** a command returns JSON data, **When** I add `--jq 'length'` to count items, **Then** the count is returned as a number
+
+---
+
+### User Story 2 - Receive Clear Error for Invalid jq Syntax (Priority: P2)
+
+As a user who makes typos or is learning jq, I want to receive clear error messages when my jq filter has invalid syntax so that I can quickly identify and fix the problem.
+
+**Why this priority**: Good error handling is essential for usability but depends on the core filtering functionality existing first.
+
+**Independent Test**: Can be tested by providing malformed jq expressions and verifying error messages are clear and actionable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid command with JSON output, **When** I provide an incomplete jq expression like `.name |`, **Then** I receive a clear syntax error message
+2. **Given** a valid command with JSON output, **When** I provide an invalid jq expression, **Then** the error message includes the word "jq" and describes the problem
+3. **Given** an invalid jq expression, **When** the command exits, **Then** it uses a non-zero exit code indicating invalid arguments
+
+---
+
+### User Story 3 - Receive Error for Incompatible Format (Priority: P2)
+
+As a user, I want to be informed when I attempt to use `--jq` with a non-JSON format so that I understand why my command failed and how to fix it.
+
+**Why this priority**: Prevents user confusion when combining incompatible options; important for usability but secondary to core functionality.
+
+**Independent Test**: Can be tested by combining `--jq` with `--format table` (or other non-JSON formats) and verifying the appropriate error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command with `--format table`, **When** I add `--jq '.[]'`, **Then** I receive an error stating jq requires JSON format
+2. **Given** a command with `--format csv`, **When** I add `--jq '.[]'`, **Then** I receive an error stating jq requires JSON format
+3. **Given** a command with `--format plain`, **When** I add `--jq '.[]'`, **Then** I receive an error stating jq requires JSON format
+
+---
+
+### User Story 4 - Handle jq Runtime Errors Gracefully (Priority: P3)
+
+As a user, I want to receive helpful error messages when my jq filter fails at runtime (e.g., accessing a non-existent field or wrong data type) so that I can debug my query.
+
+**Why this priority**: Runtime errors are less common than syntax errors but still important for a complete user experience.
+
+**Independent Test**: Can be tested by running valid jq syntax against incompatible data structures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command returns a JSON object, **When** I apply a filter expecting an array like `.[0]`, **Then** I receive a runtime error message
+2. **Given** a jq filter causes a runtime error, **When** the command exits, **Then** it uses a non-zero exit code indicating invalid arguments
+
+---
+
+### User Story 5 - Empty Results Handled Gracefully (Priority: P3)
+
+As a user, I want to see empty results clearly represented when my jq filter matches no items so that I understand the filter worked but found nothing.
+
+**Why this priority**: Edge case handling that improves usability but is not core functionality.
+
+**Independent Test**: Can be tested by running filters that select non-existent items.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command returns JSON data, **When** I apply a select filter that matches no items, **Then** an empty array `[]` is returned
+2. **Given** a jq filter returns empty results, **When** the command completes, **Then** it exits with success (zero exit code)
+
+---
+
+### Edge Cases
+
+- What happens when the JSON output is deeply nested and the jq filter navigates multiple levels?
+- How does the system handle jq filters that produce multiple separate results (not wrapped in an array)?
+- What happens when the jq filter returns a scalar value vs. an object vs. an array?
+- How are special characters in jq expressions handled (quotes, backslashes)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CLI MUST provide a `--jq` option on all commands that support `--format json` or `--format jsonl`
+- **FR-002**: CLI MUST apply the jq filter expression to JSON output after formatting
+- **FR-003**: CLI MUST pretty-print jq results as properly indented JSON
+- **FR-004**: CLI MUST display a clear error message when jq filter syntax is invalid
+- **FR-005**: CLI MUST display a clear error message when jq filter encounters a runtime error
+- **FR-006**: CLI MUST reject `--jq` option when used with non-JSON formats (table, csv, plain) with a clear error message
+- **FR-007**: CLI MUST exit with a specific error code for jq-related errors (syntax or runtime)
+- **FR-008**: CLI MUST return an empty array `[]` when a jq filter produces no results
+- **FR-009**: CLI MUST handle jq filters that produce single results (scalar, object, or array)
+- **FR-010**: CLI MUST handle jq filters that produce multiple results by wrapping them in an array
+
+### Key Entities
+
+- **JQ Filter Expression**: A string containing valid jq syntax that transforms or filters JSON data
+- **Filtered Result**: The JSON output after applying the jq filter, which may be a scalar, object, array, or empty array
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can filter JSON output without installing external tools (zero external dependencies for end users)
+- **SC-002**: The `--jq` option works consistently across all major platforms (Windows, macOS, Linux)
+- **SC-003**: Error messages for invalid jq syntax clearly indicate the problem and suggest how to fix it
+- **SC-004**: All commands supporting `--format json` also support `--jq` (100% coverage)
+- **SC-005**: Users can complete common filtering tasks (select, extract field, count) in a single command
+
+## Assumptions
+
+- Users are familiar with basic jq syntax or will refer to jq documentation
+- The jq library used provides consistent behavior across platforms
+- Performance overhead of jq filtering is negligible for typical output sizes
+- Standard jq syntax is sufficient; custom jq functions and modules are not required

--- a/specs/016-jq-filter-support/tasks.md
+++ b/specs/016-jq-filter-support/tasks.md
@@ -1,0 +1,339 @@
+# Tasks: JQ Filter Support for CLI Output
+
+**Input**: Design documents from `/specs/016-jq-filter-support/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Included per project TDD requirements (CLAUDE.md mandates strict TDD).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/mixpanel_data/`, `tests/` at repository root
+- Uses existing CLI structure in `src/mixpanel_data/cli/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add jq.py dependency to project
+
+- [X] T001 Add `jq>=1.9.0` to dependencies in pyproject.toml
+- [X] T002 Run `uv sync` to install new dependency and verify import works
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 Add JqOption type alias in src/mixpanel_data/cli/options.py
+- [X] T004 Add jq_filter parameter to output_result() signature in src/mixpanel_data/cli/utils.py
+- [X] T005 Add jq_filter parameter to present_result() signature in src/mixpanel_data/cli/utils.py
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Filter JSON Output with jq Expression (Priority: P1) 🎯 MVP
+
+**Goal**: Users can filter and transform JSON output using jq syntax
+
+**Independent Test**: Run `mp inspect events --format json --jq '.[0]'` and verify only first event is returned
+
+### Tests for User Story 1 (TDD - Write FIRST, verify FAIL)
+
+- [X] T006 [P] [US1] Unit test for _apply_jq_filter with simple dict field extraction in tests/unit/cli/test_utils.py
+- [X] T007 [P] [US1] Unit test for _apply_jq_filter with list iteration in tests/unit/cli/test_utils.py
+- [X] T008 [P] [US1] Unit test for _apply_jq_filter with select filter in tests/unit/cli/test_utils.py
+- [X] T009 [P] [US1] Unit test for _apply_jq_filter with length filter in tests/unit/cli/test_utils.py
+- [X] T010 [P] [US1] Unit test for _apply_jq_filter single vs multiple results handling in tests/unit/cli/test_utils.py
+- [X] T011 [P] [US1] Unit test for output_result with jq_filter for JSON format in tests/unit/cli/test_utils.py
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement _apply_jq_filter() function in src/mixpanel_data/cli/utils.py
+- [X] T013 [US1] Integrate _apply_jq_filter into output_result() for json format in src/mixpanel_data/cli/utils.py
+- [X] T014 [US1] Integrate _apply_jq_filter into output_result() for jsonl format in src/mixpanel_data/cli/utils.py
+- [X] T015 [US1] Verify all US1 tests pass with `just test -k test_apply_jq_filter`
+
+**Checkpoint**: Basic jq filtering works. Can filter JSON output with jq expressions.
+
+---
+
+## Phase 4: User Story 2 - Receive Clear Error for Invalid jq Syntax (Priority: P2)
+
+**Goal**: Users receive clear, actionable error messages when jq filter syntax is invalid
+
+**Independent Test**: Run `mp inspect events --format json --jq '.name |'` and verify clear syntax error message
+
+### Tests for User Story 2 (TDD - Write FIRST, verify FAIL)
+
+- [X] T016 [P] [US2] Unit test for _apply_jq_filter with invalid syntax raises typer.Exit in tests/unit/cli/test_utils.py
+- [X] T017 [P] [US2] Unit test for _apply_jq_filter error message contains "jq" in tests/unit/cli/test_utils.py
+- [X] T018 [P] [US2] Unit test for _apply_jq_filter exits with ExitCode.INVALID_ARGS in tests/unit/cli/test_utils.py
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Add ValueError exception handling for jq compile errors in _apply_jq_filter() in src/mixpanel_data/cli/utils.py
+- [X] T020 [US2] Format error message with "jq filter error:" prefix in src/mixpanel_data/cli/utils.py
+- [X] T021 [US2] Verify all US2 tests pass with `just test -k test_apply_jq_filter`
+
+**Checkpoint**: Invalid jq syntax produces clear error messages with exit code 3.
+
+---
+
+## Phase 5: User Story 3 - Receive Error for Incompatible Format (Priority: P2)
+
+**Goal**: Users are informed when `--jq` is used with non-JSON formats
+
+**Independent Test**: Run `mp inspect events --format table --jq '.[]'` and verify error stating jq requires JSON format
+
+### Tests for User Story 3 (TDD - Write FIRST, verify FAIL)
+
+- [X] T022 [P] [US3] Unit test for output_result rejects jq_filter with table format in tests/unit/cli/test_utils.py
+- [X] T023 [P] [US3] Unit test for output_result rejects jq_filter with csv format in tests/unit/cli/test_utils.py
+- [X] T024 [P] [US3] Unit test for output_result rejects jq_filter with plain format in tests/unit/cli/test_utils.py
+- [X] T025 [P] [US3] Unit test for output_result error message mentions json/jsonl requirement in tests/unit/cli/test_utils.py
+
+### Implementation for User Story 3
+
+- [X] T026 [US3] Add format validation check at start of output_result() in src/mixpanel_data/cli/utils.py
+- [X] T027 [US3] Print clear error message and raise typer.Exit(ExitCode.INVALID_ARGS) in src/mixpanel_data/cli/utils.py
+- [X] T028 [US3] Verify all US3 tests pass with `just test -k test_output_result`
+
+**Checkpoint**: Incompatible format combinations produce clear error messages.
+
+---
+
+## Phase 6: User Story 4 - Handle jq Runtime Errors Gracefully (Priority: P3)
+
+**Goal**: Users receive helpful error messages when jq filter fails at runtime
+
+**Independent Test**: Run `mp inspect events --format json --jq '.[0]'` on dict data and verify runtime error message
+
+### Tests for User Story 4 (TDD - Write FIRST, verify FAIL)
+
+- [X] T029 [P] [US4] Unit test for _apply_jq_filter runtime error (index dict as array) in tests/unit/cli/test_utils.py
+- [X] T030 [P] [US4] Unit test for _apply_jq_filter runtime error message is helpful in tests/unit/cli/test_utils.py
+- [X] T031 [P] [US4] Unit test for _apply_jq_filter runtime error exits with ExitCode.INVALID_ARGS in tests/unit/cli/test_utils.py
+
+### Implementation for User Story 4
+
+- [X] T032 [US4] Ensure ValueError from jq.input() is caught in _apply_jq_filter() in src/mixpanel_data/cli/utils.py
+- [X] T033 [US4] Verify runtime error message is distinguishable from syntax error in src/mixpanel_data/cli/utils.py
+- [X] T034 [US4] Verify all US4 tests pass with `just test -k test_apply_jq_filter`
+
+**Checkpoint**: Runtime errors produce helpful error messages.
+
+---
+
+## Phase 7: User Story 5 - Empty Results Handled Gracefully (Priority: P3)
+
+**Goal**: Users see empty array `[]` when jq filter matches no items, with success exit code
+
+**Independent Test**: Run `mp inspect events --format json --jq '.[] | select(.x > 9999)'` and verify `[]` output with exit 0
+
+### Tests for User Story 5 (TDD - Write FIRST, verify FAIL)
+
+- [X] T035 [P] [US5] Unit test for _apply_jq_filter returns "[]" when no results in tests/unit/cli/test_utils.py
+- [X] T036 [P] [US5] Unit test for _apply_jq_filter empty results does NOT raise exception in tests/unit/cli/test_utils.py
+
+### Implementation for User Story 5
+
+- [X] T037 [US5] Handle empty results list in _apply_jq_filter() returning "[]" in src/mixpanel_data/cli/utils.py
+- [X] T038 [US5] Verify all US5 tests pass with `just test -k test_apply_jq_filter`
+
+**Checkpoint**: Empty results handled gracefully with success exit code.
+
+---
+
+## Phase 8: Command Updates
+
+**Purpose**: Add jq_filter parameter to all commands with --format option
+
+### inspect.py Commands
+
+- [X] T039 [P] Add jq_filter param to inspect events command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T040 [P] Add jq_filter param to inspect properties command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T041 [P] Add jq_filter param to inspect values command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T042 [P] Add jq_filter param to inspect funnels command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T043 [P] Add jq_filter param to inspect cohorts command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T044 [P] Add jq_filter param to inspect top_events command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T045 [P] Add jq_filter param to inspect bookmarks command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T046 [P] Add jq_filter param to inspect lexicon_schemas command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T047 [P] Add jq_filter param to inspect lexicon_schema command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T048 [P] Add jq_filter param to inspect distribution command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T049 [P] Add jq_filter param to inspect numeric command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T050 [P] Add jq_filter param to inspect daily command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T051 [P] Add jq_filter param to inspect engagement command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T052 [P] Add jq_filter param to inspect coverage command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T053 [P] Add jq_filter param to inspect info command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T054 [P] Add jq_filter param to inspect tables command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T055 [P] Add jq_filter param to inspect schema command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T056 [P] Add jq_filter param to inspect sample command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T057 [P] Add jq_filter param to inspect summarize command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T058 [P] Add jq_filter param to inspect breakdown command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T059 [P] Add jq_filter param to inspect keys command in src/mixpanel_data/cli/commands/inspect.py
+- [X] T060 [P] Add jq_filter param to inspect column command in src/mixpanel_data/cli/commands/inspect.py
+
+### query.py Commands
+
+- [X] T061 [P] Add jq_filter param to query sql command in src/mixpanel_data/cli/commands/query.py
+- [X] T062 [P] Add jq_filter param to query segmentation command in src/mixpanel_data/cli/commands/query.py
+- [X] T063 [P] Add jq_filter param to query funnel command in src/mixpanel_data/cli/commands/query.py
+- [X] T064 [P] Add jq_filter param to query retention command in src/mixpanel_data/cli/commands/query.py
+- [X] T065 [P] Add jq_filter param to query jql command in src/mixpanel_data/cli/commands/query.py
+
+### fetch.py Commands
+
+- [X] T066 [P] Add jq_filter param to fetch events command in src/mixpanel_data/cli/commands/fetch.py
+- [X] T067 [P] Add jq_filter param to fetch profiles command in src/mixpanel_data/cli/commands/fetch.py
+
+**Checkpoint**: All commands now support --jq option.
+
+---
+
+## Phase 9: Integration & Property-Based Tests
+
+**Purpose**: Comprehensive testing across the feature
+
+- [X] T068 [P] Create CLI integration test file tests/unit/cli/test_jq_integration.py
+- [X] T069 [P] Integration test for inspect events with --jq in tests/unit/cli/test_jq_integration.py
+- [X] T070 [P] Integration test for query sql with --jq in tests/unit/cli/test_jq_integration.py
+- [X] T071 [P] Integration test for --jq with incompatible format in tests/unit/cli/test_jq_integration.py
+- [X] T072 [P] Create property-based test file tests/unit/cli/test_jq_pbt.py
+- [X] T073 [P] PBT: Identity filter '.' preserves structure in tests/unit/cli/test_jq_pbt.py
+- [X] T074 [P] PBT: 'length' filter returns correct count in tests/unit/cli/test_jq_pbt.py
+- [X] T075 [P] PBT: select filter never increases size in tests/unit/cli/test_jq_pbt.py
+
+**Checkpoint**: All tests pass including property-based tests.
+
+---
+
+## Phase 10: Polish & Documentation
+
+**Purpose**: Final polish and documentation updates
+
+- [X] T076 [P] Update docstring examples for inspect commands with --jq in src/mixpanel_data/cli/commands/inspect.py
+- [X] T077 [P] Update docstring examples for query commands with --jq in src/mixpanel_data/cli/commands/query.py
+- [X] T078 Run `just check` to verify lint, typecheck, and all tests pass
+- [X] T079 Verify test coverage remains ≥90% with `just test-cov`
+- [X] T080 Run quickstart.md examples manually to validate (integration tests verify functionality)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Foundational phase completion
+  - US1 (P1) must complete first (core implementation)
+  - US2, US3 (P2) can proceed after US1 (error handling builds on core)
+  - US4, US5 (P3) can proceed after US2/US3 (refinements)
+- **Command Updates (Phase 8)**: Depends on US1 completion (core filtering must work)
+- **Integration Tests (Phase 9)**: Depends on Command Updates
+- **Polish (Phase 10)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational - No dependencies on other stories - THIS IS MVP
+- **US2 (P2)**: Should start after US1 (error handling uses same function)
+- **US3 (P2)**: Can run parallel with US2 (different code path in output_result)
+- **US4 (P3)**: Should start after US2 (similar error handling pattern)
+- **US5 (P3)**: Should start after US1 (uses same function, no error case)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation makes tests pass
+- All tests verified before moving to next story
+
+### Parallel Opportunities
+
+**Phase 1-2**: Sequential (dependencies)
+
+**Phase 3 (US1)**: Tests T006-T011 can run in parallel
+
+**Phase 4-7 (US2-US5)**: Tests within each story can run in parallel
+
+**Phase 8**: All command updates T039-T067 can run in parallel (different sections of same files, but independent edits)
+
+**Phase 9**: All integration and PBT tests T068-T075 can run in parallel
+
+**Phase 10**: T076-T077 can run in parallel
+
+---
+
+## Parallel Example: Phase 8 Command Updates
+
+```bash
+# All inspect command updates can run in parallel:
+Task: "Add jq_filter param to inspect events command"
+Task: "Add jq_filter param to inspect properties command"
+Task: "Add jq_filter param to inspect values command"
+# ... (all 22 inspect commands)
+
+# All query command updates can run in parallel:
+Task: "Add jq_filter param to query sql command"
+Task: "Add jq_filter param to query segmentation command"
+# ... (all 5 query commands)
+
+# All fetch command updates can run in parallel:
+Task: "Add jq_filter param to fetch events command"
+Task: "Add jq_filter param to fetch profiles command"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (add jq dependency)
+2. Complete Phase 2: Foundational (add type and param signatures)
+3. Complete Phase 3: User Story 1 (core jq filtering)
+4. **STOP and VALIDATE**: Test with `mp inspect events --format json --jq '.[0]'`
+5. Feature is usable at this point!
+
+### Incremental Delivery
+
+1. MVP (Setup + Foundational + US1) → Core filtering works
+2. Add US2 + US3 → Error handling complete
+3. Add US4 + US5 → Edge cases handled
+4. Add Phase 8 → All commands support --jq
+5. Add Phase 9-10 → Full test coverage and documentation
+
+### Recommended Order for Single Developer
+
+1. T001-T002 (Setup)
+2. T003-T005 (Foundational)
+3. T006-T015 (US1 - MVP)
+4. T016-T021 (US2) + T022-T028 (US3) - can interleave
+5. T029-T038 (US4 + US5)
+6. T039-T067 (Command updates - mechanical, can batch)
+7. T068-T075 (Integration + PBT)
+8. T076-T080 (Polish)
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent sections, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently testable after completion
+- Verify tests fail before implementing (TDD)
+- Run `just check` frequently to catch issues early
+- The _apply_jq_filter function handles US1, US2, US4, US5 (core + all error cases)
+- The output_result function handles US3 (format validation)
+- Command updates (Phase 8) are mechanical: add param, pass to output_result

--- a/src/mixpanel_data/cli/commands/fetch.py
+++ b/src/mixpanel_data/cli/commands/fetch.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any
 
 import typer
 
-from mixpanel_data.cli.options import FormatOption
+from mixpanel_data.cli.options import FormatOption, JqOption
 from mixpanel_data.cli.utils import (
     err_console,
     get_workspace,
@@ -105,6 +105,7 @@ def fetch_events(
         ),
     ] = 1000,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Fetch events from Mixpanel into local storage.
 
@@ -205,7 +206,7 @@ def fetch_events(
         batch_size=batch_size,
     )
 
-    output_result(ctx, result.to_dict(), format=format)
+    output_result(ctx, result.to_dict(), format=format, jq_filter=jq_filter)
 
 
 @fetch_app.command("profiles")
@@ -260,6 +261,7 @@ def fetch_profiles(
         ),
     ] = 1000,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Fetch user profiles from Mixpanel into local storage.
 
@@ -352,4 +354,4 @@ def fetch_profiles(
         batch_size=batch_size,
     )
 
-    output_result(ctx, result.to_dict(), format=format)
+    output_result(ctx, result.to_dict(), format=format, jq_filter=jq_filter)

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -108,6 +108,12 @@ def query_sql(
         result = workspace.sql_scalar(sql_query)
         # For scalar output, just print the raw value
         if format == "plain":
+            # Validate jq_filter - should error, not silently ignore
+            if jq_filter:
+                err_console.print(
+                    "[red]Error:[/red] --jq requires --format json or jsonl"
+                )
+                raise typer.Exit(ExitCode.INVALID_ARGS)
             print(result)
         else:
             output_result(ctx, {"value": result}, format=format, jq_filter=jq_filter)

--- a/src/mixpanel_data/cli/commands/query.py
+++ b/src/mixpanel_data/cli/commands/query.py
@@ -24,7 +24,7 @@ from typing import Annotated
 
 import typer
 
-from mixpanel_data.cli.options import FormatOption
+from mixpanel_data.cli.options import FormatOption, JqOption
 from mixpanel_data.cli.utils import (
     ExitCode,
     err_console,
@@ -72,6 +72,7 @@ def query_sql(
         typer.Option("--scalar", "-s", help="Return single value."),
     ] = False,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Execute SQL query against local DuckDB database.
 
@@ -109,11 +110,11 @@ def query_sql(
         if format == "plain":
             print(result)
         else:
-            output_result(ctx, {"value": result}, format=format)
+            output_result(ctx, {"value": result}, format=format, jq_filter=jq_filter)
     else:
         result = workspace.sql_rows(sql_query)
         # Convert SQLResult to list of dicts for proper output formatting
-        output_result(ctx, result.to_dicts(), format=format)
+        output_result(ctx, result.to_dicts(), format=format, jq_filter=jq_filter)
 
 
 @query_app.command("segmentation")
@@ -149,6 +150,7 @@ def query_segmentation(
         typer.Option("--where", "-w", help="Filter expression."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Run live segmentation query against Mixpanel API.
 
@@ -181,7 +183,7 @@ def query_segmentation(
             where=where,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("funnel")
@@ -209,6 +211,7 @@ def query_funnel(
         typer.Option("--on", "-o", help="Property to segment by."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Run live funnel analysis against Mixpanel API.
 
@@ -235,7 +238,7 @@ def query_funnel(
             on=on,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("retention")
@@ -279,6 +282,7 @@ def query_retention(
         typer.Option("--unit", "-u", help="Time unit: day, week, month."),
     ] = "day",
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Run live retention analysis against Mixpanel API.
 
@@ -321,7 +325,7 @@ def query_retention(
             unit=validated_unit,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("jql")
@@ -341,6 +345,7 @@ def query_jql(
         typer.Option("--param", "-P", help="Parameter (key=value)."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Execute JQL script against Mixpanel API.
 
@@ -384,7 +389,7 @@ def query_jql(
             params=params if params else None,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("event-counts")
@@ -412,6 +417,7 @@ def query_event_counts(
         typer.Option("--unit", "-u", help="Time unit: day, week, month."),
     ] = "day",
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Query event counts over time for multiple events.
 
@@ -449,7 +455,7 @@ def query_event_counts(
             unit=validated_unit,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("property-counts")
@@ -485,6 +491,7 @@ def query_property_counts(
         typer.Option("--limit", "-l", help="Max property values to return."),
     ] = 10,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Query event counts broken down by property values.
 
@@ -523,7 +530,7 @@ def query_property_counts(
             limit=limit,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("activity-feed")
@@ -543,6 +550,7 @@ def query_activity_feed(
         typer.Option("--to", help="End date (YYYY-MM-DD)."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Query user activity feed for specific users.
 
@@ -573,7 +581,7 @@ def query_activity_feed(
             to_date=to_date,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("saved-report")
@@ -585,6 +593,7 @@ def query_saved_report(
         typer.Argument(help="Saved report bookmark ID."),
     ],
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Query a saved report (Insights, Retention, or Funnel) by bookmark ID.
 
@@ -606,7 +615,7 @@ def query_saved_report(
     with status_spinner(ctx, "Querying saved report..."):
         result = workspace.query_saved_report(bookmark_id=bookmark_id)
 
-    output_result(ctx, result.to_dict(), format=format)
+    output_result(ctx, result.to_dict(), format=format, jq_filter=jq_filter)
 
 
 @query_app.command("flows")
@@ -618,6 +627,7 @@ def query_flows(
         typer.Argument(help="Saved flows report bookmark ID."),
     ],
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Query a saved Flows report by bookmark ID.
 
@@ -638,7 +648,7 @@ def query_flows(
     with status_spinner(ctx, "Querying flows report..."):
         result = workspace.query_flows(bookmark_id=bookmark_id)
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("frequency")
@@ -670,6 +680,7 @@ def query_frequency(
         typer.Option("--where", "-w", help="Filter expression."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Analyze event frequency distribution (addiction analysis).
 
@@ -705,7 +716,7 @@ def query_frequency(
             where=where,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("segmentation-numeric")
@@ -745,6 +756,7 @@ def query_segmentation_numeric(
         typer.Option("--where", "-w", help="Filter expression."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Bucket events by numeric property ranges.
 
@@ -782,7 +794,7 @@ def query_segmentation_numeric(
             where=where,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("segmentation-sum")
@@ -818,6 +830,7 @@ def query_segmentation_sum(
         typer.Option("--where", "-w", help="Filter expression."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Calculate sum of numeric property over time.
 
@@ -848,7 +861,7 @@ def query_segmentation_sum(
             where=where,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)
 
 
 @query_app.command("segmentation-average")
@@ -884,6 +897,7 @@ def query_segmentation_average(
         typer.Option("--where", "-w", help="Filter expression."),
     ] = None,
     format: FormatOption = "json",
+    jq_filter: JqOption = None,
 ) -> None:
     """Calculate average of numeric property over time.
 
@@ -914,4 +928,4 @@ def query_segmentation_average(
             where=where,
         )
 
-    present_result(ctx, result, format)
+    present_result(ctx, result, format, jq_filter=jq_filter)

--- a/src/mixpanel_data/cli/options.py
+++ b/src/mixpanel_data/cli/options.py
@@ -24,3 +24,13 @@ FormatOption = Annotated[
         show_choices=False,
     ),
 ]
+
+# Reusable Annotated type for --jq option
+# Used by commands that support JSON output filtering
+JqOption = Annotated[
+    str | None,
+    typer.Option(
+        "--jq",
+        help="Apply jq filter to JSON output (requires --format json or jsonl).",
+    ),
+]

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -342,10 +342,13 @@ def _apply_jq_filter(json_str: str, filter_expr: str) -> list[Any]:
             runtime error occurs. Uses ExitCode.INVALID_ARGS (3).
 
     Example:
-        >>> _apply_jq_filter('{"name": "test"}', '.name')
-        ['test']
-        >>> _apply_jq_filter('[1, 2, 3]', 'map(. * 2)')
-        [[2, 4, 6]]
+        ```python
+        _apply_jq_filter('{"name": "test"}', '.name')
+        # ['test']
+
+        _apply_jq_filter('[1, 2, 3]', 'map(. * 2)')
+        # [[2, 4, 6]]
+        ```
     """
     try:
         # Parse the input JSON

--- a/tests/unit/cli/test_jq_integration.py
+++ b/tests/unit/cli/test_jq_integration.py
@@ -1,0 +1,387 @@
+"""Integration tests for jq filter functionality across CLI commands.
+
+These tests verify end-to-end jq filtering behavior through the CLI,
+including command invocation, output formatting, and error handling.
+
+Tests cover:
+- T068-T071: Integration tests for jq filter with various commands
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mixpanel_data.cli.main import app
+from mixpanel_data.types import SQLResult
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing commands.
+
+    Returns:
+        CliRunner instance for invoking CLI commands.
+    """
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_workspace() -> MagicMock:
+    """Create a mock Workspace for testing.
+
+    Returns:
+        MagicMock configured to act as a Workspace.
+    """
+    return MagicMock()
+
+
+class TestInspectEventsWithJq:
+    """Integration tests for inspect events with --jq option (T069)."""
+
+    def test_inspect_events_with_jq_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that inspect events applies jq filter to output.
+
+        Verifies end-to-end flow: command -> workspace call -> jq filter -> output.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        # Setup mock - inspect events returns a list of event names
+        mock_workspace.events.return_value = ["Sign Up", "Login", "Purchase"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "json", "--jq", ".[0]"],
+            )
+
+        assert result.exit_code == 0
+        # Should extract just the first event name
+        output = result.stdout.strip()
+        assert output == '"Sign Up"'
+
+    def test_inspect_events_jq_extracts_all(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test extracting all event names with jq.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Event A", "Event B", "Event C"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "json", "--jq", ".[]"],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.stdout)
+        assert parsed == ["Event A", "Event B", "Event C"]
+
+    def test_inspect_events_jq_length_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test counting events with jq length.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["A", "B", "C", "D", "E"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "json", "--jq", "length"],
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "5"
+
+
+class TestQuerySqlWithJq:
+    """Integration tests for query sql with --jq option (T070)."""
+
+    def test_query_sql_with_jq_filter(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that query sql applies jq filter to output.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        # Mock SQL query result using SQLResult like existing tests
+        mock_workspace.sql_rows.return_value = SQLResult(
+            columns=["user_id", "email"],
+            rows=[
+                (1, "user1@example.com"),
+                (2, "user2@example.com"),
+                (3, "user3@example.com"),
+            ],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "sql",
+                    "SELECT * FROM users",
+                    "--format",
+                    "json",
+                    "--jq",
+                    ".[].email",
+                ],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.stdout)
+        assert parsed == [
+            "user1@example.com",
+            "user2@example.com",
+            "user3@example.com",
+        ]
+
+    def test_query_sql_jq_length(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test using jq length filter on query results.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.sql_rows.return_value = SQLResult(
+            columns=["id"],
+            rows=[(1,), (2,), (3,), (4,), (5,)],
+        )
+
+        with patch(
+            "mixpanel_data.cli.commands.query.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "query",
+                    "sql",
+                    "SELECT id FROM events",
+                    "--format",
+                    "json",
+                    "--jq",
+                    "length",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "5"
+
+
+class TestJqWithIncompatibleFormat:
+    """Integration tests for --jq with incompatible formats (T071)."""
+
+    def test_jq_with_table_format_fails(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that --jq with --format table produces error.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Test"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "table", "--jq", "."],
+            )
+
+        # Should fail with exit code 3 (INVALID_ARGS)
+        assert result.exit_code == 3
+        # Error should mention json/jsonl requirement
+        combined = result.stdout + (result.stderr or "")
+        assert "json" in combined.lower()
+
+    def test_jq_with_csv_format_fails(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that --jq with --format csv produces error.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Test"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "csv", "--jq", "."],
+            )
+
+        assert result.exit_code == 3
+
+    def test_jq_with_plain_format_fails(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that --jq with --format plain produces error.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Test"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "plain", "--jq", "."],
+            )
+
+        assert result.exit_code == 3
+
+
+class TestJqSyntaxErrorsIntegration:
+    """Integration tests for jq syntax error handling."""
+
+    def test_invalid_jq_syntax_fails(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that invalid jq syntax produces clear error.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Test"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "json", "--jq", ".name |"],
+            )
+
+        assert result.exit_code == 3
+        # Error output should mention jq
+        combined_output = result.stdout + (result.stderr or "")
+        assert "jq" in combined_output.lower()
+
+    def test_unknown_jq_function_fails(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that unknown jq function produces error.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Test"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "json", "--jq", "nonexistent_func"],
+            )
+
+        assert result.exit_code == 3
+
+
+class TestJqWithJsonlFormat:
+    """Integration tests for --jq with jsonl format."""
+
+    def test_jq_with_jsonl_format(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that --jq works with jsonl format.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["Event A", "Event B"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["inspect", "events", "--format", "jsonl", "--jq", ".[0]"],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.stdout.strip())
+        assert parsed == "Event A"
+
+
+class TestJqEmptyResultsIntegration:
+    """Integration tests for jq filter with empty results."""
+
+    def test_jq_select_no_matches(
+        self, cli_runner: CliRunner, mock_workspace: MagicMock
+    ) -> None:
+        """Test that jq select with no matches returns empty array.
+
+        Args:
+            cli_runner: CLI runner for invoking commands.
+            mock_workspace: Mock workspace to provide test data.
+        """
+        mock_workspace.events.return_value = ["A", "B"]
+
+        with patch(
+            "mixpanel_data.cli.commands.inspect.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "inspect",
+                    "events",
+                    "--format",
+                    "json",
+                    "--jq",
+                    '.[] | select(. == "Z")',
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "[]"

--- a/tests/unit/cli/test_jq_pbt.py
+++ b/tests/unit/cli/test_jq_pbt.py
@@ -92,8 +92,9 @@ class TestIdentityFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, ".")
-        parsed = json.loads(result)
-        assert parsed == data
+        # Result is a list with single element for identity filter
+        assert len(result) == 1
+        assert result[0] == data
 
     @given(data=json_object_lists)
     @settings(max_examples=100)
@@ -110,8 +111,9 @@ class TestIdentityFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, ".")
-        parsed = json.loads(result)
-        assert parsed == data
+        # Result is a list with single element for identity filter
+        assert len(result) == 1
+        assert result[0] == data
 
     @given(data=json_values)
     @settings(max_examples=100)
@@ -126,8 +128,9 @@ class TestIdentityFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, ".")
-        parsed = json.loads(result)
-        assert parsed == data
+        # Result is a list with single element for identity filter
+        assert len(result) == 1
+        assert result[0] == data
 
 
 # =============================================================================
@@ -153,8 +156,9 @@ class TestLengthFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "length")
-        length = int(result.strip())
-        assert length == len(data)
+        # Result is a list containing the length value
+        assert len(result) == 1
+        assert result[0] == len(data)
 
     @given(data=json_objects)
     @settings(max_examples=100)
@@ -169,8 +173,9 @@ class TestLengthFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "length")
-        length = int(result.strip())
-        assert length == len(data)
+        # Result is a list containing the length value
+        assert len(result) == 1
+        assert result[0] == len(data)
 
     @given(text=st.text())
     @settings(max_examples=100)
@@ -184,8 +189,9 @@ class TestLengthFilterProperties:
         """
         json_str = json.dumps(text)
         result = _apply_jq_filter(json_str, "length")
-        length = int(result.strip())
-        assert length == len(text)
+        # Result is a list containing the length value
+        assert len(result) == 1
+        assert result[0] == len(text)
 
     @given(data=number_lists)
     @settings(max_examples=100)
@@ -199,8 +205,9 @@ class TestLengthFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "length")
-        length = int(result.strip())
-        assert length >= 0
+        # Result is a list containing the length value
+        assert len(result) == 1
+        assert result[0] >= 0
 
 
 # =============================================================================
@@ -230,17 +237,8 @@ class TestSelectFilterProperties:
         json_str = json.dumps(data)
         filter_expr = f".[] | select(.value > {threshold})"
         result = _apply_jq_filter(json_str, filter_expr)
-        parsed = json.loads(result)
-
-        # Handle single result vs array
-        if isinstance(parsed, dict):
-            result_count = 1
-        elif isinstance(parsed, list):
-            result_count = len(parsed)
-        else:
-            result_count = 0
-
-        assert result_count <= len(data)
+        # Result is already a list of matching items
+        assert len(result) <= len(data)
 
     @given(data=items_with_values)
     @settings(max_examples=100)
@@ -261,23 +259,18 @@ class TestSelectFilterProperties:
         json_str = json.dumps(data)
         # Select everything (value > -infinity effectively)
         result = _apply_jq_filter(json_str, ".[] | select(.value != null)")
-        parsed = json.loads(result)
-
-        # Handle single result case
-        if isinstance(parsed, dict):
-            parsed = [parsed]
-
-        assert len(parsed) == len(data)
+        # Result is a list of matching items
+        assert len(result) == len(data)
 
     @given(data=items_with_values)
     @settings(max_examples=100)
     def test_select_with_always_false_returns_empty(
         self, data: list[dict[str, Any]]
     ) -> None:
-        """Select with impossible condition should return empty array.
+        """Select with impossible condition should return empty list.
 
         When the select condition matches nothing, the output should
-        be an empty array.
+        be an empty list.
 
         Args:
             data: A list of dicts with 'value' key.
@@ -285,9 +278,7 @@ class TestSelectFilterProperties:
         json_str = json.dumps(data)
         # Value is integer, so checking type == "string" is always false
         result = _apply_jq_filter(json_str, '.[] | select(.value | type == "string")')
-        parsed = json.loads(result)
-
-        assert parsed == []
+        assert result == []
 
     @given(data=items_with_values)
     @settings(max_examples=100)
@@ -304,14 +295,9 @@ class TestSelectFilterProperties:
         json_str = json.dumps(data)
         filter_expr = ".[] | select(.value > 0)"
         result = _apply_jq_filter(json_str, filter_expr)
-        parsed = json.loads(result)
-
-        # Handle single result case
-        if isinstance(parsed, dict):
-            parsed = [parsed]
-
+        # Result is a list of matching items
         # All returned items should have value > 0
-        for item in parsed:
+        for item in result:
             assert item["value"] > 0
 
 
@@ -339,9 +325,9 @@ class TestMapFilterProperties:
 
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "map(. + 1)")
-        parsed = json.loads(result)
-
-        assert len(parsed) == len(data)
+        # map returns single array result wrapped in list
+        assert len(result) == 1
+        assert len(result[0]) == len(data)
 
     @given(
         data=st.lists(
@@ -357,9 +343,9 @@ class TestMapFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "map(.)")
-        parsed = json.loads(result)
-
-        assert parsed == data
+        # map returns single array result wrapped in list
+        assert len(result) == 1
+        assert result[0] == data
 
 
 class TestKeysFilterProperties:
@@ -377,9 +363,9 @@ class TestKeysFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, "keys")
-        parsed = json.loads(result)
-
-        assert set(parsed) == set(data.keys())
+        # keys returns single array result wrapped in list
+        assert len(result) == 1
+        assert set(result[0]) == set(data.keys())
 
     @given(data=json_objects)
     @settings(max_examples=100)
@@ -395,8 +381,12 @@ class TestKeysFilterProperties:
         keys_result = _apply_jq_filter(json_str, "keys")
         length_result = _apply_jq_filter(json_str, "length")
 
-        keys = json.loads(keys_result)
-        length = int(length_result.strip())
+        # keys returns single array wrapped in list
+        assert len(keys_result) == 1
+        keys = keys_result[0]
+        # length returns single value wrapped in list
+        assert len(length_result) == 1
+        length = length_result[0]
 
         assert len(keys) == length
 
@@ -424,7 +414,9 @@ class TestSliceFilterProperties:
         """
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, f".[:{n}]")
-        parsed = json.loads(result)
+        # slice returns single array wrapped in list
+        assert len(result) == 1
+        parsed = result[0]
 
         expected_length = min(n, len(data))
         assert len(parsed) == expected_length
@@ -446,6 +438,6 @@ class TestSliceFilterProperties:
         n = len(data)
         json_str = json.dumps(data)
         result = _apply_jq_filter(json_str, f".[0:{n}]")
-        parsed = json.loads(result)
-
-        assert parsed == data
+        # slice returns single array wrapped in list
+        assert len(result) == 1
+        assert result[0] == data

--- a/tests/unit/cli/test_jq_pbt.py
+++ b/tests/unit/cli/test_jq_pbt.py
@@ -1,0 +1,451 @@
+"""Property-based tests for jq filter functionality using Hypothesis.
+
+These tests verify invariants that should hold for all possible inputs,
+catching edge cases that example-based tests might miss.
+
+Properties tested:
+- Identity filter '.' preserves structure (T073)
+- 'length' filter returns correct count (T074)
+- select filter never increases size (T075)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mixpanel_data.cli.utils import _apply_jq_filter
+
+# =============================================================================
+# Custom Strategies
+# =============================================================================
+
+# JSON-safe integer range: JavaScript's MAX_SAFE_INTEGER is 2^53 - 1
+# Integers outside this range may lose precision during JSON roundtrip
+JSON_SAFE_INT_MAX = 2**53 - 1
+JSON_SAFE_INT_MIN = -(2**53 - 1)
+
+# Strategy for JSON-serializable primitive values (no datetime/date)
+json_primitives = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=JSON_SAFE_INT_MIN, max_value=JSON_SAFE_INT_MAX),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(),
+)
+
+# Strategy for JSON-serializable values (recursive: primitives, lists, dicts)
+json_values: st.SearchStrategy[Any] = st.recursive(
+    json_primitives,
+    lambda children: st.one_of(
+        st.lists(children, max_size=5),
+        st.dictionaries(st.text(), children, max_size=5),
+    ),
+    max_leaves=20,
+)
+
+# Strategy for JSON objects (dicts with string keys)
+json_objects = st.dictionaries(st.text(), json_values, max_size=10)
+
+# Strategy for lists of JSON objects (common input for CLI commands)
+json_object_lists = st.lists(json_objects, max_size=10)
+
+# Strategy for lists of numbers (for arithmetic tests)
+number_lists = st.lists(
+    st.one_of(st.integers(), st.floats(allow_nan=False, allow_infinity=False)),
+    min_size=0,
+    max_size=20,
+)
+
+# Strategy for lists of items with numeric 'value' field
+items_with_values = st.lists(
+    st.fixed_dictionaries(
+        {"value": st.integers(min_value=-1000, max_value=1000)},
+        optional={"name": st.text(max_size=10)},
+    ),
+    min_size=0,
+    max_size=15,
+)
+
+
+# =============================================================================
+# Identity Filter Property Tests (T073)
+# =============================================================================
+
+
+class TestIdentityFilterProperties:
+    """Property-based tests for identity filter '.' (T073)."""
+
+    @given(data=json_objects)
+    @settings(max_examples=100)
+    def test_identity_preserves_dict_structure(self, data: dict[str, Any]) -> None:
+        """Identity filter '.' should preserve dict structure exactly.
+
+        The identity filter should return the input unchanged, maintaining
+        all keys, values, and nested structures.
+
+        Args:
+            data: A dictionary with string keys and JSON-serializable values.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, ".")
+        parsed = json.loads(result)
+        assert parsed == data
+
+    @given(data=json_object_lists)
+    @settings(max_examples=100)
+    def test_identity_preserves_list_structure(
+        self, data: list[dict[str, Any]]
+    ) -> None:
+        """Identity filter '.' should preserve list structure exactly.
+
+        The identity filter should return the input list unchanged,
+        maintaining order and all nested structures.
+
+        Args:
+            data: A list of dictionaries with JSON-serializable values.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, ".")
+        parsed = json.loads(result)
+        assert parsed == data
+
+    @given(data=json_values)
+    @settings(max_examples=100)
+    def test_identity_preserves_any_json_value(self, data: Any) -> None:
+        """Identity filter '.' should preserve any JSON-serializable value.
+
+        This tests the identity filter with primitives, nested objects,
+        and deeply nested structures.
+
+        Args:
+            data: Any JSON-serializable value.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, ".")
+        parsed = json.loads(result)
+        assert parsed == data
+
+
+# =============================================================================
+# Length Filter Property Tests (T074)
+# =============================================================================
+
+
+class TestLengthFilterProperties:
+    """Property-based tests for 'length' filter (T074)."""
+
+    @given(data=json_object_lists)
+    @settings(max_examples=100)
+    def test_length_returns_correct_list_count(
+        self, data: list[dict[str, Any]]
+    ) -> None:
+        """Length filter should return exact list length.
+
+        The length filter on a list should return the number of elements,
+        matching Python's len() function.
+
+        Args:
+            data: A list of dictionaries.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "length")
+        length = int(result.strip())
+        assert length == len(data)
+
+    @given(data=json_objects)
+    @settings(max_examples=100)
+    def test_length_returns_correct_dict_key_count(self, data: dict[str, Any]) -> None:
+        """Length filter should return dict key count.
+
+        The length filter on an object should return the number of keys,
+        matching Python's len() on the dict.
+
+        Args:
+            data: A dictionary with string keys.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "length")
+        length = int(result.strip())
+        assert length == len(data)
+
+    @given(text=st.text())
+    @settings(max_examples=100)
+    def test_length_returns_correct_string_length(self, text: str) -> None:
+        """Length filter should return string length.
+
+        The length filter on a string should return the number of characters.
+
+        Args:
+            text: A string value.
+        """
+        json_str = json.dumps(text)
+        result = _apply_jq_filter(json_str, "length")
+        length = int(result.strip())
+        assert length == len(text)
+
+    @given(data=number_lists)
+    @settings(max_examples=100)
+    def test_length_is_non_negative(self, data: list[Any]) -> None:
+        """Length should always be non-negative.
+
+        Regardless of content, length should never return a negative value.
+
+        Args:
+            data: A list of numbers.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "length")
+        length = int(result.strip())
+        assert length >= 0
+
+
+# =============================================================================
+# Select Filter Property Tests (T075)
+# =============================================================================
+
+
+class TestSelectFilterProperties:
+    """Property-based tests for select filter (T075)."""
+
+    @given(
+        data=items_with_values, threshold=st.integers(min_value=-1000, max_value=1000)
+    )
+    @settings(max_examples=100)
+    def test_select_never_increases_size(
+        self, data: list[dict[str, Any]], threshold: int
+    ) -> None:
+        """Select filter should never return more items than input.
+
+        Filtering with select() should always produce a result set
+        that is equal to or smaller than the original list.
+
+        Args:
+            data: A list of dicts with 'value' key.
+            threshold: Integer threshold for filtering.
+        """
+        json_str = json.dumps(data)
+        filter_expr = f".[] | select(.value > {threshold})"
+        result = _apply_jq_filter(json_str, filter_expr)
+        parsed = json.loads(result)
+
+        # Handle single result vs array
+        if isinstance(parsed, dict):
+            result_count = 1
+        elif isinstance(parsed, list):
+            result_count = len(parsed)
+        else:
+            result_count = 0
+
+        assert result_count <= len(data)
+
+    @given(data=items_with_values)
+    @settings(max_examples=100)
+    def test_select_with_always_true_preserves_all(
+        self, data: list[dict[str, Any]]
+    ) -> None:
+        """Select with always-true condition should preserve all items.
+
+        When the select condition matches everything, the output should
+        equal the input.
+
+        Args:
+            data: A list of dicts with 'value' key.
+        """
+        if not data:
+            return  # Skip empty lists
+
+        json_str = json.dumps(data)
+        # Select everything (value > -infinity effectively)
+        result = _apply_jq_filter(json_str, ".[] | select(.value != null)")
+        parsed = json.loads(result)
+
+        # Handle single result case
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+
+        assert len(parsed) == len(data)
+
+    @given(data=items_with_values)
+    @settings(max_examples=100)
+    def test_select_with_always_false_returns_empty(
+        self, data: list[dict[str, Any]]
+    ) -> None:
+        """Select with impossible condition should return empty array.
+
+        When the select condition matches nothing, the output should
+        be an empty array.
+
+        Args:
+            data: A list of dicts with 'value' key.
+        """
+        json_str = json.dumps(data)
+        # Value is integer, so checking type == "string" is always false
+        result = _apply_jq_filter(json_str, '.[] | select(.value | type == "string")')
+        parsed = json.loads(result)
+
+        assert parsed == []
+
+    @given(data=items_with_values)
+    @settings(max_examples=100)
+    def test_select_result_items_match_predicate(
+        self, data: list[dict[str, Any]]
+    ) -> None:
+        """All items returned by select should match the predicate.
+
+        Every item in the result should satisfy the select condition.
+
+        Args:
+            data: A list of dicts with 'value' key.
+        """
+        json_str = json.dumps(data)
+        filter_expr = ".[] | select(.value > 0)"
+        result = _apply_jq_filter(json_str, filter_expr)
+        parsed = json.loads(result)
+
+        # Handle single result case
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+
+        # All returned items should have value > 0
+        for item in parsed:
+            assert item["value"] > 0
+
+
+# =============================================================================
+# Additional Property Tests
+# =============================================================================
+
+
+class TestMapFilterProperties:
+    """Property-based tests for map filter."""
+
+    @given(data=number_lists)
+    @settings(max_examples=100)
+    def test_map_preserves_length(self, data: list[Any]) -> None:
+        """Map transformation should preserve list length.
+
+        Mapping over a list should produce a result with the same
+        number of elements as the input.
+
+        Args:
+            data: A list of numbers.
+        """
+        if not data:
+            return  # Skip empty lists
+
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "map(. + 1)")
+        parsed = json.loads(result)
+
+        assert len(parsed) == len(data)
+
+    @given(
+        data=st.lists(
+            st.integers(min_value=-100, max_value=100), min_size=1, max_size=20
+        )
+    )
+    @settings(max_examples=100)
+    def test_map_identity_preserves_values(self, data: list[int]) -> None:
+        """Map with identity function should preserve all values.
+
+        Args:
+            data: A list of integers.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "map(.)")
+        parsed = json.loads(result)
+
+        assert parsed == data
+
+
+class TestKeysFilterProperties:
+    """Property-based tests for keys filter."""
+
+    @given(data=json_objects)
+    @settings(max_examples=100)
+    def test_keys_returns_all_dict_keys(self, data: dict[str, Any]) -> None:
+        """Keys filter should return all dict keys.
+
+        The keys filter should return every key present in the object.
+
+        Args:
+            data: A dictionary with string keys.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, "keys")
+        parsed = json.loads(result)
+
+        assert set(parsed) == set(data.keys())
+
+    @given(data=json_objects)
+    @settings(max_examples=100)
+    def test_keys_count_matches_length(self, data: dict[str, Any]) -> None:
+        """Number of keys should match length.
+
+        The keys filter result length should equal the object length.
+
+        Args:
+            data: A dictionary with string keys.
+        """
+        json_str = json.dumps(data)
+        keys_result = _apply_jq_filter(json_str, "keys")
+        length_result = _apply_jq_filter(json_str, "length")
+
+        keys = json.loads(keys_result)
+        length = int(length_result.strip())
+
+        assert len(keys) == length
+
+
+class TestSliceFilterProperties:
+    """Property-based tests for slice operations."""
+
+    @given(
+        data=st.lists(
+            st.integers(min_value=JSON_SAFE_INT_MIN, max_value=JSON_SAFE_INT_MAX),
+            min_size=0,
+            max_size=20,
+        ),
+        n=st.integers(min_value=0, max_value=25),
+    )
+    @settings(max_examples=100)
+    def test_slice_first_n_bounds(self, data: list[int], n: int) -> None:
+        """Slicing first n items should return at most n items.
+
+        The result length should be min(n, len(data)).
+
+        Args:
+            data: A list of integers.
+            n: Number of items to take.
+        """
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, f".[:{n}]")
+        parsed = json.loads(result)
+
+        expected_length = min(n, len(data))
+        assert len(parsed) == expected_length
+
+    @given(
+        data=st.lists(
+            st.integers(min_value=JSON_SAFE_INT_MIN, max_value=JSON_SAFE_INT_MAX),
+            min_size=1,
+            max_size=20,
+        )
+    )
+    @settings(max_examples=100)
+    def test_slice_preserves_elements(self, data: list[int]) -> None:
+        """Sliced elements should match original list elements.
+
+        Args:
+            data: A list of integers.
+        """
+        n = len(data)
+        json_str = json.dumps(data)
+        result = _apply_jq_filter(json_str, f".[0:{n}]")
+        parsed = json.loads(result)
+
+        assert parsed == data

--- a/uv.lock
+++ b/uv.lock
@@ -703,6 +703,49 @@ wheels = [
 ]
 
 [[package]]
+name = "jq"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/86/6935afb6c1789d4c6ba5343607e2d2f473069eaac29fac555dbbd154c2d7/jq-1.10.0.tar.gz", hash = "sha256:fc38803075dbf1867e1b4ed268fef501feecb0c50f3555985a500faedfa70f08", size = 2031308, upload-time = "2025-07-14T18:54:53.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e5/d460e048de611e8b455e1be98cba67fb70ecb194de3ba4486dc9dfba88cb/jq-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1363930e8efe63a76e6be93ffc6fea6d9201ba13a21f8a9c7943e9c6a4184cf7", size = 421078, upload-time = "2025-07-14T18:52:10.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f2/3183dd18746ef068c8798940683ff1a42397ee6519e1c1ee608843d376a1/jq-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:850c99324fdb2e42a2056c27ec45af87b1bc764a14c94cdf011f6e21d885f032", size = 427232, upload-time = "2025-07-14T18:52:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2e/a566e4b254862f92be66365488bb78994110f32f8d60f255873fdaa429a7/jq-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75aabeae63f36fe421c25cb793f5e166500400e443e7f6ce509261d06d4f8b5d", size = 739810, upload-time = "2025-07-14T18:52:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e2/ad805b9a263a89c5fde75f2aa31d252c39732b55ead67d269e775eabe8a0/jq-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b6e1f04da95c5057346954b24e65cb401cf9c64566e68c4263454717fcf464d", size = 754311, upload-time = "2025-07-14T18:52:20.172Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/39/403924bd41a2365bc1ba39c99b2922b8e3f97abe6405d0e0911018df045c/jq-1.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ff2ac703b1bde9209f124aa7948012b77e93a40f858c24cf0bbd48f150c15e8", size = 745667, upload-time = "2025-07-14T18:52:22.435Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/9f9d5e748b810bfe79f61f7dc36ed1c5d7d68feca3928659d6dfbba50e6b/jq-1.10.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:83ae246c191e6c5363cb7987af10c4c3071ec6995424eb749d225fbb985d9e47", size = 737610, upload-time = "2025-07-14T18:52:24.268Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d6/799a9f8a1588c0275411b7754cf5939dec8003978e3a71c54fb68894fc5b/jq-1.10.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:307ed7ac72c03843af46face4ec1b8238f6d0d68f5a37aab3b55d178c329ad34", size = 762500, upload-time = "2025-07-14T18:52:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/27/04/18f406ba70f7f78f9576baed53d0d84f3f02420c124d0843c1e7b16567f5/jq-1.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ded278e64dad446667656f7144cefe20cea16bb57cf6912ef6d1ddf3bddc9861", size = 763614, upload-time = "2025-07-14T18:52:32.381Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/accb3c72ece3164e7019910b387fd65fc1da805bc8b7dac4e676d48b852e/jq-1.10.0-cp311-cp311-win32.whl", hash = "sha256:5d5624d43c8597b06a4a2c5461d1577f29f23991472a5da88b742f7fa529c1d1", size = 410182, upload-time = "2025-07-14T18:52:34.771Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1d/2af863d11a5330b69af6cc875bb54ecf942da4909b75284afef7468e70b5/jq-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:08bf55484a20955264358823049ff8deb671bb0025d51707ec591b5eb18a94d7", size = 421735, upload-time = "2025-07-14T18:52:37.026Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/b9e2b7004a2cb646507c082ea5e975ac37e6265353ec4c24779a1701c54a/jq-1.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe636cfa95b7027e7b43da83ecfd61431c0de80c3e0aa4946534b087149dcb4c", size = 420103, upload-time = "2025-07-14T18:52:39.016Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ad/d6780c218040789ed3ddbfa3b1743aaf824f80be5ebd7d5f885224c5bb08/jq-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:947fc7e1baaa7e95833b950e5a66b3e13a5cff028bff2d009b8c320124d9e69b", size = 426325, upload-time = "2025-07-14T18:52:40.654Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/42/5cfc8de34e976112e1b835a83264c7a0bab2cf8f20dc703f1257aa9e07ea/jq-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9382f85a347623afa521c43f8f09439e68906fd5b3492016f969a29219796bb9", size = 738212, upload-time = "2025-07-14T18:52:42.637Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0a/eff78a2329967bda38a98580c6fb77c59696b2b7d589e97db232ca42f5c4/jq-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c376aab525d0a1debe403d3bc2f19fda9473696a1eda56bafc88248fc4ae6e7e", size = 757068, upload-time = "2025-07-14T18:52:44.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/62/353d4c0a9f363ccb2a9b5ea205f079a4ee43642622c25250d95c0fafb7ca/jq-1.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:206f230c67a46776f848858c66b9c377a8e40c2b16195552edd96fd7b45f9a52", size = 744259, upload-time = "2025-07-14T18:52:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/46/0faead425cc3a720c7cd999146f4b5f50aaf394800457efb27746c10832c/jq-1.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:06986456ebc95ccb9e9c2a1f0e842bc9d441225a554a9f9d4370ad95a19ac000", size = 740075, upload-time = "2025-07-14T18:52:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/8e0823c5a329d735cff9f3746e0f7d74e7eea4ed9b0e75f90f942d1c455a/jq-1.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d02c0be958ddb4d9254ff251b045df2f8ee5995137702eeab4ffa81158bcdbe0", size = 766475, upload-time = "2025-07-14T18:52:53.047Z" },
+    { url = "https://files.pythonhosted.org/packages/06/0c/9b5aae9081fe6620915aa0e0ca76fd016e5b9d399b80c8615852413f4404/jq-1.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37cf6fd2ebd2453e75ceef207d5a95a39fcbda371a9b8916db0bd42e8737a621", size = 770416, upload-time = "2025-07-14T18:52:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/8f4e1cc3102de31d71e6298bcbdb15d1439e2bc466f4dcf18bc3694ba61d/jq-1.10.0-cp312-cp312-win32.whl", hash = "sha256:655d75d54a343944a9b011f568156cdc29ae0b35d2fdeefb001f459a4e4fc313", size = 410113, upload-time = "2025-07-14T18:52:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/6efe0a2b69910643b80d7da39fbded8225749dee4b79ebe23d522109a310/jq-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d67c2653ae41eab48f8888c213c9e1807b43167f26ac623c9f3e00989d3edee", size = 422316, upload-time = "2025-07-14T18:52:59.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fe/eeede83103e90e8f5fd9b610514a4c714957d6575e03987ebeb77aafeafa/jq-1.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b11d6e115ebad15d738d49932c3a8b9bb302b928e0fb79acc80987598d147a43", size = 419325, upload-time = "2025-07-14T18:53:01.854Z" },
+    { url = "https://files.pythonhosted.org/packages/09/12/8b39293715d7721b2999facd4a05ca3328fe4a68cf1c094667789867aac1/jq-1.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df278904c5727dfe5bc678131a0636d731cd944879d890adf2fc6de35214b19b", size = 425344, upload-time = "2025-07-14T18:53:03.528Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f4/ace0c853d4462f1d28798d5696619d2fb68c8e1db228ef5517365a0f3c1c/jq-1.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab4c1ec69fd7719fb1356e2ade7bd2b5a63d6f0eaf5a90fdc5c9f6145f0474ce", size = 735874, upload-time = "2025-07-14T18:53:05.406Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b0/7882035062771686bd7e62db019fa0900fd9a3720b7ad8f7af65ee628484/jq-1.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd24dc21c8afcbe5aa812878251cfafa6f1dc6e1126c35d460cc7e67eb331018", size = 754355, upload-time = "2025-07-14T18:53:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/b759a764c5d05c6829e95733a8b26f7e9b14df245ec2a325c0de049393ca/jq-1.10.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c0d3e89cd239c340c3a54e145ddf52fe63de31866cb73368d22a66bfe7e823f", size = 742546, upload-time = "2025-07-14T18:53:11.756Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6b/483ddb82939d4f2f9b0486887666c67a966434cc8bc72acd851fc8063f50/jq-1.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76710b280e4c464395c3d8e656b849e2704bd06e950a4ebd767860572bbf67df", size = 738777, upload-time = "2025-07-14T18:53:14.856Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/4d0fc965a8e57f55291763bb236a5aee91430f97c844ee328667b34af19e/jq-1.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b11a56f1fb6e2985fd3627dbd8a0637f62b1a704f7b19705733d461dafa26429", size = 765307, upload-time = "2025-07-14T18:53:17.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a6/aca82622d8d20ea02bbcac8aaa92daaadd55a18c2a3ca54b2e63d98336d2/jq-1.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ac05ae44d9aa1e462329e1510e0b5139ac4446de650c7bdfdab226aafdc978ec", size = 769830, upload-time = "2025-07-14T18:53:19.937Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/a19aeada32dde0839e3a4d77f2f0d63f2764c579b57f405ff4b91a58a8db/jq-1.10.0-cp313-cp313-win32.whl", hash = "sha256:0bad90f5734e2fc9d09c4116ae9102c357a4d75efa60a85758b0ba633774eddb", size = 410285, upload-time = "2025-07-14T18:53:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/32/df4eb81cf371654d91b6779d3f0005e86519977e19068638c266a9c88af7/jq-1.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:4ec3fbca80a9dfb5349cdc2531faf14dd832e1847499513cf1fc477bcf46a479", size = 423094, upload-time = "2025-07-14T18:53:23.687Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/bd/03f20025366149cd93eba483f874511461d2c6ad3a13cfd5b9de1c0bab00/jq-1.10.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:185d450fb45cd44ad5939ec5813f1ed0d057fa0cb12a1ba6a5fe0e49d8354958", size = 406997, upload-time = "2025-07-14T18:54:27.664Z" },
+    { url = "https://files.pythonhosted.org/packages/83/28/e2a57a342040f239b384a90dfb0ff2253d061411b07d816334862645404e/jq-1.10.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e6649eb4ce390342e07c95c2fa10fed043410408620296122f0ac48a7576f1f", size = 415060, upload-time = "2025-07-14T18:54:29.88Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/e62568fb245cd207cfd2d9c931a0dcc9cbbdfe171733b688dbbbc0575b14/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:002d93e50fab9d92035dfd79fd134052692be649e1b3835662a053016d9f2ee7", size = 414979, upload-time = "2025-07-14T18:54:31.929Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fd/d00bd8f4a58b34d7e646ba9e2c9b5f7d5386472a15ef0fa8d8e65df51dfb/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1602f95ffaef7ee357b65f414b59d6284619bd3a0a588c15c3a1ae534811c1fb", size = 430400, upload-time = "2025-07-14T18:54:33.716Z" },
+    { url = "https://files.pythonhosted.org/packages/26/75/9d93d9ae98858b60c2351a33e1e87e873c0ade56dd3c4f909669ca9cbaff/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b28cfd1eac69e1dc14518ed9c33e497041e9f9310e5f6259fa9d18fe342fb50", size = 439222, upload-time = "2025-07-14T18:54:35.695Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1053,6 +1096,7 @@ source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
     { name = "httpx" },
+    { name = "jq" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "rich" },
@@ -1096,6 +1140,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=6.0" },
+    { name = "jq", specifier = ">=1.9.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2.0" },
     { name = "mkdocs-llmstxt-md", marker = "extra == 'docs'", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Summary

- Adds `--jq` global option to apply jq filters to JSON output across all CLI commands
- Supports fetch (events, profiles), inspect, and query command groups
- Validates jq expressions before execution with clear error messages
- Requires `--format json` or `--format jsonl` when using `--jq` (fails with helpful error otherwise)
- Uses native Python jq bindings for efficient processing

## Test plan

- [x] Unit tests for `apply_jq_filter` function in `test_utils.py`
- [x] Integration tests for all command groups in `test_jq_integration.py`
- [x] Property-based tests for filter robustness in `test_jq_pbt.py`
- [x] All 1530+ tests pass with `just check`
- [x] Live QA testing with actual Mixpanel account (ai-demo)
- [x] Documentation updated in docs/, mixpanel-plugin/, and specs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)