### PR TITLE
Add `query_origin` to Mixpanel requests for tracking + a couple minor fix ups

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ check: lint typecheck test mcp-check
 
 # Run tests
 test *args:
-    uv run pytest {{ args }} -vv
+    uv run pytest {{ args }}
 
 # Run tests with dev Hypothesis profile (fast, 10 examples)
 test-dev *args:

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ check: lint typecheck test mcp-check
 
 # Run tests
 test *args:
-    uv run pytest {{ args }}
+    uv run pytest {{ args }} -vv
 
 # Run tests with dev Hypothesis profile (fast, 10 examples)
 test-dev *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,5 +129,6 @@ dev = [
     "click-man>=0.5.1",
     "pre-commit>=4.5.1",
     "psutil>=7.2.0",
+    "ruff>=0.14.10",
     "types-psutil>=7.2.0.20251228",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,6 @@ dev = [
     "click-man>=0.5.1",
     "pre-commit>=4.5.1",
     "psutil>=7.2.0",
-    "ruff>=0.14.10",
+    "ruff>=0.1",
     "types-psutil>=7.2.0.20251228",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+addopts = "-vv --tb=short"
 
 [tool.coverage.run]
 source = ["src/mixpanel_data"]

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -417,9 +417,9 @@ class MixpanelAPIClient:
         """
         client = self._ensure_client()
         request_body = json_data or form_data
-        if json_data is None:
-            json_data = {}
-        json_data["query_origin"] = "mixpanel-data-cli"
+        if params is None:
+            params = {}
+        params["query_origin"] = "mixpanel-data-cli"
 
         for attempt in range(self._max_retries + 1):
             try:

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -418,7 +418,7 @@ class MixpanelAPIClient:
         client = self._ensure_client()
         request_body = json_data or form_data
         if json_data is None:
-            json_data = dict()
+            json_data = {}
         json_data["query_origin"] = "mixpanel-data-cli"
 
         for attempt in range(self._max_retries + 1):

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -417,6 +417,9 @@ class MixpanelAPIClient:
         """
         client = self._ensure_client()
         request_body = json_data or form_data
+        if json_data is None:
+            json_data = dict()
+        json_data["query_origin"] = "mixpanel-data-cli"
 
         for attempt in range(self._max_retries + 1):
             try:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1529,11 +1529,11 @@ class TestPublicRequest:
             client.request(
                 "POST",
                 "https://mixpanel.com/api/app/projects/12345/data",
-                json_body={"name": "test", "value": 123},
+                json_body={"name": "test", "value": 123, "query_origin": "mixpanel-data-cli"},
             )
 
         assert "application/json" in captured_content_type
-        assert captured_body == {"name": "test", "value": 123}
+        assert captured_body == {"name": "test", "value": 123, "query_origin": "mixpanel-data-cli"}
 
     def test_request_with_custom_headers(self, test_credentials: Credentials) -> None:
         """request() should merge custom headers with auth."""


### PR DESCRIPTION
This PR adds the `query_origin` `mixpanel-data-cli` to all requests from the tool to make it easier for Mixpanel engineers to track requests from this tool.

This PR also adds `ruff` as a dev dep to the pyproject.toml as it wasn't automatically installed previously and adds `-vv` to the just recipe for running all tests. When the tests failed after my initial change I couldn't actually see the diff without `-vv`. LMK if you'd rather not have that be added, thought it'd be useful though.