### PR TITLE
feat(mp_mcp): add 17 new MCP tools for auth, discovery, and live query

### DIFF
--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -13,8 +13,10 @@ The `mp_mcp` package provides an MCP server that connects AI assistants like Cla
 
 **Key capabilities:**
 
-- **Schema Discovery** — Explore events, properties, funnels, cohorts, and bookmarks
-- **Live Analytics** — Run segmentation, funnel, retention, and JQL queries
+- **Account Management** — List, switch, and test Mixpanel account credentials
+- **Schema Discovery** — Explore events, properties, funnels, cohorts, Lexicon schemas, and bookmarks
+- **Live Analytics** — Run segmentation, funnel, retention, JQL, and numeric aggregation queries
+- **Saved Reports** — Execute saved Insights, Retention, Funnel, and Flows reports
 - **Data Fetching** — Download events and profiles to local DuckDB storage
 - **Local Analysis** — Execute SQL queries against fetched data
 - **Intelligent Tools** — AI-powered metric diagnosis and natural language queries

--- a/mp_mcp/README.md
+++ b/mp_mcp/README.md
@@ -18,8 +18,10 @@ The MCP Server v2 transforms `mp_mcp` from a thin API wrapper into an **intellig
 
 ## Features
 
-- **Schema Discovery**: Explore events, properties, funnels, cohorts, and bookmarks
-- **Live Analytics**: Run segmentation, funnel, retention, and JQL queries
+- **Account Management**: List, switch, and test Mixpanel account credentials
+- **Schema Discovery**: Explore events, properties, funnels, cohorts, Lexicon schemas, and bookmarks
+- **Live Analytics**: Run segmentation, funnel, retention, JQL, and numeric aggregation queries
+- **Saved Reports**: Execute saved Insights, Retention, Funnel, and Flows reports
 - **Data Fetching**: Download events and profiles to local DuckDB storage
 - **Local Analysis**: Execute SQL queries against fetched data
 - **Intelligent Tools**: AI-powered metric diagnosis and natural language queries
@@ -126,7 +128,14 @@ mp_mcp --transport http --port 8000
 | **Tier 3**      | Intelligent tools (AI synthesis)           | `ctx.sample()` |
 | **Interactive** | Elicitation workflows                      | `ctx.elicit()` |
 
-### Discovery (8 tools)
+### Auth (4 tools)
+
+- `list_accounts` - List all configured Mixpanel accounts
+- `show_account` - Show details for a specific account (secret redacted)
+- `switch_account` - Set a Mixpanel account as default
+- `test_credentials` - Test account credentials by pinging the API
+
+### Discovery (11 tools)
 
 - `list_events` - List all tracked events
 - `list_properties` - Get properties for an event
@@ -136,8 +145,11 @@ mp_mcp --transport http --port 8000
 - `list_bookmarks` - List saved reports
 - `top_events` - Get most active events
 - `workspace_info` - Get workspace configuration
+- `lexicon_schemas` - List Lexicon schemas (data dictionary)
+- `lexicon_schema` - Get a single Lexicon schema by entity type and name
+- `clear_discovery_cache` - Clear cached discovery results
 
-### Live Query (8 tools)
+### Live Query (18 tools)
 
 - `segmentation` - Time series event analysis
 - `funnel` - Conversion funnel analysis
@@ -147,6 +159,16 @@ mp_mcp --transport http --port 8000
 - `property_counts` - Property value breakdown
 - `activity_feed` - User event history
 - `frequency` - Event frequency distribution
+- `query_saved_report` - Execute a saved Insights, Retention, or Funnel report
+- `query_flows` - Execute a saved Flows report
+- `segmentation_numeric` - Bucket events by numeric property ranges
+- `segmentation_sum` - Calculate sum of numeric property over time
+- `segmentation_average` - Calculate average of numeric property over time
+- `property_distribution` - Get distribution of values for a property (JQL)
+- `numeric_summary` - Get statistical summary for a numeric property (JQL)
+- `daily_counts` - Get daily event counts (JQL)
+- `engagement_distribution` - Get user engagement distribution (JQL)
+- `property_coverage` - Get property coverage statistics (JQL)
 
 ### Fetch (4 tools)
 
@@ -334,6 +356,7 @@ mp_mcp/src/mp_mcp/
 ├── resources.py           # MCP resources
 ├── prompts.py             # Framework prompts
 ├── tools/
+│   ├── auth.py            # Account management tools
 │   ├── discovery.py       # Schema discovery tools
 │   ├── live_query.py      # Live query tools
 │   ├── fetch.py           # Data fetching tools

--- a/mp_mcp/src/mp_mcp/server.py
+++ b/mp_mcp/src/mp_mcp/server.py
@@ -152,6 +152,7 @@ if _SKILLS_DIR.exists():
 # These imports must happen after mcp is defined
 from mp_mcp import prompts, resources  # noqa: E402, F401
 from mp_mcp.tools import (  # noqa: E402, F401
+    auth,
     composed,
     discovery,
     fetch,

--- a/mp_mcp/src/mp_mcp/tools/auth.py
+++ b/mp_mcp/src/mp_mcp/tools/auth.py
@@ -1,0 +1,188 @@
+"""Authentication and account management tools for MCP server.
+
+This module provides MCP tools for managing Mixpanel accounts without
+modifying credentials (read-only operations plus switch_account which
+only changes the default, not the credential values).
+
+Unlike other MCP tools, auth tools do NOT use the workspace from the
+lifespan context. They create their own ConfigManager instance to
+read from the config file directly.
+
+Example:
+    ```python
+    # List all configured accounts
+    result = list_accounts(ctx)
+    # [{"name": "prod", "username": "svc-prod", ...}]
+
+    # Show account details (secret always redacted)
+    result = show_account(ctx, name="prod")
+    # {"name": "prod", "secret": "********", ...}
+
+    # Switch default account
+    result = switch_account(ctx, name="staging")
+    # {"default": "staging"}
+
+    # Test credentials
+    result = test_credentials(ctx, account="prod")
+    # {"success": True, "events_found": 42, ...}
+    ```
+"""
+
+from typing import Any
+
+from fastmcp import Context
+
+from mixpanel_data import Workspace
+from mixpanel_data.auth import ConfigManager
+from mp_mcp.errors import handle_errors
+from mp_mcp.server import mcp
+
+
+@mcp.tool
+@handle_errors
+def list_accounts(ctx: Context) -> list[dict[str, Any]]:
+    """List all configured Mixpanel accounts.
+
+    Returns information about all accounts stored in ~/.mp/config.toml,
+    including which one is set as the default. Secrets are never exposed.
+
+    Args:
+        ctx: FastMCP context (unused, required by MCP tool signature).
+
+    Returns:
+        List of account dictionaries with name, username, project_id,
+        region, and is_default fields.
+
+    Example:
+        ```python
+        result = list_accounts(ctx)
+        # [
+        #     {"name": "prod", "username": "svc-prod", "project_id": "123",
+        #      "region": "us", "is_default": True},
+        #     {"name": "dev", "username": "svc-dev", "project_id": "456",
+        #      "region": "eu", "is_default": False}
+        # ]
+        ```
+    """
+    _ = ctx  # Unused but required by MCP signature
+    config = ConfigManager()
+    accounts = config.list_accounts()
+    return [
+        {
+            "name": acc.name,
+            "username": acc.username,
+            "project_id": acc.project_id,
+            "region": acc.region,
+            "is_default": acc.is_default,
+        }
+        for acc in accounts
+    ]
+
+
+@mcp.tool
+@handle_errors
+def show_account(ctx: Context, name: str) -> dict[str, Any]:
+    """Show details for a specific Mixpanel account.
+
+    Returns account configuration with the secret redacted for security.
+
+    Args:
+        ctx: FastMCP context (unused, required by MCP tool signature).
+        name: Account name to show.
+
+    Returns:
+        Dictionary with name, username, secret (redacted), project_id,
+        region, and is_default fields.
+
+    Raises:
+        AccountNotFoundError: If the account doesn't exist.
+
+    Example:
+        ```python
+        result = show_account(ctx, name="production")
+        # {"name": "production", "username": "svc-prod",
+        #  "secret": "********", "project_id": "123456",
+        #  "region": "us", "is_default": True}
+        ```
+    """
+    _ = ctx
+    config = ConfigManager()
+    account = config.get_account(name)
+    return {
+        "name": account.name,
+        "username": account.username,
+        "secret": "********",  # Always redacted
+        "project_id": account.project_id,
+        "region": account.region,
+        "is_default": account.is_default,
+    }
+
+
+@mcp.tool
+@handle_errors
+def switch_account(ctx: Context, name: str) -> dict[str, str]:
+    """Set a Mixpanel account as the default.
+
+    Changes which account is used by default when no account is
+    specified. This modifies ~/.mp/config.toml but does not change
+    any credential values.
+
+    Note: This only affects future operations. The current MCP session
+    will continue using whatever account was active when it started.
+    Restart the MCP server to use the new default.
+
+    Args:
+        ctx: FastMCP context (unused, required by MCP tool signature).
+        name: Account name to set as default.
+
+    Returns:
+        Dictionary confirming the new default account.
+
+    Raises:
+        AccountNotFoundError: If the account doesn't exist.
+
+    Example:
+        ```python
+        result = switch_account(ctx, name="staging")
+        # {"default": "staging"}
+        ```
+    """
+    _ = ctx
+    config = ConfigManager()
+    config.set_default(name)
+    return {"default": name}
+
+
+@mcp.tool
+@handle_errors
+def test_credentials(ctx: Context, account: str | None = None) -> dict[str, Any]:
+    """Test Mixpanel account credentials by pinging the API.
+
+    Validates that credentials are correct and can access the
+    Mixpanel API. Uses a lightweight API call (list events) to
+    verify authentication without consuming significant quota.
+
+    Args:
+        ctx: FastMCP context (unused, required by MCP tool signature).
+        account: Optional account name to test. If None, tests the
+            default account or environment variable credentials.
+
+    Returns:
+        Dictionary with success status, account name, project_id,
+        region, and count of events found.
+
+    Raises:
+        AccountNotFoundError: If named account doesn't exist.
+        AuthenticationError: If credentials are invalid.
+        ConfigError: If no credentials can be resolved.
+
+    Example:
+        ```python
+        result = test_credentials(ctx, account="production")
+        # {"success": True, "account": "production",
+        #  "project_id": "123456", "region": "us",
+        #  "events_found": 42}
+        ```
+    """
+    _ = ctx
+    return Workspace.test_credentials(account=account)

--- a/mp_mcp/src/mp_mcp/tools/live_query.py
+++ b/mp_mcp/src/mp_mcp/tools/live_query.py
@@ -8,19 +8,19 @@ Example:
     Claude uses: segmentation(event="login", from_date="2024-01-01", ...)
 """
 
-from typing import Any, Literal
+from typing import Any
 
 from fastmcp import Context
 
+from mixpanel_data import CountType, HourDayUnit, TimeUnit
 from mp_mcp.context import get_workspace
 from mp_mcp.errors import handle_errors
 from mp_mcp.server import mcp
 
-# Type aliases for parameters
-UnitType = Literal["day", "week", "month"]
-CountType = Literal["general", "unique", "average"]
-AddictionUnitType = Literal["hour", "day"]
-NumericUnitType = Literal["hour", "day"]
+# Semantic aliases pointing to canonical types from mixpanel_data
+UnitType = TimeUnit
+AddictionUnitType = HourDayUnit
+NumericUnitType = HourDayUnit
 
 
 @mcp.tool

--- a/mp_mcp/src/mp_mcp/tools/live_query.py
+++ b/mp_mcp/src/mp_mcp/tools/live_query.py
@@ -398,32 +398,51 @@ def frequency(
 def query_saved_report(
     ctx: Context,
     bookmark_id: int,
+    bookmark_type: str = "insights",
+    from_date: str | None = None,
+    to_date: str | None = None,
 ) -> dict[str, Any]:
-    """Execute a saved Insights, Retention, or Funnel report.
+    """Execute a saved Insights, Retention, Funnel, or Flows report.
 
-    Runs a saved report by its bookmark ID. The report type is
-    automatically detected from the response. Use list_bookmarks()
-    to find available report IDs.
+    Runs a saved report by its bookmark ID, routing to the appropriate
+    Mixpanel API endpoint based on bookmark_type. Use list_bookmarks()
+    to find available report IDs and their types.
 
     Args:
         ctx: FastMCP context with workspace access.
         bookmark_id: ID of saved report (from list_bookmarks or Mixpanel URL).
+        bookmark_type: Type of bookmark - "insights", "funnels", "retention",
+            or "flows". Determines which API endpoint to use. Default: "insights".
+        from_date: Start date for query (YYYY-MM-DD). Required for funnels,
+            optional for others. Defaults to last 30 days for funnels.
+        to_date: End date for query (YYYY-MM-DD). Required for funnels,
+            optional for others. Defaults to today for funnels.
 
     Returns:
-        Dictionary with report data and report_type property.
+        Dictionary with report data. The report_type property indicates
+        the detected type ("insights", "retention", "funnel", or "flows").
 
     Raises:
         QueryError: If bookmark_id is invalid or report not found.
 
     Example:
-        Ask: "Run my saved conversion report (ID 12345)"
-        Uses: query_saved_report(bookmark_id=12345)
+        Ask: "Run my saved insights report (ID 12345)"
+        Uses: query_saved_report(bookmark_id=12345, bookmark_type="insights")
 
-        Ask: "Execute the report from this Mixpanel URL"
-        Uses: query_saved_report(bookmark_id=<extracted_id>)
+        Ask: "Query funnel report 67890 for January"
+        Uses: query_saved_report(bookmark_id=67890, bookmark_type="funnels",
+              from_date="2024-01-01", to_date="2024-01-31")
+
+        Ask: "Get retention data from saved report 11111"
+        Uses: query_saved_report(bookmark_id=11111, bookmark_type="retention")
     """
     ws = get_workspace(ctx)
-    result = ws.query_saved_report(bookmark_id=bookmark_id)
+    result = ws.query_saved_report(
+        bookmark_id=bookmark_id,
+        bookmark_type=bookmark_type,
+        from_date=from_date,
+        to_date=to_date,
+    )
     return result.to_dict()
 
 

--- a/mp_mcp/tests/conftest.py
+++ b/mp_mcp/tests/conftest.py
@@ -202,6 +202,107 @@ def mock_workspace() -> MagicMock:
     # Add property_keys() method for extracting unique property keys
     workspace.property_keys.return_value = ["browser", "country", "device"]
 
+    # Lexicon schema methods
+    lexicon_schema_mock = MagicMock()
+    lexicon_schema_mock.to_dict.return_value = {
+        "name": "signup",
+        "entity_type": "event",
+        "description": "User signed up",
+    }
+    workspace.lexicon_schemas.return_value = [lexicon_schema_mock]
+    workspace.lexicon_schema.return_value = lexicon_schema_mock
+
+    # Clear cache method
+    workspace.clear_discovery_cache.return_value = None
+
+    # Saved report methods
+    workspace.query_saved_report.return_value = MagicMock(
+        to_dict=lambda: {
+            "bookmark_id": 12345,
+            "report_type": "insights",
+            "data": {"values": {"2024-01-01": 100}},
+        }
+    )
+    workspace.query_flows.return_value = MagicMock(
+        to_dict=lambda: {
+            "bookmark_id": 67890,
+            "steps": [{"count": 100}, {"count": 50}],
+            "conversion_rate": 0.5,
+        }
+    )
+
+    # Numeric segmentation methods
+    workspace.segmentation_numeric.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "buckets": [
+                {"range": "0-100", "count": 50},
+                {"range": "100-200", "count": 30},
+            ],
+        }
+    )
+    workspace.segmentation_sum.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "data": {"2024-01-01": 5000.0, "2024-01-02": 6000.0},
+        }
+    )
+    workspace.segmentation_average.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "data": {"2024-01-01": 50.0, "2024-01-02": 60.0},
+        }
+    )
+
+    # JQL-based discovery methods
+    workspace.property_distribution.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "property": "country",
+            "values": [
+                {"value": "US", "count": 100, "percentage": 50.0},
+                {"value": "UK", "count": 60, "percentage": 30.0},
+            ],
+        }
+    )
+    workspace.numeric_summary.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "property": "amount",
+            "count": 1000,
+            "min": 10.0,
+            "max": 500.0,
+            "avg": 75.5,
+            "stddev": 25.0,
+            "percentiles": {25: 40.0, 50: 70.0, 75: 100.0},
+        }
+    )
+    workspace.daily_counts.return_value = MagicMock(
+        to_dict=lambda: {
+            "counts": [
+                {"date": "2024-01-01", "event": "signup", "count": 100},
+                {"date": "2024-01-02", "event": "signup", "count": 120},
+            ],
+        }
+    )
+    workspace.engagement_distribution.return_value = MagicMock(
+        to_dict=lambda: {
+            "buckets": [
+                {"bucket_label": "1", "user_count": 500, "percentage": 50.0},
+                {"bucket_label": "2-5", "user_count": 300, "percentage": 30.0},
+            ],
+        }
+    )
+    workspace.property_coverage.return_value = MagicMock(
+        to_dict=lambda: {
+            "event": "purchase",
+            "coverage": [
+                {"property": "coupon_code", "coverage_percentage": 25.0},
+                {"property": "referrer", "coverage_percentage": 80.0},
+            ],
+        }
+    )
+
     return workspace
 
 

--- a/mp_mcp/tests/unit/test_tools_auth.py
+++ b/mp_mcp/tests/unit/test_tools_auth.py
@@ -1,0 +1,279 @@
+"""Tests for authentication and account management tools.
+
+These tests verify the auth tools work correctly with ConfigManager.
+Unlike other tool tests, auth tools do NOT use the mock_context fixture's
+workspace since they create their own ConfigManager to manage credentials.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mixpanel_data.auth import AccountInfo
+from mixpanel_data.exceptions import (
+    AccountNotFoundError,
+    AuthenticationError,
+    ConfigError,
+)
+
+
+class TestListAccountsTool:
+    """Tests for the list_accounts tool."""
+
+    def test_list_accounts_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """list_accounts tool should be registered with the MCP server."""
+        assert "list_accounts" in registered_tool_names
+
+    def test_list_accounts_returns_empty_list(self) -> None:
+        """list_accounts should return empty list when no accounts configured."""
+        from mp_mcp.tools.auth import list_accounts
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.list_accounts.return_value = []
+
+            result = list_accounts(mock_ctx)  # type: ignore[operator]
+
+            assert result == []
+            mock_config.list_accounts.assert_called_once()
+
+    def test_list_accounts_returns_account_info(self) -> None:
+        """list_accounts should return account info for all accounts."""
+        from mp_mcp.tools.auth import list_accounts
+
+        mock_ctx = MagicMock()
+        mock_accounts = [
+            AccountInfo(
+                name="prod",
+                username="svc-prod",
+                project_id="123",
+                region="us",
+                is_default=True,
+            ),
+            AccountInfo(
+                name="dev",
+                username="svc-dev",
+                project_id="456",
+                region="eu",
+                is_default=False,
+            ),
+        ]
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.list_accounts.return_value = mock_accounts
+
+            result = list_accounts(mock_ctx)  # type: ignore[operator]
+
+            assert len(result) == 2
+            assert result[0]["name"] == "prod"
+            assert result[0]["username"] == "svc-prod"
+            assert result[0]["project_id"] == "123"
+            assert result[0]["region"] == "us"
+            assert result[0]["is_default"] is True
+            assert result[1]["name"] == "dev"
+            assert result[1]["is_default"] is False
+
+
+class TestShowAccountTool:
+    """Tests for the show_account tool."""
+
+    def test_show_account_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """show_account tool should be registered with the MCP server."""
+        assert "show_account" in registered_tool_names
+
+    def test_show_account_returns_account_with_redacted_secret(self) -> None:
+        """show_account should return account info with secret redacted."""
+        from mp_mcp.tools.auth import show_account
+
+        mock_ctx = MagicMock()
+        mock_account = AccountInfo(
+            name="prod",
+            username="svc-prod",
+            project_id="123456",
+            region="us",
+            is_default=True,
+        )
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.get_account.return_value = mock_account
+
+            result = show_account(mock_ctx, name="prod")  # type: ignore[operator]
+
+            assert result["name"] == "prod"
+            assert result["username"] == "svc-prod"
+            assert result["secret"] == "********"
+            assert result["project_id"] == "123456"
+            assert result["region"] == "us"
+            assert result["is_default"] is True
+            mock_config.get_account.assert_called_once_with("prod")
+
+    def test_show_account_raises_on_not_found(self) -> None:
+        """show_account should raise ToolError when account not found."""
+        from mp_mcp.tools.auth import show_account
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.get_account.side_effect = AccountNotFoundError(
+                "nonexistent", available_accounts=["prod", "dev"]
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                show_account(mock_ctx, name="nonexistent")  # type: ignore[operator]
+
+            assert "nonexistent" in str(exc_info.value)
+
+
+class TestSwitchAccountTool:
+    """Tests for the switch_account tool."""
+
+    def test_switch_account_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """switch_account tool should be registered with the MCP server."""
+        assert "switch_account" in registered_tool_names
+
+    def test_switch_account_sets_default(self) -> None:
+        """switch_account should set the default account."""
+        from mp_mcp.tools.auth import switch_account
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.set_default.return_value = None
+
+            result = switch_account(mock_ctx, name="staging")  # type: ignore[operator]
+
+            assert result == {"default": "staging"}
+            mock_config.set_default.assert_called_once_with("staging")
+
+    def test_switch_account_raises_on_not_found(self) -> None:
+        """switch_account should raise ToolError when account not found."""
+        from mp_mcp.tools.auth import switch_account
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.ConfigManager") as mock_config_cls:
+            mock_config = mock_config_cls.return_value
+            mock_config.set_default.side_effect = AccountNotFoundError(
+                "nonexistent", available_accounts=["prod", "dev"]
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                switch_account(mock_ctx, name="nonexistent")  # type: ignore[operator]
+
+            assert "nonexistent" in str(exc_info.value)
+
+
+class TestTestCredentialsTool:
+    """Tests for the test_credentials tool."""
+
+    def test_test_credentials_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """test_credentials tool should be registered with the MCP server."""
+        assert "test_credentials" in registered_tool_names
+
+    def test_test_credentials_returns_success(self) -> None:
+        """test_credentials should return success result."""
+        from mp_mcp.tools.auth import test_credentials
+
+        mock_ctx = MagicMock()
+        mock_result: dict[str, Any] = {
+            "success": True,
+            "account": "prod",
+            "project_id": "123456",
+            "region": "us",
+            "events_found": 42,
+        }
+
+        with patch("mp_mcp.tools.auth.Workspace") as mock_workspace_cls:
+            mock_workspace_cls.test_credentials.return_value = mock_result
+
+            result = test_credentials(mock_ctx, account="prod")  # type: ignore[operator]
+
+            assert result["success"] is True
+            assert result["account"] == "prod"
+            assert result["events_found"] == 42
+            mock_workspace_cls.test_credentials.assert_called_once_with(account="prod")
+
+    def test_test_credentials_without_account_uses_default(self) -> None:
+        """test_credentials should test default account when none specified."""
+        from mp_mcp.tools.auth import test_credentials
+
+        mock_ctx = MagicMock()
+        mock_result: dict[str, Any] = {
+            "success": True,
+            "account": None,
+            "project_id": "123456",
+            "region": "us",
+            "events_found": 10,
+        }
+
+        with patch("mp_mcp.tools.auth.Workspace") as mock_workspace_cls:
+            mock_workspace_cls.test_credentials.return_value = mock_result
+
+            result = test_credentials(mock_ctx)  # type: ignore[operator]
+
+            assert result["success"] is True
+            mock_workspace_cls.test_credentials.assert_called_once_with(account=None)
+
+    def test_test_credentials_raises_on_auth_error(self) -> None:
+        """test_credentials should raise ToolError on authentication failure."""
+        from mp_mcp.tools.auth import test_credentials
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.Workspace") as mock_workspace_cls:
+            mock_workspace_cls.test_credentials.side_effect = AuthenticationError(
+                "Invalid credentials"
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                test_credentials(mock_ctx, account="prod")  # type: ignore[operator]
+
+            assert "Authentication failed" in str(exc_info.value)
+
+    def test_test_credentials_raises_on_account_not_found(self) -> None:
+        """test_credentials should raise ToolError when account not found."""
+        from mp_mcp.tools.auth import test_credentials
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.Workspace") as mock_workspace_cls:
+            mock_workspace_cls.test_credentials.side_effect = AccountNotFoundError(
+                "nonexistent", available_accounts=["prod", "dev"]
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                test_credentials(mock_ctx, account="nonexistent")  # type: ignore[operator]
+
+            assert "nonexistent" in str(exc_info.value)
+
+    def test_test_credentials_raises_on_config_error(self) -> None:
+        """test_credentials should raise ToolError on config error."""
+        from mp_mcp.tools.auth import test_credentials
+
+        mock_ctx = MagicMock()
+
+        with patch("mp_mcp.tools.auth.Workspace") as mock_workspace_cls:
+            mock_workspace_cls.test_credentials.side_effect = ConfigError(
+                "No credentials found"
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                test_credentials(mock_ctx)  # type: ignore[operator]
+
+            assert "No credentials found" in str(exc_info.value)

--- a/mp_mcp/tests/unit/test_tools_discovery.py
+++ b/mp_mcp/tests/unit/test_tools_discovery.py
@@ -124,3 +124,65 @@ class TestWorkspaceInfoTools:
         result = workspace_info(mock_context)  # type: ignore[operator]
         assert result["project_id"] == 123456
         assert result["region"] == "us"
+
+
+class TestLexiconSchemasTools:
+    """Tests for the lexicon_schemas tool."""
+
+    def test_lexicon_schemas_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """lexicon_schemas tool should be registered with the MCP server."""
+        assert "lexicon_schemas" in registered_tool_names
+
+    def test_lexicon_schemas_returns_schemas(self, mock_context: MagicMock) -> None:
+        """lexicon_schemas should return schema metadata from Workspace."""
+        from mp_mcp.tools.discovery import lexicon_schemas
+
+        result = lexicon_schemas(mock_context)  # type: ignore[operator]
+        assert len(result) == 1
+        assert result[0]["name"] == "signup"
+        assert result[0]["entity_type"] == "event"
+
+
+class TestLexiconSchemaTools:
+    """Tests for the lexicon_schema tool."""
+
+    def test_lexicon_schema_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """lexicon_schema tool should be registered with the MCP server."""
+        assert "lexicon_schema" in registered_tool_names
+
+    def test_lexicon_schema_returns_single_schema(
+        self, mock_context: MagicMock
+    ) -> None:
+        """lexicon_schema should return a single schema from Workspace."""
+        from mp_mcp.tools.discovery import lexicon_schema
+
+        result = lexicon_schema(  # type: ignore[operator]
+            mock_context, entity_type="event", name="signup"
+        )
+        assert result["name"] == "signup"
+        assert result["entity_type"] == "event"
+        assert result["description"] == "User signed up"
+
+
+class TestClearDiscoveryCacheTools:
+    """Tests for the clear_discovery_cache tool."""
+
+    def test_clear_discovery_cache_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """clear_discovery_cache tool should be registered with the MCP server."""
+        assert "clear_discovery_cache" in registered_tool_names
+
+    def test_clear_discovery_cache_returns_success(
+        self, mock_context: MagicMock
+    ) -> None:
+        """clear_discovery_cache should return success status."""
+        from mp_mcp.tools.discovery import clear_discovery_cache
+
+        result = clear_discovery_cache(mock_context)  # type: ignore[operator]
+        assert result["status"] == "success"
+        assert "cache" in result["message"].lower()

--- a/mp_mcp/tests/unit/test_tools_live_query.py
+++ b/mp_mcp/tests/unit/test_tools_live_query.py
@@ -153,3 +153,234 @@ class TestFrequencyTool:
             to_date="2024-01-31",
         )
         assert "data" in result
+
+
+class TestQuerySavedReportTool:
+    """Tests for the query_saved_report tool."""
+
+    def test_query_saved_report_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """query_saved_report tool should be registered with the MCP server."""
+        assert "query_saved_report" in registered_tool_names
+
+    def test_query_saved_report_returns_report_data(
+        self, mock_context: MagicMock
+    ) -> None:
+        """query_saved_report should return report data from Workspace."""
+        from mp_mcp.tools.live_query import query_saved_report
+
+        result = query_saved_report(mock_context, bookmark_id=12345)  # type: ignore[operator]
+        assert "bookmark_id" in result
+        assert result["report_type"] == "insights"
+
+
+class TestQueryFlowsTool:
+    """Tests for the query_flows tool."""
+
+    def test_query_flows_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """query_flows tool should be registered with the MCP server."""
+        assert "query_flows" in registered_tool_names
+
+    def test_query_flows_returns_flows_data(self, mock_context: MagicMock) -> None:
+        """query_flows should return flows report data from Workspace."""
+        from mp_mcp.tools.live_query import query_flows
+
+        result = query_flows(mock_context, bookmark_id=67890)  # type: ignore[operator]
+        assert "steps" in result
+        assert "conversion_rate" in result
+
+
+class TestSegmentationNumericTool:
+    """Tests for the segmentation_numeric tool."""
+
+    def test_segmentation_numeric_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """segmentation_numeric tool should be registered with the MCP server."""
+        assert "segmentation_numeric" in registered_tool_names
+
+    def test_segmentation_numeric_returns_bucketed_data(
+        self, mock_context: MagicMock
+    ) -> None:
+        """segmentation_numeric should return bucketed data from Workspace."""
+        from mp_mcp.tools.live_query import segmentation_numeric
+
+        result = segmentation_numeric(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            on='properties["amount"]',
+        )
+        assert "buckets" in result
+
+
+class TestSegmentationSumTool:
+    """Tests for the segmentation_sum tool."""
+
+    def test_segmentation_sum_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """segmentation_sum tool should be registered with the MCP server."""
+        assert "segmentation_sum" in registered_tool_names
+
+    def test_segmentation_sum_returns_sum_data(self, mock_context: MagicMock) -> None:
+        """segmentation_sum should return sum values from Workspace."""
+        from mp_mcp.tools.live_query import segmentation_sum
+
+        result = segmentation_sum(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            on='properties["revenue"]',
+        )
+        assert "data" in result
+
+
+class TestSegmentationAverageTool:
+    """Tests for the segmentation_average tool."""
+
+    def test_segmentation_average_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """segmentation_average tool should be registered with the MCP server."""
+        assert "segmentation_average" in registered_tool_names
+
+    def test_segmentation_average_returns_avg_data(
+        self, mock_context: MagicMock
+    ) -> None:
+        """segmentation_average should return average values from Workspace."""
+        from mp_mcp.tools.live_query import segmentation_average
+
+        result = segmentation_average(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            on='properties["amount"]',
+        )
+        assert "data" in result
+
+
+class TestPropertyDistributionTool:
+    """Tests for the property_distribution tool."""
+
+    def test_property_distribution_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """property_distribution tool should be registered with the MCP server."""
+        assert "property_distribution" in registered_tool_names
+
+    def test_property_distribution_returns_value_counts(
+        self, mock_context: MagicMock
+    ) -> None:
+        """property_distribution should return value counts from Workspace."""
+        from mp_mcp.tools.live_query import property_distribution
+
+        result = property_distribution(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            property_name="country",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+        assert "values" in result
+
+
+class TestNumericSummaryTool:
+    """Tests for the numeric_summary tool."""
+
+    def test_numeric_summary_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """numeric_summary tool should be registered with the MCP server."""
+        assert "numeric_summary" in registered_tool_names
+
+    def test_numeric_summary_returns_statistics(self, mock_context: MagicMock) -> None:
+        """numeric_summary should return statistics from Workspace."""
+        from mp_mcp.tools.live_query import numeric_summary
+
+        result = numeric_summary(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            property_name="amount",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+        assert "count" in result
+        assert "min" in result
+        assert "max" in result
+        assert "avg" in result
+
+
+class TestDailyCountsTool:
+    """Tests for the daily_counts tool."""
+
+    def test_daily_counts_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """daily_counts tool should be registered with the MCP server."""
+        assert "daily_counts" in registered_tool_names
+
+    def test_daily_counts_returns_counts(self, mock_context: MagicMock) -> None:
+        """daily_counts should return daily event counts from Workspace."""
+        from mp_mcp.tools.live_query import daily_counts
+
+        result = daily_counts(  # type: ignore[operator]
+            mock_context,
+            from_date="2024-01-01",
+            to_date="2024-01-07",
+        )
+        assert "counts" in result
+
+
+class TestEngagementDistributionTool:
+    """Tests for the engagement_distribution tool."""
+
+    def test_engagement_distribution_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """engagement_distribution tool should be registered with the MCP server."""
+        assert "engagement_distribution" in registered_tool_names
+
+    def test_engagement_distribution_returns_buckets(
+        self, mock_context: MagicMock
+    ) -> None:
+        """engagement_distribution should return user buckets from Workspace."""
+        from mp_mcp.tools.live_query import engagement_distribution
+
+        result = engagement_distribution(  # type: ignore[operator]
+            mock_context,
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+        assert "buckets" in result
+
+
+class TestPropertyCoverageTool:
+    """Tests for the property_coverage tool."""
+
+    def test_property_coverage_tool_registered(
+        self, registered_tool_names: list[str]
+    ) -> None:
+        """property_coverage tool should be registered with the MCP server."""
+        assert "property_coverage" in registered_tool_names
+
+    def test_property_coverage_returns_coverage_stats(
+        self, mock_context: MagicMock
+    ) -> None:
+        """property_coverage should return coverage stats from Workspace."""
+        from mp_mcp.tools.live_query import property_coverage
+
+        result = property_coverage(  # type: ignore[operator]
+            mock_context,
+            event="purchase",
+            properties=["coupon_code", "referrer"],
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+        assert "coverage" in result

--- a/mp_mcp/tests/unit/test_tools_live_query.py
+++ b/mp_mcp/tests/unit/test_tools_live_query.py
@@ -174,6 +174,64 @@ class TestQuerySavedReportTool:
         assert "bookmark_id" in result
         assert result["report_type"] == "insights"
 
+    def test_query_saved_report_accepts_bookmark_type(
+        self, mock_context: MagicMock
+    ) -> None:
+        """query_saved_report should accept bookmark_type parameter."""
+        from mp_mcp.tools.live_query import query_saved_report
+
+        result = query_saved_report(  # type: ignore[operator]
+            mock_context,
+            bookmark_id=12345,
+            bookmark_type="funnels",
+        )
+        assert "bookmark_id" in result
+        mock_context.lifespan_context[
+            "workspace"
+        ].query_saved_report.assert_called_with(
+            bookmark_id=12345,
+            bookmark_type="funnels",
+            from_date=None,
+            to_date=None,
+        )
+
+    def test_query_saved_report_accepts_dates(self, mock_context: MagicMock) -> None:
+        """query_saved_report should accept from_date and to_date parameters."""
+        from mp_mcp.tools.live_query import query_saved_report
+
+        result = query_saved_report(  # type: ignore[operator]
+            mock_context,
+            bookmark_id=12345,
+            bookmark_type="funnels",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+        assert "bookmark_id" in result
+        mock_context.lifespan_context[
+            "workspace"
+        ].query_saved_report.assert_called_with(
+            bookmark_id=12345,
+            bookmark_type="funnels",
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+        )
+
+    def test_query_saved_report_defaults_to_insights(
+        self, mock_context: MagicMock
+    ) -> None:
+        """query_saved_report should default bookmark_type to 'insights'."""
+        from mp_mcp.tools.live_query import query_saved_report
+
+        query_saved_report(mock_context, bookmark_id=12345)  # type: ignore[operator]
+        mock_context.lifespan_context[
+            "workspace"
+        ].query_saved_report.assert_called_with(
+            bookmark_id=12345,
+            bookmark_type="insights",
+            from_date=None,
+            to_date=None,
+        )
+
 
 class TestQueryFlowsTool:
     """Tests for the query_flows tool."""

--- a/src/mixpanel_data/_internal/services/discovery.py
+++ b/src/mixpanel_data/_internal/services/discovery.py
@@ -408,7 +408,13 @@ class DiscoveryService:
             Results are NOT cached because bookmarks may change frequently.
         """
         raw = self._api_client.list_bookmarks(bookmark_type=bookmark_type)
-        results = raw.get("results", [])
+        # API returns nested structure: {"results": {"results": [...]}}
+        results_container = raw.get("results", {})
+        if isinstance(results_container, dict):
+            results = results_container.get("results", [])
+        else:
+            # Fallback for older/different API versions returning flat list
+            results = results_container
         return [_parse_bookmark_info(bm) for bm in results]
 
     def list_top_events(

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -173,12 +173,13 @@ Valid values:
     - launch-analysis: Impact/experiment reports
 """
 
-SavedReportType = Literal["insights", "retention", "funnel"]
+SavedReportType = Literal["insights", "retention", "funnel", "flows"]
 """Report type detected from saved report query results.
 
 Derived from headers array in the API response:
     - retention: Headers contain "$retention"
     - funnel: Headers contain "$funnel"
+    - flows: Headers contain "$flows"
     - insights: Default when no special headers present
 """
 
@@ -1234,6 +1235,7 @@ class SavedReportResult:
         Returns:
             'retention' if headers contain '$retention',
             'funnel' if headers contain '$funnel',
+            'flows' if headers contain '$flows',
             'insights' otherwise.
         """
         for header in self.headers:
@@ -1241,6 +1243,8 @@ class SavedReportResult:
                 return "retention"
             if "$funnel" in header.lower():
                 return "funnel"
+            if "$flows" in header.lower():
+                return "flows"
         return "insights"
 
     @property

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1578,14 +1578,27 @@ class Workspace:
             to_date=to_date,
         )
 
-    def query_saved_report(self, bookmark_id: int) -> SavedReportResult:
-        """Query a saved report (Insights, Retention, or Funnel).
+    def query_saved_report(
+        self,
+        bookmark_id: int,
+        *,
+        bookmark_type: Literal[
+            "insights", "funnels", "retention", "flows"
+        ] = "insights",
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> SavedReportResult:
+        """Query a saved report by bookmark type.
 
-        Executes a saved report by its bookmark ID. The report type is
-        automatically detected from the response headers.
+        Routes to the appropriate Mixpanel API endpoint based on bookmark_type
+        and returns the normalized result.
 
         Args:
             bookmark_id: ID of saved report (from list_bookmarks or Mixpanel URL).
+            bookmark_type: Type of bookmark to query. Determines which API endpoint
+                is called. Defaults to 'insights'.
+            from_date: Start date (YYYY-MM-DD). Required for funnels, optional otherwise.
+            to_date: End date (YYYY-MM-DD). Required for funnels, optional otherwise.
 
         Returns:
             SavedReportResult with report data and report_type property.
@@ -1594,7 +1607,12 @@ class Workspace:
             ConfigError: If API credentials not available.
             QueryError: If bookmark_id is invalid or report not found.
         """
-        return self._live_query_service.query_saved_report(bookmark_id=bookmark_id)
+        return self._live_query_service.query_saved_report(
+            bookmark_id=bookmark_id,
+            bookmark_type=bookmark_type,
+            from_date=from_date,
+            to_date=to_date,
+        )
 
     def query_flows(self, bookmark_id: int) -> FlowsResult:
         """Query a saved Flows report.

--- a/tests/unit/test_live_query_bookmarks.py
+++ b/tests/unit/test_live_query_bookmarks.py
@@ -1,6 +1,7 @@
 """Tests for LiveQueryService bookmark methods.
 
 Phase 015: Bookmarks API - Tests for query_flows() and related methods.
+Phase 016: Smart routing for query_saved_report with bookmark_type parameter.
 """
 
 from __future__ import annotations
@@ -8,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from mixpanel_data._internal.services.live_query import LiveQueryService
-from mixpanel_data.types import FlowsResult
+from mixpanel_data.types import FlowsResult, SavedReportResult
 
 
 class TestQueryFlows:
@@ -145,3 +146,205 @@ class TestQueryFlows:
         service.query_flows(bookmark_id=12345)
 
         mock_api_client.query_flows.assert_called_once_with(bookmark_id=12345)
+
+
+class TestQuerySavedReportNormalization:
+    """Tests for LiveQueryService.query_saved_report() response normalization."""
+
+    def test_insights_normalization_preserves_headers_and_series(self) -> None:
+        """Insights responses should preserve headers and series from API."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "headers": ["$metric"],
+            "computed_at": "2024-01-15T10:00:00",
+            "date_range": {"from_date": "2024-01-01", "to_date": "2024-01-15"},
+            "series": {"Event A": {"2024-01-01": 100, "2024-01-02": 150}},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="insights")
+
+        assert isinstance(result, SavedReportResult)
+        assert result.headers == ["$metric"]
+        assert result.series == {"Event A": {"2024-01-01": 100, "2024-01-02": 150}}
+
+    def test_funnels_normalization_adds_funnel_header(self) -> None:
+        """Funnels responses should normalize to SavedReportResult with $funnel header."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "2024-01-15T10:00:00",
+            "data": {"2024-01-15": {"steps": [{"count": 100}]}},
+            "meta": {},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="funnels")
+
+        assert isinstance(result, SavedReportResult)
+        assert result.headers == ["$funnel"]
+        assert result.report_type == "funnel"
+
+    def test_funnels_normalization_extracts_dates_from_data_keys(self) -> None:
+        """Funnels responses should extract from_date/to_date from data keys."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "2024-01-15T10:00:00",
+            "data": {
+                "2024-01-10": {"steps": []},
+                "2024-01-11": {"steps": []},
+                "2024-01-15": {"steps": []},
+            },
+            "meta": {},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="funnels")
+
+        assert result.from_date == "2024-01-10"
+        assert result.to_date == "2024-01-15"
+
+    def test_funnels_normalization_stores_data_in_series(self) -> None:
+        """Funnels responses should store data in series field."""
+        mock_api_client = MagicMock()
+        funnel_data = {"2024-01-15": {"steps": [{"count": 100}]}}
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "2024-01-15T10:00:00",
+            "data": funnel_data,
+            "meta": {},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="funnels")
+
+        assert result.series == funnel_data
+
+    def test_retention_normalization_adds_retention_header(self) -> None:
+        """Retention responses should normalize to SavedReportResult with $retention header."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "2024-01-01": {
+                "first": 100,
+                "counts": [100, 80, 60],
+                "rates": [1.0, 0.8, 0.6],
+            },
+            "2024-01-02": {"first": 120, "counts": [120, 90], "rates": [1.0, 0.75]},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(
+            bookmark_id=12345, bookmark_type="retention"
+        )
+
+        assert isinstance(result, SavedReportResult)
+        assert result.headers == ["$retention"]
+        assert result.report_type == "retention"
+
+    def test_retention_normalization_uses_raw_as_series(self) -> None:
+        """Retention responses should use entire raw response as series."""
+        mock_api_client = MagicMock()
+        retention_data = {
+            "2024-01-01": {"first": 100, "counts": [100, 80], "rates": [1.0, 0.8]},
+        }
+        mock_api_client.query_saved_report.return_value = retention_data
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(
+            bookmark_id=12345, bookmark_type="retention"
+        )
+
+        assert result.series == retention_data
+
+    def test_retention_normalization_extracts_dates_from_keys(self) -> None:
+        """Retention responses should extract from_date/to_date from data keys."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "2024-01-05": {"first": 100, "counts": [100], "rates": [1.0]},
+            "2024-01-01": {"first": 100, "counts": [100], "rates": [1.0]},
+            "2024-01-10": {"first": 100, "counts": [100], "rates": [1.0]},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(
+            bookmark_id=12345, bookmark_type="retention"
+        )
+
+        assert result.from_date == "2024-01-01"
+        assert result.to_date == "2024-01-10"
+
+    def test_flows_normalization_adds_flows_header(self) -> None:
+        """Flows responses should normalize to SavedReportResult with $flows header."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "2024-01-15T10:00:00",
+            "steps": [{"step": 1, "event": "Page View"}],
+            "breakdowns": [{"path": "A -> B"}],
+            "overallConversionRate": 0.5,
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="flows")
+
+        assert isinstance(result, SavedReportResult)
+        assert result.headers == ["$flows"]
+
+    def test_flows_normalization_structures_series_correctly(self) -> None:
+        """Flows responses should structure series with steps, breakdowns, conversionRate."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "2024-01-15T10:00:00",
+            "steps": [{"step": 1, "event": "Page View"}],
+            "breakdowns": [{"path": "A -> B", "count": 100}],
+            "overallConversionRate": 0.75,
+        }
+
+        service = LiveQueryService(mock_api_client)
+        result = service.query_saved_report(bookmark_id=12345, bookmark_type="flows")
+
+        assert "steps" in result.series
+        assert "breakdowns" in result.series
+        assert "overallConversionRate" in result.series
+        assert result.series["overallConversionRate"] == 0.75
+
+    def test_service_passes_bookmark_type_to_api_client(self) -> None:
+        """LiveQueryService should pass bookmark_type to API client."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "headers": ["$metric"],
+            "computed_at": "",
+            "date_range": {"from_date": "", "to_date": ""},
+            "series": {},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        service.query_saved_report(bookmark_id=12345, bookmark_type="insights")
+
+        mock_api_client.query_saved_report.assert_called_once_with(
+            bookmark_id=12345,
+            bookmark_type="insights",
+            from_date=None,
+            to_date=None,
+        )
+
+    def test_service_passes_dates_for_funnels(self) -> None:
+        """LiveQueryService should pass from_date/to_date for funnels."""
+        mock_api_client = MagicMock()
+        mock_api_client.query_saved_report.return_value = {
+            "computed_at": "",
+            "data": {},
+            "meta": {},
+        }
+
+        service = LiveQueryService(mock_api_client)
+        service.query_saved_report(
+            bookmark_id=12345,
+            bookmark_type="funnels",
+            from_date="2024-06-01",
+            to_date="2024-06-30",
+        )
+
+        mock_api_client.query_saved_report.assert_called_once_with(
+            bookmark_id=12345,
+            bookmark_type="funnels",
+            from_date="2024-06-01",
+            to_date="2024-06-30",
+        )


### PR DESCRIPTION
## Summary

This PR adds 17 new MCP tools and fixes smart routing for `query_saved_report()` to support all bookmark types.

### New MCP Tools (17 total)

**Auth Tools (4):**
- `list_accounts` - List configured Mixpanel accounts
- `show_account` - Show current account details
- `switch_account` - Switch to a different account
- `test_credentials` - Verify credentials are valid

**Discovery Tools (+3):**
- `lexicon_schemas` - List all Lexicon schemas (events/properties with metadata)
- `lexicon_schema` - Get detailed schema for a specific entity
- `clear_discovery_cache` - Clear cached discovery data

**Live Query - Saved Reports (+2):**
- `query_saved_report` - Execute saved Insights/Funnels/Retention/Flows reports
- `query_flows` - Execute saved Flows reports (convenience wrapper)

**Live Query - Numeric Segmentation (+3):**
- `segmentation_numeric` - Bucket numeric property values
- `segmentation_sum` - Sum numeric property over time
- `segmentation_average` - Average numeric property over time

**Live Query - JQL-Based Analytics (+5):**
- `property_distribution` - Get value distribution for a property
- `numeric_summary` - Statistical summary (min/max/avg/percentiles)
- `daily_counts` - Daily event counts across all events
- `engagement_distribution` - User engagement frequency buckets
- `property_coverage` - Percentage of events with property values

**Tool Count: 39 → 56 (Tier 1: 31 → 48)**

### Smart Routing for query_saved_report

Added `bookmark_type` parameter to route to the correct Mixpanel API endpoint:

| bookmark_type | API Endpoint | Parameters |
|---------------|--------------|------------|
| insights | `/insights` | `bookmark_id` |
| funnels | `/funnels` | `funnel_id`, `from_date`, `to_date` |
| retention | `/retention` | `bookmark_id` |
| flows | `/arb_funnels` | `bookmark_id`, `query_type=flows_sankey` |

All responses normalized to `SavedReportResult` with synthetic headers (`$funnel`, `$retention`, `$flows`) for consistent `report_type` detection.

**Fixes:** "Invalid insights_id" error when querying non-insights bookmark types.

## Files Changed

- **mp_mcp/src/mp_mcp/tools/auth.py** - New auth tools
- **mp_mcp/src/mp_mcp/tools/discovery.py** - Lexicon and cache tools
- **mp_mcp/src/mp_mcp/tools/live_query.py** - Saved reports and analytics tools
- **src/mixpanel_data/_internal/api_client.py** - Smart routing logic
- **src/mixpanel_data/_internal/services/live_query.py** - Response normalization
- **src/mixpanel_data/types.py** - Added "flows" to SavedReportType
- **docs/mcp/tools.md** - Tool documentation

## Test Plan

- [x] Unit tests for new auth tools (279 lines)
- [x] Unit tests for new discovery tools (62 lines)
- [x] Unit tests for new live query tools (289 lines)
- [x] Unit tests for API client routing (8 tests)
- [x] Unit tests for service layer normalization (11 tests)
- [x] Unit tests for workspace delegation (8 tests)
- [x] Manual QA with live Mixpanel data for all 4 bookmark types
- [x] All tests passing (1861 main + 32 MCP)