### PR TITLE
fix: prevent Rich console from corrupting JSON output when piped

### DIFF
--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -462,7 +462,9 @@ def output_result(
                 output = json.dumps(results, indent=2)
         else:
             output = format_json(data)
-        console.print(output, highlight=False)
+        # soft_wrap=True prevents Rich from inserting hard line breaks at 80 chars
+        # when piped, which would corrupt JSON by putting newlines inside strings
+        console.print(output, highlight=False, soft_wrap=True)
     elif fmt == "jsonl":
         if jq_filter:
             # Apply jq filter, then output each result as JSONL (one per line)
@@ -470,23 +472,23 @@ def output_result(
             results = _apply_jq_filter(json_str, jq_filter)
             # Output each result element on its own line
             for item in results:
-                console.print(json.dumps(item), highlight=False)
+                console.print(json.dumps(item), highlight=False, soft_wrap=True)
         else:
             output = format_jsonl(data)
-            console.print(output, highlight=False)
+            console.print(output, highlight=False, soft_wrap=True)
     elif fmt == "table":
         table = format_table(data, columns)
         console.print(table)
     elif fmt == "csv":
         output = format_csv(data)
-        console.print(output, highlight=False, end="")
+        console.print(output, highlight=False, soft_wrap=True, end="")
     elif fmt == "plain":
         output = format_plain(data)
-        console.print(output, highlight=False)
+        console.print(output, highlight=False, soft_wrap=True)
     else:
         # Default to JSON for unknown formats
         output = format_json(data)
-        console.print(output, highlight=False)
+        console.print(output, highlight=False, soft_wrap=True)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- Fix Rich's Console.print() inserting hard line breaks at 80 chars when stdout is not a TTY, which corrupts JSON output
- Add `soft_wrap=True` to all console.print() calls for structured data output (JSON, JSONL, CSV, plain)
- Add regression tests to prevent future regressions

## Problem

When piping CLI output to jq (e.g., `mp inspect cohorts --format json | jq 'length'`), Rich's Console would insert literal newlines at 80-character boundaries. If this happened inside a JSON string value, it would corrupt the JSON:

```
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 107, column 39
```

## Root Cause

1. Mixpanel API returns data with control characters in string values (e.g., cohort names with embedded newlines)
2. `json.dumps()` properly escapes these as `\n`
3. Rich's `Console.print()` defaults to 80-character width when stdout is not a TTY
4. Rich inserts hard line breaks at wrap points, putting literal `0x0a` bytes inside JSON strings

## Solution

Add `soft_wrap=True` to prevent Rich from inserting hard line breaks in structured data output.

## Test plan

- [x] Added regression test `test_json_output_uses_soft_wrap_to_prevent_line_corruption`
- [x] Added tests for JSONL and CSV formats
- [x] All existing tests pass (`just check`)
- [x] Manual verification: simulated problematic data now pipes correctly to jq