### PR TITLE
Use volumes for devcontainer config with credential syncing

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,49 @@
+# Dev Container Setup
+
+This project uses a Dev Container for consistent development environments across different machines.
+
+## Configuration Storage & Syncing
+
+The devcontainer uses Docker volumes for configuration directories to ensure it works on any machine, with automatic syncing from your host if configurations exist:
+
+### Automatic Credential Syncing
+- **GitHub CLI config** (`~/.config/gh`): Automatically synced from host if it exists
+- **GCloud credentials** (`~/.config/gcloud`): Automatically synced from host if it exists
+- **Mixpanel config** (`~/.mp`): Stored in volume (create with `mp auth add` if needed)
+
+When you rebuild the container, your existing GitHub and GCloud authentication from the host will be automatically available inside the container. No manual steps required!
+
+### Manual Authentication (if needed)
+If credentials aren't found on your host, you can authenticate inside the container:
+
+```bash
+# GitHub CLI
+gh auth login
+
+# Mixpanel
+mp auth add
+```
+
+Note: GCloud is not installed in the devcontainer. If you need gcloud credentials for Vertex AI, authenticate on your host machine first and the credentials will be synced automatically.
+
+## Benefits of This Approach
+
+- **No setup required**: The container works immediately on new machines without creating directories
+- **Persistent configuration**: Your settings are preserved across container rebuilds
+- **Isolation**: Each project can have its own configuration without affecting your host system
+- **Portability**: The same setup works on macOS, Linux, and Windows
+
+## Environment Variables
+
+The dev container will automatically pass through the following environment variables from your host machine if they are set:
+
+- `CLAUDE_CODE_USE_VERTEX`: Enable Vertex AI for Claude Code
+- `ANTHROPIC_VERTEX_PROJECT_ID`: Vertex AI project ID
+- `CLOUD_ML_REGION`: Cloud ML region
+- `BASH_DEFAULT_TIMEOUT_MS`: Default timeout for bash commands
+
+These are particularly useful if you're using Claude Code with Google Cloud Vertex AI. If these variables aren't set on your host machine, they simply won't be defined in the container.
+
+## Troubleshooting
+
+If you encounter mount errors when building the container, ensure you have the latest version of this repository with the updated `.devcontainer/devcontainer.json` that uses volumes instead of bind mounts for optional directories.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,7 +11,7 @@ The devcontainer uses Docker volumes for configuration directories to ensure it 
 - **GCloud credentials** (`~/.config/gcloud`): Automatically synced from host if it exists
 - **Mixpanel config** (`~/.mp`): Stored in volume (create with `mp auth add` if needed)
 
-When you rebuild the container, your existing GitHub and GCloud authentication from the host will be automatically available inside the container. No manual steps required!
+When you start or rebuild the container, your existing GitHub and GCloud authentication from the host will be automatically available inside the container. No manual steps required!
 
 ### Manual Authentication (if needed)
 If credentials aren't found on your host, you can authenticate inside the container:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,8 +53,9 @@
   "mounts": [
     "source=mixpanel-data-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=mixpanel-data-claude-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
-    "source=${localEnv:HOME}/.mp,target=/home/vscode/.mp,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
+    "source=mixpanel-data-mp-config-${devcontainerId},target=/home/vscode/.mp,type=volume",
+    "source=mixpanel-data-gh-config-${devcontainerId},target=/home/vscode/.config/gh,type=volume",
+    "source=mixpanel-data-gcloud-config-${devcontainerId},target=/home/vscode/.config/gcloud,type=volume"
   ],
   "containerEnv": {
     "PYTHONDONTWRITEBYTECODE": "1",
@@ -64,6 +65,13 @@
     "UV_VENV_CLEAR": "1",
     "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
   },
+  "remoteEnv": {
+    "CLAUDE_CODE_USE_VERTEX": "${localEnv:CLAUDE_CODE_USE_VERTEX}",
+    "ANTHROPIC_VERTEX_PROJECT_ID": "${localEnv:ANTHROPIC_VERTEX_PROJECT_ID}",
+    "CLOUD_ML_REGION": "${localEnv:CLOUD_ML_REGION}",
+    "BASH_DEFAULT_TIMEOUT_MS": "${localEnv:BASH_DEFAULT_TIMEOUT_MS}"
+  },
+  "initializeCommand": ["/bin/bash", ".devcontainer/init-host.sh"],
   "postCreateCommand": ".devcontainer/post-create.sh",
-  "postStartCommand": "uv sync --all-extras"
+  "postStartCommand": ".devcontainer/post-start.sh && uv sync --all-extras"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,5 +73,5 @@
   },
   "initializeCommand": ["/bin/bash", ".devcontainer/init-host.sh"],
   "postCreateCommand": ".devcontainer/post-create.sh",
-  "postStartCommand": ".devcontainer/post-start.sh && uv sync --all-extras"
+  "postStartCommand": ".devcontainer/post-start.sh; uv sync --all-extras"
 }

--- a/.devcontainer/init-host.sh
+++ b/.devcontainer/init-host.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This script runs on the host machine before the container starts
+# It stages credentials for the container to use
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Clean up any previous staging
+rm -rf "$SCRIPT_DIR/.gcloud-staging" "$SCRIPT_DIR/.gh-staging"
+
+# Stage gcloud credentials if they exist
+if [ -f "$HOME/.config/gcloud/application_default_credentials.json" ]; then
+    echo "Staging gcloud credentials for container..."
+    mkdir -p "$SCRIPT_DIR/.gcloud-staging"
+    cp "$HOME/.config/gcloud/application_default_credentials.json" "$SCRIPT_DIR/.gcloud-staging/"
+
+    # Copy other useful gcloud files if they exist
+    [ -f "$HOME/.config/gcloud/active_config" ] && cp "$HOME/.config/gcloud/active_config" "$SCRIPT_DIR/.gcloud-staging/"
+    [ -d "$HOME/.config/gcloud/configurations" ] && cp -r "$HOME/.config/gcloud/configurations" "$SCRIPT_DIR/.gcloud-staging/"
+    echo "GCloud credentials staged"
+fi
+
+# Stage GitHub CLI config if it exists
+if [ -f "$HOME/.config/gh/hosts.yml" ]; then
+    echo "Staging GitHub CLI config for container..."
+    mkdir -p "$SCRIPT_DIR/.gh-staging"
+    cp -r "$HOME/.config/gh/"* "$SCRIPT_DIR/.gh-staging/"
+    echo "GitHub CLI config staged"
+fi

--- a/.devcontainer/init-host.sh
+++ b/.devcontainer/init-host.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # This script runs on the host machine before the container starts
 # It stages credentials for the container to use
 
@@ -8,7 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Clean up any previous staging
 rm -rf "$SCRIPT_DIR/.gcloud-staging" "$SCRIPT_DIR/.gh-staging"
 
-# Stage gcloud credentials if they exist
+# Stage gcloud credentials if ADC exists (the primary credential for Vertex AI)
+# Additional config files are only useful alongside ADC
 if [ -f "$HOME/.config/gcloud/application_default_credentials.json" ]; then
     echo "Staging gcloud credentials for container..."
     mkdir -p "$SCRIPT_DIR/.gcloud-staging"
@@ -24,6 +26,6 @@ fi
 if [ -f "$HOME/.config/gh/hosts.yml" ]; then
     echo "Staging GitHub CLI config for container..."
     mkdir -p "$SCRIPT_DIR/.gh-staging"
-    cp -r "$HOME/.config/gh/"* "$SCRIPT_DIR/.gh-staging/"
+    cp -a "$HOME/.config/gh/." "$SCRIPT_DIR/.gh-staging/"
     echo "GitHub CLI config staged"
 fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script runs inside the container on every start
+# It syncs staged credentials if they exist
+
+# Sync gcloud credentials if staged
+if [ -d "/workspace/.devcontainer/.gcloud-staging" ] && [ -f "/workspace/.devcontainer/.gcloud-staging/application_default_credentials.json" ]; then
+    echo "Syncing gcloud credentials into container..."
+    # Fix ownership of volume (created as root by Docker)
+    sudo chown -R vscode:vscode /home/vscode/.config/gcloud 2>/dev/null || true
+    mkdir -p /home/vscode/.config/gcloud
+    cp -r "/workspace/.devcontainer/.gcloud-staging/"* /home/vscode/.config/gcloud/
+    rm -rf "/workspace/.devcontainer/.gcloud-staging"
+    echo "GCloud credentials synced"
+fi
+
+# Sync GitHub CLI config if staged
+if [ -d "/workspace/.devcontainer/.gh-staging" ] && [ -f "/workspace/.devcontainer/.gh-staging/hosts.yml" ]; then
+    echo "Syncing GitHub CLI config into container..."
+    # Fix ownership of volume (created as root by Docker)
+    sudo chown -R vscode:vscode /home/vscode/.config/gh 2>/dev/null || true
+    mkdir -p /home/vscode/.config/gh
+    cp -r "/workspace/.devcontainer/.gh-staging/"* /home/vscode/.config/gh/
+    rm -rf "/workspace/.devcontainer/.gh-staging"
+    echo "GitHub CLI config synced"
+fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
+set -euo pipefail
 # This script runs inside the container on every start
 # It syncs staged credentials if they exist
+
+# Ensure staging directories are cleaned up even on failure
+trap 'rm -rf "/workspace/.devcontainer/.gcloud-staging" "/workspace/.devcontainer/.gh-staging"' EXIT
 
 # Sync gcloud credentials if staged
 if [ -d "/workspace/.devcontainer/.gcloud-staging" ] && [ -f "/workspace/.devcontainer/.gcloud-staging/application_default_credentials.json" ]; then
     echo "Syncing gcloud credentials into container..."
-    # Fix ownership of volume (created as root by Docker)
-    sudo chown -R vscode:vscode /home/vscode/.config/gcloud 2>/dev/null || true
     mkdir -p /home/vscode/.config/gcloud
-    cp -r "/workspace/.devcontainer/.gcloud-staging/"* /home/vscode/.config/gcloud/
-    rm -rf "/workspace/.devcontainer/.gcloud-staging"
+    # Fix ownership of volume (may have been created as root by Docker)
+    sudo chown -R vscode:vscode /home/vscode/.config/gcloud 2>/dev/null || true
+    cp -a "/workspace/.devcontainer/.gcloud-staging/." /home/vscode/.config/gcloud/
     echo "GCloud credentials synced"
 fi
 
 # Sync GitHub CLI config if staged
 if [ -d "/workspace/.devcontainer/.gh-staging" ] && [ -f "/workspace/.devcontainer/.gh-staging/hosts.yml" ]; then
     echo "Syncing GitHub CLI config into container..."
-    # Fix ownership of volume (created as root by Docker)
-    sudo chown -R vscode:vscode /home/vscode/.config/gh 2>/dev/null || true
     mkdir -p /home/vscode/.config/gh
-    cp -r "/workspace/.devcontainer/.gh-staging/"* /home/vscode/.config/gh/
-    rm -rf "/workspace/.devcontainer/.gh-staging"
+    # Fix ownership of volume (may have been created as root by Docker)
+    sudo chown -R vscode:vscode /home/vscode/.config/gh 2>/dev/null || true
+    cp -a "/workspace/.devcontainer/.gh-staging/." /home/vscode/.config/gh/
     echo "GitHub CLI config synced"
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ man/
 
 # Demo
 demo/
+
+# Credential staging (never commit)
+.devcontainer/.gcloud-staging/
+.devcontainer/.gh-staging/


### PR DESCRIPTION
## Summary

- Replace bind mounts with Docker volumes for gh, gcloud, and mp config directories to improve portability
- Add automatic credential syncing from host to container on every start
- Add remoteEnv passthrough for Vertex AI environment variables

## Changes

- **devcontainer.json**: Switch from bind mounts to named volumes, add `initializeCommand` and `remoteEnv`
- **init-host.sh**: New script that runs on host to stage credentials before container build
- **post-start.sh**: New script that syncs staged credentials into container volumes on start
- **README.md**: Document the setup and credential syncing behavior
- **.gitignore**: Exclude credential staging directories

## Test plan

- [ ] Rebuild devcontainer on a fresh machine without existing config directories
- [ ] Verify GitHub CLI auth is synced from host if it exists
- [ ] Verify gcloud credentials are synced from host if it exists
- [ ] Verify Vertex AI environment variables are passed through