### PR TITLE
feat(mp-mcp-server): migrate to FastMCP v3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ demo/
 
 # mp credentials
 .mp/
+
+# fastmcp docs
+context/fastmcp/

--- a/mp-mcp-server/pyproject.toml
+++ b/mp-mcp-server/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=2.0,<3",
+    "fastmcp[tasks]>=3.0.0b1",
     "mixpanel_data",
 ]
 

--- a/mp-mcp-server/src/mp_mcp_server/context.py
+++ b/mp-mcp-server/src/mp_mcp_server/context.py
@@ -53,8 +53,8 @@ def get_workspace(ctx: "Context") -> RateLimitedWorkspace:
             return ws.events()
         ```
     """
-    # FastMCP 2.x stores lifespan state in server._lifespan_result
-    lifespan_state = ctx.fastmcp._lifespan_result
+    # FastMCP 3.0 uses public lifespan_context property
+    lifespan_state = ctx.lifespan_context
 
     if lifespan_state is None or "workspace" not in lifespan_state:
         raise RuntimeError(

--- a/mp-mcp-server/tests/conftest.py
+++ b/mp-mcp-server/tests/conftest.py
@@ -244,8 +244,8 @@ def mock_context(mock_lifespan_state: dict[str, Any]) -> MagicMock:
         MagicMock configured as a FastMCP Context.
     """
     ctx = MagicMock()
-    # FastMCP 2.x stores lifespan state in server._lifespan_result
-    ctx.fastmcp._lifespan_result = mock_lifespan_state
+    # FastMCP 3.0 uses public lifespan_context property
+    ctx.lifespan_context = mock_lifespan_state
     # Make report_progress an async mock for tools that use progress reporting
     ctx.report_progress = AsyncMock(return_value=None)
     return ctx
@@ -265,3 +265,80 @@ async def mcp_client() -> AsyncIterator[Any]:
 
     async with Client(mcp) as client:
         yield client
+
+
+# ============================================================================
+# FastMCP v3 Registration Check Helpers
+# ============================================================================
+
+
+@pytest.fixture
+def registered_tool_names() -> list[str]:
+    """Get list of registered tool names using FastMCP v3 API.
+
+    Returns:
+        List of tool names registered with the MCP server.
+    """
+    import asyncio
+
+    from mp_mcp_server.server import mcp
+
+    async def get_tools() -> list[str]:
+        tools = await mcp.list_tools()
+        return [t.name for t in tools]
+
+    return asyncio.run(get_tools())
+
+
+@pytest.fixture
+def registered_resource_uris() -> list[str]:
+    """Get list of registered resource URIs using FastMCP v3 API.
+
+    Returns:
+        List of resource URIs registered with the MCP server.
+    """
+    import asyncio
+
+    from mp_mcp_server.server import mcp
+
+    async def get_resources() -> list[str]:
+        resources = await mcp.list_resources()
+        return [str(r.uri) for r in resources]
+
+    return asyncio.run(get_resources())
+
+
+@pytest.fixture
+def registered_prompt_names() -> list[str]:
+    """Get list of registered prompt names using FastMCP v3 API.
+
+    Returns:
+        List of prompt names registered with the MCP server.
+    """
+    import asyncio
+
+    from mp_mcp_server.server import mcp
+
+    async def get_prompts() -> list[str]:
+        prompts = await mcp.list_prompts()
+        return [p.name for p in prompts]
+
+    return asyncio.run(get_prompts())
+
+
+@pytest.fixture
+def registered_resource_template_uris() -> list[str]:
+    """Get list of registered resource template URIs using FastMCP v3 API.
+
+    Returns:
+        List of resource template URIs registered with the MCP server.
+    """
+    import asyncio
+
+    from mp_mcp_server.server import mcp
+
+    async def get_templates() -> list[str]:
+        templates = await mcp.list_resource_templates()
+        return [str(t.uri_template) for t in templates]
+
+    return asyncio.run(get_templates())

--- a/mp-mcp-server/tests/conftest.py
+++ b/mp-mcp-server/tests/conftest.py
@@ -5,7 +5,7 @@ including mock Workspace instances and FastMCP client fixtures.
 """
 
 import asyncio
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock
 
@@ -276,18 +276,17 @@ T = TypeVar("T")
 
 
 def _get_mcp_items(
-    list_func: Callable[[], Awaitable[list[T]]], extractor: Callable[[T], str]
+    list_func: Callable[[], Awaitable[Sequence[T]]], extractor: Callable[[T], str]
 ) -> list[str]:
     """Run an async MCP list function and extract item properties.
 
     Args:
-        list_func: Async function that returns a list of MCP items.
+        list_func: Async function that returns a sequence of MCP items.
         extractor: Function to extract a string property from each item.
 
     Returns:
         List of extracted string values.
     """
-    from mp_mcp_server.server import mcp  # noqa: F401 - imported for list_func binding
 
     async def get_items() -> list[str]:
         items = await list_func()

--- a/mp-mcp-server/tests/unit/test_context.py
+++ b/mp-mcp-server/tests/unit/test_context.py
@@ -35,8 +35,8 @@ class TestGetWorkspace:
         from mp_mcp_server.context import get_workspace
 
         ctx = MagicMock()
-        # FastMCP 2.x stores lifespan state in server._lifespan_result
-        ctx.fastmcp._lifespan_result = None
+        # FastMCP 3.0 uses public lifespan_context property
+        ctx.lifespan_context = None
 
         with pytest.raises(RuntimeError, match="Workspace not initialized"):
             get_workspace(ctx)
@@ -46,8 +46,8 @@ class TestGetWorkspace:
         from mp_mcp_server.context import get_workspace
 
         ctx = MagicMock()
-        # FastMCP 2.x stores lifespan state in server._lifespan_result
-        ctx.fastmcp._lifespan_result = {}
+        # FastMCP 3.0 uses public lifespan_context property
+        ctx.lifespan_context = {}
 
         with pytest.raises(RuntimeError, match="Workspace not initialized"):
             get_workspace(ctx)
@@ -60,7 +60,7 @@ class TestGetWorkspace:
 
         ctx = MagicMock()
         # Has workspace but no rate_limiter
-        ctx.fastmcp._lifespan_result = {"workspace": mock_workspace}
+        ctx.lifespan_context = {"workspace": mock_workspace}
 
         with pytest.raises(RuntimeError, match="Rate limiter not initialized"):
             get_workspace(ctx)

--- a/mp-mcp-server/tests/unit/test_prompts.py
+++ b/mp-mcp-server/tests/unit/test_prompts.py
@@ -7,45 +7,41 @@ These tests verify the MCP prompts are registered correctly.
 class TestAnalyticsWorkflowPrompt:
     """Tests for the analytics_workflow prompt."""
 
-    def test_analytics_workflow_prompt_registered(self) -> None:
+    def test_analytics_workflow_prompt_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """analytics_workflow prompt should be registered."""
-        from mp_mcp_server.server import mcp
-
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "analytics_workflow" in prompt_names
+        assert "analytics_workflow" in registered_prompt_names
 
 
 class TestFunnelAnalysisPrompt:
     """Tests for the funnel_analysis prompt."""
 
-    def test_funnel_analysis_prompt_registered(self) -> None:
+    def test_funnel_analysis_prompt_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """funnel_analysis prompt should be registered."""
-        from mp_mcp_server.server import mcp
-
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "funnel_analysis" in prompt_names
+        assert "funnel_analysis" in registered_prompt_names
 
 
 class TestRetentionAnalysisPrompt:
     """Tests for the retention_analysis prompt."""
 
-    def test_retention_analysis_prompt_registered(self) -> None:
+    def test_retention_analysis_prompt_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """retention_analysis prompt should be registered."""
-        from mp_mcp_server.server import mcp
-
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "retention_analysis" in prompt_names
+        assert "retention_analysis" in registered_prompt_names
 
 
 class TestLocalAnalysisWorkflowPrompt:
     """Tests for the local_analysis_workflow prompt."""
 
-    def test_local_analysis_workflow_prompt_registered(self) -> None:
+    def test_local_analysis_workflow_prompt_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """local_analysis_workflow prompt should be registered."""
-        from mp_mcp_server.server import mcp
-
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "local_analysis_workflow" in prompt_names
+        assert "local_analysis_workflow" in registered_prompt_names
 
 
 class TestPromptFunctionality:
@@ -55,7 +51,7 @@ class TestPromptFunctionality:
         """analytics_workflow should return workflow guide content."""
         from mp_mcp_server.prompts import analytics_workflow
 
-        result = str(analytics_workflow.fn())
+        result = str(analytics_workflow())
         assert "# Mixpanel Analytics Workflow" in result
         assert "list_events" in result
         assert "segmentation" in result
@@ -64,7 +60,7 @@ class TestPromptFunctionality:
         """funnel_analysis should return funnel-specific content."""
         from mp_mcp_server.prompts import funnel_analysis
 
-        result = str(funnel_analysis.fn(funnel_name="checkout"))
+        result = str(funnel_analysis(funnel_name="checkout"))
         assert "checkout" in result
         assert "funnel_id" in result
 
@@ -72,7 +68,7 @@ class TestPromptFunctionality:
         """retention_analysis should return retention-specific content."""
         from mp_mcp_server.prompts import retention_analysis
 
-        result = str(retention_analysis.fn(event="login"))
+        result = str(retention_analysis(event="login"))
         assert "login" in result
         assert "born_event" in result
         assert "Day 7 retention" in result
@@ -81,7 +77,7 @@ class TestPromptFunctionality:
         """local_analysis_workflow should return SQL analysis guide."""
         from mp_mcp_server.prompts import local_analysis_workflow
 
-        result = str(local_analysis_workflow.fn())
+        result = str(local_analysis_workflow())
         assert "# Local Data Analysis Workflow" in result
         assert "fetch_events" in result
         assert "SQL" in result
@@ -90,7 +86,7 @@ class TestPromptFunctionality:
         """gqm_decomposition should return GQM framework content."""
         from mp_mcp_server.prompts import gqm_decomposition
 
-        result = str(gqm_decomposition.fn(goal="improve retention"))
+        result = str(gqm_decomposition(goal="improve retention"))
         assert "# Goal-Question-Metric (GQM) Investigation Framework" in result
         assert "improve retention" in result
         assert "Metrics" in result
@@ -99,14 +95,14 @@ class TestPromptFunctionality:
         """gqm_decomposition should use default goal."""
         from mp_mcp_server.prompts import gqm_decomposition
 
-        result = str(gqm_decomposition.fn())
+        result = str(gqm_decomposition())
         assert "understand user retention" in result
 
     def test_growth_accounting_returns_content(self) -> None:
         """growth_accounting should return AARRR framework content."""
         from mp_mcp_server.prompts import growth_accounting
 
-        result = str(growth_accounting.fn(acquisition_event="register"))
+        result = str(growth_accounting(acquisition_event="register"))
         assert "# Growth Accounting: AARRR Framework Analysis" in result
         assert "register" in result
         assert "Acquisition" in result
@@ -117,14 +113,14 @@ class TestPromptFunctionality:
         """growth_accounting should use default acquisition event."""
         from mp_mcp_server.prompts import growth_accounting
 
-        result = str(growth_accounting.fn())
+        result = str(growth_accounting())
         assert "signup" in result
 
     def test_experiment_analysis_returns_content(self) -> None:
         """experiment_analysis should return A/B test guidance."""
         from mp_mcp_server.prompts import experiment_analysis
 
-        result = str(experiment_analysis.fn(experiment_name="button_color_test"))
+        result = str(experiment_analysis(experiment_name="button_color_test"))
         assert "# A/B Test Analysis: button_color_test" in result
         assert "Statistical significance" in result
         assert "control" in result
@@ -134,14 +130,14 @@ class TestPromptFunctionality:
         """experiment_analysis should use default experiment name."""
         from mp_mcp_server.prompts import experiment_analysis
 
-        result = str(experiment_analysis.fn())
+        result = str(experiment_analysis())
         assert "homepage_redesign" in result
 
     def test_data_quality_audit_returns_content(self) -> None:
         """data_quality_audit should return audit checklist."""
         from mp_mcp_server.prompts import data_quality_audit
 
-        result = str(data_quality_audit.fn(event="purchase"))
+        result = str(data_quality_audit(event="purchase"))
         assert "# Data Quality Audit: purchase" in result
         assert "purchase" in result
         assert "Coverage" in result
@@ -151,37 +147,33 @@ class TestPromptFunctionality:
         """data_quality_audit should use default event."""
         from mp_mcp_server.prompts import data_quality_audit
 
-        result = str(data_quality_audit.fn())
+        result = str(data_quality_audit())
         assert "signup" in result
 
 
 class TestAllPromptsRegistered:
     """Verify all prompts are registered with MCP server."""
 
-    def test_gqm_decomposition_registered(self) -> None:
+    def test_gqm_decomposition_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """gqm_decomposition should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "gqm_decomposition" in registered_prompt_names
 
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "gqm_decomposition" in prompt_names
-
-    def test_growth_accounting_registered(self) -> None:
+    def test_growth_accounting_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """growth_accounting should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "growth_accounting" in registered_prompt_names
 
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "growth_accounting" in prompt_names
-
-    def test_experiment_analysis_registered(self) -> None:
+    def test_experiment_analysis_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """experiment_analysis should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "experiment_analysis" in registered_prompt_names
 
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "experiment_analysis" in prompt_names
-
-    def test_data_quality_audit_registered(self) -> None:
+    def test_data_quality_audit_registered(
+        self, registered_prompt_names: list[str]
+    ) -> None:
         """data_quality_audit should be registered."""
-        from mp_mcp_server.server import mcp
-
-        prompt_names = list(mcp._prompt_manager._prompts.keys())
-        assert "data_quality_audit" in prompt_names
+        assert "data_quality_audit" in registered_prompt_names

--- a/mp-mcp-server/tests/unit/test_prompts.py
+++ b/mp-mcp-server/tests/unit/test_prompts.py
@@ -51,7 +51,7 @@ class TestPromptFunctionality:
         """analytics_workflow should return workflow guide content."""
         from mp_mcp_server.prompts import analytics_workflow
 
-        result = str(analytics_workflow())
+        result = str(analytics_workflow())  # type: ignore[operator]
         assert "# Mixpanel Analytics Workflow" in result
         assert "list_events" in result
         assert "segmentation" in result
@@ -60,7 +60,7 @@ class TestPromptFunctionality:
         """funnel_analysis should return funnel-specific content."""
         from mp_mcp_server.prompts import funnel_analysis
 
-        result = str(funnel_analysis(funnel_name="checkout"))
+        result = str(funnel_analysis(funnel_name="checkout"))  # type: ignore[operator]
         assert "checkout" in result
         assert "funnel_id" in result
 
@@ -68,7 +68,7 @@ class TestPromptFunctionality:
         """retention_analysis should return retention-specific content."""
         from mp_mcp_server.prompts import retention_analysis
 
-        result = str(retention_analysis(event="login"))
+        result = str(retention_analysis(event="login"))  # type: ignore[operator]
         assert "login" in result
         assert "born_event" in result
         assert "Day 7 retention" in result
@@ -77,7 +77,7 @@ class TestPromptFunctionality:
         """local_analysis_workflow should return SQL analysis guide."""
         from mp_mcp_server.prompts import local_analysis_workflow
 
-        result = str(local_analysis_workflow())
+        result = str(local_analysis_workflow())  # type: ignore[operator]
         assert "# Local Data Analysis Workflow" in result
         assert "fetch_events" in result
         assert "SQL" in result
@@ -86,7 +86,7 @@ class TestPromptFunctionality:
         """gqm_decomposition should return GQM framework content."""
         from mp_mcp_server.prompts import gqm_decomposition
 
-        result = str(gqm_decomposition(goal="improve retention"))
+        result = str(gqm_decomposition(goal="improve retention"))  # type: ignore[operator]
         assert "# Goal-Question-Metric (GQM) Investigation Framework" in result
         assert "improve retention" in result
         assert "Metrics" in result
@@ -95,14 +95,14 @@ class TestPromptFunctionality:
         """gqm_decomposition should use default goal."""
         from mp_mcp_server.prompts import gqm_decomposition
 
-        result = str(gqm_decomposition())
+        result = str(gqm_decomposition())  # type: ignore[operator]
         assert "understand user retention" in result
 
     def test_growth_accounting_returns_content(self) -> None:
         """growth_accounting should return AARRR framework content."""
         from mp_mcp_server.prompts import growth_accounting
 
-        result = str(growth_accounting(acquisition_event="register"))
+        result = str(growth_accounting(acquisition_event="register"))  # type: ignore[operator]
         assert "# Growth Accounting: AARRR Framework Analysis" in result
         assert "register" in result
         assert "Acquisition" in result
@@ -113,14 +113,14 @@ class TestPromptFunctionality:
         """growth_accounting should use default acquisition event."""
         from mp_mcp_server.prompts import growth_accounting
 
-        result = str(growth_accounting())
+        result = str(growth_accounting())  # type: ignore[operator]
         assert "signup" in result
 
     def test_experiment_analysis_returns_content(self) -> None:
         """experiment_analysis should return A/B test guidance."""
         from mp_mcp_server.prompts import experiment_analysis
 
-        result = str(experiment_analysis(experiment_name="button_color_test"))
+        result = str(experiment_analysis(experiment_name="button_color_test"))  # type: ignore[operator]
         assert "# A/B Test Analysis: button_color_test" in result
         assert "Statistical significance" in result
         assert "control" in result
@@ -130,14 +130,14 @@ class TestPromptFunctionality:
         """experiment_analysis should use default experiment name."""
         from mp_mcp_server.prompts import experiment_analysis
 
-        result = str(experiment_analysis())
+        result = str(experiment_analysis())  # type: ignore[operator]
         assert "homepage_redesign" in result
 
     def test_data_quality_audit_returns_content(self) -> None:
         """data_quality_audit should return audit checklist."""
         from mp_mcp_server.prompts import data_quality_audit
 
-        result = str(data_quality_audit(event="purchase"))
+        result = str(data_quality_audit(event="purchase"))  # type: ignore[operator]
         assert "# Data Quality Audit: purchase" in result
         assert "purchase" in result
         assert "Coverage" in result
@@ -147,7 +147,7 @@ class TestPromptFunctionality:
         """data_quality_audit should use default event."""
         from mp_mcp_server.prompts import data_quality_audit
 
-        result = str(data_quality_audit())
+        result = str(data_quality_audit())  # type: ignore[operator]
         assert "signup" in result
 
 

--- a/mp-mcp-server/tests/unit/test_resources.py
+++ b/mp-mcp-server/tests/unit/test_resources.py
@@ -419,30 +419,24 @@ class TestChurnInvestigationRecipeLogic:
 class TestResourceRegistration:
     """Tests for resource registration with MCP server."""
 
-    def test_resources_are_registered(self) -> None:
+    def test_resources_are_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """All resources should be registered with MCP server."""
-        from mp_mcp_server.server import mcp
-
-        # Check resources are registered
-        resources = list(mcp._resource_manager._resources.keys())
-
         # Static resources
-        assert "workspace://info" in resources
-        assert "workspace://tables" in resources
-        assert "schema://events" in resources
-        assert "schema://funnels" in resources
-        assert "schema://cohorts" in resources
-        assert "schema://bookmarks" in resources
-        assert "recipes://weekly-review" in resources
-        assert "recipes://churn-investigation" in resources
+        assert "workspace://info" in registered_resource_uris
+        assert "workspace://tables" in registered_resource_uris
+        assert "schema://events" in registered_resource_uris
+        assert "schema://funnels" in registered_resource_uris
+        assert "schema://cohorts" in registered_resource_uris
+        assert "schema://bookmarks" in registered_resource_uris
+        assert "recipes://weekly-review" in registered_resource_uris
+        assert "recipes://churn-investigation" in registered_resource_uris
 
-    def test_resource_templates_are_registered(self) -> None:
+    def test_resource_templates_are_registered(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """Resource templates should be registered with MCP server."""
-        from mp_mcp_server.server import mcp
-
-        # Check templates are registered
-        templates = list(mcp._resource_manager._templates.keys())
-
-        assert "analysis://retention/{event}/weekly" in templates
-        assert "analysis://trends/{event}/{days}" in templates
-        assert "users://{id}/journey" in templates
+        assert "analysis://retention/{event}/weekly" in registered_resource_template_uris
+        assert "analysis://trends/{event}/{days}" in registered_resource_template_uris
+        assert "users://{id}/journey" in registered_resource_template_uris

--- a/mp-mcp-server/tests/unit/test_resources_dynamic.py
+++ b/mp-mcp-server/tests/unit/test_resources_dynamic.py
@@ -54,114 +54,106 @@ class TestDateRangeHelper:
 class TestResourceTemplateRegistration:
     """Tests for dynamic resource template registration."""
 
-    def test_retention_weekly_registered(self) -> None:
+    def test_retention_weekly_registered(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """Retention weekly resource template should be registered."""
-        from mp_mcp_server.server import mcp
+        assert any("retention" in uri for uri in registered_resource_template_uris)
 
-        template_keys = list(mcp._resource_manager._templates)
-        assert any("retention" in str(k) for k in template_keys)
-
-    def test_trends_registered(self) -> None:
+    def test_trends_registered(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """Trends resource template should be registered."""
-        from mp_mcp_server.server import mcp
+        assert any("trends" in uri for uri in registered_resource_template_uris)
 
-        template_keys = list(mcp._resource_manager._templates)
-        assert any("trends" in str(k) for k in template_keys)
-
-    def test_user_journey_registered(self) -> None:
+    def test_user_journey_registered(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """User journey resource template should be registered."""
-        from mp_mcp_server.server import mcp
+        assert any("journey" in uri for uri in registered_resource_template_uris)
 
-        template_keys = list(mcp._resource_manager._templates)
-        assert any("journey" in str(k) for k in template_keys)
-
-    def test_weekly_review_registered(self) -> None:
+    def test_weekly_review_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """Weekly review recipe should be registered."""
-        from mp_mcp_server.server import mcp
+        assert any("weekly-review" in uri for uri in registered_resource_uris)
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert any("weekly-review" in str(k) for k in resource_keys)
-
-    def test_churn_investigation_registered(self) -> None:
+    def test_churn_investigation_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """Churn investigation recipe should be registered."""
-        from mp_mcp_server.server import mcp
-
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert any("churn-investigation" in str(k) for k in resource_keys)
+        assert any("churn-investigation" in uri for uri in registered_resource_uris)
 
 
 class TestStaticResourceRegistration:
     """Tests for static resource registration."""
 
-    def test_workspace_info_registered(self) -> None:
+    def test_workspace_info_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """workspace://info resource should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "workspace://info" in registered_resource_uris
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "workspace://info" in resource_keys
-
-    def test_tables_registered(self) -> None:
+    def test_tables_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """workspace://tables resource should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "workspace://tables" in registered_resource_uris
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "workspace://tables" in resource_keys
-
-    def test_events_registered(self) -> None:
+    def test_events_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """schema://events resource should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "schema://events" in registered_resource_uris
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "schema://events" in resource_keys
-
-    def test_funnels_registered(self) -> None:
+    def test_funnels_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """schema://funnels resource should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "schema://funnels" in registered_resource_uris
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "schema://funnels" in resource_keys
-
-    def test_cohorts_registered(self) -> None:
+    def test_cohorts_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """schema://cohorts resource should be registered."""
-        from mp_mcp_server.server import mcp
+        assert "schema://cohorts" in registered_resource_uris
 
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "schema://cohorts" in resource_keys
-
-    def test_bookmarks_registered(self) -> None:
+    def test_bookmarks_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
         """schema://bookmarks resource should be registered."""
-        from mp_mcp_server.server import mcp
-
-        resource_keys = list(mcp._resource_manager._resources.keys())
-        assert "schema://bookmarks" in resource_keys
+        assert "schema://bookmarks" in registered_resource_uris
 
 
 class TestResourceTemplatePatterns:
     """Tests for resource template URI patterns."""
 
-    def test_retention_template_has_event_param(self) -> None:
+    def test_retention_template_has_event_param(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """Retention template should have event parameter."""
-        from mp_mcp_server.server import mcp
+        retention_templates = [
+            uri for uri in registered_resource_template_uris if "retention" in uri
+        ]
+        assert any("{event}" in uri for uri in retention_templates)
 
-        template_keys = [str(k) for k in mcp._resource_manager._templates]
-        retention_templates = [k for k in template_keys if "retention" in k]
-        assert any("{event}" in k for k in retention_templates)
-
-    def test_trends_template_has_event_and_days(self) -> None:
+    def test_trends_template_has_event_and_days(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """Trends template should have event and days parameters."""
-        from mp_mcp_server.server import mcp
+        trends_templates = [
+            uri for uri in registered_resource_template_uris if "trends" in uri
+        ]
+        assert any("{event}" in uri and "{days}" in uri for uri in trends_templates)
 
-        template_keys = [str(k) for k in mcp._resource_manager._templates]
-        trends_templates = [k for k in template_keys if "trends" in k]
-        assert any("{event}" in k and "{days}" in k for k in trends_templates)
-
-    def test_user_journey_template_has_id(self) -> None:
+    def test_user_journey_template_has_id(
+        self, registered_resource_template_uris: list[str]
+    ) -> None:
         """User journey template should have id parameter."""
-        from mp_mcp_server.server import mcp
-
-        template_keys = [str(k) for k in mcp._resource_manager._templates]
-        journey_templates = [k for k in template_keys if "journey" in k]
-        assert any("{id}" in k for k in journey_templates)
+        journey_templates = [
+            uri for uri in registered_resource_template_uris if "journey" in uri
+        ]
+        assert any("{id}" in uri for uri in journey_templates)
 
 
 class TestResourceModuleExports:

--- a/mp-mcp-server/tests/unit/test_tools_composed.py
+++ b/mp-mcp-server/tests/unit/test_tools_composed.py
@@ -91,12 +91,9 @@ class TestCohortHelpers:
 class TestCohortComparisonTool:
     """Tests for the cohort_comparison tool."""
 
-    def test_tool_registered(self) -> None:
+    def test_tool_registered(self, registered_tool_names: list[str]) -> None:
         """cohort_comparison tool should be registered."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "cohort_comparison" in tool_names
+        assert "cohort_comparison" in registered_tool_names
 
     def test_cohort_comparison_basic(self, mock_context: MagicMock) -> None:
         """cohort_comparison should return comparison results."""
@@ -108,9 +105,9 @@ class TestCohortComparisonTool:
             {"key": ["login", "cohort_a"], "value": 100},
             {"key": ["login", "cohort_b"], "value": 50},
         ]
-        mock_context.fastmcp._lifespan_result["workspace"].jql.return_value = jql_result
+        mock_context.lifespan_context["workspace"].jql.return_value = jql_result
 
-        result = cohort_comparison.fn(
+        result = cohort_comparison(
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -187,18 +184,15 @@ class TestDashboardHelpers:
 class TestProductHealthDashboardTool:
     """Tests for the product_health_dashboard tool."""
 
-    def test_tool_registered(self) -> None:
+    def test_tool_registered(self, registered_tool_names: list[str]) -> None:
         """product_health_dashboard tool should be registered."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "product_health_dashboard" in tool_names
+        assert "product_health_dashboard" in registered_tool_names
 
     def test_dashboard_basic(self, mock_context: MagicMock) -> None:
         """product_health_dashboard should return AARRR metrics."""
         from mp_mcp_server.tools.composed.dashboard import product_health_dashboard
 
-        result = product_health_dashboard.fn(mock_context)
+        result = product_health_dashboard(mock_context)
 
         assert "period" in result
         assert "acquisition" in result
@@ -209,7 +203,7 @@ class TestProductHealthDashboardTool:
         """product_health_dashboard should accept custom events."""
         from mp_mcp_server.tools.composed.dashboard import product_health_dashboard
 
-        result = product_health_dashboard.fn(
+        result = product_health_dashboard(
             mock_context,
             acquisition_event="register",
             revenue_event="purchase",
@@ -262,18 +256,15 @@ class TestGQMHelpers:
 class TestGQMInvestigationTool:
     """Tests for the gqm_investigation tool."""
 
-    def test_tool_registered(self) -> None:
+    def test_tool_registered(self, registered_tool_names: list[str]) -> None:
         """gqm_investigation tool should be registered."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "gqm_investigation" in tool_names
+        assert "gqm_investigation" in registered_tool_names
 
     def test_investigation_basic(self, mock_context: MagicMock) -> None:
         """gqm_investigation should return investigation results."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation.fn(
+        result = gqm_investigation(
             mock_context,
             goal="understand why retention is declining",
         )
@@ -290,7 +281,7 @@ class TestGQMInvestigationTool:
         """gqm_investigation should classify the goal."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation.fn(
+        result = gqm_investigation(
             mock_context,
             goal="analyze signup performance",
         )
@@ -301,7 +292,7 @@ class TestGQMInvestigationTool:
         """gqm_investigation should accept custom dates."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation.fn(
+        result = gqm_investigation(
             mock_context,
             goal="retention analysis",
             from_date="2024-01-01",
@@ -320,7 +311,7 @@ class TestDashboardComputeFunctions:
         from mp_mcp_server.tools.composed.dashboard import _compute_acquisition
 
         # Set up mock segmentation response with series data
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.return_value = (
+        mock_context.lifespan_context["workspace"].segmentation.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "total": 1500,
@@ -343,7 +334,7 @@ class TestDashboardComputeFunctions:
         """_compute_acquisition should support segmentation."""
         from mp_mcp_server.tools.composed.dashboard import _compute_acquisition
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.return_value = (
+        mock_context.lifespan_context["workspace"].segmentation.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "total": 1500,
@@ -370,7 +361,7 @@ class TestDashboardComputeFunctions:
         """_compute_acquisition should handle errors gracefully."""
         from mp_mcp_server.tools.composed.dashboard import _compute_acquisition
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.side_effect = (
+        mock_context.lifespan_context["workspace"].segmentation.side_effect = (
             Exception("API error")
         )
 
@@ -390,7 +381,7 @@ class TestDashboardComputeFunctions:
         """_compute_activation should compute activation rate."""
         from mp_mcp_server.tools.composed.dashboard import _compute_activation
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.return_value = (
+        mock_context.lifespan_context["workspace"].segmentation.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "total": 1000,
@@ -415,7 +406,7 @@ class TestDashboardComputeFunctions:
         """_compute_activation should handle errors gracefully."""
         from mp_mcp_server.tools.composed.dashboard import _compute_activation
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.side_effect = (
+        mock_context.lifespan_context["workspace"].segmentation.side_effect = (
             Exception("API error")
         )
 
@@ -434,7 +425,7 @@ class TestDashboardComputeFunctions:
         """_compute_retention should compute retention metrics."""
         from mp_mcp_server.tools.composed.dashboard import _compute_retention
 
-        mock_context.fastmcp._lifespan_result["workspace"].retention.return_value = (
+        mock_context.lifespan_context["workspace"].retention.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "data": {
@@ -457,7 +448,7 @@ class TestDashboardComputeFunctions:
         """_compute_retention should handle errors gracefully."""
         from mp_mcp_server.tools.composed.dashboard import _compute_retention
 
-        mock_context.fastmcp._lifespan_result["workspace"].retention.side_effect = (
+        mock_context.lifespan_context["workspace"].retention.side_effect = (
             Exception("API error")
         )
 
@@ -474,7 +465,7 @@ class TestDashboardComputeFunctions:
         """_compute_revenue should compute revenue metrics."""
         from mp_mcp_server.tools.composed.dashboard import _compute_revenue
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.return_value = (
+        mock_context.lifespan_context["workspace"].segmentation.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "total": 5000,
@@ -511,7 +502,7 @@ class TestDashboardComputeFunctions:
         """_compute_revenue should handle errors gracefully."""
         from mp_mcp_server.tools.composed.dashboard import _compute_revenue
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.side_effect = (
+        mock_context.lifespan_context["workspace"].segmentation.side_effect = (
             Exception("API error")
         )
 
@@ -529,7 +520,7 @@ class TestDashboardComputeFunctions:
         """_compute_referral should compute referral metrics."""
         from mp_mcp_server.tools.composed.dashboard import _compute_referral
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.return_value = (
+        mock_context.lifespan_context["workspace"].segmentation.return_value = (
             MagicMock(
                 to_dict=lambda: {
                     "total": 200,
@@ -566,7 +557,7 @@ class TestDashboardComputeFunctions:
         """_compute_referral should handle errors gracefully."""
         from mp_mcp_server.tools.composed.dashboard import _compute_referral
 
-        mock_context.fastmcp._lifespan_result["workspace"].segmentation.side_effect = (
+        mock_context.lifespan_context["workspace"].segmentation.side_effect = (
             Exception("API error")
         )
 
@@ -882,12 +873,11 @@ class TestCohortHelpersExtended:
 class TestCohortComparison:
     """Tests for cohort_comparison tool."""
 
-    def test_cohort_comparison_tool_registered(self) -> None:
+    def test_cohort_comparison_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
         """cohort_comparison tool should be registered."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "cohort_comparison" in tool_names
+        assert "cohort_comparison" in registered_tool_names
 
     def test_cohort_comparison_with_mock(self, mock_context: MagicMock) -> None:
         """cohort_comparison should call JQL with proper scripts."""
@@ -899,9 +889,9 @@ class TestCohortComparison:
             {"key": ["login", "cohort_a"], "value": 100},
             {"key": ["login", "cohort_b"], "value": 50},
         ]
-        mock_context.fastmcp._lifespan_result["workspace"].jql.return_value = jql_mock
+        mock_context.lifespan_context["workspace"].jql.return_value = jql_mock
 
-        result = cohort_comparison.fn(
+        result = cohort_comparison(
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -917,11 +907,11 @@ class TestCohortComparison:
         """cohort_comparison should handle JQL errors."""
         from mp_mcp_server.tools.composed.cohort import cohort_comparison
 
-        mock_context.fastmcp._lifespan_result["workspace"].jql.side_effect = (
+        mock_context.lifespan_context["workspace"].jql.side_effect = (
             Exception("JQL error")
         )
 
-        result = cohort_comparison.fn(
+        result = cohort_comparison(
             mock_context,
             cohort_a_filter='properties["country"] == "US"',
             cohort_b_filter='properties["country"] == "UK"',
@@ -940,9 +930,9 @@ class TestCohortComparison:
         # Return an object that is neither a list nor has .raw attribute
         jql_mock = MagicMock(spec=[])  # Empty spec = no attributes
         del jql_mock.raw  # Ensure .raw doesn't exist
-        mock_context.fastmcp._lifespan_result["workspace"].jql.return_value = jql_mock
+        mock_context.lifespan_context["workspace"].jql.return_value = jql_mock
 
-        result = cohort_comparison.fn(
+        result = cohort_comparison(
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -965,9 +955,9 @@ class TestCohortComparison:
             {"key": ["login", "cohort_a"], "value": 100},
             {"key": ["login", "cohort_b"], "value": 50},
         ]
-        mock_context.fastmcp._lifespan_result["workspace"].jql.return_value = jql_result
+        mock_context.lifespan_context["workspace"].jql.return_value = jql_result
 
-        result = cohort_comparison.fn(
+        result = cohort_comparison(
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',

--- a/mp-mcp-server/tests/unit/test_tools_composed.py
+++ b/mp-mcp-server/tests/unit/test_tools_composed.py
@@ -107,7 +107,7 @@ class TestCohortComparisonTool:
         ]
         mock_context.lifespan_context["workspace"].jql.return_value = jql_result
 
-        result = cohort_comparison(
+        result = cohort_comparison(  # type: ignore[operator]
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -192,7 +192,7 @@ class TestProductHealthDashboardTool:
         """product_health_dashboard should return AARRR metrics."""
         from mp_mcp_server.tools.composed.dashboard import product_health_dashboard
 
-        result = product_health_dashboard(mock_context)
+        result = product_health_dashboard(mock_context)  # type: ignore[operator]
 
         assert "period" in result
         assert "acquisition" in result
@@ -203,7 +203,7 @@ class TestProductHealthDashboardTool:
         """product_health_dashboard should accept custom events."""
         from mp_mcp_server.tools.composed.dashboard import product_health_dashboard
 
-        result = product_health_dashboard(
+        result = product_health_dashboard(  # type: ignore[operator]
             mock_context,
             acquisition_event="register",
             revenue_event="purchase",
@@ -264,7 +264,7 @@ class TestGQMInvestigationTool:
         """gqm_investigation should return investigation results."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation(
+        result = gqm_investigation(  # type: ignore[operator]
             mock_context,
             goal="understand why retention is declining",
         )
@@ -281,7 +281,7 @@ class TestGQMInvestigationTool:
         """gqm_investigation should classify the goal."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation(
+        result = gqm_investigation(  # type: ignore[operator]
             mock_context,
             goal="analyze signup performance",
         )
@@ -292,7 +292,7 @@ class TestGQMInvestigationTool:
         """gqm_investigation should accept custom dates."""
         from mp_mcp_server.tools.composed.gqm import gqm_investigation
 
-        result = gqm_investigation(
+        result = gqm_investigation(  # type: ignore[operator]
             mock_context,
             goal="retention analysis",
             from_date="2024-01-01",
@@ -891,7 +891,7 @@ class TestCohortComparison:
         ]
         mock_context.lifespan_context["workspace"].jql.return_value = jql_mock
 
-        result = cohort_comparison(
+        result = cohort_comparison(  # type: ignore[operator]
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -911,7 +911,7 @@ class TestCohortComparison:
             Exception("JQL error")
         )
 
-        result = cohort_comparison(
+        result = cohort_comparison(  # type: ignore[operator]
             mock_context,
             cohort_a_filter='properties["country"] == "US"',
             cohort_b_filter='properties["country"] == "UK"',
@@ -932,7 +932,7 @@ class TestCohortComparison:
         del jql_mock.raw  # Ensure .raw doesn't exist
         mock_context.lifespan_context["workspace"].jql.return_value = jql_mock
 
-        result = cohort_comparison(
+        result = cohort_comparison(  # type: ignore[operator]
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',
@@ -957,7 +957,7 @@ class TestCohortComparison:
         ]
         mock_context.lifespan_context["workspace"].jql.return_value = jql_result
 
-        result = cohort_comparison(
+        result = cohort_comparison(  # type: ignore[operator]
             mock_context,
             cohort_a_filter='properties["sessions"] >= 10',
             cohort_b_filter='properties["sessions"] < 3',

--- a/mp-mcp-server/tests/unit/test_tools_discovery.py
+++ b/mp-mcp-server/tests/unit/test_tools_discovery.py
@@ -10,30 +10,28 @@ from unittest.mock import MagicMock
 class TestListEventsTools:
     """Tests for the list_events tool."""
 
-    def test_list_events_tool_registered(self) -> None:
+    def test_list_events_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
         """list_events tool should be registered with the MCP server."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "list_events" in tool_names
+        assert "list_events" in registered_tool_names
 
     def test_list_events_returns_event_names(self, mock_context: MagicMock) -> None:
         """list_events should return event names from Workspace."""
         from mp_mcp_server.tools.discovery import list_events
 
-        result = list_events.fn(mock_context)
+        result = list_events(mock_context)
         assert result == ["signup", "login", "purchase"]
 
 
 class TestListPropertiesTools:
     """Tests for the list_properties tool."""
 
-    def test_list_properties_tool_registered(self) -> None:
+    def test_list_properties_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
         """list_properties tool should be registered with the MCP server."""
-        from mp_mcp_server.server import mcp
-
-        tool_names = list(mcp._tool_manager._tools.keys())
-        assert "list_properties" in tool_names
+        assert "list_properties" in registered_tool_names
 
     def test_list_properties_returns_property_names(
         self, mock_context: MagicMock
@@ -41,7 +39,7 @@ class TestListPropertiesTools:
         """list_properties should return property info from Workspace."""
         from mp_mcp_server.tools.discovery import list_properties
 
-        result = list_properties.fn(mock_context, event="signup")
+        result = list_properties(mock_context, event="signup")
         assert len(result) == 2
         assert result[0]["name"] == "browser"
 
@@ -53,7 +51,7 @@ class TestListPropertyValuesTools:
         """list_property_values should return sample values."""
         from mp_mcp_server.tools.discovery import list_property_values
 
-        result = list_property_values.fn(
+        result = list_property_values(
             mock_context, event="signup", property_name="browser"
         )
         assert result == ["Chrome", "Firefox", "Safari"]
@@ -66,7 +64,7 @@ class TestListFunnelsTools:
         """list_funnels should return funnel metadata."""
         from mp_mcp_server.tools.discovery import list_funnels
 
-        result = list_funnels.fn(mock_context)
+        result = list_funnels(mock_context)
         assert len(result) == 1
         assert result[0]["name"] == "Signup Funnel"
 
@@ -78,7 +76,7 @@ class TestListCohortsTools:
         """list_cohorts should return cohort metadata."""
         from mp_mcp_server.tools.discovery import list_cohorts
 
-        result = list_cohorts.fn(mock_context)
+        result = list_cohorts(mock_context)
         assert len(result) == 1
         assert result[0]["name"] == "Active Users"
 
@@ -92,7 +90,7 @@ class TestListBookmarksTools:
         """list_bookmarks should return saved report metadata with pagination info."""
         from mp_mcp_server.tools.discovery import list_bookmarks
 
-        result = list_bookmarks.fn(mock_context)
+        result = list_bookmarks(mock_context)
         # New format returns dict with bookmarks list and pagination metadata
         assert "bookmarks" in result
         assert "truncated" in result
@@ -110,7 +108,7 @@ class TestTopEventsTools:
         """top_events should return events ranked by activity."""
         from mp_mcp_server.tools.discovery import top_events
 
-        result = top_events.fn(mock_context)
+        result = top_events(mock_context)
         assert len(result) == 2
         assert result[0]["event"] == "login"
         assert result[0]["count"] == 5000
@@ -123,6 +121,6 @@ class TestWorkspaceInfoTools:
         """workspace_info should return current workspace state."""
         from mp_mcp_server.tools.discovery import workspace_info
 
-        result = workspace_info.fn(mock_context)
+        result = workspace_info(mock_context)
         assert result["project_id"] == 123456
         assert result["region"] == "us"

--- a/mp-mcp-server/tests/unit/test_tools_discovery.py
+++ b/mp-mcp-server/tests/unit/test_tools_discovery.py
@@ -20,7 +20,7 @@ class TestListEventsTools:
         """list_events should return event names from Workspace."""
         from mp_mcp_server.tools.discovery import list_events
 
-        result = list_events(mock_context)
+        result = list_events(mock_context)  # type: ignore[operator]
         assert result == ["signup", "login", "purchase"]
 
 
@@ -39,7 +39,7 @@ class TestListPropertiesTools:
         """list_properties should return property info from Workspace."""
         from mp_mcp_server.tools.discovery import list_properties
 
-        result = list_properties(mock_context, event="signup")
+        result = list_properties(mock_context, event="signup")  # type: ignore[operator]
         assert len(result) == 2
         assert result[0]["name"] == "browser"
 
@@ -51,7 +51,7 @@ class TestListPropertyValuesTools:
         """list_property_values should return sample values."""
         from mp_mcp_server.tools.discovery import list_property_values
 
-        result = list_property_values(
+        result = list_property_values(  # type: ignore[operator]
             mock_context, event="signup", property_name="browser"
         )
         assert result == ["Chrome", "Firefox", "Safari"]
@@ -64,7 +64,7 @@ class TestListFunnelsTools:
         """list_funnels should return funnel metadata."""
         from mp_mcp_server.tools.discovery import list_funnels
 
-        result = list_funnels(mock_context)
+        result = list_funnels(mock_context)  # type: ignore[operator]
         assert len(result) == 1
         assert result[0]["name"] == "Signup Funnel"
 
@@ -76,7 +76,7 @@ class TestListCohortsTools:
         """list_cohorts should return cohort metadata."""
         from mp_mcp_server.tools.discovery import list_cohorts
 
-        result = list_cohorts(mock_context)
+        result = list_cohorts(mock_context)  # type: ignore[operator]
         assert len(result) == 1
         assert result[0]["name"] == "Active Users"
 
@@ -90,7 +90,7 @@ class TestListBookmarksTools:
         """list_bookmarks should return saved report metadata with pagination info."""
         from mp_mcp_server.tools.discovery import list_bookmarks
 
-        result = list_bookmarks(mock_context)
+        result = list_bookmarks(mock_context)  # type: ignore[operator]
         # New format returns dict with bookmarks list and pagination metadata
         assert "bookmarks" in result
         assert "truncated" in result
@@ -108,7 +108,7 @@ class TestTopEventsTools:
         """top_events should return events ranked by activity."""
         from mp_mcp_server.tools.discovery import top_events
 
-        result = top_events(mock_context)
+        result = top_events(mock_context)  # type: ignore[operator]
         assert len(result) == 2
         assert result[0]["event"] == "login"
         assert result[0]["count"] == 5000
@@ -121,6 +121,6 @@ class TestWorkspaceInfoTools:
         """workspace_info should return current workspace state."""
         from mp_mcp_server.tools.discovery import workspace_info
 
-        result = workspace_info(mock_context)
+        result = workspace_info(mock_context)  # type: ignore[operator]
         assert result["project_id"] == 123456
         assert result["region"] == "us"

--- a/mp-mcp-server/tests/unit/test_tools_fetch.py
+++ b/mp-mcp-server/tests/unit/test_tools_fetch.py
@@ -17,7 +17,7 @@ class TestFetchEventsTool:
         """fetch_events should store events in a DuckDB table."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events.fn(
+        result = await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -32,7 +32,7 @@ class TestFetchEventsTool:
         """fetch_events should return row count and metadata."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events.fn(
+        result = await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -46,7 +46,7 @@ class TestFetchEventsTool:
         """fetch_events should accept date range parameters."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events.fn(
+        result = await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-31",
@@ -63,7 +63,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should store profiles in a DuckDB table."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles.fn(mock_context)
+        result = await fetch_profiles(mock_context)
         assert "table_name" in result
         assert result["table_name"] == "profiles"
 
@@ -74,7 +74,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should return row count."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles.fn(mock_context)
+        result = await fetch_profiles(mock_context)
         assert "row_count" in result
         assert result["row_count"] == 500
 
@@ -83,7 +83,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should accept optional parameters."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles.fn(
+        result = await fetch_profiles(
             mock_context,
             table="my_profiles",
             where="email is not null",
@@ -97,7 +97,7 @@ class TestFetchProfilesTool:
         """fetch_events should accept parallel parameters."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events.fn(
+        result = await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-31",
@@ -115,7 +115,7 @@ class TestStreamEventsTool:
         """stream_events should return list of events."""
         from mp_mcp_server.tools.fetch import stream_events
 
-        result = stream_events.fn(
+        result = stream_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -129,12 +129,12 @@ class TestStreamEventsTool:
         from mp_mcp_server.tools.fetch import stream_events
 
         # Reset the mock for fresh iterator
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_events.return_value = iter(
             [{"name": "login", "distinct_id": "user1", "time": 1704067200}]
         )
 
-        result = stream_events.fn(
+        result = stream_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -147,12 +147,12 @@ class TestStreamEventsTool:
         from mp_mcp_server.tools.fetch import stream_events
 
         # Reset with events - the limit is now passed to ws.stream_events
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_events.return_value = iter(
             [{"event": f"event{i}", "properties": {}} for i in range(5)]
         )
 
-        result = stream_events.fn(
+        result = stream_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -173,7 +173,7 @@ class TestStreamProfilesTool:
         from mp_mcp_server.tools.fetch import stream_profiles
 
         # Reset mock
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter(
             [
                 {"$distinct_id": "user1", "$properties": {"email": "a@example.com"}},
@@ -181,7 +181,7 @@ class TestStreamProfilesTool:
             ]
         )
 
-        result = stream_profiles.fn(mock_context)
+        result = stream_profiles(mock_context)
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["$distinct_id"] == "user1"
@@ -190,22 +190,22 @@ class TestStreamProfilesTool:
         """stream_profiles should accept where filter."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        result = stream_profiles.fn(mock_context, where="email is not null")
+        result = stream_profiles(mock_context, where="email is not null")
         assert isinstance(result, list)
 
     def test_stream_profiles_with_distinct_id(self, mock_context: MagicMock) -> None:
         """stream_profiles should accept distinct_id parameter."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter(
             [{"$distinct_id": "user1", "$properties": {"email": "a@example.com"}}]
         )
 
-        result = stream_profiles.fn(mock_context, distinct_id="user1")
+        result = stream_profiles(mock_context, distinct_id="user1")
         assert len(result) == 1
         assert result[0]["$distinct_id"] == "user1"
         ws.stream_profiles.assert_called_once()
@@ -223,9 +223,9 @@ class TestFetchEventsOptionalParams:
         """fetch_events should pass where filter to workspace."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events.fn(
+        await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -240,9 +240,9 @@ class TestFetchEventsOptionalParams:
         """fetch_events should pass limit to workspace."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events.fn(
+        await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -257,9 +257,9 @@ class TestFetchEventsOptionalParams:
         """fetch_events should pass append flag to workspace."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events.fn(
+        await fetch_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -280,9 +280,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass cohort_id to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, cohort_id="12345")
+        await fetch_profiles(mock_context, cohort_id="12345")
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["cohort_id"] == "12345"
@@ -294,9 +294,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass output_properties to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, output_properties=["email", "name"])
+        await fetch_profiles(mock_context, output_properties=["email", "name"])
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["output_properties"] == ["email", "name"]
@@ -308,9 +308,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass distinct_id to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, distinct_id="user123")
+        await fetch_profiles(mock_context, distinct_id="user123")
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["distinct_id"] == "user123"
@@ -322,9 +322,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass distinct_ids list to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, distinct_ids=["user1", "user2", "user3"])
+        await fetch_profiles(mock_context, distinct_ids=["user1", "user2", "user3"])
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["distinct_ids"] == ["user1", "user2", "user3"]
@@ -334,9 +334,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass group_id to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, group_id="company")
+        await fetch_profiles(mock_context, group_id="company")
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["group_id"] == "company"
@@ -346,9 +346,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass append flag to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, append=True)
+        await fetch_profiles(mock_context, append=True)
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["append"] is True
@@ -360,10 +360,10 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass behaviors to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         behaviors = [{"event": "login", "count": {"min": 1}}]
 
-        await fetch_profiles.fn(mock_context, behaviors=behaviors)
+        await fetch_profiles(mock_context, behaviors=behaviors)
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["behaviors"] == behaviors
@@ -375,9 +375,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass as_of_timestamp to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, as_of_timestamp=1704067200)
+        await fetch_profiles(mock_context, as_of_timestamp=1704067200)
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["as_of_timestamp"] == 1704067200
@@ -389,9 +389,9 @@ class TestFetchProfilesOptionalParams:
         """fetch_profiles should pass include_all_users to workspace."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles.fn(mock_context, include_all_users=True)
+        await fetch_profiles(mock_context, include_all_users=True)
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["include_all_users"] is True
@@ -404,10 +404,10 @@ class TestStreamEventsOptionalParams:
         """stream_events should pass where filter to workspace."""
         from mp_mcp_server.tools.fetch import stream_events
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_events.return_value = iter([{"name": "login"}])
 
-        stream_events.fn(
+        stream_events(
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -425,10 +425,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass cohort_id to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles.fn(mock_context, cohort_id="12345")
+        stream_profiles(mock_context, cohort_id="12345")
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["cohort_id"] == "12345"
@@ -439,10 +439,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass output_properties to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles.fn(mock_context, output_properties=["email"])
+        stream_profiles(mock_context, output_properties=["email"])
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["output_properties"] == ["email"]
@@ -451,10 +451,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass distinct_ids list to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles.fn(mock_context, distinct_ids=["user1", "user2"])
+        stream_profiles(mock_context, distinct_ids=["user1", "user2"])
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["distinct_ids"] == ["user1", "user2"]
@@ -463,10 +463,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass group_id to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "company1"}])
 
-        stream_profiles.fn(mock_context, group_id="company")
+        stream_profiles(mock_context, group_id="company")
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["group_id"] == "company"
@@ -475,11 +475,11 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass behaviors to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
         behaviors = [{"event": "purchase", "count": {"min": 5}}]
 
-        stream_profiles.fn(mock_context, behaviors=behaviors)
+        stream_profiles(mock_context, behaviors=behaviors)
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["behaviors"] == behaviors
@@ -490,10 +490,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass as_of_timestamp to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles.fn(mock_context, as_of_timestamp=1704067200)
+        stream_profiles(mock_context, as_of_timestamp=1704067200)
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["as_of_timestamp"] == 1704067200
@@ -504,10 +504,10 @@ class TestStreamProfilesOptionalParams:
         """stream_profiles should pass include_all_users to workspace."""
         from mp_mcp_server.tools.fetch import stream_profiles
 
-        ws = mock_context.fastmcp._lifespan_result["workspace"]
+        ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles.fn(mock_context, include_all_users=True)
+        stream_profiles(mock_context, include_all_users=True)
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["include_all_users"] is True

--- a/mp-mcp-server/tests/unit/test_tools_fetch.py
+++ b/mp-mcp-server/tests/unit/test_tools_fetch.py
@@ -17,7 +17,7 @@ class TestFetchEventsTool:
         """fetch_events should store events in a DuckDB table."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events(
+        result = await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -32,7 +32,7 @@ class TestFetchEventsTool:
         """fetch_events should return row count and metadata."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events(
+        result = await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -46,7 +46,7 @@ class TestFetchEventsTool:
         """fetch_events should accept date range parameters."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events(
+        result = await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-31",
@@ -63,7 +63,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should store profiles in a DuckDB table."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles(mock_context)
+        result = await fetch_profiles(mock_context)  # type: ignore[operator]
         assert "table_name" in result
         assert result["table_name"] == "profiles"
 
@@ -74,7 +74,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should return row count."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles(mock_context)
+        result = await fetch_profiles(mock_context)  # type: ignore[operator]
         assert "row_count" in result
         assert result["row_count"] == 500
 
@@ -83,7 +83,7 @@ class TestFetchProfilesTool:
         """fetch_profiles should accept optional parameters."""
         from mp_mcp_server.tools.fetch import fetch_profiles
 
-        result = await fetch_profiles(
+        result = await fetch_profiles(  # type: ignore[operator]
             mock_context,
             table="my_profiles",
             where="email is not null",
@@ -97,7 +97,7 @@ class TestFetchProfilesTool:
         """fetch_events should accept parallel parameters."""
         from mp_mcp_server.tools.fetch import fetch_events
 
-        result = await fetch_events(
+        result = await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-31",
@@ -115,7 +115,7 @@ class TestStreamEventsTool:
         """stream_events should return list of events."""
         from mp_mcp_server.tools.fetch import stream_events
 
-        result = stream_events(
+        result = stream_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -134,7 +134,7 @@ class TestStreamEventsTool:
             [{"name": "login", "distinct_id": "user1", "time": 1704067200}]
         )
 
-        result = stream_events(
+        result = stream_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -152,7 +152,7 @@ class TestStreamEventsTool:
             [{"event": f"event{i}", "properties": {}} for i in range(5)]
         )
 
-        result = stream_events(
+        result = stream_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -181,7 +181,7 @@ class TestStreamProfilesTool:
             ]
         )
 
-        result = stream_profiles(mock_context)
+        result = stream_profiles(mock_context)  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["$distinct_id"] == "user1"
@@ -193,7 +193,7 @@ class TestStreamProfilesTool:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        result = stream_profiles(mock_context, where="email is not null")
+        result = stream_profiles(mock_context, where="email is not null")  # type: ignore[operator]
         assert isinstance(result, list)
 
     def test_stream_profiles_with_distinct_id(self, mock_context: MagicMock) -> None:
@@ -205,7 +205,7 @@ class TestStreamProfilesTool:
             [{"$distinct_id": "user1", "$properties": {"email": "a@example.com"}}]
         )
 
-        result = stream_profiles(mock_context, distinct_id="user1")
+        result = stream_profiles(mock_context, distinct_id="user1")  # type: ignore[operator]
         assert len(result) == 1
         assert result[0]["$distinct_id"] == "user1"
         ws.stream_profiles.assert_called_once()
@@ -225,7 +225,7 @@ class TestFetchEventsOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events(
+        await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -242,7 +242,7 @@ class TestFetchEventsOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events(
+        await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -259,7 +259,7 @@ class TestFetchEventsOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_events(
+        await fetch_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -282,7 +282,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, cohort_id="12345")
+        await fetch_profiles(mock_context, cohort_id="12345")  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["cohort_id"] == "12345"
@@ -296,7 +296,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, output_properties=["email", "name"])
+        await fetch_profiles(mock_context, output_properties=["email", "name"])  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["output_properties"] == ["email", "name"]
@@ -310,7 +310,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, distinct_id="user123")
+        await fetch_profiles(mock_context, distinct_id="user123")  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["distinct_id"] == "user123"
@@ -324,7 +324,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, distinct_ids=["user1", "user2", "user3"])
+        await fetch_profiles(mock_context, distinct_ids=["user1", "user2", "user3"])  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["distinct_ids"] == ["user1", "user2", "user3"]
@@ -336,7 +336,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, group_id="company")
+        await fetch_profiles(mock_context, group_id="company")  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["group_id"] == "company"
@@ -348,7 +348,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, append=True)
+        await fetch_profiles(mock_context, append=True)  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["append"] is True
@@ -363,7 +363,7 @@ class TestFetchProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         behaviors = [{"event": "login", "count": {"min": 1}}]
 
-        await fetch_profiles(mock_context, behaviors=behaviors)
+        await fetch_profiles(mock_context, behaviors=behaviors)  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["behaviors"] == behaviors
@@ -377,7 +377,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, as_of_timestamp=1704067200)
+        await fetch_profiles(mock_context, as_of_timestamp=1704067200)  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["as_of_timestamp"] == 1704067200
@@ -391,7 +391,7 @@ class TestFetchProfilesOptionalParams:
 
         ws = mock_context.lifespan_context["workspace"]
 
-        await fetch_profiles(mock_context, include_all_users=True)
+        await fetch_profiles(mock_context, include_all_users=True)  # type: ignore[operator]
 
         call_kwargs = ws.fetch_profiles.call_args[1]
         assert call_kwargs["include_all_users"] is True
@@ -407,7 +407,7 @@ class TestStreamEventsOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_events.return_value = iter([{"name": "login"}])
 
-        stream_events(
+        stream_events(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -428,7 +428,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles(mock_context, cohort_id="12345")
+        stream_profiles(mock_context, cohort_id="12345")  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["cohort_id"] == "12345"
@@ -442,7 +442,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles(mock_context, output_properties=["email"])
+        stream_profiles(mock_context, output_properties=["email"])  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["output_properties"] == ["email"]
@@ -454,7 +454,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles(mock_context, distinct_ids=["user1", "user2"])
+        stream_profiles(mock_context, distinct_ids=["user1", "user2"])  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["distinct_ids"] == ["user1", "user2"]
@@ -466,7 +466,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "company1"}])
 
-        stream_profiles(mock_context, group_id="company")
+        stream_profiles(mock_context, group_id="company")  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["group_id"] == "company"
@@ -479,7 +479,7 @@ class TestStreamProfilesOptionalParams:
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
         behaviors = [{"event": "purchase", "count": {"min": 5}}]
 
-        stream_profiles(mock_context, behaviors=behaviors)
+        stream_profiles(mock_context, behaviors=behaviors)  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["behaviors"] == behaviors
@@ -493,7 +493,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles(mock_context, as_of_timestamp=1704067200)
+        stream_profiles(mock_context, as_of_timestamp=1704067200)  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["as_of_timestamp"] == 1704067200
@@ -507,7 +507,7 @@ class TestStreamProfilesOptionalParams:
         ws = mock_context.lifespan_context["workspace"]
         ws.stream_profiles.return_value = iter([{"$distinct_id": "user1"}])
 
-        stream_profiles(mock_context, include_all_users=True)
+        stream_profiles(mock_context, include_all_users=True)  # type: ignore[operator]
 
         call_kwargs = ws.stream_profiles.call_args[1]
         assert call_kwargs["include_all_users"] is True

--- a/mp-mcp-server/tests/unit/test_tools_intelligent.py
+++ b/mp-mcp-server/tests/unit/test_tools_intelligent.py
@@ -108,7 +108,7 @@ class TestAskMixpanelTool:
             side_effect=Exception("Sampling not supported")
         )
 
-        result = await ask_mixpanel(
+        result = await ask_mixpanel(  # type: ignore[operator]
             mock_context,
             question="What events are most popular?",
         )
@@ -227,7 +227,7 @@ class TestDiagnoseMetricDropTool:
             side_effect=Exception("Sampling not supported")
         )
 
-        result = await diagnose_metric_drop(
+        result = await diagnose_metric_drop(  # type: ignore[operator]
             mock_context,
             event="signup",
             date="2024-01-10",
@@ -312,7 +312,7 @@ class TestFunnelOptimizationReportTool:
             }
         )
 
-        result = await funnel_optimization_report(
+        result = await funnel_optimization_report(  # type: ignore[operator]
             mock_context,
             funnel_id=123,
         )
@@ -402,7 +402,7 @@ class TestAskMixpanelSynthesis:
             side_effect=ValueError("Plan generation failed")
         )
 
-        result = await ask_mixpanel(
+        result = await ask_mixpanel(  # type: ignore[operator]
             mock_context,
             question="What events are most popular?",
         )
@@ -430,7 +430,7 @@ class TestAskMixpanelSynthesis:
         synthesis_error = ValueError("Synthesis failed")
         mock_context.sample = AsyncMock(side_effect=[plan_result, synthesis_error])
 
-        result = await ask_mixpanel(
+        result = await ask_mixpanel(  # type: ignore[operator]
             mock_context,
             question="What events are most popular?",
         )

--- a/mp-mcp-server/tests/unit/test_tools_interactive.py
+++ b/mp-mcp-server/tests/unit/test_tools_interactive.py
@@ -121,7 +121,7 @@ class TestGuidedAnalysisTool:
         """guided_analysis should work with pre-selected focus area."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="retention",
         )
@@ -140,7 +140,7 @@ class TestGuidedAnalysisTool:
             side_effect=Exception("Elicitation not supported")
         )
 
-        result = await guided_analysis(mock_context)
+        result = await guided_analysis(mock_context)  # type: ignore[operator]
 
         assert "status" in result
         # When elicitation fails and no focus_area provided, returns guidance message
@@ -155,7 +155,7 @@ class TestGuidedAnalysisTool:
         """guided_analysis should accept custom date range."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="engagement",
             time_period="custom",
@@ -224,7 +224,7 @@ class TestSafeLargeFetchTool:
             MagicMock(to_dict=lambda: {"event": "login", "count": 100}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",  # Short range
@@ -248,7 +248,7 @@ class TestSafeLargeFetchTool:
             MagicMock(to_dict=lambda: {"event": "login", "count": 10000000}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-12-31",  # Long range
@@ -263,7 +263,7 @@ class TestSafeLargeFetchTool:
         """safe_large_fetch should accept event filter."""
         from mp_mcp_server.tools.interactive.safe_fetch import safe_large_fetch
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-31",
@@ -277,7 +277,7 @@ class TestSafeLargeFetchTool:
         """safe_large_fetch should accept custom table name."""
         from mp_mcp_server.tools.interactive.safe_fetch import safe_large_fetch
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -483,7 +483,7 @@ class TestSafeFetchElicitation:
             MagicMock(to_dict=lambda: {"event": "login", "count": 10000000}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-12-31",
@@ -505,7 +505,7 @@ class TestSafeFetchElicitation:
             MagicMock(to_dict=lambda: {"event": "login", "count": 10000000}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-12-31",
@@ -533,7 +533,7 @@ class TestSafeFetchElicitation:
             MagicMock(to_dict=lambda: {"event": "login", "count": 10000000}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-12-31",
@@ -559,7 +559,7 @@ class TestSafeFetchElicitation:
             MagicMock(to_dict=lambda: {"event": "login", "count": 10000000}),
         ]
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-12-31",
@@ -582,7 +582,7 @@ class TestSafeFetchElicitation:
             Exception("Fetch failed")
         )
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -620,7 +620,7 @@ class TestGuidedAnalysisEdgeCases:
         """guided_analysis should accept time_period parameter."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="retention",
             time_period="last_7_days",
@@ -635,7 +635,7 @@ class TestGuidedAnalysisEdgeCases:
         """guided_analysis should use default dates when not provided."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="engagement",
         )
@@ -813,7 +813,7 @@ class TestGuidedAnalysisEdgeCases:
             "signup",
         ]
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="revenue",
             time_period="last_30_days",
@@ -826,7 +826,7 @@ class TestGuidedAnalysisEdgeCases:
         """guided_analysis should handle last_90_days time period."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="conversion",
             time_period="last_90_days",
@@ -840,7 +840,7 @@ class TestGuidedAnalysisEdgeCases:
         """guided_analysis should accept custom date range."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="retention",
             time_period="custom",
@@ -1149,7 +1149,7 @@ class TestGuidedAnalysisElicitationFlows:
             )
         )
 
-        result = await guided_analysis(mock_context)
+        result = await guided_analysis(mock_context)  # type: ignore[operator]
 
         assert result["focus_area"] == "engagement"
         assert "User selected focus via elicitation" in result["workflow_steps"]
@@ -1170,7 +1170,7 @@ class TestGuidedAnalysisElicitationFlows:
             )
         )
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="conversion",
         )
@@ -1195,7 +1195,7 @@ class TestGuidedAnalysisElicitationFlows:
             )
         )
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="conversion",
         )
@@ -1219,7 +1219,7 @@ class TestGuidedAnalysisElicitationFlows:
             )
         )
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="retention",
         )
@@ -1235,7 +1235,7 @@ class TestGuidedAnalysisElicitationFlows:
         """guided_analysis should provide conversion-specific suggestions."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="conversion",
         )
@@ -1250,7 +1250,7 @@ class TestGuidedAnalysisElicitationFlows:
         """guided_analysis should provide engagement-specific suggestions."""
         from mp_mcp_server.tools.interactive.guided import guided_analysis
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="engagement",
         )
@@ -1270,7 +1270,7 @@ class TestGuidedAnalysisElicitationFlows:
             "signup",
         ]
 
-        result = await guided_analysis(
+        result = await guided_analysis(  # type: ignore[operator]
             mock_context,
             focus_area="revenue",
         )
@@ -1299,7 +1299,7 @@ class TestSafeFetchWithFetchResultVariations:
             fetch_result
         )
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -1328,7 +1328,7 @@ class TestSafeFetchWithFetchResultVariations:
             fetch_result
         )
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -1351,7 +1351,7 @@ class TestSafeFetchWithFetchResultVariations:
             "row_count": 200,
         }
 
-        result = await safe_large_fetch(
+        result = await safe_large_fetch(  # type: ignore[operator]
             mock_context,
             from_date="2024-01-01",
             to_date="2024-01-07",
@@ -1367,7 +1367,7 @@ class TestSafeFetchWithFetchResultVariations:
         """safe_large_fetch should use default dates when not provided."""
         from mp_mcp_server.tools.interactive.safe_fetch import safe_large_fetch
 
-        result = await safe_large_fetch(mock_context)
+        result = await safe_large_fetch(mock_context)  # type: ignore[operator]
 
         assert result["status"] == "completed"
         assert "estimation" in result

--- a/mp-mcp-server/tests/unit/test_tools_live_query.py
+++ b/mp-mcp-server/tests/unit/test_tools_live_query.py
@@ -14,7 +14,7 @@ class TestSegmentationTool:
         """Segmentation should return time series data."""
         from mp_mcp_server.tools.live_query import segmentation
 
-        result = segmentation.fn(
+        result = segmentation(
             mock_context,
             event="login",
             from_date="2024-01-01",
@@ -27,7 +27,7 @@ class TestSegmentationTool:
         """Segmentation should support property segmentation."""
         from mp_mcp_server.tools.live_query import segmentation
 
-        result = segmentation.fn(
+        result = segmentation(
             mock_context,
             event="login",
             from_date="2024-01-01",
@@ -44,7 +44,7 @@ class TestFunnelTool:
         """Funnel should return conversion step data."""
         from mp_mcp_server.tools.live_query import funnel
 
-        result = funnel.fn(
+        result = funnel(
             mock_context,
             funnel_id=1,
             from_date="2024-01-01",
@@ -61,7 +61,7 @@ class TestRetentionTool:
         """Retention should return cohort retention data."""
         from mp_mcp_server.tools.live_query import retention
 
-        result = retention.fn(
+        result = retention(
             mock_context,
             born_event="signup",
             from_date="2024-01-01",
@@ -77,7 +77,7 @@ class TestJqlTool:
         """Jql should execute JQL script and return results."""
         from mp_mcp_server.tools.live_query import jql
 
-        result = jql.fn(
+        result = jql(
             mock_context,
             script="function main() { return Events({}); }",
         )
@@ -94,7 +94,7 @@ class TestEventCountsTool:
         """event_counts should return counts for multiple events."""
         from mp_mcp_server.tools.live_query import event_counts
 
-        result = event_counts.fn(
+        result = event_counts(
             mock_context,
             events=["login", "signup"],
             from_date="2024-01-01",
@@ -114,7 +114,7 @@ class TestPropertyCountsTool:
         """property_counts should return property value breakdown."""
         from mp_mcp_server.tools.live_query import property_counts
 
-        result = property_counts.fn(
+        result = property_counts(
             mock_context,
             event="login",
             property_name="browser",
@@ -131,7 +131,7 @@ class TestActivityFeedTool:
         """activity_feed should return events for a user."""
         from mp_mcp_server.tools.live_query import activity_feed
 
-        result = activity_feed.fn(
+        result = activity_feed(
             mock_context,
             distinct_id="user123",
         )
@@ -146,7 +146,7 @@ class TestFrequencyTool:
         """Frequency should return event frequency distribution."""
         from mp_mcp_server.tools.live_query import frequency
 
-        result = frequency.fn(
+        result = frequency(
             mock_context,
             event="login",
             from_date="2024-01-01",

--- a/mp-mcp-server/tests/unit/test_tools_live_query.py
+++ b/mp-mcp-server/tests/unit/test_tools_live_query.py
@@ -14,7 +14,7 @@ class TestSegmentationTool:
         """Segmentation should return time series data."""
         from mp_mcp_server.tools.live_query import segmentation
 
-        result = segmentation(
+        result = segmentation(  # type: ignore[operator]
             mock_context,
             event="login",
             from_date="2024-01-01",
@@ -27,7 +27,7 @@ class TestSegmentationTool:
         """Segmentation should support property segmentation."""
         from mp_mcp_server.tools.live_query import segmentation
 
-        result = segmentation(
+        result = segmentation(  # type: ignore[operator]
             mock_context,
             event="login",
             from_date="2024-01-01",
@@ -44,7 +44,7 @@ class TestFunnelTool:
         """Funnel should return conversion step data."""
         from mp_mcp_server.tools.live_query import funnel
 
-        result = funnel(
+        result = funnel(  # type: ignore[operator]
             mock_context,
             funnel_id=1,
             from_date="2024-01-01",
@@ -61,7 +61,7 @@ class TestRetentionTool:
         """Retention should return cohort retention data."""
         from mp_mcp_server.tools.live_query import retention
 
-        result = retention(
+        result = retention(  # type: ignore[operator]
             mock_context,
             born_event="signup",
             from_date="2024-01-01",
@@ -77,7 +77,7 @@ class TestJqlTool:
         """Jql should execute JQL script and return results."""
         from mp_mcp_server.tools.live_query import jql
 
-        result = jql(
+        result = jql(  # type: ignore[operator]
             mock_context,
             script="function main() { return Events({}); }",
         )
@@ -94,7 +94,7 @@ class TestEventCountsTool:
         """event_counts should return counts for multiple events."""
         from mp_mcp_server.tools.live_query import event_counts
 
-        result = event_counts(
+        result = event_counts(  # type: ignore[operator]
             mock_context,
             events=["login", "signup"],
             from_date="2024-01-01",
@@ -114,7 +114,7 @@ class TestPropertyCountsTool:
         """property_counts should return property value breakdown."""
         from mp_mcp_server.tools.live_query import property_counts
 
-        result = property_counts(
+        result = property_counts(  # type: ignore[operator]
             mock_context,
             event="login",
             property_name="browser",
@@ -131,7 +131,7 @@ class TestActivityFeedTool:
         """activity_feed should return events for a user."""
         from mp_mcp_server.tools.live_query import activity_feed
 
-        result = activity_feed(
+        result = activity_feed(  # type: ignore[operator]
             mock_context,
             distinct_id="user123",
         )
@@ -146,7 +146,7 @@ class TestFrequencyTool:
         """Frequency should return event frequency distribution."""
         from mp_mcp_server.tools.live_query import frequency
 
-        result = frequency(
+        result = frequency(  # type: ignore[operator]
             mock_context,
             event="login",
             from_date="2024-01-01",

--- a/mp-mcp-server/tests/unit/test_tools_local.py
+++ b/mp-mcp-server/tests/unit/test_tools_local.py
@@ -15,7 +15,7 @@ class TestSqlTool:
         """Sql should execute SQL query and return results."""
         from mp_mcp_server.tools.local import sql
 
-        result = sql.fn(mock_context, query="SELECT * FROM events")
+        result = sql(mock_context, query="SELECT * FROM events")
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "login"
@@ -24,7 +24,7 @@ class TestSqlTool:
         """Sql should return results as list of dicts."""
         from mp_mcp_server.tools.local import sql
 
-        result = sql.fn(mock_context, query="SELECT COUNT(*) as cnt FROM events")
+        result = sql(mock_context, query="SELECT COUNT(*) as cnt FROM events")
         assert isinstance(result, list)
 
 
@@ -35,7 +35,7 @@ class TestSqlScalarTool:
         """sql_scalar should return a single value."""
         from mp_mcp_server.tools.local import sql_scalar
 
-        result = sql_scalar.fn(mock_context, query="SELECT COUNT(*) FROM events")
+        result = sql_scalar(mock_context, query="SELECT COUNT(*) FROM events")
         assert result == 42
 
 
@@ -46,7 +46,7 @@ class TestListTablesTool:
         """list_tables should return available tables."""
         from mp_mcp_server.tools.local import list_tables
 
-        result = list_tables.fn(mock_context)
+        result = list_tables(mock_context)
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "events_jan"
@@ -59,7 +59,7 @@ class TestTableSchemaTool:
         """table_schema should return column definitions."""
         from mp_mcp_server.tools.local import table_schema
 
-        result = table_schema.fn(mock_context, table="events_jan")
+        result = table_schema(mock_context, table="events_jan")
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["column"] == "name"
@@ -72,7 +72,7 @@ class TestSampleTool:
         """Sample should return random rows from table."""
         from mp_mcp_server.tools.local import sample
 
-        result = sample.fn(mock_context, table="events_jan")
+        result = sample(mock_context, table="events_jan")
         assert isinstance(result, list)
         assert len(result) == 1
 
@@ -84,7 +84,7 @@ class TestSummarizeTool:
         """Summarize should return table statistics."""
         from mp_mcp_server.tools.local import summarize
 
-        result = summarize.fn(mock_context, table="events_jan")
+        result = summarize(mock_context, table="events_jan")
         assert "row_count" in result
         assert result["row_count"] == 1000
 
@@ -96,7 +96,7 @@ class TestEventBreakdownTool:
         """event_breakdown should return event counts."""
         from mp_mcp_server.tools.local import event_breakdown
 
-        result = event_breakdown.fn(mock_context, table="events_jan")
+        result = event_breakdown(mock_context, table="events_jan")
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "login"
@@ -109,7 +109,7 @@ class TestPropertyKeysTool:
         """property_keys should return property keys from Workspace method."""
         from mp_mcp_server.tools.local import property_keys
 
-        result = property_keys.fn(mock_context, table="events_jan")
+        result = property_keys(mock_context, table="events_jan")
         assert isinstance(result, list)
         assert result == ["browser", "country", "device"]
 
@@ -117,7 +117,7 @@ class TestPropertyKeysTool:
         """property_keys should accept optional event filter."""
         from mp_mcp_server.tools.local import property_keys
 
-        result = property_keys.fn(mock_context, table="events_jan", event="login")
+        result = property_keys(mock_context, table="events_jan", event="login")
         assert isinstance(result, list)
 
 
@@ -137,11 +137,11 @@ class TestColumnStatsTool:
                 "max_value": "2024-01-31",
             }
         ]
-        mock_context.fastmcp._lifespan_result[
+        mock_context.lifespan_context[
             "workspace"
         ].sql_rows.return_value = sql_rows_mock
 
-        result = column_stats.fn(mock_context, table="events_jan", column="time")
+        result = column_stats(mock_context, table="events_jan", column="time")
         assert result["count"] == 1000
         assert result["distinct_count"] == 500
         assert result["min_value"] == "2024-01-01"
@@ -152,11 +152,11 @@ class TestColumnStatsTool:
 
         sql_rows_mock = MagicMock()
         sql_rows_mock.to_dicts.return_value = []
-        mock_context.fastmcp._lifespan_result[
+        mock_context.lifespan_context[
             "workspace"
         ].sql_rows.return_value = sql_rows_mock
 
-        result = column_stats.fn(mock_context, table="events_jan", column="time")
+        result = column_stats(mock_context, table="events_jan", column="time")
         assert result == {
             "count": 0,
             "distinct_count": 0,
@@ -173,7 +173,7 @@ class TestDropTableTool:
         """drop_table should remove a table."""
         from mp_mcp_server.tools.local import drop_table
 
-        result = drop_table.fn(mock_context, table="events_jan")
+        result = drop_table(mock_context, table="events_jan")
         assert result["success"] is True
         assert "events_jan" in result["message"]
 
@@ -185,7 +185,7 @@ class TestDropAllTablesTool:
         """drop_all_tables should remove all tables."""
         from mp_mcp_server.tools.local import drop_all_tables
 
-        result = drop_all_tables.fn(mock_context)
+        result = drop_all_tables(mock_context)
         assert result["success"] is True
 
 
@@ -270,7 +270,7 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import column_stats
 
         with pytest.raises(ToolError, match="Invalid table name"):
-            column_stats.fn(mock_context, table="events; DROP TABLE--", column="time")
+            column_stats(mock_context, table="events; DROP TABLE--", column="time")
 
     def test_column_stats_validates_column_expression(
         self, mock_context: MagicMock
@@ -281,7 +281,7 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import column_stats
 
         with pytest.raises(ToolError, match="disallowed pattern"):
-            column_stats.fn(mock_context, table="events", column="time; DROP TABLE x")
+            column_stats(mock_context, table="events", column="time; DROP TABLE x")
 
     def test_event_breakdown_validates_table_name(
         self, mock_context: MagicMock
@@ -292,4 +292,4 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import event_breakdown
 
         with pytest.raises(ToolError, match="Invalid table name"):
-            event_breakdown.fn(mock_context, table='events"; DELETE FROM users;--')
+            event_breakdown(mock_context, table='events"; DELETE FROM users;--')

--- a/mp-mcp-server/tests/unit/test_tools_local.py
+++ b/mp-mcp-server/tests/unit/test_tools_local.py
@@ -15,7 +15,7 @@ class TestSqlTool:
         """Sql should execute SQL query and return results."""
         from mp_mcp_server.tools.local import sql
 
-        result = sql(mock_context, query="SELECT * FROM events")
+        result = sql(mock_context, query="SELECT * FROM events")  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "login"
@@ -24,7 +24,7 @@ class TestSqlTool:
         """Sql should return results as list of dicts."""
         from mp_mcp_server.tools.local import sql
 
-        result = sql(mock_context, query="SELECT COUNT(*) as cnt FROM events")
+        result = sql(mock_context, query="SELECT COUNT(*) as cnt FROM events")  # type: ignore[operator]
         assert isinstance(result, list)
 
 
@@ -35,7 +35,7 @@ class TestSqlScalarTool:
         """sql_scalar should return a single value."""
         from mp_mcp_server.tools.local import sql_scalar
 
-        result = sql_scalar(mock_context, query="SELECT COUNT(*) FROM events")
+        result = sql_scalar(mock_context, query="SELECT COUNT(*) FROM events")  # type: ignore[operator]
         assert result == 42
 
 
@@ -46,7 +46,7 @@ class TestListTablesTool:
         """list_tables should return available tables."""
         from mp_mcp_server.tools.local import list_tables
 
-        result = list_tables(mock_context)
+        result = list_tables(mock_context)  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "events_jan"
@@ -59,7 +59,7 @@ class TestTableSchemaTool:
         """table_schema should return column definitions."""
         from mp_mcp_server.tools.local import table_schema
 
-        result = table_schema(mock_context, table="events_jan")
+        result = table_schema(mock_context, table="events_jan")  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["column"] == "name"
@@ -72,7 +72,7 @@ class TestSampleTool:
         """Sample should return random rows from table."""
         from mp_mcp_server.tools.local import sample
 
-        result = sample(mock_context, table="events_jan")
+        result = sample(mock_context, table="events_jan")  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 1
 
@@ -84,7 +84,7 @@ class TestSummarizeTool:
         """Summarize should return table statistics."""
         from mp_mcp_server.tools.local import summarize
 
-        result = summarize(mock_context, table="events_jan")
+        result = summarize(mock_context, table="events_jan")  # type: ignore[operator]
         assert "row_count" in result
         assert result["row_count"] == 1000
 
@@ -96,7 +96,7 @@ class TestEventBreakdownTool:
         """event_breakdown should return event counts."""
         from mp_mcp_server.tools.local import event_breakdown
 
-        result = event_breakdown(mock_context, table="events_jan")
+        result = event_breakdown(mock_context, table="events_jan")  # type: ignore[operator]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "login"
@@ -109,7 +109,7 @@ class TestPropertyKeysTool:
         """property_keys should return property keys from Workspace method."""
         from mp_mcp_server.tools.local import property_keys
 
-        result = property_keys(mock_context, table="events_jan")
+        result = property_keys(mock_context, table="events_jan")  # type: ignore[operator]
         assert isinstance(result, list)
         assert result == ["browser", "country", "device"]
 
@@ -117,7 +117,7 @@ class TestPropertyKeysTool:
         """property_keys should accept optional event filter."""
         from mp_mcp_server.tools.local import property_keys
 
-        result = property_keys(mock_context, table="events_jan", event="login")
+        result = property_keys(mock_context, table="events_jan", event="login")  # type: ignore[operator]
         assert isinstance(result, list)
 
 
@@ -141,7 +141,7 @@ class TestColumnStatsTool:
             "workspace"
         ].sql_rows.return_value = sql_rows_mock
 
-        result = column_stats(mock_context, table="events_jan", column="time")
+        result = column_stats(mock_context, table="events_jan", column="time")  # type: ignore[operator]
         assert result["count"] == 1000
         assert result["distinct_count"] == 500
         assert result["min_value"] == "2024-01-01"
@@ -156,7 +156,7 @@ class TestColumnStatsTool:
             "workspace"
         ].sql_rows.return_value = sql_rows_mock
 
-        result = column_stats(mock_context, table="events_jan", column="time")
+        result = column_stats(mock_context, table="events_jan", column="time")  # type: ignore[operator]
         assert result == {
             "count": 0,
             "distinct_count": 0,
@@ -173,7 +173,7 @@ class TestDropTableTool:
         """drop_table should remove a table."""
         from mp_mcp_server.tools.local import drop_table
 
-        result = drop_table(mock_context, table="events_jan")
+        result = drop_table(mock_context, table="events_jan")  # type: ignore[operator]
         assert result["success"] is True
         assert "events_jan" in result["message"]
 
@@ -185,7 +185,7 @@ class TestDropAllTablesTool:
         """drop_all_tables should remove all tables."""
         from mp_mcp_server.tools.local import drop_all_tables
 
-        result = drop_all_tables(mock_context)
+        result = drop_all_tables(mock_context)  # type: ignore[operator]
         assert result["success"] is True
 
 
@@ -270,7 +270,7 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import column_stats
 
         with pytest.raises(ToolError, match="Invalid table name"):
-            column_stats(mock_context, table="events; DROP TABLE--", column="time")
+            column_stats(mock_context, table="events; DROP TABLE--", column="time")  # type: ignore[operator]
 
     def test_column_stats_validates_column_expression(
         self, mock_context: MagicMock
@@ -281,7 +281,7 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import column_stats
 
         with pytest.raises(ToolError, match="disallowed pattern"):
-            column_stats(mock_context, table="events", column="time; DROP TABLE x")
+            column_stats(mock_context, table="events", column="time; DROP TABLE x")  # type: ignore[operator]
 
     def test_event_breakdown_validates_table_name(
         self, mock_context: MagicMock
@@ -292,4 +292,4 @@ class TestSqlInjectionPrevention:
         from mp_mcp_server.tools.local import event_breakdown
 
         with pytest.raises(ToolError, match="Invalid table name"):
-            event_breakdown(mock_context, table='events"; DELETE FROM users;--')
+            event_breakdown(mock_context, table='events"; DELETE FROM users;--')  # type: ignore[operator]

--- a/mp-mcp-server/uv.lock
+++ b/mp-mcp-server/uv.lock
@@ -2,8 +2,12 @@ version = 1
 revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
@@ -477,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.4.4"
+version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -487,9 +491,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/c4/60b6068e703c78656d07b249919754f8f60e9e7da3325560574ee27b4e39/cyclopts-4.4.4.tar.gz", hash = "sha256:f30c591c971d974ab4f223e099f881668daed72de713713c984ca41479d393dd", size = 160046, upload-time = "2026-01-05T03:40:18.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/663f3285c1ac0e5d0854bd9db2c87caa6fa3d1a063185e3394a6cdca9151/cyclopts-4.5.0.tar.gz", hash = "sha256:717ac4235548b58d500baf7e688aa4d024caf0ee68f61a012ffd5e29db3099f9", size = 161980, upload-time = "2026-01-16T02:07:16.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/5b/0eceb9a5990de9025733a0d212ca43649ba9facd58b8552b6bf93c11439d/cyclopts-4.4.4-py3-none-any.whl", hash = "sha256:316f798fe2f2a30cb70e7140cfde2a46617bfbb575d31bbfdc0b2410a447bd83", size = 197398, upload-time = "2026-01-05T03:40:17.141Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a3/2e00fececc34a99ae3a5d5702a5dd29c5371e4ed016647301a2b9bcc1976/cyclopts-4.5.0-py3-none-any.whl", hash = "sha256:305b9aa90a9cd0916f0a450b43e50ad5df9c252680731a0719edfb9b20381bf5", size = 199772, upload-time = "2026-01-16T02:07:14.707Z" },
 ]
 
 [[package]]
@@ -616,29 +620,37 @@ lua = [
 
 [[package]]
 name = "fastmcp"
-version = "2.14.3"
+version = "3.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "httpx" },
+    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
-    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/b5/7c4744dc41390ed2c17fd462ef2d42f4448a1ec53dda8fe3a01ff2872313/fastmcp-2.14.3.tar.gz", hash = "sha256:abc9113d5fcf79dfb4c060a1e1c55fccb0d4bce4a2e3eab15ca352341eec8dd6", size = 8279206, upload-time = "2026-01-12T20:00:40.789Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/b4/8b44030f3697ed1d106c79eedcf640451b8060cb52cc4f079d8ad3a2ef76/fastmcp-3.0.0b1.tar.gz", hash = "sha256:adeda5562a23cde8b3607b73ebccfe27efa3c2955eb2c03b0cdd551128b7eaaf", size = 11817449, upload-time = "2026-01-20T05:00:49.872Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/dc/f7dd14213bf511690dccaa5094d436947c253b418c86c86211d1c76e6e44/fastmcp-2.14.3-py3-none-any.whl", hash = "sha256:103c6b4c6e97a9acc251c81d303f110fe4f2bdba31353df515d66272bf1b9414", size = 416220, upload-time = "2026-01-12T20:00:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/23/9836025d2b8070cae295c805f51d9fd9da9228584c85290d8fef44d1cb34/fastmcp-3.0.0b1-py3-none-any.whl", hash = "sha256:e64dd54e94411ccc6ff63459eace8e55c79d15647917bc0c178414a642089750", size = 533457, upload-time = "2026-01-20T05:00:52.153Z" },
+]
+
+[package.optional-dependencies]
+tasks = [
+    { name = "pydocket" },
 ]
 
 [[package]]
@@ -764,60 +776,65 @@ wheels = [
 
 [[package]]
 name = "jq"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/86/6935afb6c1789d4c6ba5343607e2d2f473069eaac29fac555dbbd154c2d7/jq-1.10.0.tar.gz", hash = "sha256:fc38803075dbf1867e1b4ed268fef501feecb0c50f3555985a500faedfa70f08", size = 2031308, upload-time = "2025-07-14T18:54:53.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/ef/60ec5e3d8b6ae79c02af010030692e9e7e12a3a8134bc048728de16eb137/jq-1.11.0.tar.gz", hash = "sha256:67f1032e3a61b4e5dcdd4e390527b0000db521ac9872b64517c83c5f71ef8450", size = 2031555, upload-time = "2026-01-16T16:38:32.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/18/0611ddff443f826931c6a6e13a4d6213d159a66c9e4e82db1300b856870f/jq-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9bba438d1813e537294e77f6f0ab3f4b23d3a0ae125187edf4827260a31341a0", size = 420781, upload-time = "2025-07-14T18:51:46.033Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/0c/7e53f3fe1c8d99fd19ea6d741f4268cb0efbd0800b4b25d5aa512c7b474d/jq-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3eb6aed0d9882c43ae4c1757b72afc02063504f69d14eb12352c9b2813137c71", size = 426800, upload-time = "2025-07-14T18:51:48.377Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/fd/4eefc552dfefcd11aef2a4e4a018050ff174afa5841438a61bab171335eb/jq-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c2a6a83f8b59dcb0b9a09f1e6b042e667923916767d0bee869e217d067f5f25", size = 724351, upload-time = "2025-07-14T18:51:51.679Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e9/1748212f0e7d5d1424ae3246f3ca0ce18629b020a83454a9b18cc5d84152/jq-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:731fa11ce06276365c51fe2e23821d33acf6c66e501acfc4dd95507be840dd39", size = 743455, upload-time = "2025-07-14T18:51:54.644Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/20/effb5ee6a9dbdd0fc2979ebfa2f29baca3aea09e528a0962dbef711721e4/jq-1.10.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd313711ad4b6158662a65e1de9a4e34e6f297cacaa2a563b1d7c37fd453770e", size = 732555, upload-time = "2025-07-14T18:51:57.342Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2c/cb833cc9d61d8c67996d3568f4eb855175aa04b177f1915883148b7f962b/jq-1.10.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:af859195c4a46adc52866cbc08a5d56fea86cbb8d18c9e02b95fea7d0b9c872d", size = 714972, upload-time = "2025-07-14T18:51:59.816Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/35/2dff23341d12eee4b0b5fc0196529462320a540836062162c0b743435c0e/jq-1.10.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:801d01e2c933fa3da70ce18d73adb29c4fd07ebe0e2da3f39f79719357a60014", size = 739653, upload-time = "2025-07-14T18:52:01.988Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/09/ffb7304ccd4a728f22ef6cbc8b6168143378524462ebc45900cd60d4af54/jq-1.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6557f291f0b13db045b35401fa8b67b866fa1488e3a9703a1bcc5d156948c59", size = 739776, upload-time = "2025-07-14T18:52:04.259Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c3/48c47fd1276fd8c2ef6904a81f187b76bea8ef6876c99e5711e9dce385b6/jq-1.10.0-cp310-cp310-win32.whl", hash = "sha256:148a140c16c366c42c63e5a920dc8259ab62034c6f2c6b0f410df579fdf04654", size = 411525, upload-time = "2025-07-14T18:52:05.816Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f2/70332d975fd5d1e722eef7ad3e40a96392dacbbc0b4024ef2384b3a1df7f/jq-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:f8aa3f4eb6948be7b9b7c8eb19d4fbdaa2765227d21ea875898e2d20552ad749", size = 422859, upload-time = "2025-07-14T18:52:07.138Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e5/d460e048de611e8b455e1be98cba67fb70ecb194de3ba4486dc9dfba88cb/jq-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1363930e8efe63a76e6be93ffc6fea6d9201ba13a21f8a9c7943e9c6a4184cf7", size = 421078, upload-time = "2025-07-14T18:52:10.487Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f2/3183dd18746ef068c8798940683ff1a42397ee6519e1c1ee608843d376a1/jq-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:850c99324fdb2e42a2056c27ec45af87b1bc764a14c94cdf011f6e21d885f032", size = 427232, upload-time = "2025-07-14T18:52:14.539Z" },
-    { url = "https://files.pythonhosted.org/packages/65/2e/a566e4b254862f92be66365488bb78994110f32f8d60f255873fdaa429a7/jq-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75aabeae63f36fe421c25cb793f5e166500400e443e7f6ce509261d06d4f8b5d", size = 739810, upload-time = "2025-07-14T18:52:17.557Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e2/ad805b9a263a89c5fde75f2aa31d252c39732b55ead67d269e775eabe8a0/jq-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b6e1f04da95c5057346954b24e65cb401cf9c64566e68c4263454717fcf464d", size = 754311, upload-time = "2025-07-14T18:52:20.172Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/39/403924bd41a2365bc1ba39c99b2922b8e3f97abe6405d0e0911018df045c/jq-1.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ff2ac703b1bde9209f124aa7948012b77e93a40f858c24cf0bbd48f150c15e8", size = 745667, upload-time = "2025-07-14T18:52:22.435Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5b/9f9d5e748b810bfe79f61f7dc36ed1c5d7d68feca3928659d6dfbba50e6b/jq-1.10.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:83ae246c191e6c5363cb7987af10c4c3071ec6995424eb749d225fbb985d9e47", size = 737610, upload-time = "2025-07-14T18:52:24.268Z" },
-    { url = "https://files.pythonhosted.org/packages/12/d6/799a9f8a1588c0275411b7754cf5939dec8003978e3a71c54fb68894fc5b/jq-1.10.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:307ed7ac72c03843af46face4ec1b8238f6d0d68f5a37aab3b55d178c329ad34", size = 762500, upload-time = "2025-07-14T18:52:28.881Z" },
-    { url = "https://files.pythonhosted.org/packages/27/04/18f406ba70f7f78f9576baed53d0d84f3f02420c124d0843c1e7b16567f5/jq-1.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ded278e64dad446667656f7144cefe20cea16bb57cf6912ef6d1ddf3bddc9861", size = 763614, upload-time = "2025-07-14T18:52:32.381Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f8/accb3c72ece3164e7019910b387fd65fc1da805bc8b7dac4e676d48b852e/jq-1.10.0-cp311-cp311-win32.whl", hash = "sha256:5d5624d43c8597b06a4a2c5461d1577f29f23991472a5da88b742f7fa529c1d1", size = 410182, upload-time = "2025-07-14T18:52:34.771Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/1d/2af863d11a5330b69af6cc875bb54ecf942da4909b75284afef7468e70b5/jq-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:08bf55484a20955264358823049ff8deb671bb0025d51707ec591b5eb18a94d7", size = 421735, upload-time = "2025-07-14T18:52:37.026Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d9/b9e2b7004a2cb646507c082ea5e975ac37e6265353ec4c24779a1701c54a/jq-1.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe636cfa95b7027e7b43da83ecfd61431c0de80c3e0aa4946534b087149dcb4c", size = 420103, upload-time = "2025-07-14T18:52:39.016Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ad/d6780c218040789ed3ddbfa3b1743aaf824f80be5ebd7d5f885224c5bb08/jq-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:947fc7e1baaa7e95833b950e5a66b3e13a5cff028bff2d009b8c320124d9e69b", size = 426325, upload-time = "2025-07-14T18:52:40.654Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/42/5cfc8de34e976112e1b835a83264c7a0bab2cf8f20dc703f1257aa9e07ea/jq-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9382f85a347623afa521c43f8f09439e68906fd5b3492016f969a29219796bb9", size = 738212, upload-time = "2025-07-14T18:52:42.637Z" },
-    { url = "https://files.pythonhosted.org/packages/84/0a/eff78a2329967bda38a98580c6fb77c59696b2b7d589e97db232ca42f5c4/jq-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c376aab525d0a1debe403d3bc2f19fda9473696a1eda56bafc88248fc4ae6e7e", size = 757068, upload-time = "2025-07-14T18:52:44.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/62/353d4c0a9f363ccb2a9b5ea205f079a4ee43642622c25250d95c0fafb7ca/jq-1.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:206f230c67a46776f848858c66b9c377a8e40c2b16195552edd96fd7b45f9a52", size = 744259, upload-time = "2025-07-14T18:52:47.308Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/46/0faead425cc3a720c7cd999146f4b5f50aaf394800457efb27746c10832c/jq-1.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:06986456ebc95ccb9e9c2a1f0e842bc9d441225a554a9f9d4370ad95a19ac000", size = 740075, upload-time = "2025-07-14T18:52:50.038Z" },
-    { url = "https://files.pythonhosted.org/packages/10/0c/8e0823c5a329d735cff9f3746e0f7d74e7eea4ed9b0e75f90f942d1c455a/jq-1.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d02c0be958ddb4d9254ff251b045df2f8ee5995137702eeab4ffa81158bcdbe0", size = 766475, upload-time = "2025-07-14T18:52:53.047Z" },
-    { url = "https://files.pythonhosted.org/packages/06/0c/9b5aae9081fe6620915aa0e0ca76fd016e5b9d399b80c8615852413f4404/jq-1.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37cf6fd2ebd2453e75ceef207d5a95a39fcbda371a9b8916db0bd42e8737a621", size = 770416, upload-time = "2025-07-14T18:52:55.858Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e7/8f4e1cc3102de31d71e6298bcbdb15d1439e2bc466f4dcf18bc3694ba61d/jq-1.10.0-cp312-cp312-win32.whl", hash = "sha256:655d75d54a343944a9b011f568156cdc29ae0b35d2fdeefb001f459a4e4fc313", size = 410113, upload-time = "2025-07-14T18:52:57.736Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/6efe0a2b69910643b80d7da39fbded8225749dee4b79ebe23d522109a310/jq-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d67c2653ae41eab48f8888c213c9e1807b43167f26ac623c9f3e00989d3edee", size = 422316, upload-time = "2025-07-14T18:52:59.605Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fe/eeede83103e90e8f5fd9b610514a4c714957d6575e03987ebeb77aafeafa/jq-1.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b11d6e115ebad15d738d49932c3a8b9bb302b928e0fb79acc80987598d147a43", size = 419325, upload-time = "2025-07-14T18:53:01.854Z" },
-    { url = "https://files.pythonhosted.org/packages/09/12/8b39293715d7721b2999facd4a05ca3328fe4a68cf1c094667789867aac1/jq-1.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df278904c5727dfe5bc678131a0636d731cd944879d890adf2fc6de35214b19b", size = 425344, upload-time = "2025-07-14T18:53:03.528Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f4/ace0c853d4462f1d28798d5696619d2fb68c8e1db228ef5517365a0f3c1c/jq-1.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab4c1ec69fd7719fb1356e2ade7bd2b5a63d6f0eaf5a90fdc5c9f6145f0474ce", size = 735874, upload-time = "2025-07-14T18:53:05.406Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/b0/7882035062771686bd7e62db019fa0900fd9a3720b7ad8f7af65ee628484/jq-1.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd24dc21c8afcbe5aa812878251cfafa6f1dc6e1126c35d460cc7e67eb331018", size = 754355, upload-time = "2025-07-14T18:53:07.487Z" },
-    { url = "https://files.pythonhosted.org/packages/df/7d/b759a764c5d05c6829e95733a8b26f7e9b14df245ec2a325c0de049393ca/jq-1.10.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c0d3e89cd239c340c3a54e145ddf52fe63de31866cb73368d22a66bfe7e823f", size = 742546, upload-time = "2025-07-14T18:53:11.756Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6b/483ddb82939d4f2f9b0486887666c67a966434cc8bc72acd851fc8063f50/jq-1.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76710b280e4c464395c3d8e656b849e2704bd06e950a4ebd767860572bbf67df", size = 738777, upload-time = "2025-07-14T18:53:14.856Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/72/4d0fc965a8e57f55291763bb236a5aee91430f97c844ee328667b34af19e/jq-1.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b11a56f1fb6e2985fd3627dbd8a0637f62b1a704f7b19705733d461dafa26429", size = 765307, upload-time = "2025-07-14T18:53:17.611Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/a6/aca82622d8d20ea02bbcac8aaa92daaadd55a18c2a3ca54b2e63d98336d2/jq-1.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ac05ae44d9aa1e462329e1510e0b5139ac4446de650c7bdfdab226aafdc978ec", size = 769830, upload-time = "2025-07-14T18:53:19.937Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e3/a19aeada32dde0839e3a4d77f2f0d63f2764c579b57f405ff4b91a58a8db/jq-1.10.0-cp313-cp313-win32.whl", hash = "sha256:0bad90f5734e2fc9d09c4116ae9102c357a4d75efa60a85758b0ba633774eddb", size = 410285, upload-time = "2025-07-14T18:53:21.631Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/32/df4eb81cf371654d91b6779d3f0005e86519977e19068638c266a9c88af7/jq-1.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:4ec3fbca80a9dfb5349cdc2531faf14dd832e1847499513cf1fc477bcf46a479", size = 423094, upload-time = "2025-07-14T18:53:23.687Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/1a/40c2ed6f0d27b283c46ac58047f2f7335c24c07a8ee6b01c36af7a73a0af/jq-1.10.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:591d81677336551fd9cf3b5e23c1929ae3cd039a5c2d5fb8042870ed5372fd8c", size = 406595, upload-time = "2025-07-14T18:54:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b5/bb7ac9bf5cd636eea94b8b7ae66bccb30c0baeb1234b7cf60f1c8c9f061a/jq-1.10.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:f7f68716e8533294d2f5152e8659288091ea705778a00e066ed3b418ed724d81", size = 414867, upload-time = "2025-07-14T18:54:16.924Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/62/55b0a9de733f38b77afb54782d2c55031e7de0922077e6ade563a6c450af/jq-1.10.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72658f31d5723e7b87eea929e81d5083fd4132636a9dcdbf56ba9ea0e30ecaa3", size = 415155, upload-time = "2025-07-14T18:54:18.501Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/58/7fea03a5376f380aa85ada547e9c1fd5a9c14ba1cb037a66ac8df21977d5/jq-1.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:039e84e19306f94bf0d15291f6d358c4086c702de48e2309c3183fd866bf2785", size = 430258, upload-time = "2025-07-14T18:54:21.859Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/6b/09a130d0e9fbae0f8c5013f5a1bf77a8d760380177aa701c3bf6773c51aa/jq-1.10.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e985ded6dc2105707cb04e98ca6acbe6c24614824ed0a2fae442d2b2bc78fbc4", size = 439087, upload-time = "2025-07-14T18:54:25.374Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/bd/03f20025366149cd93eba483f874511461d2c6ad3a13cfd5b9de1c0bab00/jq-1.10.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:185d450fb45cd44ad5939ec5813f1ed0d057fa0cb12a1ba6a5fe0e49d8354958", size = 406997, upload-time = "2025-07-14T18:54:27.664Z" },
-    { url = "https://files.pythonhosted.org/packages/83/28/e2a57a342040f239b384a90dfb0ff2253d061411b07d816334862645404e/jq-1.10.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e6649eb4ce390342e07c95c2fa10fed043410408620296122f0ac48a7576f1f", size = 415060, upload-time = "2025-07-14T18:54:29.88Z" },
-    { url = "https://files.pythonhosted.org/packages/59/30/e62568fb245cd207cfd2d9c931a0dcc9cbbdfe171733b688dbbbc0575b14/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:002d93e50fab9d92035dfd79fd134052692be649e1b3835662a053016d9f2ee7", size = 414979, upload-time = "2025-07-14T18:54:31.929Z" },
-    { url = "https://files.pythonhosted.org/packages/99/fd/d00bd8f4a58b34d7e646ba9e2c9b5f7d5386472a15ef0fa8d8e65df51dfb/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1602f95ffaef7ee357b65f414b59d6284619bd3a0a588c15c3a1ae534811c1fb", size = 430400, upload-time = "2025-07-14T18:54:33.716Z" },
-    { url = "https://files.pythonhosted.org/packages/26/75/9d93d9ae98858b60c2351a33e1e87e873c0ade56dd3c4f909669ca9cbaff/jq-1.10.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b28cfd1eac69e1dc14518ed9c33e497041e9f9310e5f6259fa9d18fe342fb50", size = 439222, upload-time = "2025-07-14T18:54:35.695Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/21/c90086530a9b7b444ef09fcb10df97e9b48d33e37c1c3809c1b92a994d17/jq-1.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:04376071111798aa007f74196eb251fd9e008080412d81ba0f5042fdf75a2685", size = 415261, upload-time = "2026-01-16T16:36:05.058Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a1/dc97419a5e1aa4505496e32a9758e94f2c2b1d7e4fc74142b70e8e88c21e/jq-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f298e21cdaddae7de3ec67742535c3e30acd800016aaee2f9521f77b4918094", size = 422798, upload-time = "2026-01-16T16:36:08.357Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/5dc762429e7e4f4939b4cccdf4b666fd38ee4118489715861bff74f3800e/jq-1.11.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62561f673be573e17fb80ff95ad428d17f55d29546f6c44ffa04edaccd68212f", size = 746518, upload-time = "2026-01-16T16:36:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/acdd9d263e561c21c56b783e05c98056520e0376a6808aaa2d1c2f44f33a/jq-1.11.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e63630a51a01d8a8d587cbfa5a34544d7aa7a49d5d14bb8206e6e435d18af935", size = 757810, upload-time = "2026-01-16T16:36:15.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f0/6e20be344121af026653e90391ae715de26e9bac517a6eadd592f0584fa3/jq-1.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1e674aff383d7969645b97ec77fa49b774e129dbc203be04f88b2dac1bb390cd", size = 739999, upload-time = "2026-01-16T16:36:18.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/41054871f47cf4a4e6e490e0b9752a041185699014620d043f07bea84a00/jq-1.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:669feef2326865a964e0b156f83e6608e8d7011462f773339198b4b1882fd05c", size = 755730, upload-time = "2026-01-16T16:36:20.366Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/04df19f64da9622e450b02d4502826f8f1a715eb8a17547c44eac6038f90/jq-1.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:8b56408bbe7d19e6ad3f1ba34fd70b3a2269b5acb322651e1262c9632e9e2a01", size = 407801, upload-time = "2026-01-16T16:36:22.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d1175847d2812bb81a9feb56c16fac2e6c115db2ac40ee607ca15c8095ce/jq-1.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fe1c5facefd0f1197fb95cda8f31195487f431e4c4699cb0cb207efc47553504", size = 414890, upload-time = "2026-01-16T16:36:23.656Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6c/a69b5b75defc1f2fd9102a807d9ae8f0d00df42f70b71543810a7a2f7f10/jq-1.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e8f4f1fd9fd85416d978e4e0d8e3fb7603bdb7da87f5cd6dc5e94047b75a4813", size = 422620, upload-time = "2026-01-16T16:36:25.106Z" },
+    { url = "https://files.pythonhosted.org/packages/70/16/dc00b5d536aadaf95cdfa857ea0703aa52ec5a4a048f7cedb795433d04fe/jq-1.11.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8bb8d244a6b11140c0908affbad621485788500d4236cf7c09b6f0087e991815", size = 762515, upload-time = "2026-01-16T16:36:29.167Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/a466a102e6681c244a03673226591c76013f4c925560d049beb417d8bd79/jq-1.11.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17755df4b65ad9f9021c43b90a04c02f771b32b8c429a0e7ff160a13229f787e", size = 772478, upload-time = "2026-01-16T16:36:32.395Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/5f/4c0b4b5b2bce315697cb4816ecd76830b173ae9ce1442aadc37726035938/jq-1.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a8d080c00b5fc66bb9ee2876402b978b84a7108526b4c9affd704813a2add78", size = 752141, upload-time = "2026-01-16T16:36:35.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2f/b86d089d46b89380c179ba1ccc4cd4ab42b1cd966404581b0d64b4eb0716/jq-1.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:06819d14f18187379959f0ac5fdd1bcf7f452d84623a2945d7ed1d1ceeba8499", size = 773240, upload-time = "2026-01-16T16:36:37.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/e4/bc09a6b066bd82b60cbdb57e1b17c4e63c9a613639497807c120045bbb8e/jq-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:c463edd4f45ff3e1923766a0c582a8e955bd889dd756e0ac6392d28f5ca144db", size = 407170, upload-time = "2026-01-16T16:36:39.56Z" },
+    { url = "https://files.pythonhosted.org/packages/da/59/0cc99dddf0df36818621a56c4834db73a244fb86c9a567eb42d8c3bf0eaf/jq-1.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d63c4437f256edb6c204481181d19e3e33f24781b1bfbab2db589af574567bed", size = 414638, upload-time = "2026-01-16T16:36:41.14Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/9e/731b5793e13066b229d6d17fb7a4cefc4c9a8cb93d1779a0473df15f2064/jq-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0db188d73f2b6ad4e4f62653b2a4ea06dd99b790cc9a8aba6b617d9d0806aee0", size = 422617, upload-time = "2026-01-16T16:36:42.663Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/ffce6a15730fae2da4a540607a3cfc5085dd6466c64fc3c93073870f09a7/jq-1.11.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6d0cde00e6da44f49772c5f77b0efa1d11d5866b2af923fd94e2ffbdfae89c", size = 754635, upload-time = "2026-01-16T16:36:45.684Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/0f/cb3ddaae16b56d0f3dca1bef6fe78b5828e4e4425b192b973c2c212ace47/jq-1.11.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40489d775f77d9d8b4ec1f3ab1e977415e003c5065ad3befbe61ae80810bc381", size = 773750, upload-time = "2026-01-16T16:36:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/28/98/6e2127958546603aab57acefd2196ce788b4902a223a8e05f3a4493b6c95/jq-1.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d2ac5087d6d16929cf0f9918ed83b3d4c5d765bd160d3af125131bb124001d3a", size = 742704, upload-time = "2026-01-16T16:36:51.465Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4f/1c40851bfe4c56e727abe81e2000d7a01c944fc6b409a4916b73fe38bdf1/jq-1.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a8a67a52445535edffe10733b9da493134bfbf354acdbeb29d9ef28fd39938ac", size = 768539, upload-time = "2026-01-16T16:36:53.948Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/de/2529c874fd6c192931fa1aeb9a9f0a7f9555a296a560d41958ebc0a546b3/jq-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:824a295e62802a67a21f13e4b2d32a24ff5849f7bd435b042e68a9c598c8e778", size = 409287, upload-time = "2026-01-16T16:36:55.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/9b/eeb893591371ed1d6badc8c3d6ca0033e764a90b221734d578049ea9898a/jq-1.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9aba6e4a4e66a8d55f45137c7039dd56a65ad95ef4c1c1c208190971966429b9", size = 414359, upload-time = "2026-01-16T16:36:58.003Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ff/f80f75b398052e9d09ae09c9bb175ee2679c9a13dea42e9a8ffcc03fbc20/jq-1.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5295d6d2a6c1de53f9ca1cd3211f5728e20c0be1e6456486a9e6b6016102e173", size = 422335, upload-time = "2026-01-16T16:36:59.684Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6f/a0d8353e03b6f2e1dec08eddb4d1accf2f37605730f9539412c4a1ae0a5c/jq-1.11.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04a8c3b0b4d78cab658ec8cd1b34f7c9a711355ff6d8aa01a3b24955b3eb531", size = 748178, upload-time = "2026-01-16T16:37:01.511Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/85de5a406c36133b71f80c1a4f3872baa2d5b598ea0179e25fb7e1fb385b/jq-1.11.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e08573ee9a5448166f1e8f068ce05fba21db15adcebbaf2472729d36ec92a1e", size = 767262, upload-time = "2026-01-16T16:37:03.31Z" },
+    { url = "https://files.pythonhosted.org/packages/74/51/926c0dee6c5c0cf71a8d6d4665b44ad0dbd18eb5a40455c9b93fa327a188/jq-1.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd4376b62fc18e8c3f5334f388f92a48b148cf755610ad44d22958a41edcbc8d", size = 737316, upload-time = "2026-01-16T16:37:05.027Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/49c02ee479b29083047a323c3f4ca6a6c8ef2a9ae1bfe6d86d73d4f283b7/jq-1.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:680edbd5838fb04539469e39e3e147ae3890b90af3e727d6028e370f8a202b1c", size = 762343, upload-time = "2026-01-16T16:37:07.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/16/4697abf6c1d92e8297e07c3fba6d400b5a9c71780a24072480d9076451d7/jq-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:54f896e878c89cef4c05aff53f822de62a08e91d08bad7cbf4f7e91b7a06a460", size = 409686, upload-time = "2026-01-16T16:37:09.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b3/c05827ed6dd55815b74a124d4c8d2cf9557370d96e78a6cf6fa44c6f4926/jq-1.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:07100bc8338f4030c12fb87816f2f04d4cac78363152dbb8f8cb12fcb3dbbd5f", size = 414414, upload-time = "2026-01-16T16:37:12.663Z" },
+    { url = "https://files.pythonhosted.org/packages/02/df/43c82fc8a25e9f972299d41e41ce14010fc0b2b64969519a2261f651e85c/jq-1.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7051d8443d36e0df151fd509a34dff8c03bb8c99a0224b25a784920ea5059689", size = 422832, upload-time = "2026-01-16T16:37:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/48/6bb1ecf18fbd396fb7df71274b186c9b3dce8824a4fb7175c8f37147c78e/jq-1.11.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87fec2d61b50ef1b9aaae8de78593a689504c22ec9933a02de202d407b74424c", size = 746548, upload-time = "2026-01-16T16:37:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6c/415cd991045588a846fc089581c42ebce2a9fce29fe006778081885c4897/jq-1.11.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40ee2639e5ff8af74651a6531d79309871ccb722aa4ad28b35f53bdc504d41f7", size = 759982, upload-time = "2026-01-16T16:37:20.614Z" },
+    { url = "https://files.pythonhosted.org/packages/54/be/1366d4c091291db01ecfe64ae2fb029e9613e7f0fa2f1c846d292cf2e5b3/jq-1.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9ecaa3193e11ade477eed608e017354f1d9ef66b97e7fe94575a579aee9b394b", size = 734879, upload-time = "2026-01-16T16:37:22.689Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/e90f7143347e05bb136a0ca9ef37e62ec80951db9bae44defd7a03ac1282/jq-1.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:05c9520b89e2fc99ac397b67ba5672897671c0116b397707cfbc1f8da8722f5a", size = 754295, upload-time = "2026-01-16T16:37:26.472Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8d/e8e82ce41532e3f7b0dfefbb7be840fc5d72a16a58fde499ff7b306e378e/jq-1.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:00ee063b24bb3cc721d6dd92ac05ef2882096c7a9f50972959ef4655486d7a69", size = 428086, upload-time = "2026-01-16T16:37:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/95a1a4a6c109396972699ed8ce8b13d770f9c09fda128a0c608ef0d13c84/jq-1.11.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c4c769ee81de2d799856868bf3bdb1a835e0fb26a62f67a5d8d6ab5392b6e7fa", size = 417816, upload-time = "2026-01-16T16:37:28.825Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/26/f86a1cc57cb087e1a5ee8fc314a59d47f588cb479f8e2680e516c5a4234c/jq-1.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f6857f2770d1afb8a202f9b6702a7f099cf4052d820f76d01c59dfc6e44d4709", size = 428286, upload-time = "2026-01-16T16:37:30.985Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fd/a16a5b90341392d756f9f1577c27977fc53554b194d00b308878f672476a/jq-1.11.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0f6287977012657776f85fa15ca3c072974ded3d98a3400a765c49e84dfb16e", size = 777522, upload-time = "2026-01-16T16:37:33.764Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d6/ea0b9caa71a7966159177e0c2279b7926ccd80da6d4703668df6ec461186/jq-1.11.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cf7f44b346c4494be880d3f07c1c72ff56066714b2f8ae2400009afdbdb4adc", size = 773198, upload-time = "2026-01-16T16:37:36.082Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/65/e41f566f5ce79ec9fbaeaea86944f4e2f9f258622ad2fe165c275f8711b7/jq-1.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e46494407cb074d2ffc35337cbe841686aa42f3d1a49901fab3571b55c2e2463", size = 757153, upload-time = "2026-01-16T16:37:38.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/05/7dce2693991526c40b227c552e2829210099c38ef1c1d0f545ceafa57f0b/jq-1.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2bea91038d8ea749c54cc06f916afe07a2dbfa05817f3945f89efa75e3dd9517", size = 765389, upload-time = "2026-01-16T16:37:40.136Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b6/355daf5412b0d7730416e693b835d6688cc4a717b249beeb3faf073c0a47/jq-1.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:219ff02280ee55d2a57c0519b1b122003e538975e30522c21372d6df74b12317", size = 429233, upload-time = "2026-01-16T16:37:43.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/67/a677b54f7db47a629bd2d417d04ee9d3b02148c87e60e78eef5d1477c6dd/jq-1.11.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:62b8fd1b93ba3bad1f1051fa955ff675d076466c2e900c59afe2393bc09c49bc", size = 401389, upload-time = "2026-01-16T16:38:19.759Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9d/c513b229d2ed90b96f1402eb8890b0a5191ca8829aef40af9024d8278228/jq-1.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:77686477535191cdd2a01acfdcf3d67e71b4319edf33cab5bf5e383bbe147291", size = 410983, upload-time = "2026-01-16T16:38:21.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8d/dc6be3df591340f963351c002413cc5e418f290f1f6011eb5831aba4fa28/jq-1.11.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bfeb6627f8dace23e0eaf7818ba4c5227e60bc2e843c9eafe895d59c0d274d1", size = 410635, upload-time = "2026-01-16T16:38:23.962Z" },
+    { url = "https://files.pythonhosted.org/packages/48/39/0d819962352f178492069ba2767b4983e302a9867e856cec624f06bd21ed/jq-1.11.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:594ebd007244e16b333bd2f35a5b766176be107ee99f9d92883a79d50439b93c", size = 425107, upload-time = "2026-01-16T16:38:26.969Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -882,75 +899,75 @@ wheels = [
 
 [[package]]
 name = "librt"
-version = "0.7.7"
+version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/29/47f29026ca17f35cf299290292d5f8331f5077364974b7675a353179afa2/librt-0.7.7.tar.gz", hash = "sha256:81d957b069fed1890953c3b9c3895c7689960f233eea9a1d9607f71ce7f00b2c", size = 145910, upload-time = "2026-01-01T23:52:22.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", size = 148323, upload-time = "2026-01-14T12:56:16.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/84/2cfb1f3b9b60bab52e16a220c931223fc8e963d0d7bb9132bef012aafc3f/librt-0.7.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4836c5645f40fbdc275e5670819bde5ab5f2e882290d304e3c6ddab1576a6d0", size = 54709, upload-time = "2026-01-01T23:50:48.326Z" },
-    { url = "https://files.pythonhosted.org/packages/19/a1/3127b277e9d3784a8040a54e8396d9ae5c64d6684dc6db4b4089b0eedcfb/librt-0.7.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ae8aec43117a645a31e5f60e9e3a0797492e747823b9bda6972d521b436b4e8", size = 56658, upload-time = "2026-01-01T23:50:49.74Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/e9/b91b093a5c42eb218120445f3fef82e0b977fa2225f4d6fc133d25cdf86a/librt-0.7.7-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:aea05f701ccd2a76b34f0daf47ca5068176ff553510b614770c90d76ac88df06", size = 161026, upload-time = "2026-01-01T23:50:50.853Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/cb/1ded77d5976a79d7057af4a010d577ce4f473ff280984e68f4974a3281e5/librt-0.7.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b16ccaeff0ed4355dfb76fe1ea7a5d6d03b5ad27f295f77ee0557bc20a72495", size = 169529, upload-time = "2026-01-01T23:50:52.24Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/6ca5bdaa701e15f05000ac1a4c5d1475c422d3484bd3d1ca9e8c2f5be167/librt-0.7.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c48c7e150c095d5e3cea7452347ba26094be905d6099d24f9319a8b475fcd3e0", size = 183271, upload-time = "2026-01-01T23:50:55.287Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2d/55c0e38073997b4bbb5ddff25b6d1bbba8c2f76f50afe5bb9c844b702f34/librt-0.7.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4dcee2f921a8632636d1c37f1bbdb8841d15666d119aa61e5399c5268e7ce02e", size = 179039, upload-time = "2026-01-01T23:50:56.807Z" },
-    { url = "https://files.pythonhosted.org/packages/33/4e/3662a41ae8bb81b226f3968426293517b271d34d4e9fd4b59fc511f1ae40/librt-0.7.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:14ef0f4ac3728ffd85bfc58e2f2f48fb4ef4fa871876f13a73a7381d10a9f77c", size = 173505, upload-time = "2026-01-01T23:50:58.291Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5d/cf768deb8bdcbac5f8c21fcb32dd483d038d88c529fd351bbe50590b945d/librt-0.7.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e4ab69fa37f8090f2d971a5d2bc606c7401170dbdae083c393d6cbf439cb45b8", size = 193570, upload-time = "2026-01-01T23:50:59.546Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/ea/ee70effd13f1d651976d83a2812391f6203971740705e3c0900db75d4bce/librt-0.7.7-cp310-cp310-win32.whl", hash = "sha256:4bf3cc46d553693382d2abf5f5bd493d71bb0f50a7c0beab18aa13a5545c8900", size = 42600, upload-time = "2026-01-01T23:51:00.694Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/eb/dc098730f281cba76c279b71783f5de2edcba3b880c1ab84a093ef826062/librt-0.7.7-cp310-cp310-win_amd64.whl", hash = "sha256:f0c8fe5aeadd8a0e5b0598f8a6ee3533135ca50fd3f20f130f9d72baf5c6ac58", size = 48977, upload-time = "2026-01-01T23:51:01.726Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/56/30b5c342518005546df78841cb0820ae85a17e7d07d521c10ef367306d0d/librt-0.7.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a487b71fbf8a9edb72a8c7a456dda0184642d99cd007bc819c0b7ab93676a8ee", size = 54709, upload-time = "2026-01-01T23:51:02.774Z" },
-    { url = "https://files.pythonhosted.org/packages/72/78/9f120e3920b22504d4f3835e28b55acc2cc47c9586d2e1b6ba04c3c1bf01/librt-0.7.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f4d4efb218264ecf0f8516196c9e2d1a0679d9fb3bb15df1155a35220062eba8", size = 56663, upload-time = "2026-01-01T23:51:03.838Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ea/7d7a1ee7dfc1151836028eba25629afcf45b56bbc721293e41aa2e9b8934/librt-0.7.7-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b8bb331aad734b059c4b450cd0a225652f16889e286b2345af5e2c3c625c3d85", size = 161705, upload-time = "2026-01-01T23:51:04.917Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a5/952bc840ac8917fbcefd6bc5f51ad02b89721729814f3e2bfcc1337a76d6/librt-0.7.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:467dbd7443bda08338fc8ad701ed38cef48194017554f4c798b0a237904b3f99", size = 171029, upload-time = "2026-01-01T23:51:06.09Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/bf/c017ff7da82dc9192cf40d5e802a48a25d00e7639b6465cfdcee5893a22c/librt-0.7.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50d1d1ee813d2d1a3baf2873634ba506b263032418d16287c92ec1cc9c1a00cb", size = 184704, upload-time = "2026-01-01T23:51:07.549Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ec/72f3dd39d2cdfd6402ab10836dc9cbf854d145226062a185b419c4f1624a/librt-0.7.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e5070cf3ec92d98f57574da0224f8c73faf1ddd6d8afa0b8c9f6e86997bc74", size = 180719, upload-time = "2026-01-01T23:51:09.062Z" },
-    { url = "https://files.pythonhosted.org/packages/78/86/06e7a1a81b246f3313bf515dd9613a1c81583e6fd7843a9f4d625c4e926d/librt-0.7.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bdb9f3d865b2dafe7f9ad7f30ef563c80d0ddd2fdc8cc9b8e4f242f475e34d75", size = 174537, upload-time = "2026-01-01T23:51:10.611Z" },
-    { url = "https://files.pythonhosted.org/packages/83/08/f9fb2edc9c7a76e95b2924ce81d545673f5b034e8c5dd92159d1c7dae0c6/librt-0.7.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8185c8497d45164e256376f9da5aed2bb26ff636c798c9dabe313b90e9f25b28", size = 195238, upload-time = "2026-01-01T23:51:11.762Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/56/ea2d2489d3ea1f47b301120e03a099e22de7b32c93df9a211e6ff4f9bf38/librt-0.7.7-cp311-cp311-win32.whl", hash = "sha256:44d63ce643f34a903f09ff7ca355aae019a3730c7afd6a3c037d569beeb5d151", size = 42939, upload-time = "2026-01-01T23:51:13.192Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7b/c288f417e42ba2a037f1c0753219e277b33090ed4f72f292fb6fe175db4c/librt-0.7.7-cp311-cp311-win_amd64.whl", hash = "sha256:7d13cc340b3b82134f8038a2bfe7137093693dcad8ba5773da18f95ad6b77a8a", size = 49240, upload-time = "2026-01-01T23:51:14.264Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/24/738eb33a6c1516fdb2dfd2a35db6e5300f7616679b573585be0409bc6890/librt-0.7.7-cp311-cp311-win_arm64.whl", hash = "sha256:983de36b5a83fe9222f4f7dcd071f9b1ac6f3f17c0af0238dadfb8229588f890", size = 42613, upload-time = "2026-01-01T23:51:15.268Z" },
-    { url = "https://files.pythonhosted.org/packages/56/72/1cd9d752070011641e8aee046c851912d5f196ecd726fffa7aed2070f3e0/librt-0.7.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2a85a1fc4ed11ea0eb0a632459ce004a2d14afc085a50ae3463cd3dfe1ce43fc", size = 55687, upload-time = "2026-01-01T23:51:16.291Z" },
-    { url = "https://files.pythonhosted.org/packages/50/aa/d5a1d4221c4fe7e76ae1459d24d6037783cb83c7645164c07d7daf1576ec/librt-0.7.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c87654e29a35938baead1c4559858f346f4a2a7588574a14d784f300ffba0efd", size = 57136, upload-time = "2026-01-01T23:51:17.363Z" },
-    { url = "https://files.pythonhosted.org/packages/23/6f/0c86b5cb5e7ef63208c8cc22534df10ecc5278efc0d47fb8815577f3ca2f/librt-0.7.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c9faaebb1c6212c20afd8043cd6ed9de0a47d77f91a6b5b48f4e46ed470703fe", size = 165320, upload-time = "2026-01-01T23:51:18.455Z" },
-    { url = "https://files.pythonhosted.org/packages/16/37/df4652690c29f645ffe405b58285a4109e9fe855c5bb56e817e3e75840b3/librt-0.7.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1908c3e5a5ef86b23391448b47759298f87f997c3bd153a770828f58c2bb4630", size = 174216, upload-time = "2026-01-01T23:51:19.599Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/d6/d3afe071910a43133ec9c0f3e4ce99ee6df0d4e44e4bddf4b9e1c6ed41cc/librt-0.7.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dbc4900e95a98fc0729523be9d93a8fedebb026f32ed9ffc08acd82e3e181503", size = 189005, upload-time = "2026-01-01T23:51:21.052Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/18/74060a870fe2d9fd9f47824eba6717ce7ce03124a0d1e85498e0e7efc1b2/librt-0.7.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a7ea4e1fbd253e5c68ea0fe63d08577f9d288a73f17d82f652ebc61fa48d878d", size = 183961, upload-time = "2026-01-01T23:51:22.493Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/5e/918a86c66304af66a3c1d46d54df1b2d0b8894babc42a14fb6f25511497f/librt-0.7.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ef7699b7a5a244b1119f85c5bbc13f152cd38240cbb2baa19b769433bae98e50", size = 177610, upload-time = "2026-01-01T23:51:23.874Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d7/b5e58dc2d570f162e99201b8c0151acf40a03a39c32ab824dd4febf12736/librt-0.7.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:955c62571de0b181d9e9e0a0303c8bc90d47670a5eff54cf71bf5da61d1899cf", size = 199272, upload-time = "2026-01-01T23:51:25.341Z" },
-    { url = "https://files.pythonhosted.org/packages/18/87/8202c9bd0968bdddc188ec3811985f47f58ed161b3749299f2c0dd0f63fb/librt-0.7.7-cp312-cp312-win32.whl", hash = "sha256:1bcd79be209313b270b0e1a51c67ae1af28adad0e0c7e84c3ad4b5cb57aaa75b", size = 43189, upload-time = "2026-01-01T23:51:26.799Z" },
-    { url = "https://files.pythonhosted.org/packages/61/8d/80244b267b585e7aa79ffdac19f66c4861effc3a24598e77909ecdd0850e/librt-0.7.7-cp312-cp312-win_amd64.whl", hash = "sha256:4353ee891a1834567e0302d4bd5e60f531912179578c36f3d0430f8c5e16b456", size = 49462, upload-time = "2026-01-01T23:51:27.813Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1f/75db802d6a4992d95e8a889682601af9b49d5a13bbfa246d414eede1b56c/librt-0.7.7-cp312-cp312-win_arm64.whl", hash = "sha256:a76f1d679beccccdf8c1958e732a1dfcd6e749f8821ee59d7bec009ac308c029", size = 42828, upload-time = "2026-01-01T23:51:28.804Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/5e/d979ccb0a81407ec47c14ea68fb217ff4315521730033e1dd9faa4f3e2c1/librt-0.7.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f4a0b0a3c86ba9193a8e23bb18f100d647bf192390ae195d84dfa0a10fb6244", size = 55746, upload-time = "2026-01-01T23:51:29.828Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2c/3b65861fb32f802c3783d6ac66fc5589564d07452a47a8cf9980d531cad3/librt-0.7.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5335890fea9f9e6c4fdf8683061b9ccdcbe47c6dc03ab8e9b68c10acf78be78d", size = 57174, upload-time = "2026-01-01T23:51:31.226Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/030b50614b29e443607220097ebaf438531ea218c7a9a3e21ea862a919cd/librt-0.7.7-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b4346b1225be26def3ccc6c965751c74868f0578cbcba293c8ae9168483d811", size = 165834, upload-time = "2026-01-01T23:51:32.278Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e1/bd8d1eacacb24be26a47f157719553bbd1b3fe812c30dddf121c0436fd0b/librt-0.7.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a10b8eebdaca6e9fdbaf88b5aefc0e324b763a5f40b1266532590d5afb268a4c", size = 174819, upload-time = "2026-01-01T23:51:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7d/91d6c3372acf54a019c1ad8da4c9ecf4fc27d039708880bf95f48dbe426a/librt-0.7.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:067be973d90d9e319e6eb4ee2a9b9307f0ecd648b8a9002fa237289a4a07a9e7", size = 189607, upload-time = "2026-01-01T23:51:34.604Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ac/44604d6d3886f791fbd1c6ae12d5a782a8f4aca927484731979f5e92c200/librt-0.7.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:23d2299ed007812cccc1ecef018db7d922733382561230de1f3954db28433977", size = 184586, upload-time = "2026-01-01T23:51:35.845Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/26/d8a6e4c17117b7f9b83301319d9a9de862ae56b133efb4bad8b3aa0808c9/librt-0.7.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6b6f8ea465524aa4c7420c7cc4ca7d46fe00981de8debc67b1cc2e9957bb5b9d", size = 178251, upload-time = "2026-01-01T23:51:37.018Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ab/98d857e254376f8e2f668e807daccc1f445e4b4fc2f6f9c1cc08866b0227/librt-0.7.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8df32a99cc46eb0ee90afd9ada113ae2cafe7e8d673686cf03ec53e49635439", size = 199853, upload-time = "2026-01-01T23:51:38.195Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/55/4523210d6ae5134a5da959900be43ad8bab2e4206687b6620befddb5b5fd/librt-0.7.7-cp313-cp313-win32.whl", hash = "sha256:86f86b3b785487c7760247bcdac0b11aa8bf13245a13ed05206286135877564b", size = 43247, upload-time = "2026-01-01T23:51:39.629Z" },
-    { url = "https://files.pythonhosted.org/packages/25/40/3ec0fed5e8e9297b1cf1a3836fb589d3de55f9930e3aba988d379e8ef67c/librt-0.7.7-cp313-cp313-win_amd64.whl", hash = "sha256:4862cb2c702b1f905c0503b72d9d4daf65a7fdf5a9e84560e563471e57a56949", size = 49419, upload-time = "2026-01-01T23:51:40.674Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/7a/aab5f0fb122822e2acbc776addf8b9abfb4944a9056c00c393e46e543177/librt-0.7.7-cp313-cp313-win_arm64.whl", hash = "sha256:0996c83b1cb43c00e8c87835a284f9057bc647abd42b5871e5f941d30010c832", size = 42828, upload-time = "2026-01-01T23:51:41.731Z" },
-    { url = "https://files.pythonhosted.org/packages/69/9c/228a5c1224bd23809a635490a162e9cbdc68d99f0eeb4a696f07886b8206/librt-0.7.7-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:23daa1ab0512bafdd677eb1bfc9611d8ffbe2e328895671e64cb34166bc1b8c8", size = 55188, upload-time = "2026-01-01T23:51:43.14Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c2/0e7c6067e2b32a156308205e5728f4ed6478c501947e9142f525afbc6bd2/librt-0.7.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:558a9e5a6f3cc1e20b3168fb1dc802d0d8fa40731f6e9932dcc52bbcfbd37111", size = 56895, upload-time = "2026-01-01T23:51:44.534Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/77/de50ff70c80855eb79d1d74035ef06f664dd073fb7fb9d9fb4429651b8eb/librt-0.7.7-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2567cb48dc03e5b246927ab35cbb343376e24501260a9b5e30b8e255dca0d1d2", size = 163724, upload-time = "2026-01-01T23:51:45.571Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/19/f8e4bf537899bdef9e0bb9f0e4b18912c2d0f858ad02091b6019864c9a6d/librt-0.7.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6066c638cdf85ff92fc6f932d2d73c93a0e03492cdfa8778e6d58c489a3d7259", size = 172470, upload-time = "2026-01-01T23:51:46.823Z" },
-    { url = "https://files.pythonhosted.org/packages/42/4c/dcc575b69d99076768e8dd6141d9aecd4234cba7f0e09217937f52edb6ed/librt-0.7.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a609849aca463074c17de9cda173c276eb8fee9e441053529e7b9e249dc8b8ee", size = 186806, upload-time = "2026-01-01T23:51:48.009Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f8/4094a2b7816c88de81239a83ede6e87f1138477d7ee956c30f136009eb29/librt-0.7.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:add4e0a000858fe9bb39ed55f31085506a5c38363e6eb4a1e5943a10c2bfc3d1", size = 181809, upload-time = "2026-01-01T23:51:49.35Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/ac/821b7c0ab1b5a6cd9aee7ace8309c91545a2607185101827f79122219a7e/librt-0.7.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a3bfe73a32bd0bdb9a87d586b05a23c0a1729205d79df66dee65bb2e40d671ba", size = 175597, upload-time = "2026-01-01T23:51:50.636Z" },
-    { url = "https://files.pythonhosted.org/packages/71/f9/27f6bfbcc764805864c04211c6ed636fe1d58f57a7b68d1f4ae5ed74e0e0/librt-0.7.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0ecce0544d3db91a40f8b57ae26928c02130a997b540f908cefd4d279d6c5848", size = 196506, upload-time = "2026-01-01T23:51:52.535Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ba/c9b9c6fc931dd7ea856c573174ccaf48714905b1a7499904db2552e3bbaf/librt-0.7.7-cp314-cp314-win32.whl", hash = "sha256:8f7a74cf3a80f0c3b0ec75b0c650b2f0a894a2cec57ef75f6f72c1e82cdac61d", size = 39747, upload-time = "2026-01-01T23:51:53.683Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/cd1269337c4cde3ee70176ee611ab0058aa42fc8ce5c9dce55f48facfcd8/librt-0.7.7-cp314-cp314-win_amd64.whl", hash = "sha256:3d1fe2e8df3268dd6734dba33ededae72ad5c3a859b9577bc00b715759c5aaab", size = 45971, upload-time = "2026-01-01T23:51:54.697Z" },
-    { url = "https://files.pythonhosted.org/packages/79/fd/e0844794423f5583108c5991313c15e2b400995f44f6ec6871f8aaf8243c/librt-0.7.7-cp314-cp314-win_arm64.whl", hash = "sha256:2987cf827011907d3dfd109f1be0d61e173d68b1270107bb0e89f2fca7f2ed6b", size = 39075, upload-time = "2026-01-01T23:51:55.726Z" },
-    { url = "https://files.pythonhosted.org/packages/42/02/211fd8f7c381e7b2a11d0fdfcd410f409e89967be2e705983f7c6342209a/librt-0.7.7-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8e92c8de62b40bfce91d5e12c6e8b15434da268979b1af1a6589463549d491e6", size = 57368, upload-time = "2026-01-01T23:51:56.706Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/aca257affae73ece26041ae76032153266d110453173f67d7603058e708c/librt-0.7.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f683dcd49e2494a7535e30f779aa1ad6e3732a019d80abe1309ea91ccd3230e3", size = 59238, upload-time = "2026-01-01T23:51:58.066Z" },
-    { url = "https://files.pythonhosted.org/packages/96/47/7383a507d8e0c11c78ca34c9d36eab9000db5989d446a2f05dc40e76c64f/librt-0.7.7-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b15e5d17812d4d629ff576699954f74e2cc24a02a4fc401882dd94f81daba45", size = 183870, upload-time = "2026-01-01T23:51:59.204Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/b8/50f3d8eec8efdaf79443963624175c92cec0ba84827a66b7fcfa78598e51/librt-0.7.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c084841b879c4d9b9fa34e5d5263994f21aea7fd9c6add29194dbb41a6210536", size = 194608, upload-time = "2026-01-01T23:52:00.419Z" },
-    { url = "https://files.pythonhosted.org/packages/23/d9/1b6520793aadb59d891e3b98ee057a75de7f737e4a8b4b37fdbecb10d60f/librt-0.7.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c8fb9966f84737115513fecbaf257f9553d067a7dd45a69c2c7e5339e6a8dc", size = 206776, upload-time = "2026-01-01T23:52:01.705Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/db/331edc3bba929d2756fa335bfcf736f36eff4efcb4f2600b545a35c2ae58/librt-0.7.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5fb1ecb2c35362eab2dbd354fd1efa5a8440d3e73a68be11921042a0edc0ff", size = 203206, upload-time = "2026-01-01T23:52:03.315Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/e1/6af79ec77204e85f6f2294fc171a30a91bb0e35d78493532ed680f5d98be/librt-0.7.7-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d1454899909d63cc9199a89fcc4f81bdd9004aef577d4ffc022e600c412d57f3", size = 196697, upload-time = "2026-01-01T23:52:04.857Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/46/de55ecce4b2796d6d243295c221082ca3a944dc2fb3a52dcc8660ce7727d/librt-0.7.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7ef28f2e7a016b29792fe0a2dd04dec75725b32a1264e390c366103f834a9c3a", size = 217193, upload-time = "2026-01-01T23:52:06.159Z" },
-    { url = "https://files.pythonhosted.org/packages/41/61/33063e271949787a2f8dd33c5260357e3d512a114fc82ca7890b65a76e2d/librt-0.7.7-cp314-cp314t-win32.whl", hash = "sha256:5e419e0db70991b6ba037b70c1d5bbe92b20ddf82f31ad01d77a347ed9781398", size = 40277, upload-time = "2026-01-01T23:52:07.625Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/1abd972349f83a696ea73159ac964e63e2d14086fdd9bc7ca878c25fced4/librt-0.7.7-cp314-cp314t-win_amd64.whl", hash = "sha256:d6b7d93657332c817b8d674ef6bf1ab7796b4f7ce05e420fd45bd258a72ac804", size = 46765, upload-time = "2026-01-01T23:52:08.647Z" },
-    { url = "https://files.pythonhosted.org/packages/51/0e/b756c7708143a63fca65a51ca07990fa647db2cc8fcd65177b9e96680255/librt-0.7.7-cp314-cp314t-win_arm64.whl", hash = "sha256:142c2cd91794b79fd0ce113bd658993b7ede0fe93057668c2f98a45ca00b7e91", size = 39724, upload-time = "2026-01-01T23:52:09.745Z" },
+    { url = "https://files.pythonhosted.org/packages/44/13/57b06758a13550c5f09563893b004f98e9537ee6ec67b7df85c3571c8832/librt-0.7.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b45306a1fc5f53c9330fbee134d8b3227fe5da2ab09813b892790400aa49352d", size = 56521, upload-time = "2026-01-14T12:54:40.066Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/24/bbea34d1452a10612fb45ac8356f95351ba40c2517e429602160a49d1fd0/librt-0.7.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:864c4b7083eeee250ed55135d2127b260d7eb4b5e953a9e5df09c852e327961b", size = 58456, upload-time = "2026-01-14T12:54:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/04/72/a168808f92253ec3a810beb1eceebc465701197dbc7e865a1c9ceb3c22c7/librt-0.7.8-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6938cc2de153bc927ed8d71c7d2f2ae01b4e96359126c602721340eb7ce1a92d", size = 164392, upload-time = "2026-01-14T12:54:42.843Z" },
+    { url = "https://files.pythonhosted.org/packages/14/5c/4c0d406f1b02735c2e7af8ff1ff03a6577b1369b91aa934a9fa2cc42c7ce/librt-0.7.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66daa6ac5de4288a5bbfbe55b4caa7bf0cd26b3269c7a476ffe8ce45f837f87d", size = 172959, upload-time = "2026-01-14T12:54:44.602Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5f/3e85351c523f73ad8d938989e9a58c7f59fb9c17f761b9981b43f0025ce7/librt-0.7.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4864045f49dc9c974dadb942ac56a74cd0479a2aafa51ce272c490a82322ea3c", size = 186717, upload-time = "2026-01-14T12:54:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f8/18bfe092e402d00fe00d33aa1e01dda1bd583ca100b393b4373847eade6d/librt-0.7.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a36515b1328dc5b3ffce79fe204985ca8572525452eacabee2166f44bb387b2c", size = 184585, upload-time = "2026-01-14T12:54:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/fc/f43972ff56fd790a9fa55028a52ccea1875100edbb856b705bd393b601e3/librt-0.7.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b7e7f140c5169798f90b80d6e607ed2ba5059784968a004107c88ad61fb3641d", size = 180497, upload-time = "2026-01-14T12:54:48.946Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3a/25e36030315a410d3ad0b7d0f19f5f188e88d1613d7d3fd8150523ea1093/librt-0.7.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ff71447cb778a4f772ddc4ce360e6ba9c95527ed84a52096bd1bbf9fee2ec7c0", size = 200052, upload-time = "2026-01-14T12:54:50.382Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b8/f3a5a1931ae2a6ad92bf6893b9ef44325b88641d58723529e2c2935e8abe/librt-0.7.8-cp310-cp310-win32.whl", hash = "sha256:047164e5f68b7a8ebdf9fae91a3c2161d3192418aadd61ddd3a86a56cbe3dc85", size = 43477, upload-time = "2026-01-14T12:54:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/91/c4202779366bc19f871b4ad25db10fcfa1e313c7893feb942f32668e8597/librt-0.7.8-cp310-cp310-win_amd64.whl", hash = "sha256:d6f254d096d84156a46a84861183c183d30734e52383602443292644d895047c", size = 49806, upload-time = "2026-01-14T12:54:53.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a3/87ea9c1049f2c781177496ebee29430e4631f439b8553a4969c88747d5d8/librt-0.7.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3e9c11aa260c31493d4b3197d1e28dd07768594a4f92bec4506849d736248f", size = 56507, upload-time = "2026-01-14T12:54:54.156Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4a/23bcef149f37f771ad30203d561fcfd45b02bc54947b91f7a9ac34815747/librt-0.7.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddb52499d0b3ed4aa88746aaf6f36a08314677d5c346234c3987ddc506404eac", size = 58455, upload-time = "2026-01-14T12:54:55.978Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6e/46eb9b85c1b9761e0f42b6e6311e1cc544843ac897457062b9d5d0b21df4/librt-0.7.8-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e9c0afebbe6ce177ae8edba0c7c4d626f2a0fc12c33bb993d163817c41a7a05c", size = 164956, upload-time = "2026-01-14T12:54:57.311Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/3f/aa7c7f6829fb83989feb7ba9aa11c662b34b4bd4bd5b262f2876ba3db58d/librt-0.7.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:631599598e2c76ded400c0a8722dec09217c89ff64dc54b060f598ed68e7d2a8", size = 174364, upload-time = "2026-01-14T12:54:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2d/d57d154b40b11f2cb851c4df0d4c4456bacd9b1ccc4ecb593ddec56c1a8b/librt-0.7.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c1ba843ae20db09b9d5c80475376168feb2640ce91cd9906414f23cc267a1ff", size = 188034, upload-time = "2026-01-14T12:55:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f9/36c4dad00925c16cd69d744b87f7001792691857d3b79187e7a673e812fb/librt-0.7.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b5b007bb22ea4b255d3ee39dfd06d12534de2fcc3438567d9f48cdaf67ae1ae3", size = 186295, upload-time = "2026-01-14T12:55:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9b/8a9889d3df5efb67695a67785028ccd58e661c3018237b73ad081691d0cb/librt-0.7.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dbd79caaf77a3f590cbe32dc2447f718772d6eea59656a7dcb9311161b10fa75", size = 181470, upload-time = "2026-01-14T12:55:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/43/64/54d6ef11afca01fef8af78c230726a9394759f2addfbf7afc5e3cc032a45/librt-0.7.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:87808a8d1e0bd62a01cafc41f0fd6818b5a5d0ca0d8a55326a81643cdda8f873", size = 201713, upload-time = "2026-01-14T12:55:03.919Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/29/73e7ed2991330b28919387656f54109139b49e19cd72902f466bd44415fd/librt-0.7.8-cp311-cp311-win32.whl", hash = "sha256:31724b93baa91512bd0a376e7cf0b59d8b631ee17923b1218a65456fa9bda2e7", size = 43803, upload-time = "2026-01-14T12:55:04.996Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/de/66766ff48ed02b4d78deea30392ae200bcbd99ae61ba2418b49fd50a4831/librt-0.7.8-cp311-cp311-win_amd64.whl", hash = "sha256:978e8b5f13e52cf23a9e80f3286d7546baa70bc4ef35b51d97a709d0b28e537c", size = 50080, upload-time = "2026-01-14T12:55:06.489Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e3/33450438ff3a8c581d4ed7f798a70b07c3206d298cf0b87d3806e72e3ed8/librt-0.7.8-cp311-cp311-win_arm64.whl", hash = "sha256:20e3946863d872f7cabf7f77c6c9d370b8b3d74333d3a32471c50d3a86c0a232", size = 43383, upload-time = "2026-01-14T12:55:07.49Z" },
+    { url = "https://files.pythonhosted.org/packages/56/04/79d8fcb43cae376c7adbab7b2b9f65e48432c9eced62ac96703bcc16e09b/librt-0.7.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63", size = 57472, upload-time = "2026-01-14T12:55:08.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ba/60b96e93043d3d659da91752689023a73981336446ae82078cddf706249e/librt-0.7.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93", size = 58986, upload-time = "2026-01-14T12:55:09.466Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/26/5215e4cdcc26e7be7eee21955a7e13cbf1f6d7d7311461a6014544596fac/librt-0.7.8-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592", size = 168422, upload-time = "2026-01-14T12:55:10.499Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/84/e8d1bc86fa0159bfc24f3d798d92cafd3897e84c7fea7fe61b3220915d76/librt-0.7.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850", size = 177478, upload-time = "2026-01-14T12:55:11.577Z" },
+    { url = "https://files.pythonhosted.org/packages/57/11/d0268c4b94717a18aa91df1100e767b010f87b7ae444dafaa5a2d80f33a6/librt-0.7.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62", size = 192439, upload-time = "2026-01-14T12:55:12.7Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/56/1e8e833b95fe684f80f8894ae4d8b7d36acc9203e60478fcae599120a975/librt-0.7.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b", size = 191483, upload-time = "2026-01-14T12:55:13.838Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/f11cf28a2cb6c31f282009e2208312aa84a5ee2732859f7856ee306176d5/librt-0.7.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714", size = 185376, upload-time = "2026-01-14T12:55:15.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/d7c116c6da561b9155b184354a60a3d5cdbf08fc7f3678d09c95679d13d9/librt-0.7.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449", size = 206234, upload-time = "2026-01-14T12:55:16.571Z" },
+    { url = "https://files.pythonhosted.org/packages/61/de/1975200bb0285fc921c5981d9978ce6ce11ae6d797df815add94a5a848a3/librt-0.7.8-cp312-cp312-win32.whl", hash = "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac", size = 44057, upload-time = "2026-01-14T12:55:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/cd/724f2d0b3461426730d4877754b65d39f06a41ac9d0a92d5c6840f72b9ae/librt-0.7.8-cp312-cp312-win_amd64.whl", hash = "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708", size = 50293, upload-time = "2026-01-14T12:55:19.179Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cf/7e899acd9ee5727ad8160fdcc9994954e79fab371c66535c60e13b968ffc/librt-0.7.8-cp312-cp312-win_arm64.whl", hash = "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0", size = 43574, upload-time = "2026-01-14T12:55:20.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fe/b1f9de2829cf7fc7649c1dcd202cfd873837c5cc2fc9e526b0e7f716c3d2/librt-0.7.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc", size = 57500, upload-time = "2026-01-14T12:55:21.219Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d4/4a60fbe2e53b825f5d9a77325071d61cd8af8506255067bf0c8527530745/librt-0.7.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2", size = 59019, upload-time = "2026-01-14T12:55:22.256Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/37/61ff80341ba5159afa524445f2d984c30e2821f31f7c73cf166dcafa5564/librt-0.7.8-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3", size = 169015, upload-time = "2026-01-14T12:55:23.24Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/86/13d4f2d6a93f181ebf2fc953868826653ede494559da8268023fe567fca3/librt-0.7.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6", size = 178161, upload-time = "2026-01-14T12:55:24.826Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/e24ef01305954fc4d771f1f09f3dd682f9eb610e1bec188ffb719374d26e/librt-0.7.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d", size = 193015, upload-time = "2026-01-14T12:55:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a0/92b6bd060e720d7a31ed474d046a69bd55334ec05e9c446d228c4b806ae3/librt-0.7.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e", size = 192038, upload-time = "2026-01-14T12:55:27.208Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bb/6f4c650253704279c3a214dad188101d1b5ea23be0606628bc6739456624/librt-0.7.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca", size = 186006, upload-time = "2026-01-14T12:55:28.594Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/00/1c409618248d43240cadf45f3efb866837fa77e9a12a71481912135eb481/librt-0.7.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93", size = 206888, upload-time = "2026-01-14T12:55:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/83/b2cfe8e76ff5c1c77f8a53da3d5de62d04b5ebf7cf913e37f8bca43b5d07/librt-0.7.8-cp313-cp313-win32.whl", hash = "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951", size = 44126, upload-time = "2026-01-14T12:55:31.44Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0b/c59d45de56a51bd2d3a401fc63449c0ac163e4ef7f523ea8b0c0dee86ec5/librt-0.7.8-cp313-cp313-win_amd64.whl", hash = "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34", size = 50262, upload-time = "2026-01-14T12:55:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b9/973455cec0a1ec592395250c474164c4a58ebf3e0651ee920fef1a2623f1/librt-0.7.8-cp313-cp313-win_arm64.whl", hash = "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09", size = 43600, upload-time = "2026-01-14T12:55:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/73/fa8814c6ce2d49c3827829cadaa1589b0bf4391660bd4510899393a23ebc/librt-0.7.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418", size = 57049, upload-time = "2026-01-14T12:55:35.056Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fe/f6c70956da23ea235fd2e3cc16f4f0b4ebdfd72252b02d1164dd58b4e6c3/librt-0.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611", size = 58689, upload-time = "2026-01-14T12:55:36.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4d/7a2481444ac5fba63050d9abe823e6bc16896f575bfc9c1e5068d516cdce/librt-0.7.8-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758", size = 166808, upload-time = "2026-01-14T12:55:37.595Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/3c/10901d9e18639f8953f57c8986796cfbf4c1c514844a41c9197cf87cb707/librt-0.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea", size = 175614, upload-time = "2026-01-14T12:55:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/01/5cbdde0951a5090a80e5ba44e6357d375048123c572a23eecfb9326993a7/librt-0.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac", size = 189955, upload-time = "2026-01-14T12:55:39.939Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b4/e80528d2f4b7eaf1d437fcbd6fc6ba4cbeb3e2a0cb9ed5a79f47c7318706/librt-0.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398", size = 189370, upload-time = "2026-01-14T12:55:41.057Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ab/938368f8ce31a9787ecd4becb1e795954782e4312095daf8fd22420227c8/librt-0.7.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81", size = 183224, upload-time = "2026-01-14T12:55:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/10/559c310e7a6e4014ac44867d359ef8238465fb499e7eb31b6bfe3e3f86f5/librt-0.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83", size = 203541, upload-time = "2026-01-14T12:55:43.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/db/a0db7acdb6290c215f343835c6efda5b491bb05c3ddc675af558f50fdba3/librt-0.7.8-cp314-cp314-win32.whl", hash = "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d", size = 40657, upload-time = "2026-01-14T12:55:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e0/4f9bdc2a98a798511e81edcd6b54fe82767a715e05d1921115ac70717f6f/librt-0.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44", size = 46835, upload-time = "2026-01-14T12:55:45.655Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3d/59c6402e3dec2719655a41ad027a7371f8e2334aa794ed11533ad5f34969/librt-0.7.8-cp314-cp314-win_arm64.whl", hash = "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce", size = 39885, upload-time = "2026-01-14T12:55:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/2481d80950b83085fb14ba3c595db56330d21bbc7d88a19f20165f3538db/librt-0.7.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f", size = 59161, upload-time = "2026-01-14T12:55:48.45Z" },
+    { url = "https://files.pythonhosted.org/packages/96/79/108df2cfc4e672336765d54e3ff887294c1cc36ea4335c73588875775527/librt-0.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde", size = 61008, upload-time = "2026-01-14T12:55:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/30179898f9994a5637459d6e169b6abdc982012c0a4b2d4c26f50c06f911/librt-0.7.8-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e", size = 187199, upload-time = "2026-01-14T12:55:50.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/da/f7563db55cebdc884f518ba3791ad033becc25ff68eb70902b1747dc0d70/librt-0.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b", size = 198317, upload-time = "2026-01-14T12:55:51.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6c/4289acf076ad371471fa86718c30ae353e690d3de6167f7db36f429272f1/librt-0.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666", size = 210334, upload-time = "2026-01-14T12:55:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7f/377521ac25b78ac0a5ff44127a0360ee6d5ddd3ce7327949876a30533daa/librt-0.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581", size = 211031, upload-time = "2026-01-14T12:55:54.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/e1e96c3e20b23d00cf90f4aad48f0deb4cdfec2f0ed8380d0d85acf98bbf/librt-0.7.8-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a", size = 204581, upload-time = "2026-01-14T12:55:56.811Z" },
+    { url = "https://files.pythonhosted.org/packages/43/71/0f5d010e92ed9747e14bef35e91b6580533510f1e36a8a09eb79ee70b2f0/librt-0.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca", size = 224731, upload-time = "2026-01-14T12:55:58.175Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
 ]
 
 [[package]]
@@ -1081,7 +1098,8 @@ dependencies = [
     { name = "duckdb" },
     { name = "httpx" },
     { name = "jq" },
-    { name = "pandas" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1139,7 +1157,7 @@ name = "mp-mcp-server"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["tasks"] },
     { name = "mixpanel-data" },
 ]
 
@@ -1154,7 +1172,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0,<3" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.0.0b1" },
     { name = "mixpanel-data", directory = "../" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1289,8 +1307,12 @@ name = "numpy"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz", hash = "sha256:a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690", size = 20721320, upload-time = "2026-01-10T06:44:59.619Z" }
 wheels = [
@@ -1393,80 +1415,26 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-prometheus"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
 name = "packaging"
-version = "25.0"
+version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1520,6 +1488,74 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/da/b1dc0481ab8d55d0f46e343cfe67d4551a0e14fcee52bd38ca1bd73258d8/pandas-3.0.0.tar.gz", hash = "sha256:0facf7e87d38f721f0af46fe70d97373a37701b1c09f7ed7aeeb292ade5c050f", size = 4633005, upload-time = "2026-01-21T15:52:04.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/1e/b184654a856e75e975a6ee95d6577b51c271cd92cb2b020c9378f53e0032/pandas-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d64ce01eb9cdca96a15266aa679ae50212ec52757c79204dbc7701a222401850", size = 10313247, upload-time = "2026-01-21T15:50:15.775Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/e04a547ad0f0183bf151fd7c7a477468e3b85ff2ad231c566389e6cc9587/pandas-3.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:613e13426069793aa1ec53bdcc3b86e8d32071daea138bbcf4fa959c9cdaa2e2", size = 9913131, upload-time = "2026-01-21T15:50:18.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/93/bb77bfa9fc2aba9f7204db807d5d3fb69832ed2854c60ba91b4c65ba9219/pandas-3.0.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0192fee1f1a8e743b464a6607858ee4b071deb0b118eb143d71c2a1d170996d5", size = 10741925, upload-time = "2026-01-21T15:50:21.058Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/89319812eb1d714bfc04b7f177895caeba8ab4a37ef6712db75ed786e2e0/pandas-3.0.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0b853319dec8d5e0c8b875374c078ef17f2269986a78168d9bd57e49bf650ae", size = 11245979, upload-time = "2026-01-21T15:50:23.413Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/63/684120486f541fc88da3862ed31165b3b3e12b6a1c7b93be4597bc84e26c/pandas-3.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:707a9a877a876c326ae2cb640fbdc4ef63b0a7b9e2ef55c6df9942dcee8e2af9", size = 11756337, upload-time = "2026-01-21T15:50:25.932Z" },
+    { url = "https://files.pythonhosted.org/packages/39/92/7eb0ad232312b59aec61550c3c81ad0743898d10af5df7f80bc5e5065416/pandas-3.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:afd0aa3d0b5cda6e0b8ffc10dbcca3b09ef3cbcd3fe2b27364f85fdc04e1989d", size = 12325517, upload-time = "2026-01-21T15:50:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/51/27/bf9436dd0a4fc3130acec0828951c7ef96a0631969613a9a35744baf27f6/pandas-3.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:113b4cca2614ff7e5b9fee9b6f066618fe73c5a83e99d721ffc41217b2bf57dd", size = 9881576, upload-time = "2026-01-21T15:50:30.149Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/c618b871fce0159fd107516336e82891b404e3f340821853c2fc28c7830f/pandas-3.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c14837eba8e99a8da1527c0280bba29b0eb842f64aa94982c5e21227966e164b", size = 9140807, upload-time = "2026-01-21T15:50:32.308Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/38/db33686f4b5fa64d7af40d96361f6a4615b8c6c8f1b3d334eee46ae6160e/pandas-3.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9803b31f5039b3c3b10cc858c5e40054adb4b29b4d81cb2fd789f4121c8efbcd", size = 10334013, upload-time = "2026-01-21T15:50:34.771Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7b/9254310594e9774906bacdd4e732415e1f86ab7dbb4b377ef9ede58cd8ec/pandas-3.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:14c2a4099cd38a1d18ff108168ea417909b2dea3bd1ebff2ccf28ddb6a74d740", size = 9874154, upload-time = "2026-01-21T15:50:36.67Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/726c5a67a13bc66643e66d2e9ff115cead482a44fc56991d0c4014f15aaf/pandas-3.0.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d257699b9a9960e6125686098d5714ac59d05222bef7a5e6af7a7fd87c650801", size = 10384433, upload-time = "2026-01-21T15:50:39.132Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/9211f09bedb04f9832122942de8b051804b31a39cfbad199a819bb88d9f3/pandas-3.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:69780c98f286076dcafca38d8b8eee1676adf220199c0a39f0ecbf976b68151a", size = 10864519, upload-time = "2026-01-21T15:50:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/50858522cdc46ac88b9afdc3015e298959a70a08cd21e008a44e9520180c/pandas-3.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4a66384f017240f3858a4c8a7cf21b0591c3ac885cddb7758a589f0f71e87ebb", size = 11394124, upload-time = "2026-01-21T15:50:43.377Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3f/83b2577db02503cd93d8e95b0f794ad9d4be0ba7cb6c8bcdcac964a34a42/pandas-3.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be8c515c9bc33989d97b89db66ea0cececb0f6e3c2a87fcc8b69443a6923e95f", size = 11920444, upload-time = "2026-01-21T15:50:45.932Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2d/4f8a2f192ed12c90a0aab47f5557ece0e56b0370c49de9454a09de7381b2/pandas-3.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:a453aad8c4f4e9f166436994a33884442ea62aa8b27d007311e87521b97246e1", size = 9730970, upload-time = "2026-01-21T15:50:47.962Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/64/ff571be435cf1e643ca98d0945d76732c0b4e9c37191a89c8550b105eed1/pandas-3.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:da768007b5a33057f6d9053563d6b74dd6d029c337d93c6d0d22a763a5c2ecc0", size = 9041950, upload-time = "2026-01-21T15:50:50.422Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fa/7f0ac4ca8877c57537aaff2a842f8760e630d8e824b730eb2e859ffe96ca/pandas-3.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b78d646249b9a2bc191040988c7bb524c92fa8534fb0898a0741d7e6f2ffafa6", size = 10307129, upload-time = "2026-01-21T15:50:52.877Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/11/28a221815dcea4c0c9414dfc845e34a84a6a7dabc6da3194498ed5ba4361/pandas-3.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bc9cba7b355cb4162442a88ce495e01cb605f17ac1e27d6596ac963504e0305f", size = 9850201, upload-time = "2026-01-21T15:50:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/da/53bbc8c5363b7e5bd10f9ae59ab250fc7a382ea6ba08e4d06d8694370354/pandas-3.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c9a1a149aed3b6c9bf246033ff91e1b02d529546c5d6fb6b74a28fea0cf4c70", size = 10354031, upload-time = "2026-01-21T15:50:57.463Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a3/51e02ebc2a14974170d51e2410dfdab58870ea9bcd37cda15bd553d24dc4/pandas-3.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95683af6175d884ee89471842acfca29172a85031fccdabc35e50c0984470a0e", size = 10861165, upload-time = "2026-01-21T15:50:59.32Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fe/05a51e3cac11d161472b8297bd41723ea98013384dd6d76d115ce3482f9b/pandas-3.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1fbbb5a7288719e36b76b4f18d46ede46e7f916b6c8d9915b756b0a6c3f792b3", size = 11359359, upload-time = "2026-01-21T15:51:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/56/ba620583225f9b85a4d3e69c01df3e3870659cc525f67929b60e9f21dcd1/pandas-3.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8e8b9808590fa364416b49b2a35c1f4cf2785a6c156935879e57f826df22038e", size = 11912907, upload-time = "2026-01-21T15:51:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8c/c6638d9f67e45e07656b3826405c5cc5f57f6fd07c8b2572ade328c86e22/pandas-3.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:98212a38a709feb90ae658cb6227ea3657c22ba8157d4b8f913cd4c950de5e7e", size = 9732138, upload-time = "2026-01-21T15:51:07.569Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bf/bd1335c3bf1770b6d8fed2799993b11c4971af93bb1b729b9ebbc02ca2ec/pandas-3.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:177d9df10b3f43b70307a149d7ec49a1229a653f907aa60a48f1877d0e6be3be", size = 9033568, upload-time = "2026-01-21T15:51:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c6/f5e2171914d5e29b9171d495344097d54e3ffe41d2d85d8115baba4dc483/pandas-3.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2713810ad3806767b89ad3b7b69ba153e1c6ff6d9c20f9c2140379b2a98b6c98", size = 10741936, upload-time = "2026-01-21T15:51:11.693Z" },
+    { url = "https://files.pythonhosted.org/packages/51/88/9a0164f99510a1acb9f548691f022c756c2314aad0d8330a24616c14c462/pandas-3.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:15d59f885ee5011daf8335dff47dcb8a912a27b4ad7826dc6cbe809fd145d327", size = 10393884, upload-time = "2026-01-21T15:51:14.197Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/53/b34d78084d88d8ae2b848591229da8826d1e65aacf00b3abe34023467648/pandas-3.0.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24e6547fb64d2c92665dd2adbfa4e85fa4fd70a9c070e7cfb03b629a0bbab5eb", size = 10310740, upload-time = "2026-01-21T15:51:16.093Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d3/bee792e7c3d6930b74468d990604325701412e55d7aaf47460a22311d1a5/pandas-3.0.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48ee04b90e2505c693d3f8e8f524dab8cb8aaf7ddcab52c92afa535e717c4812", size = 10700014, upload-time = "2026-01-21T15:51:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/55/db/2570bc40fb13aaed1cbc3fbd725c3a60ee162477982123c3adc8971e7ac1/pandas-3.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:66f72fb172959af42a459e27a8d8d2c7e311ff4c1f7db6deb3b643dbc382ae08", size = 11323737, upload-time = "2026-01-21T15:51:20.784Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/2e/297ac7f21c8181b62a4cccebad0a70caf679adf3ae5e83cb676194c8acc3/pandas-3.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4a4a400ca18230976724a5066f20878af785f36c6756e498e94c2a5e5d57779c", size = 11771558, upload-time = "2026-01-21T15:51:22.977Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/46/e1c6876d71c14332be70239acce9ad435975a80541086e5ffba2f249bcf6/pandas-3.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:940eebffe55528074341a5a36515f3e4c5e25e958ebbc764c9502cfc35ba3faa", size = 10473771, upload-time = "2026-01-21T15:51:25.285Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/db/0270ad9d13c344b7a36fa77f5f8344a46501abf413803e885d22864d10bf/pandas-3.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:597c08fb9fef0edf1e4fa2f9828dd27f3d78f9b8c9b4a748d435ffc55732310b", size = 10312075, upload-time = "2026-01-21T15:51:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9f/c176f5e9717f7c91becfe0f55a52ae445d3f7326b4a2cf355978c51b7913/pandas-3.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:447b2d68ac5edcbf94655fe909113a6dba6ef09ad7f9f60c80477825b6c489fe", size = 9900213, upload-time = "2026-01-21T15:51:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e7/63ad4cc10b257b143e0a5ebb04304ad806b4e1a61c5da25f55896d2ca0f4/pandas-3.0.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:debb95c77ff3ed3ba0d9aa20c3a2f19165cc7956362f9873fce1ba0a53819d70", size = 10428768, upload-time = "2026-01-21T15:51:33.018Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/4e4c2d8210f20149fd2248ef3fff26623604922bd564d915f935a06dd63d/pandas-3.0.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fedabf175e7cd82b69b74c30adbaa616de301291a5231138d7242596fc296a8d", size = 10882954, upload-time = "2026-01-21T15:51:35.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/60/c9de8ac906ba1f4d2250f8a951abe5135b404227a55858a75ad26f84db47/pandas-3.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:412d1a89aab46889f3033a386912efcdfa0f1131c5705ff5b668dda88305e986", size = 11430293, upload-time = "2026-01-21T15:51:37.57Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/69/806e6637c70920e5787a6d6896fd707f8134c2c55cd761e7249a97b7dc5a/pandas-3.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e979d22316f9350c516479dd3a92252be2937a9531ed3a26ec324198a99cdd49", size = 11952452, upload-time = "2026-01-21T15:51:39.618Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/de/918621e46af55164c400ab0ef389c9d969ab85a43d59ad1207d4ddbe30a5/pandas-3.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:083b11415b9970b6e7888800c43c82e81a06cd6b06755d84804444f0007d6bb7", size = 9851081, upload-time = "2026-01-21T15:51:41.758Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a1/3562a18dd0bd8c73344bfa26ff90c53c72f827df119d6d6b1dacc84d13e3/pandas-3.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:5db1e62cb99e739fa78a28047e861b256d17f88463c76b8dafc7c1338086dca8", size = 9174610, upload-time = "2026-01-21T15:51:44.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/26/430d91257eaf366f1737d7a1c158677caaf6267f338ec74e3a1ec444111c/pandas-3.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:697b8f7d346c68274b1b93a170a70974cdc7d7354429894d5927c1effdcccd73", size = 10761999, upload-time = "2026-01-21T15:51:46.899Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1a/954eb47736c2b7f7fe6a9d56b0cb6987773c00faa3c6451a43db4beb3254/pandas-3.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8cb3120f0d9467ed95e77f67a75e030b67545bcfa08964e349252d674171def2", size = 10410279, upload-time = "2026-01-21T15:51:48.89Z" },
+    { url = "https://files.pythonhosted.org/packages/20/fc/b96f3a5a28b250cd1b366eb0108df2501c0f38314a00847242abab71bb3a/pandas-3.0.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33fd3e6baa72899746b820c31e4b9688c8e1b7864d7aec2de7ab5035c285277a", size = 10330198, upload-time = "2026-01-21T15:51:51.015Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b3/d0e2952f103b4fbef1ef22d0c2e314e74fc9064b51cee30890b5e3286ee6/pandas-3.0.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8942e333dc67ceda1095227ad0febb05a3b36535e520154085db632c40ad084", size = 10728513, upload-time = "2026-01-21T15:51:53.387Z" },
+    { url = "https://files.pythonhosted.org/packages/76/81/832894f286df828993dc5fd61c63b231b0fb73377e99f6c6c369174cf97e/pandas-3.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:783ac35c4d0fe0effdb0d67161859078618b1b6587a1af15928137525217a721", size = 11345550, upload-time = "2026-01-21T15:51:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/ed160a00fb4f37d806406bc0a79a8b62fe67f29d00950f8d16203ff3409b/pandas-3.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:125eb901e233f155b268bbef9abd9afb5819db74f0e677e89a61b246228c71ac", size = 11799386, upload-time = "2026-01-21T15:51:57.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c8/2ac00d7255252c5e3cf61b35ca92ca25704b0188f7454ca4aec08a33cece/pandas-3.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b86d113b6c109df3ce0ad5abbc259fe86a1bd4adfd4a31a89da42f84f65509bb", size = 10873041, upload-time = "2026-01-21T15:52:00.034Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/a80ac00acbc6b35166b42850e98a4f466e2c0d9c64054161ba9620f95680/pandas-3.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1c39eab3ad38f2d7a249095f0a3d8f8c22cc0f847e98ccf5bbe732b272e2d9fa", size = 9441003, upload-time = "2026-01-21T15:52:02.281Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1566,11 +1602,11 @@ wheels = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/8f/35d31c925f33a494b3f4f10ee25bf47757aff2d63424a06af13814293f13/prometheus_client-0.24.0.tar.gz", hash = "sha256:726b40c0d499f4904d4b5b7abe8d43e6aff090de0d468ae8f2226290b331c667", size = 85590, upload-time = "2026-01-12T20:12:48.963Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/dd/50260b80759f90e3be66f094e0cd1fdef680b18d9f91edc9ae1b627624ba/prometheus_client-0.24.0-py3-none-any.whl", hash = "sha256:4ab6d4fb5a1b25ad74b58e6271857e356fff3399473e599d227ab5d0ce6637f0", size = 64062, upload-time = "2026-01-12T20:12:47.501Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]
@@ -1616,11 +1652,11 @@ wheels = [
 
 [[package]]
 name = "pycparser"
-version = "2.23"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1777,15 +1813,13 @@ wheels = [
 
 [[package]]
 name = "pydocket"
-version = "0.16.6"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "fakeredis", extra = ["lua"] },
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-instrumentation" },
     { name = "prometheus-client" },
     { name = "py-key-value-aio", extra = ["memory", "redis"] },
     { name = "python-json-logger" },
@@ -1794,9 +1828,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/00/26befe5f58df7cd1aeda4a8d10bc7d1908ffd86b80fd995e57a2a7b3f7bd/pydocket-0.16.6.tar.gz", hash = "sha256:b96c96ad7692827214ed4ff25fcf941ec38371314db5dcc1ae792b3e9d3a0294", size = 299054, upload-time = "2026-01-09T22:09:15.405Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/46/d61842164f7f623c24927dd67b4e19e3b52b6b5127401ab959a0d8273fe4/pydocket-0.17.1.tar.gz", hash = "sha256:de5b39241f728c2c0abbcb419b0cd3a5eab3ed48e228c4c7add15b02e234a68c", size = 323972, upload-time = "2026-01-22T16:59:25.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/3f/7483e5a6dc6326b6e0c640619b5c5bd1d6e3c20e54d58f5fb86267cef00e/pydocket-0.16.6-py3-none-any.whl", hash = "sha256:683d21e2e846aa5106274e7d59210331b242d7fb0dce5b08d3b82065663ed183", size = 67697, upload-time = "2026-01-09T22:09:13.436Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/cc/019dbc2646dc638caead6349f7427a396257c97b7edbf60dedb52b5ed93d/pydocket-0.17.1-py3-none-any.whl", hash = "sha256:0902c08e7879a9ba8ebcdee2503541bf26dc203d94cab1c2e48d18567383f505", size = 87371, upload-time = "2026-01-22T16:59:23.915Z" },
 ]
 
 [[package]]
@@ -2211,28 +2245,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.11"
+version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/77/9a7fe084d268f8855d493e5031ea03fa0af8cc05887f638bf1c4e3363eb8/ruff-0.14.11.tar.gz", hash = "sha256:f6dc463bfa5c07a59b1ff2c3b9767373e541346ea105503b4c0369c520a66958", size = 5993417, upload-time = "2026-01-08T19:11:58.322Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/a6/a4c40a5aaa7e331f245d2dc1ac8ece306681f52b636b40ef87c88b9f7afd/ruff-0.14.11-py3-none-linux_armv6l.whl", hash = "sha256:f6ff2d95cbd335841a7217bdfd9c1d2e44eac2c584197ab1385579d55ff8830e", size = 12951208, upload-time = "2026-01-08T19:12:09.218Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/5c/360a35cb7204b328b685d3129c08aca24765ff92b5a7efedbdd6c150d555/ruff-0.14.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f6eb5c1c8033680f4172ea9c8d3706c156223010b8b97b05e82c59bdc774ee6", size = 13330075, upload-time = "2026-01-08T19:12:02.549Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9e/0cc2f1be7a7d33cae541824cf3f95b4ff40d03557b575912b5b70273c9ec/ruff-0.14.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fc34cc896f90080fca01259f96c566f74069a04b25b6205d55379d12a6855e", size = 12257809, upload-time = "2026-01-08T19:12:00.366Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e5/5faab97c15bb75228d9f74637e775d26ac703cc2b4898564c01ab3637c02/ruff-0.14.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53386375001773ae812b43205d6064dae49ff0968774e6befe16a994fc233caa", size = 12678447, upload-time = "2026-01-08T19:12:13.899Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/33/e9767f60a2bef779fb5855cab0af76c488e0ce90f7bb7b8a45c8a2ba4178/ruff-0.14.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a697737dce1ca97a0a55b5ff0434ee7205943d4874d638fe3ae66166ff46edbe", size = 12758560, upload-time = "2026-01-08T19:11:42.55Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/84/4c6cf627a21462bb5102f7be2a320b084228ff26e105510cd2255ea868e5/ruff-0.14.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6845ca1da8ab81ab1dce755a32ad13f1db72e7fba27c486d5d90d65e04d17b8f", size = 13599296, upload-time = "2026-01-08T19:11:30.371Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e1/92b5ed7ea66d849f6157e695dc23d5d6d982bd6aa8d077895652c38a7cae/ruff-0.14.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e36ce2fd31b54065ec6f76cb08d60159e1b32bdf08507862e32f47e6dde8bcbf", size = 15048981, upload-time = "2026-01-08T19:12:04.742Z" },
-    { url = "https://files.pythonhosted.org/packages/61/df/c1bd30992615ac17c2fb64b8a7376ca22c04a70555b5d05b8f717163cf9f/ruff-0.14.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:590bcc0e2097ecf74e62a5c10a6b71f008ad82eb97b0a0079e85defe19fe74d9", size = 14633183, upload-time = "2026-01-08T19:11:40.069Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e9/fe552902f25013dd28a5428a42347d9ad20c4b534834a325a28305747d64/ruff-0.14.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53fe71125fc158210d57fe4da26e622c9c294022988d08d9347ec1cf782adafe", size = 14050453, upload-time = "2026-01-08T19:11:37.555Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/93/f36d89fa021543187f98991609ce6e47e24f35f008dfe1af01379d248a41/ruff-0.14.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a35c9da08562f1598ded8470fcfef2afb5cf881996e6c0a502ceb61f4bc9c8a3", size = 13757889, upload-time = "2026-01-08T19:12:07.094Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/9f/c7fb6ecf554f28709a6a1f2a7f74750d400979e8cd47ed29feeaa1bd4db8/ruff-0.14.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0f3727189a52179393ecf92ec7057c2210203e6af2676f08d92140d3e1ee72c1", size = 13955832, upload-time = "2026-01-08T19:11:55.064Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a0/153315310f250f76900a98278cf878c64dfb6d044e184491dd3289796734/ruff-0.14.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:eb09f849bd37147a789b85995ff734a6c4a095bed5fd1608c4f56afc3634cde2", size = 12586522, upload-time = "2026-01-08T19:11:35.356Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2b/a73a2b6e6d2df1d74bf2b78098be1572191e54bec0e59e29382d13c3adc5/ruff-0.14.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c61782543c1231bf71041461c1f28c64b961d457d0f238ac388e2ab173d7ecb7", size = 12724637, upload-time = "2026-01-08T19:11:47.796Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/41/09100590320394401cd3c48fc718a8ba71c7ddb1ffd07e0ad6576b3a3df2/ruff-0.14.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:82ff352ea68fb6766140381748e1f67f83c39860b6446966cff48a315c3e2491", size = 13145837, upload-time = "2026-01-08T19:11:32.87Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/d8/e035db859d1d3edf909381eb8ff3e89a672d6572e9454093538fe6f164b0/ruff-0.14.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:728e56879df4ca5b62a9dde2dd0eb0edda2a55160c0ea28c4025f18c03f86984", size = 13850469, upload-time = "2026-01-08T19:12:11.694Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/02/bb3ff8b6e6d02ce9e3740f4c17dfbbfb55f34c789c139e9cd91985f356c7/ruff-0.14.11-py3-none-win32.whl", hash = "sha256:337c5dd11f16ee52ae217757d9b82a26400be7efac883e9e852646f1557ed841", size = 12851094, upload-time = "2026-01-08T19:11:45.163Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f1/90ddc533918d3a2ad628bc3044cdfc094949e6d4b929220c3f0eb8a1c998/ruff-0.14.11-py3-none-win_amd64.whl", hash = "sha256:f981cea63d08456b2c070e64b79cb62f951aa1305282974d4d5216e6e0178ae6", size = 14001379, upload-time = "2026-01-08T19:11:52.591Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1c/1dbe51782c0e1e9cfce1d1004752672d2d4629ea46945d19d731ad772b3b/ruff-0.14.11-py3-none-win_arm64.whl", hash = "sha256:649fb6c9edd7f751db276ef42df1f3df41c38d67d199570ae2a7bd6cbc3590f0", size = 12938644, upload-time = "2026-01-08T19:11:50.027Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
 
 [[package]]
@@ -2240,8 +2274,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2277,28 +2311,28 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.1.2"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/34/f5df66cb383efdbf4f2db23cabb27f51b1dcb737efaf8a558f6f1d195134/sse_starlette-3.1.2.tar.gz", hash = "sha256:55eff034207a83a0eb86de9a68099bd0157838f0b8b999a1b742005c71e33618", size = 26303, upload-time = "2025-12-31T08:02:20.023Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/95/8c4b76eec9ae574474e5d2997557cebf764bcd3586458956c30631ae08f4/sse_starlette-3.1.2-py3-none-any.whl", hash = "sha256:cd800dd349f4521b317b9391d3796fa97b71748a4da9b9e00aafab32dda375c8", size = 12484, upload-time = "2025-12-31T08:02:18.894Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
 ]
 
 [[package]]
 name = "starlette"
-version = "0.51.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/65/5a1fadcc40c5fdc7df421a7506b79633af8f5d5e3a95c3e72acacec644b9/starlette-0.51.0.tar.gz", hash = "sha256:4c4fda9b1bc67f84037d3d14a5112e523509c369d9d47b111b2f984b0cc5ba6c", size = 2647658, upload-time = "2026-01-10T20:23:15.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/c4/09985a03dba389d4fe16a9014147a7b02fa76ef3519bf5846462a485876d/starlette-0.51.0-py3-none-any.whl", hash = "sha256:fb460a3d6fd3c958d729fdd96aee297f89a51b0181f16401fe8fd4cb6129165d", size = 74133, upload-time = "2026-01-10T20:23:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -2433,6 +2467,109 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2498,75 +2635,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
-    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
-    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
-    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
-    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
-    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
-    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
-    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
-    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
-    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
-    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade mp-mcp-server from FastMCP 2.x to FastMCP 3.0.0b1
- Replace internal API usage with public v3 APIs
- Update all test fixtures and assertions for v3 compatibility

## Changes

### Core API Migration
- `ctx.fastmcp._lifespan_result` → `ctx.lifespan_context` (public API)
- Decorators now return functions directly, not `FunctionTool` objects
- Use `mcp.list_tools()`, `mcp.list_prompts()`, `mcp.list_resources()` instead of internal managers

### Files Modified
- `pyproject.toml`: Update dependency to `fastmcp[tasks]>=3.0.0b1`
- `context.py`: Use `ctx.lifespan_context`
- `conftest.py`: Add v3-compatible test fixtures
- 12 test files: Update to use new public APIs

## Test plan

- [x] All 452 tests pass
- [x] mypy --strict passes
- [x] Unit tests (448) pass
- [x] Integration tests (4) pass

## Notes

There are 2 warnings about `task=True` with Context for `fetch_events` and `fetch_profiles` - these can be addressed in a follow-up PR by using Docket dependencies.