### PR TITLE
Move marketplace.json to repo root for proper plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
-  "name": "mixpanel-data-dev",
-  "description": "Development marketplace for Mixpanel Data plugin",
+  "name": "mixpanel-data",
+  "description": "Mixpanel Data plugin marketplace",
   "owner": {
     "name": "Jared McFarland",
     "url": "https://github.com/jaredmcfarland"
@@ -10,7 +10,7 @@
       "name": "mixpanel-data",
       "description": "Mixpanel analytics data integration for Claude Code - fetch, query, and analyze event data with interactive commands and comprehensive guidance",
       "version": "1.0.0",
-      "source": "./",
+      "source": "./mixpanel-plugin",
       "author": {
         "name": "Jared McFarland",
         "email": "jaredcolin@gmail.com",

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -120,11 +120,11 @@ Then restart Claude Code.
 
 ### For Development/Testing
 
-Use the local development marketplace:
+Use the local marketplace from the repository root:
 
 ```bash
-/plugin marketplace add /workspace/mixpanel-plugin
-/plugin install mixpanel-data@mixpanel-data-dev
+/plugin marketplace add /path/to/mixpanel_data
+/plugin install mixpanel-data
 ```
 
 Restart Claude Code to load the plugin.


### PR DESCRIPTION
## Summary
- Moved marketplace.json from `mixpanel-plugin/.claude-plugin/` to repo root `.claude-plugin/`
- Updated source path to point to `./mixpanel-plugin`
- Updated plugin README development instructions

The `/plugin marketplace add owner/repo` command expects marketplace.json at `.claude-plugin/marketplace.json` in the repo root, not in a subdirectory.

## Test plan
- [ ] Verify `/plugin marketplace add jaredmcfarland/mixpanel_data` works correctly
- [ ] Verify `/plugin install mixpanel-data` installs the plugin