### PR TITLE
feat(mp-mcp-server): integrate FastMCP v3 Skills Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ demo/
 
 # fastmcp docs
 context/fastmcp/
+
+# MCP client configuration (local dev only)
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "fastmcp": {
+      "type": "http",
+      "url": "https://gofastmcp.com/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "fastmcp": {
-      "type": "http",
-      "url": "https://gofastmcp.com/mcp"
-    }
-  }
-}

--- a/mixpanel-plugin/skills/mp-mcp/SKILL.md
+++ b/mixpanel-plugin/skills/mp-mcp/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: mp-mcp
+description: Use the Mixpanel MCP server for analytics. Triggers on mentions of Mixpanel MCP tools, MCP resources, analytics queries via MCP, segmentation, funnels, retention, cohort_comparison, product_health_dashboard, ask_mixpanel, diagnose_metric_drop, guided_analysis, fetch_events, or SQL queries on local DuckDB data.
+---
+
+# Mixpanel MCP Server
+
+The Mixpanel MCP server exposes analytics capabilities through 40+ tools, 8 resources, and 8 prompts.
+
+## Reference Files
+
+When you need detailed information, read these reference files:
+
+| File | When to Read |
+|------|--------------|
+| [tools.md](references/tools.md) | Complete tool signatures, parameters, return types for all 40+ tools |
+| [resources.md](references/resources.md) | Resource URIs (workspace://, schema://, analysis://, users://, recipes://) |
+| [prompts.md](references/prompts.md) | Guided workflow prompts (analytics_workflow, funnel_analysis, retention_analysis, etc.) |
+| [patterns.md](references/patterns.md) | Usage patterns, JSON property access, error handling, best practices |
+
+## Tool Categories
+
+| Category | Purpose | Key Tools |
+|----------|---------|-----------|
+| **Discovery** | Explore schema | `list_events`, `list_properties`, `list_funnels`, `list_cohorts`, `top_events` |
+| **Live Query** | Real-time API | `segmentation`, `funnel`, `retention`, `jql`, `event_counts`, `property_counts` |
+| **Fetch** | Download data | `fetch_events`, `fetch_profiles`, `stream_events`, `stream_profiles` |
+| **Local** | SQL analysis | `sql`, `sql_scalar`, `list_tables`, `sample`, `summarize`, `event_breakdown` |
+| **Composed** | Multi-primitive | `cohort_comparison`, `product_health_dashboard`, `gqm_investigation` |
+| **Intelligent** | AI-powered | `ask_mixpanel`, `diagnose_metric_drop`, `funnel_optimization_report` |
+| **Interactive** | Guided workflows | `guided_analysis`, `safe_large_fetch` |
+
+## Quick Patterns
+
+### Explore -> Query -> Analyze
+
+```
+1. list_events() -> top_events()     # Find what to analyze
+2. list_properties(event)            # Understand the data
+3. segmentation() or funnel()        # Quick insights
+4. fetch_events() + sql()            # Deep local analysis
+```
+
+### Diagnostic Investigation
+
+```
+1. diagnose_metric_drop(event, date)  # Automatic root cause analysis
+2. cohort_comparison(a_filter, b_filter)  # Isolate segment differences
+3. ask_mixpanel("Why did X happen?")  # Natural language queries
+```
+
+### Product Health
+
+```
+1. product_health_dashboard()         # AARRR snapshot
+2. guided_analysis(focus_area)        # Interactive drill-down
+3. funnel_optimization_report(id)     # Bottleneck analysis
+```
+
+## Resources (Read-Only)
+
+| URI | Content |
+|-----|---------|
+| `workspace://info` | Project connection status, tables |
+| `schema://events` | All tracked event names |
+| `schema://funnels` | Saved funnel definitions |
+| `schema://cohorts` | Saved cohort definitions |
+| `analysis://retention/{event}/weekly` | 12-week retention curve |
+| `analysis://trends/{event}/{days}` | Daily event counts |
+| `users://{id}/journey` | User's 90-day activity |
+| `recipes://weekly-review` | Weekly analytics checklist |
+
+## JSON Property Access (Critical)
+
+Events and profiles store properties as JSON. Access with DuckDB JSON syntax:
+
+```sql
+-- DuckDB SQL (local queries)
+SELECT properties->>'$.country' as country FROM events
+WHERE properties->>'$.plan' = 'premium'
+```
+
+## Filter Expressions
+
+Use SQL-like syntax for filtering in API calls:
+
+```python
+# WHERE parameter
+where='properties["amount"] > 100 and properties["plan"] in ["premium", "enterprise"]'
+
+# ON parameter (segmentation)
+on='properties["country"]'
+```
+
+## Error Handling
+
+All tools return structured errors with actionable suggestions:
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `TableExistsError` | Table already exists | Use `append=True` or drop table first |
+| `AuthenticationError` | Invalid credentials | Check `workspace_info()` |
+| `RateLimitError` | API rate limited | Wait and retry |
+
+## Middleware
+
+The server includes automatic:
+- **Rate limiting**: Respects Mixpanel API limits (60 req/hour for query, 3 req/sec for export)
+- **Response caching**: Discovery operations cached for 5 minutes
+- **Audit logging**: All requests logged with timing

--- a/mixpanel-plugin/skills/mp-mcp/references/patterns.md
+++ b/mixpanel-plugin/skills/mp-mcp/references/patterns.md
@@ -1,0 +1,339 @@
+# Usage Patterns & Best Practices
+
+Common patterns and best practices for using the Mixpanel MCP server.
+
+## Workflow Patterns
+
+### Pattern 1: Exploration -> Query -> Download -> Analyze
+
+For comprehensive analysis of a new dataset:
+
+```
+1. list_events()                          # What events exist?
+2. top_events(limit=10)                   # Which are most active?
+3. list_properties(event="top_event")     # What data is captured?
+4. segmentation(event="top_event", ...)   # Quick trend analysis
+5. fetch_events(from_date=..., to_date=...) # Download for deep analysis
+6. sample(table="events")                 # Preview the data
+7. sql("SELECT ... GROUP BY ...")         # Custom analysis
+8. drop_table("events")                   # Clean up when done
+```
+
+### Pattern 2: Diagnostic Investigation
+
+For root cause analysis of metric changes:
+
+```
+1. diagnose_metric_drop(event="signup", date="2024-01-07")
+   # Automatic comparison of baseline vs drop period
+   # Identifies contributing segments
+
+2. cohort_comparison(
+       cohort_a_filter='properties["source"] == "ads"',
+       cohort_b_filter='properties["source"] == "organic"'
+   )
+   # Compare specific segments
+
+3. ask_mixpanel("Why did signups drop last week?")
+   # Natural language investigation
+```
+
+### Pattern 3: Product Health Monitoring
+
+For regular product health checks:
+
+```
+1. product_health_dashboard(acquisition_event="signup")
+   # AARRR snapshot with health scores
+
+2. guided_analysis(focus_area="retention")
+   # Interactive drill-down on weak areas
+
+3. funnel_optimization_report(funnel_id=123)
+   # Detailed bottleneck analysis
+
+4. retention(born_event="signup", unit="week", interval_count=12)
+   # Long-term retention trends
+```
+
+### Pattern 4: Safe Large-Scale Operations
+
+For downloading large datasets:
+
+```
+1. safe_large_fetch(from_date="2024-01-01", to_date="2024-12-31")
+   # Estimates count, requests confirmation if > 100k events
+
+2. fetch_events(..., parallel=True, workers=4)
+   # Use parallel fetching for large date ranges (>7 days)
+
+3. Monitor progress via task tracking
+   # fetch_events is task-enabled with progress reporting
+```
+
+---
+
+## JSON Property Access in DuckDB SQL
+
+Events and profiles store properties as JSON columns. Use DuckDB's JSON operators:
+
+### Basic Access
+
+```sql
+-- Extract string property
+SELECT properties->>'$.country' as country FROM events
+
+-- Extract nested property
+SELECT properties->>'$.user.plan' as plan FROM events
+
+-- Filter by property value
+SELECT * FROM events
+WHERE properties->>'$.amount' > '100'
+```
+
+### Type Casting
+
+```sql
+-- Cast to integer for comparison
+SELECT * FROM events
+WHERE CAST(properties->>'$.amount' AS INTEGER) > 100
+
+-- Cast to timestamp
+SELECT * FROM events
+WHERE CAST(properties->>'$.timestamp' AS TIMESTAMP) > '2024-01-01'
+```
+
+### Aggregation with Properties
+
+```sql
+-- Count by property value
+SELECT
+    properties->>'$.country' as country,
+    COUNT(*) as count
+FROM events
+GROUP BY properties->>'$.country'
+ORDER BY count DESC
+
+-- Sum numeric property
+SELECT
+    properties->>'$.plan' as plan,
+    SUM(CAST(properties->>'$.amount' AS DECIMAL)) as total
+FROM events
+GROUP BY properties->>'$.plan'
+```
+
+### Filtering with Multiple Properties
+
+```sql
+SELECT * FROM events
+WHERE properties->>'$.platform' = 'mobile'
+  AND properties->>'$.country' IN ('US', 'UK', 'CA')
+  AND properties->>'$.is_premium' = 'true'
+```
+
+### Working with Arrays
+
+```sql
+-- Check if array contains value (using json_array_contains)
+SELECT * FROM events
+WHERE json_array_contains(properties->'$.tags', '"important"')
+```
+
+---
+
+## Filter Expressions for API Calls
+
+Filter expressions use a SQL-like syntax for the Mixpanel API.
+
+### WHERE Parameter Syntax
+
+```python
+# Property comparison
+where='properties["amount"] > 100'
+
+# String equality
+where='properties["country"] == "US"'
+
+# IN operator
+where='properties["plan"] in ["premium", "enterprise"]'
+
+# Boolean
+where='properties["is_active"] == true'
+
+# NOT IN
+where='properties["status"] not in ["cancelled", "suspended"]'
+
+# Combining with AND/OR
+where='properties["amount"] > 100 and properties["plan"] == "premium"'
+where='(properties["country"] == "US") or (properties["country"] == "UK")'
+```
+
+### ON Parameter (Segmentation)
+
+```python
+# Segment by property (bare names auto-wrapped)
+segmentation(event="purchase", on="country")
+
+# Or explicit property accessor
+segmentation(event="purchase", on='properties["country"]')
+```
+
+---
+
+## Error Handling
+
+All tools return structured errors with actionable information.
+
+### Common Errors
+
+| Error Code | Meaning | Action |
+|------------|---------|--------|
+| `TABLE_EXISTS_ERROR` | Table already exists | Use `append=True` or call `drop_table` first |
+| `AUTHENTICATION_ERROR` | Invalid credentials | Check credentials with `workspace_info()` |
+| `RATE_LIMIT_ERROR` | API rate limited | Wait `retry_after` seconds and retry |
+| `EVENT_NOT_FOUND_ERROR` | Event doesn't exist | Check with `list_events()` |
+| `DATE_RANGE_TOO_LARGE_ERROR` | >100 days without parallel | Use `parallel=True` |
+
+### Error Response Structure
+
+```json
+{
+  "code": "RATE_LIMIT_ERROR",
+  "message": "Rate limit exceeded. Please wait before retrying.",
+  "details": {
+    "retry_after": 60,
+    "limit": 60,
+    "remaining": 0
+  },
+  "suggestions": [
+    "Wait 60 seconds before retrying",
+    "Consider batching requests"
+  ]
+}
+```
+
+---
+
+## Rate Limiting
+
+The MCP server includes automatic rate limiting.
+
+### API Limits
+
+| API | Limit | Tools Affected |
+|-----|-------|----------------|
+| Query API | 60 req/hour | `segmentation`, `funnel`, `retention`, `frequency`, `jql` |
+| Export API | 3 req/sec | `fetch_events`, `fetch_profiles` |
+
+### Best Practices
+
+1. **Cache discovery calls** - Schema rarely changes; `list_events`, `list_funnels` are cached for 5 minutes
+2. **Batch event counts** - Use `event_counts(events=[...])` instead of multiple `segmentation` calls
+3. **Use composed tools** - `cohort_comparison` uses JQL for 1-2 API calls vs 80+ segmentation calls
+4. **Fetch once, query locally** - Download data with `fetch_events`, then use `sql` for unlimited queries
+
+---
+
+## Tool Selection Guide
+
+| Need | Tool | Why |
+|------|------|-----|
+| List events | `list_events` | Discovery, cached |
+| Event trends | `segmentation` | Time series with optional segmentation |
+| Compare cohorts | `cohort_comparison` | Efficient JQL-based comparison |
+| Funnel conversion | `funnel` | Step-by-step conversion analysis |
+| User retention | `retention` | Cohort retention curves |
+| Custom queries | `jql` | Full JavaScript flexibility |
+| Multiple event counts | `event_counts` | Batch multiple events efficiently |
+| Property distribution | `property_counts` | Break down by property values |
+| User activity | `activity_feed` | Chronological event history |
+| Product overview | `product_health_dashboard` | AARRR metrics snapshot |
+| Root cause analysis | `diagnose_metric_drop` | AI-powered investigation |
+| Natural language | `ask_mixpanel` | Question -> query -> answer |
+| Local SQL | `sql` | Unlimited queries on downloaded data |
+| Safe large fetch | `safe_large_fetch` | Confirmation before large downloads |
+
+---
+
+## Middleware Behavior
+
+### Caching
+
+Discovery tools are cached for 5 minutes:
+- `list_events`
+- `list_properties`
+- `list_funnels`
+- `list_cohorts`
+- `list_bookmarks`
+- `top_events`
+
+### Audit Logging
+
+All requests are logged with:
+- Tool name
+- Start/end time
+- Success/failure status
+- Error details if applicable
+
+### Rate Limiting
+
+Rate limits are applied per tool category:
+- Query tools share a 60/hour limit
+- Export tools share a 3/second limit
+- Discovery tools are not rate-limited (cached instead)
+
+---
+
+## Task-Enabled Tools
+
+Some tools support progress reporting and cancellation:
+
+- `fetch_events` - Reports progress by day for long date ranges
+- `fetch_profiles` - Reports progress by page
+
+### Cancellation Behavior
+
+When cancelled, these tools return partial results:
+```json
+{
+  "status": "cancelled",
+  "table_name": "events",
+  "row_count": 25000,
+  "days_fetched": 5,
+  "message": "Cancelled after 5/10 days"
+}
+```
+
+---
+
+## Integration Patterns
+
+### With External Tools
+
+```bash
+# Export to CSV via streaming
+stream_events(...) | jq -r '[.event, .distinct_id] | @csv' > events.csv
+
+# Pipe to pandas
+fetch_events(...) && python -c "import pandas; df = ..."
+```
+
+### With Other MCP Servers
+
+```
+# Read context from Mixpanel
+Read workspace://info from mixpanel
+
+# Use in analysis prompt
+Use the connected project {project_id} for analysis
+```
+
+### Combining Tools
+
+```
+# Pattern: Discover -> Analyze -> Detail
+
+1. list_funnels() -> Get funnel IDs
+2. funnel(funnel_id=X, ...) -> Get conversion data
+3. diagnose_metric_drop(event=bottom_step, date=drop_date) -> Investigate drops
+```

--- a/mixpanel-plugin/skills/mp-mcp/references/patterns.md
+++ b/mixpanel-plugin/skills/mp-mcp/references/patterns.md
@@ -86,9 +86,9 @@ SELECT properties->>'$.country' as country FROM events
 -- Extract nested property
 SELECT properties->>'$.user.plan' as plan FROM events
 
--- Filter by property value
+-- Filter by numeric property (use CAST for correct comparison)
 SELECT * FROM events
-WHERE properties->>'$.amount' > '100'
+WHERE CAST(properties->>'$.amount' AS INTEGER) > 100
 ```
 
 ### Type Casting

--- a/mixpanel-plugin/skills/mp-mcp/references/prompts.md
+++ b/mixpanel-plugin/skills/mp-mcp/references/prompts.md
@@ -1,0 +1,226 @@
+# MCP Prompts Reference
+
+Prompts provide structured templates that guide users through analytics workflows and best practices.
+
+## Available Prompts
+
+### analytics_workflow
+
+Guide through a complete analytics exploration workflow.
+
+**Parameters**: None
+
+**Workflow Steps**:
+1. **Discover Your Schema** - Use `list_events`, `list_funnels`, `list_cohorts`
+2. **Explore Key Events** - Use `list_properties`, `top_events`
+3. **Run Initial Analysis** - Use `segmentation`, `funnel`, `retention`
+4. **Deep Dive with Local Data** - Use `fetch_events`, `sql`, `sample`
+
+**Best For**: New users exploring a Mixpanel project for the first time.
+
+---
+
+### funnel_analysis
+
+Guide through funnel analysis workflow.
+
+**Parameters**:
+- `funnel_name`: Name of the funnel to analyze (default: "signup")
+
+**Workflow Steps**:
+1. **Find Your Funnel** - Use `list_funnels` to get funnel ID
+2. **Analyze Conversion** - Use `funnel` for overall and step-by-step conversion
+3. **Segment the Analysis** - Add segment parameters to break down by user properties
+4. **Identify Improvements** - Find high drop-off steps and better-converting segments
+
+**Best For**: Understanding conversion paths and identifying bottlenecks.
+
+---
+
+### retention_analysis
+
+Guide through retention analysis workflow.
+
+**Parameters**:
+- `event`: The birth event for cohort analysis (default: "signup")
+
+**Workflow Steps**:
+1. **Define the Cohort** - Choose born event and return event
+2. **Choose Time Frame** - Recent (30 days) for trends, historical for patterns
+3. **Run Retention Analysis** - Use `retention` with appropriate parameters
+4. **Interpret Results** - D1, D7, D30 retention benchmarks
+5. **Compare Segments** - Analyze by source, user type, onboarding
+
+**Best For**: Understanding user stickiness and long-term engagement.
+
+---
+
+### local_analysis_workflow
+
+Guide through local data analysis with SQL.
+
+**Parameters**: None
+
+**Workflow Steps**:
+1. **Fetch Your Data** - Use `fetch_events` to download to local storage
+2. **Explore the Data** - Use `list_tables`, `table_schema`, `sample`
+3. **Query with SQL** - Use `sql` for custom analysis
+4. **Advanced Analysis** - Join events with profiles, calculate user-level metrics
+5. **Clean Up** - Use `drop_table` when done
+
+**Best For**: Complex analysis requiring custom SQL queries.
+
+---
+
+### gqm_decomposition
+
+Goal-Question-Metric decomposition prompt.
+
+**Parameters**:
+- `goal`: The high-level goal to investigate (default: "understand user retention")
+
+**Framework**:
+- **Goal**: Define what you want to achieve (conceptual level)
+- **Questions**: Identify what you need to know (operational level)
+- **Metrics**: Determine what to measure (quantitative level)
+
+**Workflow Steps**:
+1. **Clarify the Goal** - Define business outcome, stakeholders, success criteria
+2. **Generate Questions** - Current state, trends, segments, correlations, external factors
+3. **Define Metrics** - Primary, supporting, and leading indicators
+4. **Execute the Investigation** - Use appropriate tools
+5. **Synthesize Findings** - Patterns, hypotheses, recommendations
+
+**Best For**: Structured investigation of complex analytics questions.
+
+---
+
+### growth_accounting
+
+AARRR (Pirate Metrics) growth accounting prompt.
+
+**Parameters**:
+- `acquisition_event`: The event that marks user acquisition (default: "signup")
+
+**AARRR Stages**:
+1. **Acquisition** - How users find you (2-5% landing page conversion B2C, 5-15% B2B)
+2. **Activation** - First value experience (20-40% onboarding completion)
+3. **Retention** - Users coming back (D1: 25-40% consumer, D7: 15-25%)
+4. **Revenue** - Monetization (2-5% free to paid)
+5. **Referral** - Users bringing others (5-10% referral rate)
+
+**Suggested Tools**:
+- `segmentation` and `property_counts` for acquisition analysis
+- `funnel` for activation steps
+- `retention` for stickiness
+- Quick overview: `product_health_dashboard`
+
+**Best For**: Comprehensive product health analysis with industry benchmarks.
+
+---
+
+### experiment_analysis
+
+A/B test evaluation prompt.
+
+**Parameters**:
+- `experiment_name`: Name of the experiment to analyze (default: "homepage_redesign")
+
+**Pre-Analysis Checklist**:
+- Control and treatment groups properly defined
+- Sufficient sample size
+- Test ran for 1-2 business cycles
+- No overlapping experiments
+
+**Analysis Steps**:
+1. **Segment the Data** - Use `cohort_comparison` for variant separation
+2. **Check Sample Sizes** - Minimum 100 conversions per variant
+3. **Calculate Results** - Conversion rate, lift, p-value, confidence interval
+4. **Interpret Results** - Significant positive = ship, negative = don't ship, not significant = need more data
+5. **Consider Segments** - Check effects by user type, platform, geography
+
+**Common Pitfalls**:
+- Peeking (checking too early)
+- Cherry-picking (only reporting winners)
+- Ignoring segments
+- Ignoring practical significance
+
+**Best For**: Rigorous A/B test analysis with statistical considerations.
+
+---
+
+### data_quality_audit
+
+Data quality audit prompt.
+
+**Parameters**:
+- `event`: Primary event to audit (default: "signup")
+
+**Audit Dimensions**:
+
+1. **Event Coverage Audit**
+   - Is the event firing consistently?
+   - Are there gaps in the data?
+   - Red flags: >50% day-over-day variance, missing days, bot patterns
+
+2. **Property Completeness Audit**
+   - What properties are captured?
+   - What % have each property?
+   - Check: user identification, timestamp, device, attribution
+
+3. **Identity Resolution Audit**
+   - Are users properly identified?
+   - Is identity stitching working?
+   - Red flags: high anonymous %, shared IDs, duplicate profiles
+
+4. **Data Freshness Audit**
+   - How recent is the data?
+   - Is there processing lag?
+   - Red flags: events >24h late, timestamp inconsistencies
+
+5. **Schema Consistency Audit**
+   - Are property names consistent?
+   - Are data types stable?
+   - Best practices: consistent naming, typed values, no PII
+
+**Best For**: Assessing data implementation quality and reliability.
+
+---
+
+## Prompt Usage Patterns
+
+### Discovery -> Analysis Flow
+
+```
+1. Request "analytics_workflow" prompt
+2. Follow schema discovery steps
+3. Choose analysis type based on findings
+4. Request specific prompt (funnel_analysis, retention_analysis, etc.)
+```
+
+### Investigation Flow
+
+```
+1. Request "gqm_decomposition" prompt with your goal
+2. Work through Goal -> Questions -> Metrics
+3. Use suggested tools to gather data
+4. Synthesize findings
+```
+
+### Product Review Flow
+
+```
+1. Request "growth_accounting" prompt
+2. Analyze each AARRR stage
+3. Compare to industry benchmarks
+4. Identify weakest areas for improvement
+```
+
+### Quality Check Flow
+
+```
+1. Request "data_quality_audit" prompt
+2. Work through each audit dimension
+3. Document findings and red flags
+4. Create prioritized fix list
+```

--- a/mixpanel-plugin/skills/mp-mcp/references/resources.md
+++ b/mixpanel-plugin/skills/mp-mcp/references/resources.md
@@ -1,0 +1,267 @@
+# MCP Resources Reference
+
+Resources provide read-only access to cacheable data. MCP clients can read these for context without making tool calls.
+
+## Static Resources
+
+### workspace://info
+
+Workspace configuration and connection status.
+
+**Returns**: JSON with project_id, region, account, path, size_mb, created_at, and tables.
+
+```json
+{
+  "project_id": 123456,
+  "region": "us",
+  "account": "production",
+  "path": "/path/to/workspace.duckdb",
+  "size_mb": 125.5,
+  "created_at": "2024-01-01T00:00:00",
+  "tables": [
+    {"name": "events", "row_count": 50000, "type": "events"},
+    {"name": "profiles", "row_count": 1000, "type": "profiles"}
+  ]
+}
+```
+
+---
+
+### workspace://tables
+
+List of locally stored tables.
+
+**Returns**: JSON array of table metadata with names, row counts, and types.
+
+```json
+[
+  {"name": "events", "row_count": 50000, "type": "events"},
+  {"name": "jan_events", "row_count": 10000, "type": "events"},
+  {"name": "profiles", "row_count": 1000, "type": "profiles"}
+]
+```
+
+---
+
+### schema://events
+
+List of event names tracked in the project.
+
+**Returns**: JSON array of event names.
+
+```json
+["signup", "login", "purchase", "page_view", "button_click"]
+```
+
+---
+
+### schema://funnels
+
+Saved funnel definitions.
+
+**Returns**: JSON array of funnel metadata with funnel_id, name, and step information.
+
+```json
+[
+  {"funnel_id": 1, "name": "Signup Funnel", "steps": 3},
+  {"funnel_id": 2, "name": "Purchase Funnel", "steps": 5}
+]
+```
+
+---
+
+### schema://cohorts
+
+Saved cohort definitions.
+
+**Returns**: JSON array of cohort metadata with cohort_id, name, and user count.
+
+```json
+[
+  {"cohort_id": 1, "name": "Active Users", "count": 5000},
+  {"cohort_id": 2, "name": "Premium Users", "count": 1200}
+]
+```
+
+---
+
+### schema://bookmarks
+
+Saved report bookmarks.
+
+**Returns**: JSON array of bookmark metadata with bookmark_id, name, type, and URL.
+
+```json
+[
+  {"bookmark_id": 1, "name": "Weekly DAU", "type": "insights", "url": "..."},
+  {"bookmark_id": 2, "name": "Signup Funnel", "type": "funnels", "url": "..."}
+]
+```
+
+---
+
+## Dynamic Resource Templates
+
+These resources accept parameters in the URI path.
+
+### analysis://retention/{event}/weekly
+
+12-week retention curve for an event.
+
+**Parameters**:
+- `{event}`: Event name for cohort entry (born event)
+
+**Returns**: JSON with event, period, from_date, to_date, weeks, and retention data.
+
+**Example URI**: `analysis://retention/signup/weekly`
+
+```json
+{
+  "event": "signup",
+  "period": "weekly",
+  "from_date": "2024-10-15",
+  "to_date": "2025-01-13",
+  "weeks": 12,
+  "data": {
+    "cohorts": [...],
+    "retention_rates": [100, 45, 32, 28, 25, ...]
+  }
+}
+```
+
+---
+
+### analysis://trends/{event}/{days}
+
+Daily event counts for the specified period.
+
+**Parameters**:
+- `{event}`: Event name to analyze
+- `{days}`: Number of days to look back (1-365, defaults to 30 if invalid)
+
+**Returns**: JSON with event, days, from_date, to_date, unit, and time series data.
+
+**Example URI**: `analysis://trends/login/30`
+
+```json
+{
+  "event": "login",
+  "days": 30,
+  "from_date": "2024-12-14",
+  "to_date": "2025-01-13",
+  "unit": "day",
+  "data": {
+    "2024-12-14": 1234,
+    "2024-12-15": 1456,
+    ...
+  }
+}
+```
+
+---
+
+### users://{id}/journey
+
+User's complete event journey.
+
+**Parameters**:
+- `{id}`: User's distinct_id
+
+**Returns**: JSON with distinct_id, period, summary, and events (last 90 days, limited to 100 events).
+
+**Example URI**: `users://user123/journey`
+
+```json
+{
+  "distinct_id": "user123",
+  "period": {
+    "from_date": "2024-10-15",
+    "to_date": "2025-01-13"
+  },
+  "summary": {
+    "total_events": 256,
+    "unique_events": 12,
+    "event_breakdown": {
+      "page_view": 150,
+      "button_click": 50,
+      "purchase": 5
+    }
+  },
+  "events": [...],
+  "truncated": true
+}
+```
+
+---
+
+## Recipe Resources
+
+Structured playbooks for common analytics workflows.
+
+### recipes://weekly-review
+
+Weekly analytics review checklist.
+
+**Returns**: JSON with name, description, current_period, comparison_period, checklist, and report_template.
+
+**Checklist Steps**:
+1. Core Metrics Review - Compare key metrics WoW
+2. Conversion Health - Review funnel performance
+3. Retention Check - Analyze user return rates
+4. Anomaly Detection - Look for unusual patterns
+5. User Feedback - Review qualitative signals
+
+**Suggested Tools**:
+- `event_counts` for WAU comparison
+- `list_funnels` and `funnel` for conversion
+- `retention` for stickiness
+- `diagnose_metric_drop` and `top_events` for anomalies
+- `activity_feed` and `stream_events` for user sessions
+
+---
+
+### recipes://churn-investigation
+
+Churn investigation playbook.
+
+**Returns**: JSON with name, description, phases, and benchmarks.
+
+**Investigation Phases**:
+1. **Define Churn** - Establish clear churn criteria
+2. **Measure Baseline** - Quantify current churn rates (D1/D7/D30 retention, weekly/monthly churn)
+3. **Identify Patterns** - Find common characteristics of churned users
+4. **Analyze Behavior** - Deep dive into churned user journeys
+5. **Prioritize Interventions** - Identify highest-impact fixes
+
+**Benchmarks**:
+- Good D1 retention: 40-60%
+- Good D7 retention: 20-30%
+- Good D30 retention: 10-20%
+- Acceptable monthly churn: <5% for B2B, <10% for B2C
+
+---
+
+## When to Use Resources vs Tools
+
+| Use Case | Resource | Tool |
+|----------|----------|------|
+| Quick context lookup | `schema://events` | - |
+| Cached schema data | `schema://funnels` | - |
+| Standard retention curve | `analysis://retention/{event}/weekly` | - |
+| Custom date range | - | `retention(...)` |
+| User overview | `users://{id}/journey` | - |
+| Full activity history | - | `activity_feed(...)` |
+| Workflow guidance | `recipes://weekly-review` | - |
+| AI-powered investigation | - | `diagnose_metric_drop(...)` |
+
+**Resources** are best for:
+- Read-only, cacheable data
+- Standard time periods (last 12 weeks, last N days)
+- Context gathering before analysis
+- Guided workflow templates
+
+**Tools** are best for:
+- Custom parameters and date ranges
+- Data modification (fetch, drop)
+- Complex queries (SQL, JQL)
+- Interactive workflows

--- a/mixpanel-plugin/skills/mp-mcp/references/tools.md
+++ b/mixpanel-plugin/skills/mp-mcp/references/tools.md
@@ -1,0 +1,928 @@
+# MCP Tools Reference
+
+Complete reference for all 40+ tools in the Mixpanel MCP server.
+
+## Discovery Tools
+
+Schema exploration tools for understanding available data.
+
+### list_events
+
+List all event names tracked in the Mixpanel project.
+
+```
+list_events() -> list[str]
+```
+
+**Returns**: List of event names sorted alphabetically.
+
+**Example**: "What events do I have?" -> `["login", "purchase", "signup", ...]`
+
+---
+
+### list_properties
+
+List properties for a specific event.
+
+```
+list_properties(event: str) -> list[dict]
+```
+
+**Parameters**:
+- `event`: Event name to get properties for
+
+**Returns**: List of property definitions with name and type (type is always "unknown" as Mixpanel API doesn't expose types).
+
+**Example**: "What properties does the signup event have?" -> `[{"name": "browser", "type": "unknown"}, ...]`
+
+---
+
+### list_property_values
+
+List sample values for a specific property.
+
+```
+list_property_values(
+    event: str,
+    property_name: str,
+    limit: int = 100
+) -> list[Any]
+```
+
+**Parameters**:
+- `event`: Event name containing the property
+- `property_name`: Property name to get values for
+- `limit`: Maximum number of values to return (default 100)
+
+**Returns**: List of sample values for the property.
+
+**Example**: "What values does the browser property have?" -> `["Chrome", "Firefox", "Safari", ...]`
+
+---
+
+### list_funnels
+
+List saved funnels in the Mixpanel project.
+
+```
+list_funnels() -> list[dict]
+```
+
+**Returns**: List of funnel metadata dictionaries with funnel_id, name, and step count.
+
+**Example**: "Show me my saved funnels" -> `[{"funnel_id": 1, "name": "Signup Funnel", "steps": 3}, ...]`
+
+---
+
+### list_cohorts
+
+List saved cohorts (user segments) in the Mixpanel project.
+
+```
+list_cohorts() -> list[dict]
+```
+
+**Returns**: List of cohort metadata dictionaries with cohort_id, name, and user count.
+
+**Example**: "What cohorts do I have?" -> `[{"cohort_id": 1, "name": "Active Users", "count": 1000}, ...]`
+
+---
+
+### list_bookmarks
+
+List saved reports (bookmarks) in the Mixpanel project.
+
+```
+list_bookmarks(
+    bookmark_type: str | None = None,
+    limit: int = 100
+) -> dict
+```
+
+**Parameters**:
+- `bookmark_type`: Optional filter by type (insights, funnels, retention, flows, launch-analysis). RECOMMENDED for large projects.
+- `limit`: Maximum number of bookmarks to return (default 100). Set to 0 for unlimited.
+
+**Returns**: Dictionary with bookmarks list, truncated flag, and total_count.
+
+**Example**: "Show me my saved funnel reports" -> `list_bookmarks(bookmark_type="funnels")`
+
+---
+
+### top_events
+
+List events ranked by activity volume.
+
+```
+top_events(
+    limit: int = 10,
+    type: Literal["general", "average", "unique"] = "general"
+) -> list[dict]
+```
+
+**Parameters**:
+- `limit`: Maximum number of events to return (default 10)
+- `type`: Count type - general (total), average, or unique users
+
+**Returns**: List of events with their activity counts, sorted by volume.
+
+**Example**: "What are my most popular events by unique users?" -> `top_events(limit=10, type="unique")`
+
+---
+
+### workspace_info
+
+Get current workspace state and configuration.
+
+```
+workspace_info() -> dict
+```
+
+**Returns**: Dictionary with project_id, region, and table information.
+
+**Example**: "What project am I connected to?" -> `{"project_id": 123456, "region": "us", "tables": [...]}`
+
+---
+
+## Live Query Tools
+
+Real-time analytics queries against Mixpanel API.
+
+### segmentation
+
+Run a segmentation query to analyze event trends over time.
+
+```
+segmentation(
+    event: str,
+    from_date: str,
+    to_date: str,
+    segment_property: str | None = None,
+    unit: Literal["day", "week", "month"] = "day",
+    where: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `event`: Event name to analyze
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `segment_property`: Optional property to segment by
+- `unit`: Time unit for aggregation (day, week, month)
+- `where`: Optional filter expression (e.g., `'properties["country"] == "US"'`)
+
+**Returns**: Dictionary with time series data.
+
+**Example**:
+```
+segmentation(
+    event="login",
+    from_date="2024-01-01",
+    to_date="2024-01-07",
+    where='properties["platform"] == "mobile"'
+)
+```
+
+---
+
+### funnel
+
+Analyze conversion through a saved funnel.
+
+```
+funnel(
+    funnel_id: int,
+    from_date: str,
+    to_date: str,
+    unit: Literal["day", "week", "month"] = "day",
+    on: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `funnel_id`: ID of the saved funnel to analyze
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `unit`: Time unit for cohort grouping
+- `on`: Optional property to segment funnel by. Must use property accessor format (e.g., `'properties["country"]'`)
+
+**Returns**: Dictionary with funnel conversion data.
+
+**Example**:
+```
+funnel(
+    funnel_id=1,
+    from_date="2024-01-01",
+    to_date="2024-01-31",
+    on='properties["country"]'
+)
+```
+
+---
+
+### retention
+
+Analyze user retention over time.
+
+```
+retention(
+    born_event: str,
+    from_date: str,
+    to_date: str,
+    return_event: str | None = None,
+    born_where: str | None = None,
+    return_where: str | None = None,
+    interval: int = 1,
+    interval_count: int = 7,
+    unit: Literal["day", "week", "month"] = "day"
+) -> dict
+```
+
+**Parameters**:
+- `born_event`: Event that defines cohort entry
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `return_event`: Event to measure return (defaults to born_event)
+- `born_where`: Optional filter for born event
+- `return_where`: Optional filter for return event
+- `interval`: Length of each retention interval (default: 1)
+- `interval_count`: Number of retention intervals to analyze
+- `unit`: Time unit for intervals (day, week, month)
+
+**Returns**: Dictionary with retention cohort data.
+
+**Example**:
+```
+retention(
+    born_event="signup",
+    from_date="2024-01-01",
+    to_date="2024-01-31",
+    born_where='properties["platform"] == "mobile"'
+)
+```
+
+---
+
+### jql
+
+Execute a JQL (JavaScript Query Language) script.
+
+```
+jql(
+    script: str,
+    params: dict | None = None
+) -> list[Any]
+```
+
+**Parameters**:
+- `script`: JQL script to execute
+- `params`: Optional parameters to pass to the script
+
+**Returns**: List of result dictionaries from the JQL execution.
+
+**Example**:
+```
+jql(
+    script="function main() { return Events({...}).groupBy(...) }",
+    params={"from_date": "2024-01-01"}
+)
+```
+
+---
+
+### event_counts
+
+Get counts for multiple events in a single query.
+
+```
+event_counts(
+    events: list[str],
+    from_date: str,
+    to_date: str,
+    unit: Literal["day", "week", "month"] = "day",
+    type: Literal["general", "unique", "average"] = "general"
+) -> dict
+```
+
+**Parameters**:
+- `events`: List of event names to count
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `unit`: Time unit for aggregation
+- `type`: Count type - general (total), unique (unique users), or average
+
+**Returns**: Dictionary with counts for each event.
+
+**Example**: "Compare unique login and signup users this month" -> `event_counts(events=["login", "signup"], ..., type="unique")`
+
+---
+
+### property_counts
+
+Get event counts broken down by property value.
+
+```
+property_counts(
+    event: str,
+    property_name: str,
+    from_date: str,
+    to_date: str,
+    type: Literal["general", "unique", "average"] = "general",
+    unit: Literal["day", "week", "month"] = "day",
+    values: list[str] | None = None,
+    limit: int | None = None
+) -> dict
+```
+
+**Parameters**:
+- `event`: Event name to analyze
+- `property_name`: Property to break down by
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `type`: Count type - general, unique, or average
+- `unit`: Time unit for aggregation
+- `values`: Optional list of specific property values to include
+- `limit`: Optional maximum number of property values to return
+
+**Returns**: Dictionary with counts per property value.
+
+**Example**: "What are the top 5 browsers users log in with?" -> `property_counts(event="login", property_name="browser", ..., limit=5)`
+
+---
+
+### activity_feed
+
+Get activity feed for a specific user.
+
+```
+activity_feed(
+    distinct_id: str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    limit: int = 100
+) -> dict
+```
+
+**Parameters**:
+- `distinct_id`: User identifier to look up
+- `from_date`: Optional start date (YYYY-MM-DD)
+- `to_date`: Optional end date (YYYY-MM-DD)
+- `limit`: Maximum number of events to return (default 100). Set to 0 for unlimited.
+
+**Returns**: Dictionary with user events, truncated flag, and total_events count.
+
+**Example**: "What has user alice done recently?" -> `activity_feed(distinct_id="alice")`
+
+---
+
+### frequency
+
+Analyze how often users perform events (addiction analysis).
+
+```
+frequency(
+    from_date: str,
+    to_date: str,
+    event: str | None = None,
+    unit: Literal["day", "week", "month"] = "day",
+    addiction_unit: Literal["hour", "day"] = "hour",
+    where: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `event`: Optional event name to filter (None = all events)
+- `unit`: Time unit for aggregation
+- `addiction_unit`: Time unit for measuring frequency (hour or day)
+- `where`: Optional filter expression
+
+**Returns**: Dictionary with frequency distribution data.
+
+---
+
+## Fetch Tools
+
+Download data from Mixpanel to local DuckDB storage.
+
+### fetch_events
+
+Fetch events from Mixpanel and store in local database.
+
+```
+fetch_events(
+    from_date: str,
+    to_date: str,
+    table: str | None = None,
+    events: list[str] | None = None,
+    where: str | None = None,
+    limit: int | None = None,
+    append: bool = False,
+    parallel: bool = False,
+    workers: int = 4
+) -> dict
+```
+
+**Parameters**:
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `table`: Optional table name (auto-generated if not provided)
+- `events`: Optional list of event names to filter by
+- `where`: Optional filter expression
+- `limit`: Optional maximum number of events to fetch
+- `append`: Append to existing table instead of creating new one
+- `parallel`: Use parallel fetching for large date ranges
+- `workers`: Number of parallel workers (if parallel=True)
+
+**Returns**: Dictionary with table_name, row_count, and status.
+
+**Note**: This is a task-enabled tool with progress reporting and cancellation support.
+
+**Example**: "Download last week's login events" -> `fetch_events(from_date="2024-01-01", to_date="2024-01-07", events=["login"])`
+
+---
+
+### fetch_profiles
+
+Fetch user profiles from Mixpanel and store in local database.
+
+```
+fetch_profiles(
+    table: str | None = None,
+    where: str | None = None,
+    cohort_id: str | None = None,
+    output_properties: list[str] | None = None,
+    distinct_id: str | None = None,
+    distinct_ids: list[str] | None = None,
+    group_id: str | None = None,
+    behaviors: list[dict] | None = None,
+    as_of_timestamp: int | None = None,
+    include_all_users: bool = False,
+    append: bool = False,
+    parallel: bool = False,
+    workers: int = 4
+) -> dict
+```
+
+**Parameters**:
+- `table`: Optional table name (default: "profiles")
+- `where`: Optional filter expression
+- `cohort_id`: Optional cohort ID to filter profiles by
+- `output_properties`: Optional list of properties to include
+- `distinct_id`: Optional single user ID to fetch
+- `distinct_ids`: Optional list of user IDs to fetch
+- `group_id`: Optional group ID for group profiles
+- `behaviors`: Optional list of behavioral filter conditions
+- `as_of_timestamp`: Optional Unix timestamp for point-in-time profile state
+- `include_all_users`: Include all users with cohort membership markers
+- `append`: Append to existing table
+- `parallel`: Use parallel fetching
+- `workers`: Number of parallel workers
+
+**Returns**: Dictionary with table_name, row_count, and status.
+
+**Example**: "Download profiles from the 'Active Users' cohort" -> `fetch_profiles(cohort_id="12345")`
+
+---
+
+### stream_events
+
+Stream events directly without storing them.
+
+```
+stream_events(
+    from_date: str,
+    to_date: str,
+    events: list[str] | None = None,
+    where: str | None = None,
+    limit: int = 1000
+) -> list[dict]
+```
+
+**Parameters**:
+- `from_date`: Start date (YYYY-MM-DD format)
+- `to_date`: End date (YYYY-MM-DD format)
+- `events`: Optional list of event names to filter by
+- `where`: Optional filter expression
+- `limit`: Maximum events to return
+
+**Returns**: List of event dictionaries.
+
+---
+
+### stream_profiles
+
+Stream profiles directly without storing them.
+
+```
+stream_profiles(
+    where: str | None = None,
+    cohort_id: str | None = None,
+    output_properties: list[str] | None = None,
+    distinct_id: str | None = None,
+    distinct_ids: list[str] | None = None,
+    group_id: str | None = None,
+    behaviors: list[dict] | None = None,
+    as_of_timestamp: int | None = None,
+    include_all_users: bool = False
+) -> list[dict]
+```
+
+**Returns**: List of profile dictionaries.
+
+---
+
+## Local Query Tools
+
+SQL analysis on locally stored data.
+
+### sql
+
+Execute a SQL query against local data.
+
+```
+sql(query: str) -> list[dict]
+```
+
+**Parameters**:
+- `query`: SQL query to execute
+
+**Returns**: List of result rows as dictionaries.
+
+**Example**: "Count events by name" -> `sql(query="SELECT event_name, COUNT(*) as cnt FROM events GROUP BY event_name")`
+
+---
+
+### sql_scalar
+
+Execute a SQL query that returns a single value.
+
+```
+sql_scalar(query: str) -> int | float | str | bool | None
+```
+
+**Parameters**:
+- `query`: SQL query returning a single value
+
+**Returns**: The scalar result value.
+
+**Example**: "How many events are there?" -> `sql_scalar(query="SELECT COUNT(*) FROM events")`
+
+---
+
+### list_tables
+
+List all tables in the local database.
+
+```
+list_tables() -> list[dict]
+```
+
+**Returns**: List of table metadata dictionaries with name, row_count, and type.
+
+---
+
+### table_schema
+
+Get the schema (column definitions) for a table.
+
+```
+table_schema(table: str) -> list[dict]
+```
+
+**Parameters**:
+- `table`: Name of the table
+
+**Returns**: List of column definitions.
+
+---
+
+### sample
+
+Get a random sample of rows from a table.
+
+```
+sample(table: str, limit: int = 10) -> list[dict]
+```
+
+**Parameters**:
+- `table`: Name of the table
+- `limit`: Number of rows to return
+
+**Returns**: List of sample rows.
+
+---
+
+### summarize
+
+Get summary statistics for a table.
+
+```
+summarize(table: str) -> dict
+```
+
+**Parameters**:
+- `table`: Name of the table
+
+**Returns**: Dictionary with table, row_count, and columns statistics.
+
+---
+
+### event_breakdown
+
+Get event counts by name from a local table.
+
+```
+event_breakdown(table: str) -> list[dict]
+```
+
+**Parameters**:
+- `table`: Name of the events table
+
+**Returns**: List of event names with counts.
+
+---
+
+### property_keys
+
+Extract unique property keys from event properties.
+
+```
+property_keys(table: str, event: str | None = None) -> list[str]
+```
+
+**Parameters**:
+- `table`: Name of the events table
+- `event`: Optional event name to filter by
+
+**Returns**: List of unique property key names.
+
+---
+
+### column_stats
+
+Get detailed statistics for a specific column.
+
+```
+column_stats(table: str, column: str) -> dict
+```
+
+**Parameters**:
+- `table`: Name of the table
+- `column`: Name of the column or JSON path expression (e.g., `"properties->>'$.field'"`)
+
+**Returns**: Dictionary with count, distinct_count, min_value, and max_value.
+
+---
+
+### drop_table
+
+Remove a table from the local database.
+
+```
+drop_table(table: str) -> dict
+```
+
+**Parameters**:
+- `table`: Name of the table to drop
+
+**Returns**: Dictionary with success status.
+
+---
+
+### drop_all_tables
+
+Remove all tables from the local database.
+
+```
+drop_all_tables() -> dict
+```
+
+**Returns**: Dictionary with success status.
+
+---
+
+## Composed Tools
+
+Higher-level tools that orchestrate multiple primitive tools.
+
+### cohort_comparison
+
+Compare two user cohorts across behavioral dimensions.
+
+```
+cohort_comparison(
+    cohort_a_filter: str,
+    cohort_b_filter: str,
+    cohort_a_name: str = "Cohort A",
+    cohort_b_name: str = "Cohort B",
+    from_date: str | None = None,
+    to_date: str | None = None,
+    acquisition_event: str = "signup",
+    compare_dimensions: list[str] | None = None
+) -> dict
+```
+
+**Parameters**:
+- `cohort_a_filter`: Filter expression for cohort A (e.g., `'properties["sessions"] >= 10'`)
+- `cohort_b_filter`: Filter expression for cohort B
+- `cohort_a_name`: Display name for cohort A
+- `cohort_b_name`: Display name for cohort B
+- `from_date`: Start date for analysis (defaults to 30 days ago)
+- `to_date`: End date for analysis (defaults to today)
+- `acquisition_event`: Event for retention analysis (default: signup)
+- `compare_dimensions`: Dimensions to compare (event_frequency, retention, top_events)
+
+**Returns**: Dictionary with cohort metrics, comparisons, statistical_significance, and key_differences.
+
+**Example**:
+```
+cohort_comparison(
+    cohort_a_filter='properties["sessions"] >= 10',
+    cohort_b_filter='properties["sessions"] < 3',
+    cohort_a_name="Power Users",
+    cohort_b_name="Casual Users"
+)
+```
+
+---
+
+### product_health_dashboard
+
+Generate a comprehensive AARRR product health dashboard.
+
+```
+product_health_dashboard(
+    acquisition_event: str = "signup",
+    activation_event: str | None = None,
+    retention_event: str | None = None,
+    revenue_event: str | None = None,
+    referral_event: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    segment_by: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `acquisition_event`: Event indicating acquisition (default: "signup")
+- `activation_event`: Event indicating activation/first value moment
+- `retention_event`: Event for retention analysis
+- `revenue_event`: Event indicating revenue (e.g., "purchase")
+- `referral_event`: Event indicating referral (e.g., "invite_sent")
+- `from_date`: Start date (defaults to 30 days ago)
+- `to_date`: End date (defaults to today)
+- `segment_by`: Optional property to segment acquisition by
+
+**Returns**: Dictionary with acquisition, activation, retention, revenue, referral metrics and health_score (1-10) for each.
+
+---
+
+### gqm_investigation
+
+Perform structured investigation using GQM methodology.
+
+```
+gqm_investigation(
+    goal: str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    acquisition_event: str = "signup",
+    max_questions: int = 5
+) -> dict
+```
+
+**Parameters**:
+- `goal`: High-level goal to investigate (e.g., "understand why retention is declining")
+- `from_date`: Start date (defaults to 30 days ago)
+- `to_date`: End date (defaults to today)
+- `acquisition_event`: Event to use for analysis (default: "signup")
+- `max_questions`: Maximum questions to generate (default: 5)
+
+**Returns**: Dictionary with interpreted_goal, aarrr_category, questions, findings, synthesis, and next_steps.
+
+---
+
+## Intelligent Tools
+
+AI-powered analysis with LLM synthesis.
+
+### ask_mixpanel
+
+Answer natural language analytics questions.
+
+```
+ask_mixpanel(
+    question: str,
+    from_date: str | None = None,
+    to_date: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `question`: Natural language question about your analytics data
+- `from_date`: Optional start date (defaults to 30 days ago)
+- `to_date`: Optional end date (defaults to today)
+
+**Returns**: Dictionary with status, answer, plan, and results.
+
+**Example**: "What features do our best users engage with?" -> `ask_mixpanel(question="What features do our best users engage with?")`
+
+---
+
+### diagnose_metric_drop
+
+Diagnose a metric drop with AI-powered analysis.
+
+```
+diagnose_metric_drop(
+    event: str,
+    date: str,
+    dimensions: list[str] | None = None
+) -> dict
+```
+
+**Parameters**:
+- `event`: Event name to analyze (e.g., "signup", "login")
+- `date`: Date of the observed drop (YYYY-MM-DD format)
+- `dimensions`: Optional list of property dimensions to analyze (defaults to common dimensions)
+
+**Returns**: Dictionary with findings, raw_data, and analysis_hints.
+
+**Example**: "Why did signups drop on January 7th?" -> `diagnose_metric_drop(event="signup", date="2026-01-07")`
+
+---
+
+### funnel_optimization_report
+
+Generate comprehensive funnel optimization report.
+
+```
+funnel_optimization_report(
+    funnel_id: int,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    segment_properties: list[str] | None = None
+) -> dict
+```
+
+**Parameters**:
+- `funnel_id`: ID of the saved funnel to analyze
+- `from_date`: Start date (defaults to 30 days ago)
+- `to_date`: End date (defaults to today)
+- `segment_properties`: Properties to segment by (defaults to browser and OS)
+
+**Returns**: Dictionary with executive_summary, overall_conversion_rate, bottleneck analysis, top/underperforming segments, and recommendations.
+
+---
+
+## Interactive Tools
+
+Guided workflows with user interaction.
+
+### guided_analysis
+
+Interactive guided analysis with multi-step workflow.
+
+```
+guided_analysis(
+    focus_area: Literal["conversion", "retention", "engagement", "revenue"] | None = None,
+    time_period: Literal["last_7_days", "last_30_days", "last_90_days", "custom"] | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None
+) -> dict
+```
+
+**Parameters**:
+- `focus_area`: Pre-selected focus area (conversion, retention, engagement, revenue)
+- `time_period`: Pre-selected time period
+- `from_date`: Custom start date for analysis
+- `to_date`: Custom end date for analysis
+
+**Returns**: Dictionary with status, focus_area, initial_analysis, segment_analysis, and suggestions.
+
+---
+
+### safe_large_fetch
+
+Safely fetch events with confirmation for large operations.
+
+```
+safe_large_fetch(
+    from_date: str | None = None,
+    to_date: str | None = None,
+    events: list[str] | None = None,
+    table: str | None = None,
+    confirmation_threshold: int = 100000
+) -> dict
+```
+
+**Parameters**:
+- `from_date`: Start date (defaults to 30 days ago)
+- `to_date`: End date (defaults to today)
+- `events`: Optional list of specific events to fetch
+- `table`: Optional table name for storing results
+- `confirmation_threshold`: Number of events above which to require confirmation (default: 100,000)
+
+**Returns**: Dictionary with status, estimated_count, actual_count, table_name, and message.

--- a/mp-mcp-server/src/mp_mcp_server/server.py
+++ b/mp-mcp-server/src/mp_mcp_server/server.py
@@ -27,8 +27,7 @@ from fastmcp import FastMCP
 from mixpanel_data import Workspace
 
 # Skills directory path - resolved to absolute for reliability
-# _SERVER_DIR = mp_mcp_server/ (server.py's parent)
-# .parent = src/, .parent.parent = mp-mcp-server/, .parent.parent.parent = mixpanel_data/
+# Path: server.py → mp_mcp_server/ → src/ → mp-mcp-server/ → mixpanel_data/ (repo root)
 _SERVER_DIR = Path(__file__).resolve().parent
 _SKILLS_DIR = _SERVER_DIR.parent.parent.parent / "mixpanel-plugin" / "skills"
 

--- a/mp-mcp-server/src/mp_mcp_server/server.py
+++ b/mp-mcp-server/src/mp_mcp_server/server.py
@@ -19,11 +19,18 @@ Example:
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
 
 from mixpanel_data import Workspace
+
+# Skills directory path - resolved to absolute for reliability
+# _SERVER_DIR = mp_mcp_server/ (server.py's parent)
+# .parent = src/, .parent.parent = mp-mcp-server/, .parent.parent.parent = mixpanel_data/
+_SERVER_DIR = Path(__file__).resolve().parent
+_SKILLS_DIR = _SERVER_DIR.parent.parent.parent / "mixpanel-plugin" / "skills"
 
 # Module-level account setting (set by CLI before server starts)
 _account: str | None = None
@@ -130,6 +137,17 @@ _rate_limiter = MixpanelRateLimitMiddleware()
 mcp.add_middleware(create_audit_middleware())
 mcp.add_middleware(_rate_limiter)
 mcp.add_middleware(create_caching_middleware())
+
+# Add skills provider (guarded to work outside monorepo context)
+if _SKILLS_DIR.exists():
+    from fastmcp.server.providers.skills import SkillsDirectoryProvider  # noqa: E402
+
+    mcp.add_provider(
+        SkillsDirectoryProvider(
+            roots=_SKILLS_DIR,
+            supporting_files="resources",  # Expose all reference files directly
+        )
+    )
 
 # Import tool modules to register them with the server
 # These imports must happen after mcp is defined

--- a/mp-mcp-server/tests/unit/test_skills_provider.py
+++ b/mp-mcp-server/tests/unit/test_skills_provider.py
@@ -1,0 +1,114 @@
+"""Tests for Skills Provider integration.
+
+These tests verify that the mp-mcp skill and its reference files are
+properly registered as MCP resources via the SkillsDirectoryProvider.
+"""
+
+import pytest
+
+
+class TestSkillsProviderConfiguration:
+    """Tests for skills provider setup."""
+
+    def test_skills_directory_path_is_absolute(self) -> None:
+        """Skills directory path should be absolute."""
+        from mp_mcp_server.server import _SKILLS_DIR
+
+        assert _SKILLS_DIR.is_absolute()
+
+    def test_skills_directory_path_is_resolved(self) -> None:
+        """Skills directory path should not contain relative components."""
+        from mp_mcp_server.server import _SKILLS_DIR
+
+        # Resolved paths should equal themselves when resolved again
+        assert _SKILLS_DIR.resolve() == _SKILLS_DIR
+
+    def test_mp_mcp_skill_structure_exists(self) -> None:
+        """mp-mcp skill should have required directory structure."""
+        from mp_mcp_server.server import _SKILLS_DIR
+
+        skill_dir = _SKILLS_DIR / "mp-mcp"
+        assert skill_dir.exists(), f"Expected skill directory at {skill_dir}"
+        assert (skill_dir / "SKILL.md").exists(), "SKILL.md missing"
+        assert (skill_dir / "references").is_dir(), "references directory missing"
+
+    def test_mp_mcp_skill_has_all_reference_files(self) -> None:
+        """mp-mcp skill should have all expected reference files."""
+        from mp_mcp_server.server import _SKILLS_DIR
+
+        skill_dir = _SKILLS_DIR / "mp-mcp"
+        refs_dir = skill_dir / "references"
+
+        expected_files = ["tools.md", "resources.md", "prompts.md", "patterns.md"]
+        for filename in expected_files:
+            assert (refs_dir / filename).exists(), f"Reference file {filename} missing"
+
+
+class TestSkillResourceRegistration:
+    """Tests for skill resource registration with MCP server."""
+
+    def test_mp_mcp_skill_main_file_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
+        """mp-mcp SKILL.md should be registered as a resource."""
+        assert "skill://mp-mcp/SKILL.md" in registered_resource_uris
+
+    def test_mp_mcp_skill_manifest_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
+        """mp-mcp manifest should be registered for content hashing."""
+        assert "skill://mp-mcp/_manifest" in registered_resource_uris
+
+    @pytest.mark.parametrize(
+        "reference_file",
+        ["tools.md", "resources.md", "prompts.md", "patterns.md"],
+    )
+    def test_mp_mcp_reference_files_registered(
+        self, registered_resource_uris: list[str], reference_file: str
+    ) -> None:
+        """mp-mcp reference files should be registered as resources."""
+        expected_uri = f"skill://mp-mcp/references/{reference_file}"
+        assert expected_uri in registered_resource_uris, (
+            f"Expected {expected_uri} in registered resources"
+        )
+
+    def test_mixpanel_data_skill_also_registered(
+        self, registered_resource_uris: list[str]
+    ) -> None:
+        """Existing mixpanel-data skill should also be exposed."""
+        assert "skill://mixpanel-data/SKILL.md" in registered_resource_uris
+
+
+class TestSkillResourceContent:
+    """Tests for skill resource content accessibility."""
+
+    @pytest.mark.asyncio
+    async def test_mp_mcp_skill_content_readable(self) -> None:
+        """mp-mcp SKILL.md content should be readable via MCP."""
+        from fastmcp import Client
+
+        from mp_mcp_server.server import mcp
+
+        async with Client(mcp) as client:
+            result = await client.read_resource("skill://mp-mcp/SKILL.md")
+            # result is a list of content items
+            assert len(result) > 0
+            content = result[0].text if hasattr(result[0], "text") else str(result[0])
+            assert "Mixpanel MCP Server" in content
+            assert "Tool Categories" in content
+
+    @pytest.mark.asyncio
+    async def test_mp_mcp_tools_reference_readable(self) -> None:
+        """mp-mcp tools reference should contain tool documentation."""
+        from fastmcp import Client
+
+        from mp_mcp_server.server import mcp
+
+        async with Client(mcp) as client:
+            result = await client.read_resource("skill://mp-mcp/references/tools.md")
+            assert len(result) > 0
+            content = result[0].text if hasattr(result[0], "text") else str(result[0])
+            # Should contain tool documentation
+            assert "list_events" in content
+            assert "segmentation" in content
+            assert "fetch_events" in content


### PR DESCRIPTION
## Summary

- Add `SkillsDirectoryProvider` to expose skills as MCP resources via `skill://` URIs
- Create new `mp-mcp` skill documenting the MCP server's 40+ tools, 8 resources, and 8 prompts
- Existing `mixpanel-data` skill is also exposed automatically

## Test plan

- [x] All 461 unit tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Skill resources readable via MCP client
- [ ] Manual verification with MCP inspector