### PR TITLE
fix: prevent Rich from stripping bracket-prefixed content

### DIFF
--- a/src/mixpanel_data/cli/formatters.py
+++ b/src/mixpanel_data/cli/formatters.py
@@ -16,6 +16,7 @@ import json
 from datetime import date, datetime
 from typing import Any
 
+from rich.markup import escape as rich_escape
 from rich.table import Table
 
 
@@ -116,7 +117,8 @@ def _format_cell(value: Any) -> str:
     """Format a single cell value for Rich table display.
 
     Converts various Python types to human-readable string representations
-    suitable for display in terminal tables.
+    suitable for display in terminal tables. All output is escaped to prevent
+    Rich from interpreting square brackets as markup tags.
 
     Args:
         value: The value to format. Handles None, bool, datetime, date,
@@ -124,7 +126,8 @@ def _format_cell(value: Any) -> str:
 
     Returns:
         Formatted string: empty for None, "Yes"/"No" for bool, ISO format
-        for dates, JSON for collections, str() for others.
+        for dates, JSON for collections, str() for others. All strings are
+        escaped to prevent Rich markup interpretation.
     """
     if value is None:
         return ""
@@ -133,8 +136,9 @@ def _format_cell(value: Any) -> str:
     if isinstance(value, datetime | date):
         return value.isoformat()
     if isinstance(value, list | dict):
-        return json.dumps(value, default=_json_serializer, ensure_ascii=False)
-    return str(value)
+        result = json.dumps(value, default=_json_serializer, ensure_ascii=False)
+        return rich_escape(result)
+    return rich_escape(str(value))
 
 
 def format_csv(data: dict[str, Any] | list[Any]) -> str:

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -55,25 +55,9 @@ class ResultWithTableAndDict(Protocol):
 
 # Console instances for stdout/stderr separation
 # Data output goes to stdout; progress/errors go to stderr
+# Note: Table cell content is escaped via rich_escape() in formatters.py
 console = Console()
 err_console = Console(stderr=True, no_color=bool(os.environ.get("NO_COLOR")))
-
-# Plain console for machine-readable output (JSON, JSONL, CSV, plain text)
-# Disables all Rich formatting that could corrupt structured data:
-# - markup=False: Prevents [text] from being interpreted as style tags
-# - highlight=False: Disables syntax highlighting of URLs, numbers, UUIDs
-# - emoji=False: Prevents :emoji_name: from being converted to emoji
-# - soft_wrap=True: Disables word wrapping that could break long lines
-# - force_terminal=False: Never emit ANSI escape codes
-# - no_color=True: Belt-and-suspenders for color disabling
-plain_console = Console(
-    markup=False,
-    highlight=False,
-    emoji=False,
-    soft_wrap=True,
-    force_terminal=False,
-    no_color=True,
-)
 
 
 class ExitCode(IntEnum):
@@ -479,7 +463,7 @@ def output_result(
                 output = json.dumps(results, indent=2)
         else:
             output = format_json(data)
-        plain_console.print(output)
+        print(output)
     elif fmt == "jsonl":
         if jq_filter:
             # Apply jq filter, then output each result as JSONL (one per line)
@@ -487,24 +471,24 @@ def output_result(
             results = _apply_jq_filter(json_str, jq_filter)
             # Output each result element on its own line
             for item in results:
-                plain_console.print(json.dumps(item))
+                print(json.dumps(item))
         else:
             output = format_jsonl(data)
-            plain_console.print(output)
+            print(output)
     elif fmt == "table":
-        # Tables use styled console for visual formatting
+        # Tables use styled console for box-drawing characters
         table = format_table(data, columns)
         console.print(table)
     elif fmt == "csv":
         output = format_csv(data)
-        plain_console.print(output, end="")
+        print(output, end="")
     elif fmt == "plain":
         output = format_plain(data)
-        plain_console.print(output)
+        print(output)
     else:
         # Default to JSON for unknown formats
         output = format_json(data)
-        plain_console.print(output)
+        print(output)
 
 
 @contextmanager

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -464,7 +464,8 @@ def output_result(
             output = format_json(data)
         # soft_wrap=True prevents Rich from inserting hard line breaks at 80 chars
         # when piped, which would corrupt JSON by putting newlines inside strings
-        console.print(output, highlight=False, soft_wrap=True)
+        # markup=False prevents Rich from interpreting [...] as markup tags
+        console.print(output, highlight=False, markup=False, soft_wrap=True)
     elif fmt == "jsonl":
         if jq_filter:
             # Apply jq filter, then output each result as JSONL (one per line)
@@ -472,23 +473,23 @@ def output_result(
             results = _apply_jq_filter(json_str, jq_filter)
             # Output each result element on its own line
             for item in results:
-                console.print(json.dumps(item), highlight=False, soft_wrap=True)
+                console.print(json.dumps(item), highlight=False, markup=False, soft_wrap=True)
         else:
             output = format_jsonl(data)
-            console.print(output, highlight=False, soft_wrap=True)
+            console.print(output, highlight=False, markup=False, soft_wrap=True)
     elif fmt == "table":
         table = format_table(data, columns)
         console.print(table)
     elif fmt == "csv":
         output = format_csv(data)
-        console.print(output, highlight=False, soft_wrap=True, end="")
+        console.print(output, highlight=False, markup=False, soft_wrap=True, end="")
     elif fmt == "plain":
         output = format_plain(data)
-        console.print(output, highlight=False, soft_wrap=True)
+        console.print(output, highlight=False, markup=False, soft_wrap=True)
     else:
         # Default to JSON for unknown formats
         output = format_json(data)
-        console.print(output, highlight=False, soft_wrap=True)
+        console.print(output, highlight=False, markup=False, soft_wrap=True)
 
 
 @contextmanager

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -520,11 +520,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "json"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, {"key": "value"})
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             # First argument should be the JSON string
             assert '"key"' in call_args[0][0]
             assert '"value"' in call_args[0][0]
@@ -544,11 +544,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "csv"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, [{"name": "test"}])
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             assert "name" in call_args[0][0]
             assert "test" in call_args[0][0]
 
@@ -557,11 +557,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "plain"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, ["item1", "item2"])
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             assert "item1" in call_args[0][0]
 
     def test_outputs_jsonl_format(self) -> None:
@@ -569,11 +569,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "jsonl"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, [{"a": 1}, {"b": 2}])
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             output = call_args[0][0]
             # JSONL should have one object per line
             lines = output.strip().split("\n")
@@ -584,11 +584,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}  # No format in context
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, {"key": "value"}, format="json")
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             assert '"key"' in call_args[0][0]
 
     def test_explicit_format_overrides_context(self) -> None:
@@ -596,11 +596,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "table"}  # Context says table
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, {"key": "value"}, format="json")  # Explicit json
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             # Should be JSON, not table
             assert '"key"' in call_args[0][0]
             assert '"value"' in call_args[0][0]
@@ -610,11 +610,11 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}  # No format in context
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, {"key": "value"})  # No explicit format
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             # Should default to JSON
             assert '"key"' in call_args[0][0]
 
@@ -623,12 +623,12 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "json"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             data = {"name": "test", "count": 42}
             output_result(ctx, data, format="json", jq_filter=".name")
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             output = call_args[0][0]
             # Should only have the name field extracted
             assert output.strip() == '"test"'
@@ -638,67 +638,67 @@ class TestOutputResult:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "jsonl"}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             data = [{"name": "a"}, {"name": "b"}]
             output_result(ctx, data, format="jsonl", jq_filter=".[0]")
 
-            mock_console.print.assert_called_once()
-            call_args = mock_console.print.call_args
+            mock_print.assert_called_once()
+            call_args = mock_print.call_args
             output = call_args[0][0]
             # Should extract first element
             parsed = json.loads(output.strip())
             assert parsed == {"name": "a"}
 
-    def test_json_output_uses_plain_console(self) -> None:
-        """Test that JSON output uses plain_console for machine-readable output.
+    def test_json_output_uses_builtin_print(self) -> None:
+        """Test that JSON output uses builtin print() for machine-readable output.
 
-        The plain_console is configured with soft_wrap=True, markup=False, and
-        other settings to prevent Rich from corrupting structured data output.
+        Using print() directly avoids Rich formatting issues like markup
+        interpretation, syntax highlighting, and word wrapping.
         """
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {"format": "json"}
 
-        # Data with escaped newline that would appear near column 80 in output
+        # Data with bracket content that Rich would interpret as markup
         data = [
             {
                 "id": 3764793,
-                "name": "Long Name With Newline (Blueprint \n2)92f003ec-uuid",
+                "name": "[dbt] Activation Reached",
                 "count": 0,
-                "description": "",
             }
         ]
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, data, format="json")
 
-            # Verify plain_console.print was called (plain_console has soft_wrap=True)
-            mock_console.print.assert_called_once()
+            # Verify print was called and bracket content preserved
+            mock_print.assert_called_once()
+            output = mock_print.call_args[0][0]
+            assert "[dbt]" in output
 
     @pytest.mark.parametrize(
         "fmt, data",
         [
-            ("jsonl", [{"name": "Value with newline\nin it"}]),
+            ("jsonl", [{"name": "[tag] Value"}]),
             ("csv", [{"name": "test"}]),
-            ("plain", ["a long line of text that might otherwise be wrapped"]),
+            ("plain", ["a long line of text"]),
             ("unknown_format", {"key": "value"}),  # Tests the default case
         ],
     )
-    def test_structured_data_formats_use_plain_console(
+    def test_structured_data_formats_use_builtin_print(
         self, fmt: str, data: Any
     ) -> None:
-        """Test that JSONL, CSV, plain, and default formats use plain_console.
+        """Test that JSONL, CSV, plain, and default formats use builtin print().
 
-        The plain_console is configured with soft_wrap=True, markup=False, and
-        other settings to prevent Rich from corrupting structured data output.
+        Using print() directly avoids Rich formatting issues.
         """
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, data, format=fmt)
 
-            # Verify plain_console.print was called
-            mock_console.print.assert_called_once()
+            # Verify print was called
+            mock_print.assert_called_once()
 
 
 class TestApplyJqFilter:
@@ -899,33 +899,33 @@ class TestOutputResultFormatValidation:
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, {"name": "test"}, format="json", jq_filter=".name")
-            mock_console.print.assert_called_once()
+            mock_print.assert_called_once()
 
     def test_jq_filter_allowed_with_jsonl_format(self) -> None:
         """Test that jq_filter works with jsonl format."""
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             output_result(ctx, [{"a": 1}], format="jsonl", jq_filter=".[0]")
-            mock_console.print.assert_called_once()
+            mock_print.assert_called_once()
 
     def test_jq_filter_jsonl_outputs_per_line(self) -> None:
         """Test that jq filter with jsonl outputs each result on its own line."""
         ctx = MagicMock(spec=typer.Context)
         ctx.obj = {}
 
-        with patch("mixpanel_data.cli.utils.plain_console") as mock_console:
+        with patch("builtins.print") as mock_print:
             # Filter that produces multiple results
             output_result(
                 ctx, [{"x": 1}, {"x": 2}, {"x": 3}], format="jsonl", jq_filter=".[].x"
             )
             # Each result should be printed separately (3 calls for 3 results)
-            assert mock_console.print.call_count == 3
+            assert mock_print.call_count == 3
             # Each call should have a single JSON value (1, 2, 3)
-            calls = mock_console.print.call_args_list
+            calls = mock_print.call_args_list
             assert calls[0][0][0] == "1"
             assert calls[1][0][0] == "2"
             assert calls[2][0][0] == "3"


### PR DESCRIPTION
## Summary

- Fix Rich's `console.print()` silently stripping `[bracket]` content by interpreting it as markup tags
- Use builtin `print()` for machine-readable formats (JSON, JSONL, CSV, plain) instead of Rich console
- Keep Rich console only for table output (provides box-drawing characters)
- Add `rich_escape()` to table cell formatting to preserve brackets in table output

## Problem

Event names like `[dbt] Activation Reached` were being displayed as ` Activation Reached` (leading space, missing prefix). Rich interprets `[text]` as markup tags, and when the tag name isn't a valid style, it silently removes the brackets.

## Solution

- **JSON/JSONL/CSV/plain formats**: Use `print()` directly (no Rich involvement)
- **Table format**: Use `console.print(table)` with cell content escaped via `rich_escape()`
- **Error messages**: Continue using `err_console` for styled output to stderr

## Test plan

- [x] All 1829 tests pass
- [x] Verified `[Company Profile]`, `[Experiments]`, `[Heat Maps]` prefixes preserved in all formats
- [x] Manual QA of JSON, JSONL, table, CSV output with bracket-prefixed event names