### PR TITLE
Fix incorrect properties.* dot notation in on parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ result = ws.segmentation(
     event=events[0].name,
     from_date="2025-01-01",
     to_date="2025-01-31",
-    on="properties.country"
+    on="country"
 )
 print(result.df)  # pandas DataFrame
 

--- a/context/mixpanel_data-api-specification.md
+++ b/context/mixpanel_data-api-specification.md
@@ -710,7 +710,7 @@ def segmentation(
             event="Purchase",
             from_date="2024-01-01",
             to_date="2024-01-31",
-            on="properties.country",
+            on="country",
             unit="day"
         )
         print(result.total)  # Total events
@@ -1808,7 +1808,7 @@ result = ws.segmentation(
     event="Purchase",
     from_date="2024-01-01",
     to_date="2024-01-31",
-    on="properties.country"
+    on="country"
 )
 
 print(f"Total purchases: {result.total}")

--- a/context/mixpanel_data-design.md
+++ b/context/mixpanel_data-design.md
@@ -987,7 +987,7 @@ result = ws.segmentation(
     event="Purchase",
     from_date="2024-01-01",
     to_date="2024-01-31",
-    on="properties.country"
+    on="country"
 )
 print(f"Total: {result.total}")
 result.df.head(10)

--- a/docs/guide/live-analytics.md
+++ b/docs/guide/live-analytics.md
@@ -41,7 +41,7 @@ Time-series event counts with optional property segmentation:
         event="Purchase",
         from_date="2025-01-01",
         to_date="2025-01-31",
-        on="properties.country"
+        on="country"
     )
 
     # With filtering
@@ -49,7 +49,7 @@ Time-series event counts with optional property segmentation:
         event="Purchase",
         from_date="2025-01-01",
         to_date="2025-01-31",
-        on="properties.country",
+        on="country",
         where='properties["plan"] == "premium"',
         unit="week"  # day, week, month
     )
@@ -112,7 +112,7 @@ Analyze conversion through a sequence of steps:
         funnel_id=12345,
         from_date="2025-01-01",
         to_date="2025-01-31",
-        on="properties.country"
+        on="country"
     )
 
     # Access results
@@ -442,7 +442,7 @@ result = ws.segmentation_numeric(
     event="Purchase",
     from_date="2025-01-01",
     to_date="2025-01-31",
-    on="properties.amount",
+    on="amount",
     type="general"  # or "linear", "logarithmic"
 )
 ```
@@ -454,7 +454,7 @@ result = ws.segmentation_sum(
     event="Purchase",
     from_date="2025-01-01",
     to_date="2025-01-31",
-    on="properties.amount"
+    on="amount"
 )
 # Total revenue per time period
 ```
@@ -466,7 +466,7 @@ result = ws.segmentation_average(
     event="Purchase",
     from_date="2025-01-01",
     to_date="2025-01-31",
-    on="properties.amount"
+    on="amount"
 )
 # Average purchase amount per time period
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ segmentation = ws.segmentation(
     event=events[0].name,
     from_date="2025-01-01",
     to_date="2025-01-31",
-    on="properties.country"
+    on="country"
 )
 
 funnel = ws.funnel(

--- a/specs/001-foundation-layer/contracts/result-types.md
+++ b/specs/001-foundation-layer/contracts/result-types.md
@@ -257,7 +257,7 @@ seg = ws.segmentation(
     event="Purchase",
     from_date="2024-01-01",
     to_date="2024-01-31",
-    on="properties.country",
+    on="country",
 )
 print(f"Total: {seg.total}")
 seg.df.head()

--- a/specs/002-api-client/quickstart.md
+++ b/specs/002-api-client/quickstart.md
@@ -91,7 +91,7 @@ with MixpanelAPIClient(credentials) as client:
         event="Purchase",
         from_date="2024-01-01",
         to_date="2024-01-31",
-        on="properties.country",
+        on='properties["country"]',
         unit="day"
     )
     print(result["data"]["values"])

--- a/specs/009-workspace/quickstart.md
+++ b/specs/009-workspace/quickstart.md
@@ -174,7 +174,7 @@ result = ws.segmentation(
     event="Purchase",
     from_date="2024-01-01",
     to_date="2024-01-31",
-    on="properties.country",
+    on="country",
     unit="week"
 )
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -599,10 +599,10 @@ class TestSegmentation:
 
         with create_mock_client(test_credentials, handler) as client:
             client.segmentation(
-                "Purchase", "2024-01-01", "2024-01-31", on="properties.country"
+                "Purchase", "2024-01-01", "2024-01-31", on='properties["country"]'
             )
 
-        assert captured_params["on"] == "properties.country"
+        assert captured_params["on"] == 'properties["country"]'
 
     def test_segmentation_with_where(self, test_credentials: Credentials) -> None:
         """Should include 'where' filter."""


### PR DESCRIPTION
## Summary
- Fixed incorrect dot notation syntax (`on="properties.country"`) used throughout documentation and examples
- Corrected 15 instances across 9 files to use proper syntax

## Problem
The `on` parameter was incorrectly documented with dot notation like `on="properties.country"`. This syntax gets incorrectly normalized to `properties["properties.country"]`, which attempts to access a property literally named "properties.country" rather than the intended "country" property.

## Solution
Updated all instances to use one of the two correct forms:
1. **Bare property name** (recommended): `on="country"` - automatically wrapped to `properties["country"]`
2. **Full filter expression**: `on='properties["country"]'` - when explicit syntax is needed

## Files Changed
- README.md
- docs/index.md  
- docs/guide/live-analytics.md (6 instances)
- context/mixpanel_data-design.md
- context/mixpanel_data-api-specification.md (2 instances)
- tests/unit/test_api_client.py
- specs/001-foundation-layer/contracts/result-types.md
- specs/002-api-client/quickstart.md
- specs/009-workspace/quickstart.md

## Test Plan
- [x] All unit tests pass
- [x] Verified normalization function correctly handles bare property names
- [x] Confirmed filter expression syntax remains unchanged
- [x] No instances of incorrect dot notation remain in codebase