### PR TITLE
feat: OAuth 2.0 PKCE auth, App API client, and workspace scoping

### DIFF
--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -41,7 +41,7 @@ Load only the minimal necessary context from each artifact:
 
 - Overview/Context
 - Functional Requirements
-- Non-Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
 - User Stories
 - Edge Cases (if present)
 
@@ -68,7 +68,7 @@ Load only the minimal necessary context from each artifact:
 
 Create internal representations (do not include raw artifacts in output):
 
-- **Requirements inventory**: Each functional + non-functional requirement with a stable key (derive slug based on imperative phrase; e.g., "User can upload file" → `user-can-upload-file`)
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
 - **User story/action inventory**: Discrete user actions with acceptance criteria
 - **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
 - **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
@@ -102,7 +102,7 @@ Focus on high-signal findings. Limit to 50 findings total; aggregate remainder i
 
 - Requirements with zero associated tasks
 - Tasks with no mapped requirement/story
-- Non-functional requirements not reflected in tasks (e.g., performance, security)
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
 
 #### F. Inconsistency
 

--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -91,9 +91,10 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Generate unique checklist filename:
      - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
      - Format: `[domain].md`
-     - If file exists, append to existing file
-   - Number items sequentially starting from CHK001
-   - Each `/speckit.checklist` run creates a NEW file (never overwrites existing checklists)
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
 
    **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
    Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
@@ -205,13 +206,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
 
-7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
    - Focus areas selected
    - Depth level
    - Actor/timing
    - Any explicit user-specified must-have items incorporated
 
-**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows:
+**Important**: Each `/speckit.checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
 
 - Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
 - Simple, memorable filenames that indicate checklist purpose

--- a/.claude/commands/speckit.clarify.md
+++ b/.claude/commands/speckit.clarify.md
@@ -86,7 +86,7 @@ Execution steps:
    - Information is better deferred to planning phase (note internally)
 
 3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
-    - Maximum of 10 total questions across the whole session.
+    - Maximum of 5 total questions across the whole session.
     - Each question must be answerable with EITHER:
        - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
        - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
@@ -142,7 +142,7 @@ Execution steps:
        - Functional ambiguity → Update or add a bullet in Functional Requirements.
        - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
        - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
-       - Non-functional constraint → Add/modify measurable criteria in Non-Functional / Quality Attributes section (convert vague adjective to metric or explicit target).
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
        - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
        - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
     - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -18,9 +18,11 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
 Follow this execution flow:
 
-1. Load the existing constitution template at `.specify/memory/constitution.md`.
+1. Load the existing constitution at `.specify/memory/constitution.md`.
    - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
    **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
 

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -10,6 +10,40 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -85,7 +119,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
    - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
    - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
-   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
    - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
    - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
    - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
@@ -133,3 +167,32 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Report final status with summary of completed work
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -18,6 +18,40 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -34,6 +68,35 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 ## Phases
 
@@ -69,10 +132,11 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Validation rules from requirements
    - State transitions if applicable
 
-2. **Generate API contracts** from functional requirements:
-   - For each user action → endpoint
-   - Use standard REST/GraphQL patterns
-   - Output OpenAPI/GraphQL schema to `/contracts/`
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
 3. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh claude`

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -18,6 +18,40 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
@@ -36,33 +70,20 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create the feature branch** by running the script with `--short-name` (and `--json`). In sequential mode, do NOT pass `--number` — the script auto-detects the next available number. In timestamp mode, the script generates a `YYYYMMDD-HHMMSS` prefix automatically:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
+   **Branch numbering mode**: Before running the script, check if `.specify/init-options.json` exists and read the `branch_numbering` value.
+   - If `"timestamp"`, add `--timestamp` (Bash) or `-Timestamp` (PowerShell) to the script invocation
+   - If `"sequential"` or absent, do not add any extra flag (default behavior)
 
-      ```bash
-      git fetch --all --prune
-      ```
-
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   - Bash example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" --json --short-name "user-auth" "Add user authentication"`
+   - Bash (timestamp): `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" --json --timestamp --short-name "user-auth" "Add user authentication"`
+   - PowerShell example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" -Json -ShortName "user-auth" "Add user authentication"`
+   - PowerShell (timestamp): `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" -Json -Timestamp -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Do NOT pass `--number` — the script determines the correct next number automatically
+   - Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
@@ -145,7 +166,7 @@ Given that feature description, do this:
 
    c. **Handle Validation Results**:
 
-      - **If all items pass**: Mark checklist complete and proceed to step 6
+      - **If all items pass**: Mark checklist complete and proceed to step 7
 
       - **If items fail (excluding [NEEDS CLARIFICATION])**:
         1. List the failing items and specific issues
@@ -192,9 +213,36 @@ Given that feature description, do this:
 
 7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
-**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+8. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
 
-## General Guidelines
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 
 ## Quick Guidelines
 
@@ -232,7 +280,7 @@ When creating this spec from a user prompt:
 - Performance targets: Standard web/mobile app expectations unless specified
 - Error handling: User-friendly messages with appropriate fallbacks
 - Authentication method: Standard session-based or OAuth2 for web apps
-- Integration patterns: RESTful APIs unless specified otherwise
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
 
 ### Success Criteria Guidelines
 

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -19,20 +19,54 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
-   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 
 3. **Execute task generation workflow**:
    - Load plan.md and extract tech stack, libraries, project structure
    - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
    - If data-model.md exists: Extract entities and map to user stories
-   - If contracts/ exists: Map endpoints to user stories
+   - If contracts/ exists: Map interface contracts to user stories
    - If research.md exists: Extract decisions for setup tasks
    - Generate tasks organized by user story (see Task Generation Rules below)
    - Generate dependency graph showing user story completion order
@@ -59,6 +93,35 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Independent test criteria for each story
    - Suggested MVP scope (typically just User Story 1)
    - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 Context for task generation: $ARGUMENTS
 
@@ -109,13 +172,13 @@ Every task MUST strictly follow this format:
    - Map all related components to their story:
      - Models needed for that story
      - Services needed for that story
-     - Endpoints/UI needed for that story
+     - Interfaces/UI needed for that story
      - If tests requested: Tests specific to that story
    - Mark story dependencies (most stories should be independent)
 
 2. **From Contracts**:
-   - Map each contract/endpoint → to the user story it serves
-   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
 
 3. **From Data Model**:
    - Map each entity to the user story(ies) that need it

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,11 @@
+{
+  "ai": "claude",
+  "ai_commands_dir": null,
+  "ai_skills": false,
+  "branch_numbering": "sequential",
+  "here": true,
+  "offline": false,
+  "preset": null,
+  "script": "sh",
+  "speckit_version": "0.4.2"
+}

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -79,15 +79,28 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
-        printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
-            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
+        if has_jq; then
+            jq -cn \
+                --arg repo_root "$REPO_ROOT" \
+                --arg branch "$CURRENT_BRANCH" \
+                --arg feature_dir "$FEATURE_DIR" \
+                --arg feature_spec "$FEATURE_SPEC" \
+                --arg impl_plan "$IMPL_PLAN" \
+                --arg tasks "$TASKS" \
+                '{REPO_ROOT:$repo_root,BRANCH:$branch,FEATURE_DIR:$feature_dir,FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,TASKS:$tasks}'
+        else
+            printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
+                "$(json_escape "$REPO_ROOT")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$TASKS")"
+        fi
     else
         echo "REPO_ROOT: $REPO_ROOT"
         echo "BRANCH: $CURRENT_BRANCH"
@@ -141,14 +154,25 @@ fi
 # Output results
 if $JSON_MODE; then
     # Build JSON array of documents
-    if [[ ${#docs[@]} -eq 0 ]]; then
-        json_docs="[]"
+    if has_jq; then
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '%s\n' "${docs[@]}" | jq -R . | jq -s .)
+        fi
+        jq -cn \
+            --arg feature_dir "$FEATURE_DIR" \
+            --argjson docs "$json_docs" \
+            '{FEATURE_DIR:$feature_dir,AVAILABLE_DOCS:$docs}'
     else
-        json_docs=$(printf '"%s",' "${docs[@]}")
-        json_docs="[${json_docs%,}]"
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(for d in "${docs[@]}"; do printf '"%s",' "$(json_escape "$d")"; done)
+            json_docs="[${json_docs%,}]"
+        fi
+        printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$(json_escape "$FEATURE_DIR")" "$json_docs"
     fi
-    
-    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$FEATURE_DIR" "$json_docs"
 else
     # Text output
     echo "FEATURE_DIR:$FEATURE_DIR"

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -1,15 +1,48 @@
 #!/usr/bin/env bash
 # Common functions and variables for all scripts
 
-# Get repository root, with fallback for non-git repositories
+# Find repository root by searching upward for .specify directory
+# This is the primary marker for spec-kit projects
+find_specify_root() {
+    local dir="${1:-$(pwd)}"
+    # Normalize to absolute path to prevent infinite loop with relative paths
+    # Use -- to handle paths starting with - (e.g., -P, -L)
+    dir="$(cd -- "$dir" 2>/dev/null && pwd)" || return 1
+    local prev_dir=""
+    while true; do
+        if [ -d "$dir/.specify" ]; then
+            echo "$dir"
+            return 0
+        fi
+        # Stop if we've reached filesystem root or dirname stops changing
+        if [ "$dir" = "/" ] || [ "$dir" = "$prev_dir" ]; then
+            break
+        fi
+        prev_dir="$dir"
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+# Get repository root, prioritizing .specify directory over git
+# This prevents using a parent git repo when spec-kit is initialized in a subdirectory
 get_repo_root() {
+    # First, look for .specify directory (spec-kit's own marker)
+    local specify_root
+    if specify_root=$(find_specify_root); then
+        echo "$specify_root"
+        return
+    fi
+
+    # Fallback to git if no .specify found
     if git rev-parse --show-toplevel >/dev/null 2>&1; then
         git rev-parse --show-toplevel
-    else
-        # Fall back to script location for non-git repos
-        local script_dir="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        (cd "$script_dir/../../.." && pwd)
+        return
     fi
+
+    # Final fallback to script location for non-git repos
+    local script_dir="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    (cd "$script_dir/../../.." && pwd)
 }
 
 # Get current branch, with fallback for non-git repositories
@@ -20,29 +53,40 @@ get_current_branch() {
         return
     fi
 
-    # Then check git if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
+    # Then check git if available at the spec-kit root (not parent)
+    local repo_root=$(get_repo_root)
+    if has_git; then
+        git -C "$repo_root" rev-parse --abbrev-ref HEAD
         return
     fi
 
     # For non-git repos, try to find the latest feature directory
-    local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
     if [[ -d "$specs_dir" ]]; then
         local latest_feature=""
         local highest=0
+        local latest_timestamp=""
 
         for dir in "$specs_dir"/*; do
             if [[ -d "$dir" ]]; then
                 local dirname=$(basename "$dir")
-                if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+                if [[ "$dirname" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
+                    # Timestamp-based branch: compare lexicographically
+                    local ts="${BASH_REMATCH[1]}"
+                    if [[ "$ts" > "$latest_timestamp" ]]; then
+                        latest_timestamp="$ts"
+                        latest_feature=$dirname
+                    fi
+                elif [[ "$dirname" =~ ^([0-9]{3})- ]]; then
                     local number=${BASH_REMATCH[1]}
                     number=$((10#$number))
                     if [[ "$number" -gt "$highest" ]]; then
                         highest=$number
-                        latest_feature=$dirname
+                        # Only update if no timestamp branch found yet
+                        if [[ -z "$latest_timestamp" ]]; then
+                            latest_feature=$dirname
+                        fi
                     fi
                 fi
             fi
@@ -57,9 +101,17 @@ get_current_branch() {
     echo "main"  # Final fallback
 }
 
-# Check if we have git available
+# Check if we have git available at the spec-kit root level
+# Returns true only if git is installed and the repo root is inside a git work tree
+# Handles both regular repos (.git directory) and worktrees/submodules (.git file)
 has_git() {
-    git rev-parse --show-toplevel >/dev/null 2>&1
+    # First check if git command is available (before calling get_repo_root which may use git)
+    command -v git >/dev/null 2>&1 || return 1
+    local repo_root=$(get_repo_root)
+    # Check if .git exists (directory or file for worktrees/submodules)
+    [ -e "$repo_root/.git" ] || return 1
+    # Verify it's actually a valid git work tree
+    git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
 
 check_feature_branch() {
@@ -72,9 +124,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    if [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
+        echo "Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name" >&2
         return 1
     fi
 
@@ -90,14 +142,17 @@ find_feature_dir_by_prefix() {
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
 
-    # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
-    if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
-        # If branch doesn't have numeric prefix, fall back to exact match
+    # Extract prefix from branch (e.g., "004" from "004-whatever" or "20260319-143022" from timestamp branches)
+    local prefix=""
+    if [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
+        prefix="${BASH_REMATCH[1]}"
+    elif [[ "$branch_name" =~ ^([0-9]{3})- ]]; then
+        prefix="${BASH_REMATCH[1]}"
+    else
+        # If branch doesn't have a recognized prefix, fall back to exact match
         echo "$specs_dir/$branch_name"
         return
     fi
-
-    local prefix="${BASH_REMATCH[1]}"
 
     # Search for directories in specs/ that start with this prefix
     local matches=()
@@ -119,8 +174,8 @@ find_feature_dir_by_prefix() {
     else
         # Multiple matches - this shouldn't happen with proper naming convention
         echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
-        echo "Please ensure only one spec directory exists per numeric prefix." >&2
-        echo "$specs_dir/$branch_name"  # Return something to avoid breaking the script
+        echo "Please ensure only one spec directory exists per prefix." >&2
+        return 1
     fi
 }
 
@@ -134,23 +189,142 @@ get_feature_paths() {
     fi
 
     # Use prefix-based lookup to support multiple branches per spec
-    local feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
+    local feature_dir
+    if ! feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch"); then
+        echo "ERROR: Failed to resolve feature directory" >&2
+        return 1
+    fi
 
-    cat <<EOF
-REPO_ROOT='$repo_root'
-CURRENT_BRANCH='$current_branch'
-HAS_GIT='$has_git_repo'
-FEATURE_DIR='$feature_dir'
-FEATURE_SPEC='$feature_dir/spec.md'
-IMPL_PLAN='$feature_dir/plan.md'
-TASKS='$feature_dir/tasks.md'
-RESEARCH='$feature_dir/research.md'
-DATA_MODEL='$feature_dir/data-model.md'
-QUICKSTART='$feature_dir/quickstart.md'
-CONTRACTS_DIR='$feature_dir/contracts'
-EOF
+    # Use printf '%q' to safely quote values, preventing shell injection
+    # via crafted branch names or paths containing special characters
+    printf 'REPO_ROOT=%q\n' "$repo_root"
+    printf 'CURRENT_BRANCH=%q\n' "$current_branch"
+    printf 'HAS_GIT=%q\n' "$has_git_repo"
+    printf 'FEATURE_DIR=%q\n' "$feature_dir"
+    printf 'FEATURE_SPEC=%q\n' "$feature_dir/spec.md"
+    printf 'IMPL_PLAN=%q\n' "$feature_dir/plan.md"
+    printf 'TASKS=%q\n' "$feature_dir/tasks.md"
+    printf 'RESEARCH=%q\n' "$feature_dir/research.md"
+    printf 'DATA_MODEL=%q\n' "$feature_dir/data-model.md"
+    printf 'QUICKSTART=%q\n' "$feature_dir/quickstart.md"
+    printf 'CONTRACTS_DIR=%q\n' "$feature_dir/contracts"
+}
+
+# Check if jq is available for safe JSON construction
+has_jq() {
+    command -v jq >/dev/null 2>&1
+}
+
+# Escape a string for safe embedding in a JSON value (fallback when jq is unavailable).
+# Handles backslash, double-quote, and JSON-required control character escapes (RFC 8259).
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\b'/\\b}"
+    s="${s//$'\f'/\\f}"
+    # Escape any remaining U+0001-U+001F control characters as \uXXXX.
+    # (U+0000/NUL cannot appear in bash strings and is excluded.)
+    # LC_ALL=C ensures ${#s} counts bytes and ${s:$i:1} yields single bytes,
+    # so multi-byte UTF-8 sequences (first byte >= 0xC0) pass through intact.
+    local LC_ALL=C
+    local i char code
+    for (( i=0; i<${#s}; i++ )); do
+        char="${s:$i:1}"
+        printf -v code '%d' "'$char" 2>/dev/null || code=256
+        if (( code >= 1 && code <= 31 )); then
+            printf '\\u%04x' "$code"
+        else
+            printf '%s' "$char"
+        fi
+    done
 }
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+
+# Resolve a template name to a file path using the priority stack:
+#   1. .specify/templates/overrides/
+#   2. .specify/presets/<preset-id>/templates/ (sorted by priority from .registry)
+#   3. .specify/extensions/<ext-id>/templates/
+#   4. .specify/templates/ (core)
+resolve_template() {
+    local template_name="$1"
+    local repo_root="$2"
+    local base="$repo_root/.specify/templates"
+
+    # Priority 1: Project overrides
+    local override="$base/overrides/${template_name}.md"
+    [ -f "$override" ] && echo "$override" && return 0
+
+    # Priority 2: Installed presets (sorted by priority from .registry)
+    local presets_dir="$repo_root/.specify/presets"
+    if [ -d "$presets_dir" ]; then
+        local registry_file="$presets_dir/.registry"
+        if [ -f "$registry_file" ] && command -v python3 >/dev/null 2>&1; then
+            # Read preset IDs sorted by priority (lower number = higher precedence).
+            # The python3 call is wrapped in an if-condition so that set -e does not
+            # abort the function when python3 exits non-zero (e.g. invalid JSON).
+            local sorted_presets=""
+            if sorted_presets=$(SPECKIT_REGISTRY="$registry_file" python3 -c "
+import json, sys, os
+try:
+    with open(os.environ['SPECKIT_REGISTRY']) as f:
+        data = json.load(f)
+    presets = data.get('presets', {})
+    for pid, meta in sorted(presets.items(), key=lambda x: x[1].get('priority', 10)):
+        print(pid)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null); then
+                if [ -n "$sorted_presets" ]; then
+                    # python3 succeeded and returned preset IDs — search in priority order
+                    while IFS= read -r preset_id; do
+                        local candidate="$presets_dir/$preset_id/templates/${template_name}.md"
+                        [ -f "$candidate" ] && echo "$candidate" && return 0
+                    done <<< "$sorted_presets"
+                fi
+                # python3 succeeded but registry has no presets — nothing to search
+            else
+                # python3 failed (missing, or registry parse error) — fall back to unordered directory scan
+                for preset in "$presets_dir"/*/; do
+                    [ -d "$preset" ] || continue
+                    local candidate="$preset/templates/${template_name}.md"
+                    [ -f "$candidate" ] && echo "$candidate" && return 0
+                done
+            fi
+        else
+            # Fallback: alphabetical directory order (no python3 available)
+            for preset in "$presets_dir"/*/; do
+                [ -d "$preset" ] || continue
+                local candidate="$preset/templates/${template_name}.md"
+                [ -f "$candidate" ] && echo "$candidate" && return 0
+            done
+        fi
+    fi
+
+    # Priority 3: Extension-provided templates
+    local ext_dir="$repo_root/.specify/extensions"
+    if [ -d "$ext_dir" ]; then
+        for ext in "$ext_dir"/*/; do
+            [ -d "$ext" ] || continue
+            # Skip hidden directories (e.g. .backup, .cache)
+            case "$(basename "$ext")" in .*) continue;; esac
+            local candidate="$ext/templates/${template_name}.md"
+            [ -f "$candidate" ] && echo "$candidate" && return 0
+        done
+    fi
+
+    # Priority 4: Core templates
+    local core="$base/${template_name}.md"
+    [ -f "$core" ] && echo "$core" && return 0
+
+    # Template not found in any location.
+    # Return 1 so callers can distinguish "not found" from "found".
+    # Callers running under set -e should use: TEMPLATE=$(resolve_template ...) || true
+    return 1
+}
 

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -5,13 +5,14 @@ set -e
 JSON_MODE=false
 SHORT_NAME=""
 BRANCH_NUMBER=""
+USE_TIMESTAMP=false
 ARGS=()
 i=1
 while [ $i -le $# ]; do
     arg="${!i}"
     case "$arg" in
-        --json) 
-            JSON_MODE=true 
+        --json)
+            JSON_MODE=true
             ;;
         --short-name)
             if [ $((i + 1)) -gt $# ]; then
@@ -40,22 +41,27 @@ while [ $i -le $# ]; do
             fi
             BRANCH_NUMBER="$next_arg"
             ;;
-        --help|-h) 
-            echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
+        --timestamp)
+            USE_TIMESTAMP=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--json] [--short-name <name>] [--number N] [--timestamp] <feature_description>"
             echo ""
             echo "Options:"
             echo "  --json              Output in JSON format"
             echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
             echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --timestamp         Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
             echo "  --help, -h          Show this help message"
             echo ""
             echo "Examples:"
             echo "  $0 'Add user authentication system' --short-name 'user-auth'"
             echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            echo "  $0 --timestamp --short-name 'user-auth' 'Add user authentication'"
             exit 0
             ;;
-        *) 
-            ARGS+=("$arg") 
+        *)
+            ARGS+=("$arg")
             ;;
     esac
     i=$((i + 1))
@@ -63,22 +69,16 @@ done
 
 FEATURE_DESCRIPTION="${ARGS[*]}"
 if [ -z "$FEATURE_DESCRIPTION" ]; then
-    echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>" >&2
+    echo "Usage: $0 [--json] [--short-name <name>] [--number N] [--timestamp] <feature_description>" >&2
     exit 1
 fi
 
-# Function to find the repository root by searching for existing project markers
-find_repo_root() {
-    local dir="$1"
-    while [ "$dir" != "/" ]; do
-        if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
-}
+# Trim whitespace and validate description is not empty (e.g., user passed only whitespace)
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Error: Feature description cannot be empty or contain only whitespace" >&2
+    exit 1
+fi
 
 # Function to get highest number from specs directory
 get_highest_from_specs() {
@@ -89,10 +89,13 @@ get_highest_from_specs() {
         for dir in "$specs_dir"/*; do
             [ -d "$dir" ] || continue
             dirname=$(basename "$dir")
-            number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
-            number=$((10#$number))
-            if [ "$number" -gt "$highest" ]; then
-                highest=$number
+            # Only match sequential prefixes (###-*), skip timestamp dirs
+            if echo "$dirname" | grep -q '^[0-9]\{3\}-'; then
+                number=$(echo "$dirname" | grep -o '^[0-9]\{3\}')
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
             fi
         done
     fi
@@ -131,7 +134,7 @@ check_existing_branches() {
     local specs_dir="$1"
 
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-    git fetch --all --prune 2>/dev/null || true
+    git fetch --all --prune >/dev/null 2>&1 || true
 
     # Get highest number from ALL branches (not just matching short name)
     local highest_branch=$(get_highest_from_branches)
@@ -155,20 +158,16 @@ clean_branch_name() {
     echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
 }
 
-# Resolve repository root. Prefer git information when available, but fall back
-# to searching for repository markers so the workflow still functions in repositories that
-# were initialised with --no-git.
+# Resolve repository root using common.sh functions which prioritize .specify over git
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
-if git rev-parse --show-toplevel >/dev/null 2>&1; then
-    REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_ROOT=$(get_repo_root)
+
+# Check if git is available at this repo root (not a parent)
+if has_git; then
     HAS_GIT=true
 else
-    REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
-    if [ -z "$REPO_ROOT" ]; then
-        echo "Error: Could not determine repository root. Please run this script from within the repository." >&2
-        exit 1
-    fi
     HAS_GIT=false
 fi
 
@@ -234,29 +233,42 @@ else
     BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
 fi
 
-# Determine branch number
-if [ -z "$BRANCH_NUMBER" ]; then
-    if [ "$HAS_GIT" = true ]; then
-        # Check existing branches on remotes
-        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
-    else
-        # Fall back to local directory check
-        HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
-        BRANCH_NUMBER=$((HIGHEST + 1))
-    fi
+# Warn if --number and --timestamp are both specified
+if [ "$USE_TIMESTAMP" = true ] && [ -n "$BRANCH_NUMBER" ]; then
+    >&2 echo "[specify] Warning: --number is ignored when --timestamp is used"
+    BRANCH_NUMBER=""
 fi
 
-# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
-FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+# Determine branch prefix
+if [ "$USE_TIMESTAMP" = true ]; then
+    FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
+    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+else
+    # Determine branch number
+    if [ -z "$BRANCH_NUMBER" ]; then
+        if [ "$HAS_GIT" = true ]; then
+            # Check existing branches on remotes
+            BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+        else
+            # Fall back to local directory check
+            HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+            BRANCH_NUMBER=$((HIGHEST + 1))
+        fi
+    fi
+
+    # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+    FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+fi
 
 # GitHub enforces a 244-byte limit on branch names
 # Validate and truncate if necessary
 MAX_BRANCH_LENGTH=244
 if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     # Calculate how much we need to trim from suffix
-    # Account for: feature number (3) + hyphen (1) = 4 chars
-    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+    # Account for prefix length: timestamp (15) + hyphen (1) = 16, or sequential (3) + hyphen (1) = 4
+    PREFIX_LENGTH=$(( ${#FEATURE_NUM} + 1 ))
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - PREFIX_LENGTH))
     
     # Truncate suffix at word boundary if possible
     TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
@@ -272,7 +284,20 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
 fi
 
 if [ "$HAS_GIT" = true ]; then
-    git checkout -b "$BRANCH_NAME"
+    if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+        # Check if branch already exists
+        if git branch --list "$BRANCH_NAME" | grep -q .; then
+            if [ "$USE_TIMESTAMP" = true ]; then
+                >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
+            else
+                >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+            fi
+            exit 1
+        else
+            >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
+            exit 1
+        fi
+    fi
 else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi
@@ -280,18 +305,31 @@ fi
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
+TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT") || true
 SPEC_FILE="$FEATURE_DIR/spec.md"
-if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
+if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then
+    cp "$TEMPLATE" "$SPEC_FILE"
+else
+    echo "Warning: Spec template not found; created empty spec file" >&2
+    touch "$SPEC_FILE"
+fi
 
-# Set the SPECIFY_FEATURE environment variable for the current session
-export SPECIFY_FEATURE="$BRANCH_NAME"
+# Inform the user how to persist the feature variable in their own shell
+printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg branch_name "$BRANCH_NAME" \
+            --arg spec_file "$SPEC_FILE" \
+            --arg feature_num "$FEATURE_NUM" \
+            '{BRANCH_NAME:$branch_name,SPEC_FILE:$spec_file,FEATURE_NUM:$feature_num}'
+    else
+        printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")"
+    fi
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"
     echo "FEATURE_NUM: $FEATURE_NUM"
-    echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
+    printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
 fi

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -28,7 +28,9 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
 # Check if we're on a proper feature branch (only for git repos)
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
@@ -37,20 +39,30 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 mkdir -p "$FEATURE_DIR"
 
 # Copy plan template if it exists
-TEMPLATE="$REPO_ROOT/.specify/templates/plan-template.md"
-if [[ -f "$TEMPLATE" ]]; then
+TEMPLATE=$(resolve_template "plan-template" "$REPO_ROOT") || true
+if [[ -n "$TEMPLATE" ]] && [[ -f "$TEMPLATE" ]]; then
     cp "$TEMPLATE" "$IMPL_PLAN"
     echo "Copied plan template to $IMPL_PLAN"
 else
-    echo "Warning: Plan template not found at $TEMPLATE"
+    echo "Warning: Plan template not found"
     # Create a basic plan file if template doesn't exist
     touch "$IMPL_PLAN"
 fi
 
 # Output results
 if $JSON_MODE; then
-    printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
-        "$FEATURE_SPEC" "$IMPL_PLAN" "$FEATURE_DIR" "$CURRENT_BRANCH" "$HAS_GIT"
+    if has_jq; then
+        jq -cn \
+            --arg feature_spec "$FEATURE_SPEC" \
+            --arg impl_plan "$IMPL_PLAN" \
+            --arg specs_dir "$FEATURE_DIR" \
+            --arg branch "$CURRENT_BRANCH" \
+            --arg has_git "$HAS_GIT" \
+            '{FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,SPECS_DIR:$specs_dir,BRANCH:$branch,HAS_GIT:$has_git}'
+    else
+        printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
+            "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$HAS_GIT")"
+    fi
 else
     echo "FEATURE_SPEC: $FEATURE_SPEC"
     echo "IMPL_PLAN: $IMPL_PLAN" 

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -30,12 +30,12 @@
 #
 # 5. Multi-Agent Support
 #    - Handles agent-specific file paths and naming conventions
-#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, or Amazon Q Developer CLI
+#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Junie, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, Tabnine CLI, Kiro CLI, Mistral Vibe, Kimi Code, Pi Coding Agent, iFlow CLI, Antigravity or Generic
 #    - Can update single agents or all existing agent files
 #    - Creates default Claude file if no agent files exist
 #
 # Usage: ./update-agent-context.sh [agent_type]
-# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|shai|q|bob|qoder
+# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|junie|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|trae|pi|iflow|generic
 # Leave empty to update all existing agent files
 
 set -e
@@ -53,7 +53,9 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
 NEW_PLAN="$IMPL_PLAN"  # Alias for compatibility with existing code
 AGENT_TYPE="${1:-}"
@@ -66,15 +68,24 @@ CURSOR_FILE="$REPO_ROOT/.cursor/rules/specify-rules.mdc"
 QWEN_FILE="$REPO_ROOT/QWEN.md"
 AGENTS_FILE="$REPO_ROOT/AGENTS.md"
 WINDSURF_FILE="$REPO_ROOT/.windsurf/rules/specify-rules.md"
+JUNIE_FILE="$REPO_ROOT/.junie/AGENTS.md"
 KILOCODE_FILE="$REPO_ROOT/.kilocode/rules/specify-rules.md"
 AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 CODEBUDDY_FILE="$REPO_ROOT/CODEBUDDY.md"
 QODER_FILE="$REPO_ROOT/QODER.md"
-AMP_FILE="$REPO_ROOT/AGENTS.md"
+# Amp, Kiro CLI, IBM Bob, and Pi all share AGENTS.md — use AGENTS_FILE to avoid
+# updating the same file multiple times.
+AMP_FILE="$AGENTS_FILE"
 SHAI_FILE="$REPO_ROOT/SHAI.md"
-Q_FILE="$REPO_ROOT/AGENTS.md"
-BOB_FILE="$REPO_ROOT/AGENTS.md"
+TABNINE_FILE="$REPO_ROOT/TABNINE.md"
+KIRO_FILE="$AGENTS_FILE"
+AGY_FILE="$REPO_ROOT/.agent/rules/specify-rules.md"
+BOB_FILE="$AGENTS_FILE"
+VIBE_FILE="$REPO_ROOT/.vibe/agents/specify-agents.md"
+KIMI_FILE="$REPO_ROOT/KIMI.md"
+TRAE_FILE="$REPO_ROOT/.trae/rules/AGENTS.md"
+IFLOW_FILE="$REPO_ROOT/IFLOW.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -108,6 +119,8 @@ log_warning() {
 # Cleanup function for temporary files
 cleanup() {
     local exit_code=$?
+    # Disarm traps to prevent re-entrant loop
+    trap - EXIT INT TERM
     rm -f /tmp/agent_update_*_$$
     rm -f /tmp/manual_additions_$$
     exit $exit_code
@@ -350,10 +363,19 @@ create_new_agent_file() {
     # Convert \n sequences to actual newlines
     newline=$(printf '\n')
     sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
-    
+
     # Clean up backup files
     rm -f "$temp_file.bak" "$temp_file.bak2"
-    
+
+    # Prepend Cursor frontmatter for .mdc files so rules are auto-included
+    if [[ "$target_file" == *.mdc ]]; then
+        local frontmatter_file
+        frontmatter_file=$(mktemp) || return 1
+        printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
+        cat "$temp_file" >> "$frontmatter_file"
+        mv "$frontmatter_file" "$temp_file"
+    fi
+
     return 0
 }
 
@@ -463,7 +485,7 @@ update_existing_agent_file() {
         fi
         
         # Update timestamp
-        if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
+        if [[ "$line" =~ (\*\*)?Last\ updated(\*\*)?:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
             echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
         else
             echo "$line" >> "$temp_file"
@@ -491,13 +513,24 @@ update_existing_agent_file() {
         changes_entries_added=true
     fi
     
+    # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
+    if [[ "$target_file" == *.mdc ]]; then
+        if ! head -1 "$temp_file" | grep -q '^---'; then
+            local frontmatter_file
+            frontmatter_file=$(mktemp) || { rm -f "$temp_file"; return 1; }
+            printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
+            cat "$temp_file" >> "$frontmatter_file"
+            mv "$frontmatter_file" "$temp_file"
+        fi
+    fi
+
     # Move temp file to target atomically
     if ! mv "$temp_file" "$target_file"; then
         log_error "Failed to update target file"
         rm -f "$temp_file"
         return 1
     fi
-    
+
     return 0
 }
 #==============================================================================
@@ -583,148 +616,155 @@ update_specific_agent() {
     
     case "$agent_type" in
         claude)
-            update_agent_file "$CLAUDE_FILE" "Claude Code"
+            update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
             ;;
         gemini)
-            update_agent_file "$GEMINI_FILE" "Gemini CLI"
+            update_agent_file "$GEMINI_FILE" "Gemini CLI" || return 1
             ;;
         copilot)
-            update_agent_file "$COPILOT_FILE" "GitHub Copilot"
+            update_agent_file "$COPILOT_FILE" "GitHub Copilot" || return 1
             ;;
         cursor-agent)
-            update_agent_file "$CURSOR_FILE" "Cursor IDE"
+            update_agent_file "$CURSOR_FILE" "Cursor IDE" || return 1
             ;;
         qwen)
-            update_agent_file "$QWEN_FILE" "Qwen Code"
+            update_agent_file "$QWEN_FILE" "Qwen Code" || return 1
             ;;
         opencode)
-            update_agent_file "$AGENTS_FILE" "opencode"
+            update_agent_file "$AGENTS_FILE" "opencode" || return 1
             ;;
         codex)
-            update_agent_file "$AGENTS_FILE" "Codex CLI"
+            update_agent_file "$AGENTS_FILE" "Codex CLI" || return 1
             ;;
         windsurf)
-            update_agent_file "$WINDSURF_FILE" "Windsurf"
+            update_agent_file "$WINDSURF_FILE" "Windsurf" || return 1
+            ;;
+        junie)
+            update_agent_file "$JUNIE_FILE" "Junie" || return 1
             ;;
         kilocode)
-            update_agent_file "$KILOCODE_FILE" "Kilo Code"
+            update_agent_file "$KILOCODE_FILE" "Kilo Code" || return 1
             ;;
         auggie)
-            update_agent_file "$AUGGIE_FILE" "Auggie CLI"
+            update_agent_file "$AUGGIE_FILE" "Auggie CLI" || return 1
             ;;
         roo)
-            update_agent_file "$ROO_FILE" "Roo Code"
+            update_agent_file "$ROO_FILE" "Roo Code" || return 1
             ;;
         codebuddy)
-            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
+            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI" || return 1
             ;;
-        qoder)
-            update_agent_file "$QODER_FILE" "Qoder CLI"
+        qodercli)
+            update_agent_file "$QODER_FILE" "Qoder CLI" || return 1
             ;;
         amp)
-            update_agent_file "$AMP_FILE" "Amp"
+            update_agent_file "$AMP_FILE" "Amp" || return 1
             ;;
         shai)
-            update_agent_file "$SHAI_FILE" "SHAI"
+            update_agent_file "$SHAI_FILE" "SHAI" || return 1
             ;;
-        q)
-            update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
+        tabnine)
+            update_agent_file "$TABNINE_FILE" "Tabnine CLI" || return 1
+            ;;
+        kiro-cli)
+            update_agent_file "$KIRO_FILE" "Kiro CLI" || return 1
+            ;;
+        agy)
+            update_agent_file "$AGY_FILE" "Antigravity" || return 1
             ;;
         bob)
-            update_agent_file "$BOB_FILE" "IBM Bob"
+            update_agent_file "$BOB_FILE" "IBM Bob" || return 1
+            ;;
+        vibe)
+            update_agent_file "$VIBE_FILE" "Mistral Vibe" || return 1
+            ;;
+        kimi)
+            update_agent_file "$KIMI_FILE" "Kimi Code" || return 1
+            ;;
+        trae)
+            update_agent_file "$TRAE_FILE" "Trae" || return 1
+            ;;
+        pi)
+            update_agent_file "$AGENTS_FILE" "Pi Coding Agent" || return 1
+            ;;
+        iflow)
+            update_agent_file "$IFLOW_FILE" "iFlow CLI" || return 1
+            ;;
+        generic)
+            log_info "Generic agent: no predefined context file. Use the agent-specific update script for your agent."
             ;;
         *)
             log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|shai|q|bob|qoder"
+            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|junie|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|trae|pi|iflow|generic"
             exit 1
             ;;
     esac
 }
 
+# Helper: skip non-existent files and files already updated (dedup by
+# realpath so that variables pointing to the same file — e.g. AMP_FILE,
+# KIRO_FILE, BOB_FILE all resolving to AGENTS_FILE — are only written once).
+# Uses a linear array instead of associative array for bash 3.2 compatibility.
+# Note: defined at top level because bash 3.2 does not support true
+# nested/local functions. _updated_paths, _found_agent, and _all_ok are
+# initialised exclusively inside update_all_existing_agents so that
+# sourcing this script has no side effects on the caller's environment.
+
+_update_if_new() {
+    local file="$1" name="$2"
+    [[ -f "$file" ]] || return 0
+    local real_path
+    real_path=$(realpath "$file" 2>/dev/null || echo "$file")
+    local p
+    if [[ ${#_updated_paths[@]} -gt 0 ]]; then
+        for p in "${_updated_paths[@]}"; do
+            [[ "$p" == "$real_path" ]] && return 0
+        done
+    fi
+    # Record the file as seen before attempting the update so that:
+    # (a) aliases pointing to the same path are not retried on failure
+    # (b) _found_agent reflects file existence, not update success
+    _updated_paths+=("$real_path")
+    _found_agent=true
+    update_agent_file "$file" "$name"
+}
+
 update_all_existing_agents() {
-    local found_agent=false
-    
-    # Check each possible agent file and update if it exists
-    if [[ -f "$CLAUDE_FILE" ]]; then
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$GEMINI_FILE" ]]; then
-        update_agent_file "$GEMINI_FILE" "Gemini CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$COPILOT_FILE" ]]; then
-        update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-        found_agent=true
-    fi
-    
-    if [[ -f "$CURSOR_FILE" ]]; then
-        update_agent_file "$CURSOR_FILE" "Cursor IDE"
-        found_agent=true
-    fi
-    
-    if [[ -f "$QWEN_FILE" ]]; then
-        update_agent_file "$QWEN_FILE" "Qwen Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$AGENTS_FILE" ]]; then
-        update_agent_file "$AGENTS_FILE" "Codex/opencode"
-        found_agent=true
-    fi
-    
-    if [[ -f "$WINDSURF_FILE" ]]; then
-        update_agent_file "$WINDSURF_FILE" "Windsurf"
-        found_agent=true
-    fi
-    
-    if [[ -f "$KILOCODE_FILE" ]]; then
-        update_agent_file "$KILOCODE_FILE" "Kilo Code"
-        found_agent=true
-    fi
+    _found_agent=false
+    _updated_paths=()
+    local _all_ok=true
 
-    if [[ -f "$AUGGIE_FILE" ]]; then
-        update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$ROO_FILE" ]]; then
-        update_agent_file "$ROO_FILE" "Roo Code"
-        found_agent=true
-    fi
+    _update_if_new "$CLAUDE_FILE" "Claude Code"           || _all_ok=false
+    _update_if_new "$GEMINI_FILE" "Gemini CLI"             || _all_ok=false
+    _update_if_new "$COPILOT_FILE" "GitHub Copilot"        || _all_ok=false
+    _update_if_new "$CURSOR_FILE" "Cursor IDE"             || _all_ok=false
+    _update_if_new "$QWEN_FILE" "Qwen Code"                || _all_ok=false
+    _update_if_new "$AGENTS_FILE" "Codex/opencode"         || _all_ok=false
+    _update_if_new "$AMP_FILE" "Amp"                       || _all_ok=false
+    _update_if_new "$KIRO_FILE" "Kiro CLI"                 || _all_ok=false
+    _update_if_new "$BOB_FILE" "IBM Bob"                   || _all_ok=false
+    _update_if_new "$WINDSURF_FILE" "Windsurf"             || _all_ok=false
+    _update_if_new "$JUNIE_FILE" "Junie"                || _all_ok=false
+    _update_if_new "$KILOCODE_FILE" "Kilo Code"            || _all_ok=false
+    _update_if_new "$AUGGIE_FILE" "Auggie CLI"             || _all_ok=false
+    _update_if_new "$ROO_FILE" "Roo Code"                  || _all_ok=false
+    _update_if_new "$CODEBUDDY_FILE" "CodeBuddy CLI"       || _all_ok=false
+    _update_if_new "$SHAI_FILE" "SHAI"                     || _all_ok=false
+    _update_if_new "$TABNINE_FILE" "Tabnine CLI"           || _all_ok=false
+    _update_if_new "$QODER_FILE" "Qoder CLI"               || _all_ok=false
+    _update_if_new "$AGY_FILE" "Antigravity"               || _all_ok=false
+    _update_if_new "$VIBE_FILE" "Mistral Vibe"             || _all_ok=false
+    _update_if_new "$KIMI_FILE" "Kimi Code"                || _all_ok=false
+    _update_if_new "$TRAE_FILE" "Trae"                     || _all_ok=false
+    _update_if_new "$IFLOW_FILE" "iFlow CLI"               || _all_ok=false
 
-    if [[ -f "$CODEBUDDY_FILE" ]]; then
-        update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-        found_agent=true
-    fi
-
-    if [[ -f "$SHAI_FILE" ]]; then
-        update_agent_file "$SHAI_FILE" "SHAI"
-        found_agent=true
-    fi
-
-    if [[ -f "$QODER_FILE" ]]; then
-        update_agent_file "$QODER_FILE" "Qoder CLI"
-        found_agent=true
-    fi
-
-    if [[ -f "$Q_FILE" ]]; then
-        update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$BOB_FILE" ]]; then
-        update_agent_file "$BOB_FILE" "IBM Bob"
-        found_agent=true
-    fi
-    
     # If no agent files exist, create a default Claude file
-    if [[ "$found_agent" == false ]]; then
+    if [[ "$_found_agent" == false ]]; then
         log_info "No existing agent files found, creating default Claude file..."
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
+        update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
     fi
+
+    [[ "$_all_ok" == true ]]
 }
 print_summary() {
     echo
@@ -743,8 +783,7 @@ print_summary() {
     fi
     
     echo
-
-    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|shai|q|bob|qoder]"
+    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|junie|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|trae|pi|iflow|generic]"
 }
 
 #==============================================================================
@@ -796,4 +835,3 @@ main() {
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     main "$@"
 fi
-

--- a/.specify/templates/constitution-template.md
+++ b/.specify/templates/constitution-template.md
@@ -1,0 +1,50 @@
+# [PROJECT_NAME] Constitution
+<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+
+## Core Principles
+
+### [PRINCIPLE_1_NAME]
+<!-- Example: I. Library-First -->
+[PRINCIPLE_1_DESCRIPTION]
+<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+
+### [PRINCIPLE_2_NAME]
+<!-- Example: II. CLI Interface -->
+[PRINCIPLE_2_DESCRIPTION]
+<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+
+### [PRINCIPLE_3_NAME]
+<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
+[PRINCIPLE_3_DESCRIPTION]
+<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+
+### [PRINCIPLE_4_NAME]
+<!-- Example: IV. Integration Testing -->
+[PRINCIPLE_4_DESCRIPTION]
+<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+
+### [PRINCIPLE_5_NAME]
+<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+[PRINCIPLE_5_DESCRIPTION]
+<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+
+## [SECTION_2_NAME]
+<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+
+[SECTION_2_CONTENT]
+<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+
+## [SECTION_3_NAME]
+<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+
+[SECTION_3_CONTENT]
+<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+
+## Governance
+<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
+
+[GOVERNANCE_RULES]
+<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+
+**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
+<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -3,7 +3,7 @@
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
@@ -17,12 +17,12 @@
   the iteration process.
 -->
 
-**Language/Version**: [e.g., Python 3.10, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
 **Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [single/web/mobile - determines source structure]  
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
 **Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -113,3 +113,16 @@
 - **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
 - **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
 - **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,17 @@ src/mixpanel_data/
 ├── exceptions.py            # Exception hierarchy
 ├── types.py                 # Result types (FetchResult, SegmentationResult, etc.)
 ├── _internal/               # Private implementation (do not import directly)
-│   ├── config.py            # ConfigManager, Credentials
-│   ├── api_client.py        # MixpanelAPIClient
+│   ├── config.py            # ConfigManager, Credentials, AuthMethod
+│   ├── api_client.py        # MixpanelAPIClient (Basic Auth + OAuth Bearer)
 │   ├── storage.py           # StorageEngine (DuckDB)
+│   ├── pagination.py        # Cursor-based App API pagination
+│   ├── auth/                # OAuth 2.0 PKCE authentication
+│   │   ├── flow.py          # OAuthFlow orchestrator
+│   │   ├── token.py         # OAuthTokens, OAuthClientInfo models
+│   │   ├── storage.py       # OAuthStorage (~/.mp/oauth/)
+│   │   ├── pkce.py          # PKCE challenge generation (RFC 7636)
+│   │   ├── callback_server.py  # Local HTTP callback server
+│   │   └── client_registration.py  # Dynamic Client Registration (RFC 7591)
 │   └── services/            # Discovery, Fetcher, LiveQuery services
 └── cli/
     ├── main.py              # Typer app entry point
@@ -170,6 +178,7 @@ just mutate-check        # Check score meets 80% threshold
 - **Explicit table management**: Tables never implicitly overwritten; `TableExistsError` if exists
 - **Streaming ingestion**: API returns iterators, storage accepts iterators (memory efficient)
 - **JSON property storage**: Properties stored as JSON columns, queried with `properties->>'$.field'`
+- **Dual authentication**: Service accounts (Basic Auth) and OAuth 2.0 PKCE with automatic credential resolution
 - **Immutable credentials**: Resolved once at Workspace construction
 - **Dependency injection**: Services accept dependencies as constructor arguments for testing
 
@@ -181,9 +190,11 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_SECRET` | Service account secret |
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency (us, eu, in) |
+| `MP_WORKSPACE_ID` | Workspace ID for App API operations |
 | `MP_CONFIG_PATH` | Override config file location |
 
 Config file: `~/.mp/config.toml`
+OAuth tokens: `~/.mp/oauth/{region}/tokens.json`
 
 ## Development
 
@@ -297,6 +308,8 @@ Skill(skill="mixpanel-data:mixpanel-analyst")  # Will fail!
 - DuckDB (via mixpanel_data Workspace - shared session state) (020-mcp-server)
 - Python 3.10+ + FastMCP 2.x, mixpanel_data, Pydantic v2 (021-mcp-server-v2)
 - DuckDB (via mixpanel_data.Workspace), in-memory for middleware caches (021-mcp-server-v2)
+- Python 3.10+ (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), Typer (CLI), Rich (output) (023-oauth-app-api-infra)
+- JSON files at `~/.mp/oauth/` (token + client info persistence); DuckDB unchanged (023-oauth-app-api-infra)
 
 ## Recent Changes
 - 017-parallel-export: Added Python 3.10+ + concurrent.futures (stdlib), threading (stdlib), queue (stdlib) - no new external dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_CONFIG_PATH` | Override config file location |
 
 Config file: `~/.mp/config.toml`
-OAuth tokens: `~/.mp/oauth/{region}/tokens.json`
+OAuth tokens: `~/.mp/oauth/tokens_{region}.json`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,19 @@ mp --version
 
 ## Quick Start
 
-### 1. Configure Service Account Credentials
+### 1. Authenticate
+
+**Option A: OAuth Login (interactive, recommended)**
 
 ```bash
-# Interactive prompt (secure, recommended)
+mp auth login --region us --project-id 12345  # Opens browser
+mp auth status  # Verify connection
+```
+
+**Option B: Service Account (scripts, CI/CD)**
+
+```bash
+# Interactive prompt (secure)
 mp auth add production --username sa_xxx --project 12345 --region us
 # You'll be prompted for the service account secret with hidden input
 
@@ -167,7 +176,7 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 ## CLI Reference
 
-**`mp auth`** — Manage accounts: `list`, `add`, `remove`, `switch`, `show`, `test`
+**`mp auth`** — Authentication: `login`, `logout`, `status`, `token` (OAuth); `list`, `add`, `remove`, `switch`, `show`, `test` (service accounts)
 
 **`mp fetch`** — Extract data: `events`, `profiles` (add `--parallel` for up to 10x faster event exports or 5x faster profile exports, `--stdout` to stream as JSONL)
 
@@ -236,6 +245,7 @@ Key design features:
 - **Structured output**: All CLI commands support `--format json` for machine-readable responses, plus `--jq` for inline filtering
 - **Parallel fetching**: Up to 10x faster event exports for large date ranges, 5x faster profile exports via `--parallel` or `parallel=True`
 - **Local SQL iteration**: Fetch once, query repeatedly—no re-fetching needed
+- **Dual authentication**: Service accounts (Basic Auth) for automation, OAuth 2.0 PKCE for interactive use
 - **Typed exceptions**: Error codes and context for programmatic handling
 
 ## Claude Code Plugin

--- a/context/RUST_PARITY_GAP_ANALYSIS.md
+++ b/context/RUST_PARITY_GAP_ANALYSIS.md
@@ -1,0 +1,1225 @@
+# Python–Rust Parity Gap Analysis
+
+> Generated 2026-03-25 — `mixpanel_data` (Python) vs `mixpanel_data_rust` (Rust)
+>
+> All Rust file references are relative to `mixpanel_data_rust/crates/`
+
+---
+
+## Executive Summary
+
+| Metric | Python | Rust | Gap |
+|--------|--------|------|-----|
+| Workspace methods | 67 | 165 | **~98** |
+| API client methods | ~30 | ~167 | **~137** |
+| CLI command groups | 4 | 19 | **15** |
+| CLI subcommands | ~45 | ~130 | **~85** |
+| Domain type files | 1 (`types.py`) | 18 | — |
+| Auth methods | Basic Auth | Basic + OAuth PKCE | **OAuth PKCE** |
+| Workspace scoping | None | All App API domains | **Full** |
+
+**Coverage: Python implements ~35% of Rust's API surface.**
+
+The Python library is a read-only analytics client. The Rust port expands it to full CRUD across 15+ entity types with OAuth 2.0 PKCE authentication and workspace-scoped endpoints. Bridging this gap requires:
+- 1 new auth module (OAuth PKCE, 7 files)
+- App API infrastructure (request method, pagination, workspace scoping)
+- ~98 new Workspace methods
+- ~137 new API client methods
+- 15 new CLI command groups (~85 subcommands)
+- ~54 new Pydantic types
+
+---
+
+## Shared Capabilities (Already in Both)
+
+| Capability | Python | Rust |
+|-----------|--------|------|
+| Basic Auth (service accounts) | `Credentials` in `_internal/config.py` | `Credentials` in `config.rs` |
+| Regional endpoints (US/EU/IN) | `ENDPOINTS` dict in `api_client.py:87` | `Region` enum in `literal_types.rs` |
+| Config management (TOML) | `ConfigManager` in `_internal/config.py` | `ConfigManager` in `config.rs` |
+| Event discovery | `events()`, `properties()`, etc. | Same methods |
+| Data export (events) | `fetch_events()`, `stream_events()` | Same + parallel variants |
+| Data export (profiles) | `fetch_profiles()`, `stream_profiles()` | Same + parallel variants |
+| Analytics queries (12 types) | segmentation, funnel, retention, JQL, etc. | Same queries |
+| JQL discovery (5 types) | property_distribution, numeric_summary, etc. | Same queries |
+| Local DuckDB storage + SQL | `sql()`, `sql_scalar()`, `tables()`, etc. | Same methods |
+| CLI: auth, fetch, query, inspect | 4 command groups | Same + 15 more |
+
+---
+
+## Gap Inventory by Domain
+
+### Domain 0a: OAuth 2.0 PKCE Authentication
+
+**Summary**: Full OAuth 2.0 Authorization Code flow with PKCE (RFC 7636) for accessing App API endpoints. Required prerequisite for all CRUD operations.
+
+**Complexity**: L | **Dependencies**: None (prerequisite for everything else)
+
+#### Rust Auth Module (`mixpanel_data/src/auth/`)
+
+| Component | Rust File | Line | Description |
+|-----------|-----------|------|-------------|
+| `OAuthClientInfo` | `auth/mod.rs` | 27 | Client registration metadata |
+| `PkceChallenge` | `auth/pkce.rs` | 8 | S256 challenge/verifier pair |
+| `PkceChallenge::generate()` | `auth/pkce.rs` | 31 | 64 random bytes → base64url verifier → SHA-256 challenge |
+| `OAuthTokens` | `auth/token.rs` | 54 | Access/refresh tokens with SecretString, expiry tracking |
+| `OAuthTokens::is_expired()` | `auth/token.rs` | 88 | 30-second expiry buffer |
+| `OAuthStorage` | `auth/storage.rs` | 11 | JSON file persistence at `~/.mp/oauth/` |
+| `OAuthStorage::new()` | `auth/storage.rs` | 20 | Uses `MP_OAUTH_STORAGE_DIR` env or default path, 0o700 perms |
+| `OAuthStorage::load_tokens()` | `auth/storage.rs` | ~60 | Load tokens from JSON file |
+| `OAuthStorage::save_tokens()` | `auth/storage.rs` | ~75 | Save tokens with 0o600 perms |
+| `CallbackResult` | `auth/callback_server.rs` | 5 | OAuth redirect callback data |
+| `CALLBACK_PORTS` | `auth/callback_server.rs` | 11 | `[19284, 19285, 19286, 19287]` |
+| `start_callback_server()` | `auth/callback_server.rs` | 180 | Bind + wait for redirect |
+| `ensure_client_registered()` | `auth/client_registration.rs` | 43 | Dynamic Client Registration (RFC 7591) |
+| `DEFAULT_SCOPES` | `auth/client_registration.rs` | 38 | OAuth scope string |
+| `OAuthFlow` | `auth/flow.rs` | 44 | Flow orchestrator |
+| `OAuthFlow::login()` | `auth/flow.rs` | 109 | Full interactive PKCE flow |
+| `OAuthFlow::exchange_code()` | `auth/flow.rs` | 195 | Code → tokens exchange |
+| `OAuthFlow::refresh_tokens()` | `auth/flow.rs` | 217 | Refresh expired tokens |
+| `OAuthFlow::get_valid_token()` | `auth/flow.rs` | 235 | Auto-refresh if expired |
+
+#### Python Implementation Target
+
+| Python File | What to Add |
+|-------------|-------------|
+| `_internal/auth/__init__.py` | Module re-exports |
+| `_internal/auth/pkce.py` | `PkceChallenge` class (stdlib `hashlib`, `secrets`, `base64`) |
+| `_internal/auth/token.py` | `OAuthTokens` Pydantic model with `SecretStr` |
+| `_internal/auth/storage.py` | `OAuthStorage` class (JSON files, Unix perms) |
+| `_internal/auth/callback_server.py` | Ephemeral HTTP server (stdlib `http.server` + `threading`) |
+| `_internal/auth/client_registration.py` | DCR via `httpx` POST |
+| `_internal/auth/flow.py` | `OAuthFlow` orchestrator |
+| `_internal/config.py` | `AuthMethod` enum, extended `Credentials` |
+| `exceptions.py` | `OAuthError` exception class |
+
+#### CLI Commands to Add
+
+| Command | Rust Reference | Line |
+|---------|---------------|------|
+| `mp auth login` | `mp_cli/src/commands/auth.rs` | 52 |
+| `mp auth logout` | `mp_cli/src/commands/auth.rs` | 56 |
+| `mp auth status` | — (new, Rust has implicit) | — |
+| `mp auth token` | `mp_cli/src/commands/auth.rs` | 58 |
+
+---
+
+### Domain 0b: App API Infrastructure
+
+**Summary**: Generic HTTP request infrastructure for `/api/app/...` endpoints with Bearer auth, cursor-based pagination, and workspace scoping.
+
+**Complexity**: M | **Dependencies**: Domain 0a (OAuth)
+
+#### Rust References
+
+| Component | Rust File | Line | Description |
+|-----------|-----------|------|-------------|
+| `ApiCategory::App` | `internal/api_client.rs` | ~302 | App API category enum |
+| `app_api_request()` | `internal/api_client.rs` | ~400 | Generic App API request with workspace scoping |
+| `app_api_request_raw()` | `internal/api_client.rs` | ~450 | Raw variant for multipart/binary |
+| `maybe_scoped_path()` | `internal/api_client.rs` | ~500 | Optional workspace scoping (top-level pattern) |
+| `require_scoped_path()` | `internal/api_client.rs` | ~530 | Required workspace scoping (project-nested pattern) |
+| `build_raw_app_url()` | `internal/api_client.rs` | ~560 | URL builder for raw requests |
+| `set_workspace_id()` | `internal/api_client.rs` | 370 | Workspace ID setter |
+| `PaginatedResponse<T>` | `types/pagination.rs` | 8 | Generic cursor pagination wrapper |
+| `CursorPagination` | `types/pagination.rs` | 44 | Cursor-based pagination fields |
+| `PublicWorkspace` | `types/common.rs` | 334 | Workspace metadata type |
+| `list_workspaces()` | `workspace.rs` | 309 | List project workspaces |
+| `resolve_workspace_id()` | `workspace.rs` | 304 | Auto-discover or use explicit workspace ID |
+
+#### Python Implementation Target
+
+| Python File | What to Add |
+|-------------|-------------|
+| `_internal/api_client.py` | `app_request()` method, Bearer auth header, workspace scoping logic |
+| `_internal/pagination.py` (new) | `PaginatedResponse`, `CursorPagination` Pydantic models, `paginate_all()` helper |
+| `workspace.py` | `list_workspaces()`, `resolve_workspace_id()`, `workspace_id` property |
+| `cli/main.py` | `--workspace-id` global option |
+| `types.py` | `PublicWorkspace` Pydantic model |
+
+**Key insight**: Python's `api_client.py:87-106` already has `"app"` URLs in the `ENDPOINTS` dict for all regions. The `_build_url("app", path)` call will work — just need to add Bearer auth header support alongside existing Basic Auth.
+
+---
+
+### Domain 1: Dashboards
+
+**Summary**: Full CRUD for Mixpanel dashboards including favorites, pins, bulk operations, blueprint templates, RCA dashboards, and ERF metrics.
+
+**Complexity**: L | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_dashboards(ids)` | `workspace.rs` | 407 | List dashboards, optionally filtered by IDs |
+| `create_dashboard(params)` | `workspace.rs` | 412 | Create new dashboard |
+| `get_dashboard(id)` | `workspace.rs` | 417 | Get dashboard by ID |
+| `update_dashboard(id, params)` | `workspace.rs` | 422 | Update dashboard |
+| `delete_dashboard(id)` | `workspace.rs` | 431 | Delete dashboard |
+| `bulk_delete_dashboards(ids)` | `workspace.rs` | 436 | Bulk delete |
+| `favorite_dashboard(id)` | `workspace.rs` | 441 | Mark as favorite |
+| `unfavorite_dashboard(id)` | `workspace.rs` | 446 | Remove from favorites |
+| `pin_dashboard(id)` | `workspace.rs` | 451 | Pin dashboard |
+| `unpin_dashboard(id)` | `workspace.rs` | 456 | Unpin dashboard |
+| `remove_report_from_dashboard(dashboard_id, bookmark_id)` | `workspace.rs` | 464 | Remove report card |
+| `get_bookmark_dashboard_ids(bookmark_id)` | `workspace.rs` | 1227 | Get dashboards containing bookmark |
+| `get_dashboard_erf(dashboard_id)` | `workspace.rs` | 1234 | ERF metrics |
+| `update_report_link(dashboard_id, report_link_id, params)` | `workspace.rs` | 1239 | Update report link |
+| `update_text_card(dashboard_id, text_card_id, params)` | `workspace.rs` | 1251 | Update text card |
+| `create_rca_dashboard(params)` | `workspace.rs` | 1219 | Create RCA dashboard |
+| `list_blueprint_templates(include_reports)` | `workspace.rs` | 1192 | List blueprint templates |
+| `create_blueprint(template_type)` | `workspace.rs` | 1199 | Create blueprint from template |
+| `get_blueprint_config(dashboard_id)` | `workspace.rs` | 1204 | Get blueprint config |
+| `update_blueprint_cohorts(cohorts)` | `workspace.rs` | 1209 | Update blueprint cohorts |
+| `finalize_blueprint(params)` | `workspace.rs` | 1214 | Finalize blueprint dashboard |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_dashboards()` | GET | `dashboards/` | `api_client.rs` | 1160 |
+| `create_dashboard()` | POST | `dashboards/` | `api_client.rs` | 1174 |
+| `get_dashboard()` | GET | `dashboards/{id}/` | `api_client.rs` | 1183 |
+| `update_dashboard()` | PATCH | `dashboards/{id}/` | `api_client.rs` | 1189 |
+| `delete_dashboard()` | DELETE | `dashboards/{id}/` | `api_client.rs` | 1204 |
+| `bulk_delete_dashboards()` | POST | `dashboards/bulk-delete/` | `api_client.rs` | 1211 |
+| `favorite_dashboard()` | POST | `dashboards/{id}/favorites/` | `api_client.rs` | 1230 |
+| `unfavorite_dashboard()` | DELETE | `dashboards/{id}/favorites/` | `api_client.rs` | 1236 |
+| `pin_dashboard()` | POST | `dashboards/{id}/pin/` | `api_client.rs` | 1243 |
+| `unpin_dashboard()` | DELETE | `dashboards/{id}/pin/` | `api_client.rs` | 1249 |
+| `remove_report_from_dashboard()` | PATCH | `dashboards/{id}/` | `api_client.rs` | 1259 |
+| `list_blueprint_templates()` | GET | `dashboards/blueprints-all/` | `api_client.rs` | 2634 |
+| `create_blueprint()` | GET | `dashboards/blueprints/` | `api_client.rs` | 2649 |
+| `get_blueprint_config()` | GET | `dashboards/{id}/blueprints-config/` | `api_client.rs` | 2661 |
+| `update_blueprint_cohorts()` | PATCH | `dashboards/blueprints-cohorts/` | `api_client.rs` | 2667 |
+| `finalize_blueprint()` | PATCH | `dashboards/blueprints-finish/` | `api_client.rs` | 2675 |
+| `create_rca_dashboard()` | POST | `dashboards/create-rca-dashboard/` | `api_client.rs` | 2685 |
+| `get_bookmark_dashboard_ids()` | GET | `dashboards/bookmarks/{id}/dashboard-ids/` | `api_client.rs` | 2711 |
+| `get_dashboard_erf()` | GET | `dashboards/{id}/erf/` | `api_client.rs` | 2719 |
+| `update_report_link()` | PATCH | `dashboards/{id}/report-links/{id}/` | `api_client.rs` | 2727 |
+| `update_text_card()` | PATCH | `dashboards/{id}/textcard/{id}/` | `api_client.rs` | 2742 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `Dashboard` | `types/dashboard.rs` | 11 | id, title, description, is_private, creator_id/name/email, created, modified, is_favorited, pinned_date, layout_version, filters, breakdowns, time_filter |
+| `CreateDashboardParams` | `types/dashboard.rs` | 94 | title, description, is_private, is_restricted, filters, breakdowns, time_filter, duplicate |
+| `UpdateDashboardParams` | `types/dashboard.rs` | 114 | title, description, is_private, is_restricted, filters, breakdowns, time_filter, layout, content |
+| `BlueprintTemplate` | `types/dashboard.rs` | 139 | title_key, description_key, number_of_reports |
+| `BlueprintConfig` | `types/dashboard.rs` | 150 | variables |
+| `BlueprintFinishParams` | `types/dashboard.rs` | 173 | dashboard_id, cards |
+| `CreateRcaDashboardParams` | `types/dashboard.rs` | 180 | rca_source_id, rca_source_data |
+| `UpdateReportLinkParams` | `types/dashboard.rs` | 198 | link_type |
+| `UpdateTextCardParams` | `types/dashboard.rs` | 205 | markdown |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp dashboards list` | `commands/dashboards.rs` | 25 |
+| `mp dashboards create` | `commands/dashboards.rs` | 29 |
+| `mp dashboards get` | `commands/dashboards.rs` | 33 |
+| `mp dashboards update` | `commands/dashboards.rs` | 39 |
+| `mp dashboards delete` | `commands/dashboards.rs` | 45 |
+| `mp dashboards bulk-delete` | `commands/dashboards.rs` | 52 |
+| `mp dashboards favorite` | `commands/dashboards.rs` | 56 |
+| `mp dashboards unfavorite` | `commands/dashboards.rs` | 60 |
+| `mp dashboards pin` | `commands/dashboards.rs` | 66 |
+| `mp dashboards unpin` | `commands/dashboards.rs` | 70 |
+| `mp dashboards remove-report` | `commands/dashboards.rs` | 78 |
+| `mp dashboards blueprints` | `commands/dashboards.rs` | 85 |
+| `mp dashboards blueprint-create` | `commands/dashboards.rs` | 92 |
+| `mp dashboards rca` | `commands/dashboards.rs` | 99 |
+| `mp dashboards erf` | `commands/dashboards.rs` | 103 |
+| `mp dashboards update-report-link` | `commands/dashboards.rs` | 110 |
+| `mp dashboards update-text-card` | `commands/dashboards.rs` | 117 |
+
+---
+
+### Domain 2: Reports/Bookmarks
+
+**Summary**: Full CRUD for saved reports (bookmarks) including bulk operations, history, and linked dashboard tracking.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_bookmarks_v2(type, ids)` | `workspace.rs` | 481 | List bookmarks (v2, paginated) |
+| `create_bookmark(params)` | `workspace.rs` | 492 | Create new bookmark |
+| `get_bookmark(id)` | `workspace.rs` | 497 | Get bookmark by ID |
+| `update_bookmark(id, params)` | `workspace.rs` | 502 | Update bookmark |
+| `delete_bookmark(id)` | `workspace.rs` | 511 | Delete bookmark |
+| `bulk_delete_bookmarks(ids)` | `workspace.rs` | 516 | Bulk delete |
+| `bulk_update_bookmarks(entries)` | `workspace.rs` | 521 | Bulk update |
+| `bookmark_linked_dashboard_ids(id)` | `workspace.rs` | 529 | Get linked dashboards |
+| `get_bookmark_history(id, cursor, page_size)` | `workspace.rs` | 1283 | Change history |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_bookmarks_v2()` | GET | `bookmarks/` | `api_client.rs` | 1283 |
+| `create_bookmark()` | POST | `bookmarks/` | `api_client.rs` | 1316 |
+| `get_bookmark()` | GET | `bookmarks/{id}/` | `api_client.rs` | 1326 |
+| `update_bookmark()` | PATCH | `bookmarks/{id}/` | `api_client.rs` | 1333 |
+| `delete_bookmark()` | DELETE | `bookmarks/{id}/` | `api_client.rs` | 1349 |
+| `bulk_delete_bookmarks()` | POST | `bookmarks/bulk-delete/` | `api_client.rs` | 1356 |
+| `bulk_update_bookmarks()` | POST | `bookmarks/bulk-update/` | `api_client.rs` | 1375 |
+| `bookmark_linked_dashboard_ids()` | GET | `bookmarks/{id}/linked-dashboard-ids/` | `api_client.rs` | 1399 |
+| `get_bookmark_history()` | GET | `bookmarks/{id}/history/` | `api_client.rs` | 2787 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `Bookmark` | `types/bookmark.rs` | 12 | id, project_id, name, bookmark_type, description, params, creator_id/name/email, created, modified, metadata |
+| `CreateBookmarkParams` | `types/bookmark.rs` | 89 | name, bookmark_type, params, description, dashboard_id |
+| `UpdateBookmarkParams` | `types/bookmark.rs` | 108 | name, params, description, deleted |
+| `BulkUpdateBookmarkEntry` | `types/bookmark.rs` | 129 | id, name, params, description |
+| `BookmarkHistoryResponse` | `types/bookmark.rs` | 149 | results, pagination |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp reports list` | `commands/reports.rs` | 20 |
+| `mp reports create` | `commands/reports.rs` | 24 |
+| `mp reports get` | `commands/reports.rs` | 28 |
+| `mp reports update` | `commands/reports.rs` | 34 |
+| `mp reports delete` | `commands/reports.rs` | 40 |
+| `mp reports bulk-delete` | `commands/reports.rs` | 47 |
+| `mp reports bulk-update` | `commands/reports.rs` | 54 |
+| `mp reports linked-dashboards` | `commands/reports.rs` | 61 |
+| `mp reports dashboard-ids` | `commands/reports.rs` | 68 |
+| `mp reports history` | `commands/reports.rs` | 72 |
+
+---
+
+### Domain 3: Cohorts (CRUD Extension)
+
+**Summary**: Extend existing read-only cohort listing to full CRUD. Python already has `cohorts()` for discovery; this adds get, create, update, delete, and bulk operations via the App API.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_cohorts_full(data_group_id, ids)` | `workspace.rs` | 542 | Full list via App API (vs discovery `cohorts()`) |
+| `get_cohort(id)` | `workspace.rs` | 553 | Get cohort by ID |
+| `create_cohort(params)` | `workspace.rs` | 558 | Create behavioral or static cohort |
+| `update_cohort(id, params)` | `workspace.rs` | 563 | Update cohort |
+| `delete_cohort(id)` | `workspace.rs` | 568 | Delete cohort |
+| `bulk_delete_cohorts(ids)` | `workspace.rs` | 573 | Bulk delete |
+| `bulk_update_cohorts(entries)` | `workspace.rs` | 578 | Bulk update |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_cohorts_app()` | GET | `cohorts/` | `api_client.rs` | 1409 |
+| `get_cohort()` | GET | `cohorts/{id}/` | `api_client.rs` | 1434 |
+| `create_cohort()` | POST | `cohorts/` | `api_client.rs` | 1440 |
+| `update_cohort()` | PATCH | `cohorts/{id}/` | `api_client.rs` | 1449 |
+| `delete_cohort()` | DELETE | `cohorts/{id}/` | `api_client.rs` | 1460 |
+| `bulk_delete_cohorts()` | POST | `cohorts/bulk-delete/` | `api_client.rs` | 1469 |
+| `bulk_update_cohorts()` | POST | `cohorts/bulk-update/` | `api_client.rs` | 1491 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `Cohort` | `types/cohorts.rs` | 14 | id, name, description, count, is_visible, is_locked, data_group_id, created_by, permissions |
+| `CreateCohortParams` | `types/cohorts.rs` | 72 | name, description, data_group_id, definition |
+| `UpdateCohortParams` | `types/cohorts.rs` | 94 | name, description, definition |
+| `BulkUpdateCohortEntry` | `types/cohorts.rs` | 114 | id, name, description, definition |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp cohorts list` | `commands/cohorts.rs` | 22 |
+| `mp cohorts create` | `commands/cohorts.rs` | 26 |
+| `mp cohorts get` | `commands/cohorts.rs` | 30 |
+| `mp cohorts update` | `commands/cohorts.rs` | 36 |
+| `mp cohorts delete` | `commands/cohorts.rs` | 42 |
+| `mp cohorts bulk-delete` | `commands/cohorts.rs` | 49 |
+| `mp cohorts bulk-update` | `commands/cohorts.rs` | 56 |
+
+---
+
+### Domain 4: Feature Flags
+
+**Summary**: Full CRUD with lifecycle management (archive, restore, duplicate), test user overrides, change history, and account limits. Uses workspace-scoped (project-nested) URL pattern.
+
+**Complexity**: L | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_feature_flags(include_archived)` | `workspace.rs` | 592 | List flags |
+| `create_feature_flag(params)` | `workspace.rs` | 599 | Create flag |
+| `get_feature_flag(id)` | `workspace.rs` | 607 | Get by UUID |
+| `update_feature_flag(id, params)` | `workspace.rs` | 612 | Update (PUT, full replacement) |
+| `delete_feature_flag(id)` | `workspace.rs` | 621 | Delete |
+| `archive_feature_flag(id)` | `workspace.rs` | 626 | Archive (soft delete) |
+| `restore_feature_flag(id)` | `workspace.rs` | 631 | Restore from archive |
+| `duplicate_feature_flag(id)` | `workspace.rs` | 636 | Duplicate |
+| `set_flag_test_users(id, params)` | `workspace.rs` | 641 | Set test user overrides |
+| `get_flag_history(id, params)` | `workspace.rs` | 650 | Change history |
+| `get_flag_limits()` | `workspace.rs` | 659 | Account limits |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_feature_flags()` | GET | `workspaces/{wid}/feature-flags/` | `api_client.rs` | 1528 |
+| `create_feature_flag()` | POST | `workspaces/{wid}/feature-flags/` | `api_client.rs` | 1540 |
+| `get_feature_flag()` | GET | `workspaces/{wid}/feature-flags/{id}/` | `api_client.rs` | 1553 |
+| `update_feature_flag()` | PUT | `workspaces/{wid}/feature-flags/{id}/` | `api_client.rs` | 1559 |
+| `delete_feature_flag()` | DELETE | `workspaces/{wid}/feature-flags/{id}/` | `api_client.rs` | 1573 |
+| `archive_feature_flag()` | POST | `workspaces/{wid}/feature-flags/{id}/archive/` | `api_client.rs` | 1580 |
+| `restore_feature_flag()` | DELETE | `workspaces/{wid}/feature-flags/{id}/archive/` | `api_client.rs` | 1586 |
+| `duplicate_feature_flag()` | POST | `workspaces/{wid}/feature-flags/{id}/duplicate/` | `api_client.rs` | 1593 |
+| `set_flag_test_users()` | PUT | `workspaces/{wid}/feature-flags/{id}/test-users/` | `api_client.rs` | 1601 |
+| `get_flag_history()` | GET | `workspaces/{wid}/feature-flags/{id}/history/` | `api_client.rs` | 1615 |
+| `get_flag_limits()` | GET | `feature-flags/limits/` | `api_client.rs` | 1638 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `FeatureFlag` | `types/feature_flags.rs` | 46 | id, project_id, name, key, description, status, tags, serving_method, ruleset, hash_salt |
+| `FeatureFlagStatus` | `types/feature_flags.rs` | 11 | Enabled, Disabled, Archived |
+| `ServingMethod` | `types/feature_flags.rs` | 21 | Client, Server, RemoteOrLocal, RemoteOnly |
+| `FlagRuleset` | `types/feature_flags.rs` | 105 | variants, rollout, test |
+| `FlagVariant` | `types/feature_flags.rs` | 116 | key, value, description, is_control, split |
+| `FlagRollout` | `types/feature_flags.rs` | 155 | name, cohort_definition, rollout_percentage, variant_splits |
+| `CreateFeatureFlagParams` | `types/feature_flags.rs` | 181 | name, key, description, status, tags, ruleset |
+| `UpdateFeatureFlagParams` | `types/feature_flags.rs` | 210 | name, key, description, status, tags, ruleset |
+| `SetTestUsersParams` | `types/feature_flags.rs` | 230 | users |
+| `FlagHistoryParams` | `types/feature_flags.rs` | 240 | page, page_size |
+| `FlagHistoryResponse` | `types/feature_flags.rs` | 249 | events, count |
+| `FlagLimitsResponse` | `types/feature_flags.rs` | 256 | limit, is_trial, current_usage |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp flags list` | `commands/flags.rs` | 20 |
+| `mp flags create` | `commands/flags.rs` | 24 |
+| `mp flags get` | `commands/flags.rs` | 28 |
+| `mp flags update` | `commands/flags.rs` | 34 |
+| `mp flags delete` | `commands/flags.rs` | 40 |
+| `mp flags archive` | `commands/flags.rs` | 44 |
+| `mp flags restore` | `commands/flags.rs` | 48 |
+| `mp flags duplicate` | `commands/flags.rs` | 52 |
+| `mp flags set-test-users` | `commands/flags.rs` | 58 |
+| `mp flags history` | `commands/flags.rs` | 63 |
+| `mp flags limits` | `commands/flags.rs` | 67 |
+
+---
+
+### Domain 5: Experiments
+
+**Summary**: Full A/B experiment lifecycle — create, launch, conclude, decide winner, archive, restore, duplicate.
+
+**Complexity**: L | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_experiments(include_archived)` | `workspace.rs` | 670 | List experiments |
+| `create_experiment(params)` | `workspace.rs` | 675 | Create experiment |
+| `get_experiment(id)` | `workspace.rs` | 680 | Get by UUID |
+| `update_experiment(id, params)` | `workspace.rs` | 685 | Update (PATCH) |
+| `delete_experiment(id)` | `workspace.rs` | 694 | Delete |
+| `launch_experiment(id)` | `workspace.rs` | 699 | Launch (DRAFT→ACTIVE) |
+| `conclude_experiment(id, params)` | `workspace.rs` | 704 | Force-conclude |
+| `decide_experiment(id, params)` | `workspace.rs` | 713 | Decide winner |
+| `archive_experiment(id)` | `workspace.rs` | 722 | Archive |
+| `restore_experiment(id)` | `workspace.rs` | 727 | Restore |
+| `duplicate_experiment(id, params)` | `workspace.rs` | 732 | Duplicate |
+| `list_erf_experiments()` | `workspace.rs` | 1278 | List ERF experiments |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_experiments()` | GET | `experiments/` | `api_client.rs` | 1646 |
+| `create_experiment()` | POST | `experiments/` | `api_client.rs` | 1658 |
+| `get_experiment()` | GET | `experiments/{id}` | `api_client.rs` | 1667 |
+| `update_experiment()` | PATCH | `experiments/{id}` | `api_client.rs` | 1674 |
+| `delete_experiment()` | DELETE | `experiments/{id}` | `api_client.rs` | 1689 |
+| `launch_experiment()` | PUT | `experiments/{id}/launch` | `api_client.rs` | 1696 |
+| `conclude_experiment()` | PUT | `experiments/{id}/force_conclude` | `api_client.rs` | 1702 |
+| `decide_experiment()` | PATCH | `experiments/{id}/decide` | `api_client.rs` | 1719 |
+| `archive_experiment()` | POST | `experiments/{id}/archive` | `api_client.rs` | 1731 |
+| `restore_experiment()` | DELETE | `experiments/{id}/archive` | `api_client.rs` | 1737 |
+| `duplicate_experiment()` | POST | `experiments/{id}/duplicate` | `api_client.rs` | 1744 |
+| `list_erf_experiments()` | GET | `experiments/erf/` | `api_client.rs` | 2779 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `Experiment` | `types/experiments.rs` | 38 | id, name, description, hypothesis, status, variants, metrics, settings, start_date, end_date, creator |
+| `ExperimentStatus` | `types/experiments.rs` | 11 | Draft, Active, Concluded, Success, Fail |
+| `CreateExperimentParams` | `types/experiments.rs` | 92 | name, description, hypothesis, settings |
+| `UpdateExperimentParams` | `types/experiments.rs` | 113 | name, description, variants, metrics, settings, status |
+| `ExperimentDecideParams` | `types/experiments.rs` | 150 | success, variant, message |
+| `ExperimentConcludeParams` | `types/experiments.rs` | 160 | end_date |
+| `DuplicateExperimentParams` | `types/experiments.rs` | 144 | name |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp experiments list` | `commands/experiments.rs` | 20 |
+| `mp experiments create` | `commands/experiments.rs` | 24 |
+| `mp experiments get` | `commands/experiments.rs` | 28 |
+| `mp experiments update` | `commands/experiments.rs` | 34 |
+| `mp experiments delete` | `commands/experiments.rs` | 40 |
+| `mp experiments launch` | `commands/experiments.rs` | 46 |
+| `mp experiments conclude` | `commands/experiments.rs` | 50 |
+| `mp experiments decide` | `commands/experiments.rs` | 56 |
+| `mp experiments archive` | `commands/experiments.rs` | 62 |
+| `mp experiments restore` | `commands/experiments.rs` | 66 |
+| `mp experiments duplicate` | `commands/experiments.rs` | 70 |
+| `mp experiments erf` | `commands/experiments.rs` | 74 |
+
+---
+
+### Domain 6: Alerts
+
+**Summary**: Custom alert CRUD with history, testing, screenshots, bookmark validation, and bulk operations.
+
+**Complexity**: L | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_alerts(bookmark_id, skip_user_filter)` | `workspace.rs` | 743 | List alerts |
+| `create_alert(params)` | `workspace.rs` | 754 | Create alert |
+| `get_alert(id)` | `workspace.rs` | 759 | Get by ID |
+| `update_alert(id, params)` | `workspace.rs` | 764 | Update |
+| `delete_alert(id)` | `workspace.rs` | 769 | Delete |
+| `bulk_delete_alerts(ids)` | `workspace.rs` | 774 | Bulk delete |
+| `get_alert_count(alert_type)` | `workspace.rs` | 779 | Count and limits |
+| `get_alert_history(id, ...)` | `workspace.rs` | 784 | Trigger history |
+| `test_alert(params)` | `workspace.rs` | 797 | Test alert config |
+| `get_alert_screenshot_url(gcs_key)` | `workspace.rs` | 1263 | Screenshot URL |
+| `validate_alerts_for_bookmark(params)` | `workspace.rs` | 1268 | Validate alerts |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_alerts()` | GET | `alerts/custom/` | `api_client.rs` | 2896 |
+| `create_alert()` | POST | `alerts/custom/` | `api_client.rs` | 2917 |
+| `get_alert()` | GET | `alerts/custom/{id}/` | `api_client.rs` | 2926 |
+| `update_alert()` | PATCH | `alerts/custom/{id}/` | `api_client.rs` | 2932 |
+| `delete_alert()` | DELETE | `alerts/custom/{id}/` | `api_client.rs` | 2943 |
+| `bulk_delete_alerts()` | POST | `alerts/custom/bulk-delete/` | `api_client.rs` | 2950 |
+| `get_alert_count()` | GET | `alerts/custom/alert-count/` | `api_client.rs` | 2969 |
+| `get_alert_history()` | GET | `alerts/custom/{id}/history/` | `api_client.rs` | 2985 |
+| `test_alert()` | POST | `alerts/custom/test/` | `api_client.rs` | 3034 |
+| `get_alert_screenshot_url()` | GET | `alerts/custom/screenshot/` | `api_client.rs` | 2759 |
+| `validate_alerts_for_bookmark()` | POST | `alerts/custom/validate-alerts-for-bookmark/` | `api_client.rs` | 2766 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `CustomAlert` | `types/alerts.rs` | 25 | id, name, bookmark, condition, frequency, paused, subscriptions, creator |
+| `CreateAlertParams` | `types/alerts.rs` | 83 | bookmark_id, name, condition, frequency, paused, subscriptions |
+| `UpdateAlertParams` | `types/alerts.rs` | 97 | name, bookmark_id, condition, frequency, paused |
+| `AlertCount` | `types/alerts.rs` | 116 | anomaly_alerts_count, alert_limit, is_below_limit |
+| `AlertHistoryResponse` | `types/alerts.rs` | 127 | results, pagination |
+| `AlertFrequencyPreset` | `types/alerts.rs` | 147 | Hourly, Daily, Weekly |
+| `AlertScreenshotResponse` | `types/alerts.rs` | 206 | signed_url |
+| `ValidateAlertsForBookmarkParams` | `types/alerts.rs` | 212 | alert_ids, bookmark_type |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp alerts list` | `commands/alerts.rs` | 26 |
+| `mp alerts create` | `commands/alerts.rs` | 32 |
+| `mp alerts get` | `commands/alerts.rs` | 36 |
+| `mp alerts update` | `commands/alerts.rs` | 42 |
+| `mp alerts delete` | `commands/alerts.rs` | 48 |
+| `mp alerts bulk-delete` | `commands/alerts.rs` | 55 |
+| `mp alerts count` | `commands/alerts.rs` | 59 |
+| `mp alerts history` | `commands/alerts.rs` | 63 |
+| `mp alerts test` | `commands/alerts.rs` | 67 |
+| `mp alerts screenshot` | `commands/alerts.rs` | 73 |
+| `mp alerts validate` | `commands/alerts.rs` | 79 |
+
+---
+
+### Domain 7: Annotations
+
+**Summary**: Timeline annotation CRUD with tag management.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_annotations(from_date, to_date, tags)` | `workspace.rs` | 804 | List annotations |
+| `create_annotation(params)` | `workspace.rs` | 816 | Create annotation |
+| `get_annotation(id)` | `workspace.rs` | 822 | Get by ID |
+| `update_annotation(id, params)` | `workspace.rs` | 827 | Update |
+| `delete_annotation(id)` | `workspace.rs` | 835 | Delete |
+| `list_annotation_tags()` | `workspace.rs` | 840 | List tags |
+| `create_annotation_tag(params)` | `workspace.rs` | 845 | Create tag |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_annotations()` | GET | `annotations/` | `api_client.rs` | 3044 |
+| `create_annotation()` | POST | `annotations/` | `api_client.rs` | 3078 |
+| `get_annotation()` | GET | `annotations/{id}/` | `api_client.rs` | 3087 |
+| `update_annotation()` | PATCH | `annotations/{id}/` | `api_client.rs` | 3093 |
+| `delete_annotation()` | DELETE | `annotations/{id}/` | `api_client.rs` | 3105 |
+| `list_annotation_tags()` | GET | `annotations/tags/` | `api_client.rs` | 3112 |
+| `create_annotation_tag()` | POST | `annotations/tags/` | `api_client.rs` | 3118 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `Annotation` | `types/annotations.rs` | 11 | id, project_id, date, description, user, tags |
+| `AnnotationUser` | `types/annotations.rs` | 27 | id, first_name, last_name |
+| `AnnotationTag` | `types/annotations.rs` | 38 | id, name, project_id |
+| `CreateAnnotationParams` | `types/annotations.rs` | 52 | date, description, tags, user_id |
+| `UpdateAnnotationParams` | `types/annotations.rs` | 63 | description, tags |
+| `CreateAnnotationTagParams` | `types/annotations.rs` | 72 | name |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp annotations list` | `commands/annotations.rs` | 25 |
+| `mp annotations create` | `commands/annotations.rs` | 29 |
+| `mp annotations get` | `commands/annotations.rs` | 33 |
+| `mp annotations update` | `commands/annotations.rs` | 39 |
+| `mp annotations delete` | `commands/annotations.rs` | 45 |
+| `mp annotations tags list` | `commands/annotations.rs` | 125 |
+| `mp annotations tags create` | `commands/annotations.rs` | 131 |
+
+---
+
+### Domain 8: Webhooks
+
+**Summary**: Project webhook CRUD with endpoint connectivity testing.
+
+**Complexity**: S | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_webhooks()` | `workspace.rs` | 859 | List webhooks |
+| `create_webhook(params)` | `workspace.rs` | 864 | Create webhook |
+| `update_webhook(id, params)` | `workspace.rs` | 872 | Update |
+| `delete_webhook(id)` | `workspace.rs` | 881 | Delete |
+| `test_webhook(params)` | `workspace.rs` | 886 | Test connectivity |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_webhooks()` | GET | `webhooks/` | `api_client.rs` | 1760 |
+| `create_webhook()` | POST | `webhooks/` | `api_client.rs` | 1766 |
+| `update_webhook()` | PATCH | `webhooks/{id}/` | `api_client.rs` | 1784 |
+| `delete_webhook()` | DELETE | `webhooks/{id}/` | `api_client.rs` | 1815 |
+| `test_webhook()` | POST | `webhooks/test/` | `api_client.rs` | 1822 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `ProjectWebhook` | `types/webhooks.rs` | 20 | id, name, url, is_enabled, auth_type, created, modified |
+| `WebhookAuthType` | `types/webhooks.rs` | 11 | Basic, Unknown |
+| `CreateWebhookParams` | `types/webhooks.rs` | 42 | name, url, auth_type, username, password |
+| `UpdateWebhookParams` | `types/webhooks.rs` | 78 | name, url, auth_type, is_enabled |
+| `WebhookTestParams` | `types/webhooks.rs` | 130 | url, name, auth_type |
+| `WebhookTestResult` | `types/webhooks.rs` | 167 | success, status_code, message |
+| `WebhookMutationResult` | `types/webhooks.rs` | 181 | id, name |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp webhooks list` | `commands/webhooks.rs` | 22 |
+| `mp webhooks create` | `commands/webhooks.rs` | 26 |
+| `mp webhooks update` | `commands/webhooks.rs` | 32 |
+| `mp webhooks delete` | `commands/webhooks.rs` | 38 |
+| `mp webhooks test` | `commands/webhooks.rs` | 42 |
+
+---
+
+### Domain 9: Data Definitions / Lexicon (Write Operations)
+
+**Summary**: Write operations for event/property definitions, tags, export, tracking metadata, and definition history. Python already reads schemas via discovery; this adds mutation support.
+
+**Complexity**: L | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `get_event_definitions(names)` | `workspace.rs` | 897 | Get event definitions |
+| `update_event_definition(name, params)` | `workspace.rs` | 902 | Update event def |
+| `delete_event_definition(name)` | `workspace.rs` | 913 | Delete event def |
+| `get_property_definitions(names, resource_type)` | `workspace.rs` | 918 | Get property definitions |
+| `update_property_definition(name, params)` | `workspace.rs` | 929 | Update property def |
+| `list_lexicon_tags()` | `workspace.rs` | 940 | List tags |
+| `create_lexicon_tag(params)` | `workspace.rs` | 945 | Create tag |
+| `update_lexicon_tag(id, params)` | `workspace.rs` | 950 | Update tag |
+| `delete_lexicon_tag(name)` | `workspace.rs` | 958 | Delete tag |
+| `bulk_update_event_definitions(params)` | `workspace.rs` | 995 | Bulk update events |
+| `bulk_update_property_definitions(params)` | `workspace.rs` | 1005 | Bulk update properties |
+| `get_tracking_metadata(event_name)` | `workspace.rs` | 1108 | Tracking metadata |
+| `get_event_history(event_name)` | `workspace.rs` | 1113 | Event change history |
+| `get_property_history(property_name, entity_type)` | `workspace.rs` | 1118 | Property change history |
+| `export_lexicon(export_types)` | `workspace.rs` | 1451 | Export definitions |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `get_event_definitions()` | GET | `data-definitions/events/` | `api_client.rs` | 1881 |
+| `update_event_definition()` | PATCH | `data-definitions/events/` | `api_client.rs` | 1893 |
+| `delete_event_definition()` | DELETE | `data-definitions/events/` | `api_client.rs` | 1917 |
+| `get_property_definitions()` | GET | `data-definitions/properties/` | `api_client.rs` | 1925 |
+| `update_property_definition()` | PATCH | `data-definitions/properties/` | `api_client.rs` | 1944 |
+| `bulk_update_event_definitions()` | PATCH | `data-definitions/events/` | `api_client.rs` | 2270 |
+| `bulk_update_property_definitions()` | PATCH | `data-definitions/properties/` | `api_client.rs` | 2281 |
+| `list_lexicon_tags()` | GET | `data-definitions/tags/` | `api_client.rs` | 1966 |
+| `create_lexicon_tag()` | POST | `data-definitions/tags/` | `api_client.rs` | 1972 |
+| `update_lexicon_tag()` | PATCH | `data-definitions/tags/{id}/` | `api_client.rs` | 1981 |
+| `delete_lexicon_tag()` | POST | `data-definitions/tags/` | `api_client.rs` | 1997 |
+| `get_tracking_metadata()` | GET | `data-definitions/events/tracking-metadata/` | `api_client.rs` | 2485 |
+| `get_event_history()` | GET | `data-definitions/events/{name}/history/` | `api_client.rs` | 2497 |
+| `get_property_history()` | GET | `data-definitions/properties/{name}/history/` | `api_client.rs` | 2504 |
+| `export_lexicon()` | GET | `data-definitions/export/` | `api_client.rs` | 2820 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `EventDefinition` | `types/data_definitions.rs` | 41 | id, name, display_name, description, hidden, dropped, tags |
+| `PropertyDefinition` | `types/data_definitions.rs` | 100 | id, name, resource_type, description, hidden, dropped |
+| `UpdateEventDefinitionParams` | `types/data_definitions.rs` | 132 | hidden, dropped, merged, verified, tags, description |
+| `UpdatePropertyDefinitionParams` | `types/data_definitions.rs` | 149 | hidden, dropped, merged, sensitive, description |
+| `LexiconTag` | `types/data_definitions.rs` | 164 | id, name |
+| `CreateTagParams` | `types/data_definitions.rs` | 171 | name |
+| `UpdateTagParams` | `types/data_definitions.rs` | 177 | name |
+| `BulkUpdateEventsParams` | `types/data_definitions.rs` | 338 | events |
+| `BulkUpdatePropertiesParams` | `types/data_definitions.rs` | 367 | properties |
+| `TrackingMetadata` | `types/data_definitions.rs` | 580 | tracking metadata fields |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp lexicon events get` | `commands/lexicon.rs` | 60 |
+| `mp lexicon events update` | `commands/lexicon.rs` | 60 |
+| `mp lexicon events delete` | `commands/lexicon.rs` | 60 |
+| `mp lexicon events bulk-update` | `commands/lexicon.rs` | 60 |
+| `mp lexicon properties get` | `commands/lexicon.rs` | 80 |
+| `mp lexicon properties update` | `commands/lexicon.rs` | 80 |
+| `mp lexicon properties bulk-update` | `commands/lexicon.rs` | 80 |
+| `mp lexicon tags list/create/update/delete` | `commands/lexicon.rs` | 98 |
+| `mp lexicon export` | `commands/lexicon.rs` | 30 |
+| `mp lexicon event-history` | `commands/lexicon.rs` | 42 |
+| `mp lexicon property-history` | `commands/lexicon.rs` | 45 |
+| `mp lexicon tracking-metadata` | `commands/lexicon.rs` | 48 |
+
+---
+
+### Domain 10: Custom Properties
+
+**Summary**: Custom computed property CRUD with validation.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_custom_properties()` | `workspace.rs` | 1462 | List custom properties |
+| `create_custom_property(params)` | `workspace.rs` | 1467 | Create |
+| `get_custom_property(id)` | `workspace.rs` | 1475 | Get by ID |
+| `update_custom_property(id, params)` | `workspace.rs` | 1480 | Update (PUT) |
+| `delete_custom_property(id)` | `workspace.rs` | 1489 | Delete |
+| `validate_custom_property(params)` | `workspace.rs` | 1494 | Validate formula |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_custom_properties()` | GET | `custom_properties/` | `api_client.rs` | 2835 |
+| `create_custom_property()` | POST | `custom_properties/` | `api_client.rs` | 2841 |
+| `get_custom_property()` | GET | `custom_properties/{id}/` | `api_client.rs` | 2854 |
+| `update_custom_property()` | PUT | `custom_properties/{id}/` | `api_client.rs` | 2860 |
+| `delete_custom_property()` | DELETE | `custom_properties/{id}/` | `api_client.rs` | 2875 |
+| `validate_custom_property()` | POST | `custom_properties/validate/` | `api_client.rs` | 2882 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `CustomProperty` | `types/custom_properties.rs` | 47 | custom_property_id, name, description, resource_type, display_formula, composed_properties |
+| `CustomPropertyResourceType` | `types/custom_properties.rs` | 31 | Events, UserProfiles, GroupProfiles |
+| `CreateCustomPropertyParams` | `types/custom_properties.rs` | 91 | name, resource_type, display_formula, composed_properties, behavior |
+| `UpdateCustomPropertyParams` | `types/custom_properties.rs` | 161 | name, description, display_formula, composed_properties |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp custom-properties list` | `commands/custom_properties.rs` | 21 |
+| `mp custom-properties get` | `commands/custom_properties.rs` | 23 |
+| `mp custom-properties create` | `commands/custom_properties.rs` | 25 |
+| `mp custom-properties update` | `commands/custom_properties.rs` | 27 |
+| `mp custom-properties delete` | `commands/custom_properties.rs` | 29 |
+| `mp custom-properties validate` | `commands/custom_properties.rs` | 31 |
+
+---
+
+### Domain 11: Custom Events
+
+**Summary**: Custom event management (list, update, delete). Read through discovery; this adds mutation.
+
+**Complexity**: S | **Dependencies**: Domain 0a, 0b
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| Uses data-definitions endpoints for custom events — custom events are managed through event definitions with `custom_event_id` field |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp custom-events list` | `commands/custom_events.rs` | 21 |
+| `mp custom-events update` | `commands/custom_events.rs` | 23 |
+| `mp custom-events delete` | `commands/custom_events.rs` | 25 |
+
+---
+
+### Domain 12: Drop Filters
+
+**Summary**: Event drop filter CRUD with account limits.
+
+**Complexity**: S | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_drop_filters()` | `workspace.rs` | 964 | List drop filters |
+| `create_drop_filter(params)` | `workspace.rs` | 969 | Create filter |
+| `update_drop_filter(params)` | `workspace.rs` | 977 | Update filter |
+| `delete_drop_filter(id)` | `workspace.rs` | 985 | Delete filter |
+| `get_drop_filter_limits()` | `workspace.rs` | 990 | Account limits |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_drop_filters()` | GET | `data-definitions/events/drop-filters/` | `api_client.rs` | 2228 |
+| `create_drop_filter()` | POST | `data-definitions/events/drop-filters/` | `api_client.rs` | 2234 |
+| `update_drop_filter()` | PATCH | `data-definitions/events/drop-filters/` | `api_client.rs` | 2245 |
+| `delete_drop_filter()` | DELETE | `data-definitions/events/drop-filters/` | `api_client.rs` | 2256 |
+| `get_drop_filter_limits()` | GET | `data-definitions/events/drop-filters/limits/` | `api_client.rs` | 2264 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `DropFilter` | `types/data_definitions.rs` | 295 | id, event_name, filters, active, display_name |
+| `CreateDropFilterParams` | `types/data_definitions.rs` | 313 | event_name, filters |
+| `UpdateDropFilterParams` | `types/data_definitions.rs` | 320 | id, event_name, filters, active |
+| `DropFilterLimitsResponse` | `types/data_definitions.rs` | 332 | filter_limit |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp drop-filters list` | `commands/drop_filters.rs` | 18 |
+| `mp drop-filters create` | `commands/drop_filters.rs` | 20 |
+| `mp drop-filters update` | `commands/drop_filters.rs` | 22 |
+| `mp drop-filters delete` | `commands/drop_filters.rs` | 24 |
+
+---
+
+### Domain 13: Lookup Tables
+
+**Summary**: Lookup table CRUD with 3-step CSV upload (get URL → upload to GCS → mark ready) and download.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_lookup_tables(data_group_id)` | `workspace.rs` | 1295 | List tables |
+| `mark_lookup_table_ready(params)` | `workspace.rs` | 1300 | Mark uploaded table ready |
+| `update_lookup_table(data_group_id, params)` | `workspace.rs` | 1308 | Update table |
+| `delete_lookup_tables(data_group_ids)` | `workspace.rs` | 1319 | Delete tables |
+| `get_lookup_upload_url(content_type)` | `workspace.rs` | 1326 | Get signed upload URL |
+| `get_lookup_upload_status(upload_id)` | `workspace.rs` | 1331 | Check upload status |
+| `upload_lookup_table(params)` | `workspace.rs` | 1344 | Full 3-step upload flow |
+| `download_lookup_table(data_group_id, ...)` | `workspace.rs` | 1433 | Download as CSV bytes |
+| `get_lookup_download_url(data_group_id)` | `workspace.rs` | 1129 | Get download URL |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_lookup_tables()` | GET | `data-definitions/lookup-tables/` | `api_client.rs` | 2007 |
+| `mark_lookup_table_ready()` | POST | `data-definitions/lookup-tables/` | `api_client.rs` | 2020 |
+| `update_lookup_table()` | PATCH | `data-definitions/lookup-tables/` | `api_client.rs` | 2035 |
+| `delete_lookup_tables()` | DELETE | `data-definitions/lookup-tables/` | `api_client.rs` | 2057 |
+| `get_lookup_upload_url()` | GET | `data-definitions/lookup-tables/upload-url/` | `api_client.rs` | 2071 |
+| `get_lookup_upload_status()` | GET | `data-definitions/lookup-tables/upload-status/` | `api_client.rs` | 2079 |
+| `upload_to_signed_url()` | PUT | `{signed_gcs_url}` (external) | `api_client.rs` | 2090 |
+| `register_lookup_table()` | POST | `data-definitions/lookup-tables/` (form) | `api_client.rs` | 2117 |
+| `download_lookup_table()` | GET | `data-definitions/lookup-tables/download/` | `api_client.rs` | 2181 |
+| `get_lookup_download_url()` | GET | `data-definitions/lookup-tables/download-url/` | `api_client.rs` | 2524 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `LookupTable` | `types/data_definitions.rs` | 188 | id, name, token, created_at, has_mapped_properties |
+| `UploadLookupTableParams` | `types/data_definitions.rs` | 245 | name, file_path, data_group_id |
+| `MarkLookupTableReadyParams` | `types/data_definitions.rs` | 259 | name, key, data_group_id |
+| `LookupTableUploadUrl` | `types/data_definitions.rs` | 285 | url, path, key |
+| `UpdateLookupTableParams` | `types/data_definitions.rs` | 278 | name |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp lookup-tables list` | `commands/lookup_tables.rs` | 24 |
+| `mp lookup-tables create` | `commands/lookup_tables.rs` | 32 |
+| `mp lookup-tables update` | `commands/lookup_tables.rs` | 36 |
+| `mp lookup-tables delete` | `commands/lookup_tables.rs` | 41 |
+| `mp lookup-tables upload-url` | `commands/lookup_tables.rs` | 48 |
+| `mp lookup-tables download` | `commands/lookup_tables.rs` | 52 |
+| `mp lookup-tables download-url` | `commands/lookup_tables.rs` | 59 |
+
+---
+
+### Domain 14: Schema Registry
+
+**Summary**: Schema registry CRUD for data governance (create, update, delete schemas with bulk variants).
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `list_schema_registry(entity_type)` | `workspace.rs` | 1136 | List schemas |
+| `create_schema(entity_type, entity_name, schema_json)` | `workspace.rs` | 1141 | Create schema |
+| `create_schemas_bulk(params)` | `workspace.rs` | 1153 | Bulk create |
+| `update_schema(entity_type, entity_name, schema_json)` | `workspace.rs` | 1161 | Update schema |
+| `update_schemas_bulk(params)` | `workspace.rs` | 1173 | Bulk update |
+| `delete_schemas(entity_type, entity_name)` | `workspace.rs` | 1181 | Delete schemas |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `list_schema_registry()` | GET | `schemas/` | `api_client.rs` | 2538 |
+| `create_schema()` | POST | `schemas/{type}/{name}/` | `api_client.rs` | 2550 |
+| `create_schemas_bulk()` | POST | `schemas/` | `api_client.rs` | 2566 |
+| `update_schema()` | PATCH | `schemas/{type}/{name}/` | `api_client.rs` | 2577 |
+| `update_schemas_bulk()` | PATCH | `schemas/` | `api_client.rs` | 2593 |
+| `delete_schemas()` | DELETE | `schemas/` | `api_client.rs` | 2604 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `SchemaEntity` | `types/discovery.rs` | 66 | entity_type, name, schema_json |
+| `SchemaEntry` | `types/discovery.rs` | 75 | name, entity_type, version, schema_json |
+| `BulkCreateSchemasParams` | `types/discovery.rs` | 86 | truncate, entity_type, entries |
+| `BulkCreateSchemasResponse` | `types/discovery.rs` | 96 | added, deleted |
+| `DeleteSchemasResponse` | `types/discovery.rs` | 118 | delete_count |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp schemas list` | `commands/schemas.rs` | 18 |
+| `mp schemas create` | `commands/schemas.rs` | 20 |
+| `mp schemas update` | `commands/schemas.rs` | 24 |
+| `mp schemas delete` | `commands/schemas.rs` | 28 |
+
+---
+
+### Domain 15: Schema Enforcement & Data Governance
+
+**Summary**: Schema enforcement configuration, data audit, volume anomalies, and event deletion requests.
+
+**Complexity**: M | **Dependencies**: Domain 0a, 0b
+
+#### Rust Workspace Methods
+
+| Method | Rust File | Line | Description |
+|--------|-----------|------|-------------|
+| `get_schema_enforcement(fields)` | `workspace.rs` | 1015 | Get enforcement config |
+| `init_schema_enforcement(params)` | `workspace.rs` | 1023 | Initialize enforcement |
+| `update_schema_enforcement(params)` | `workspace.rs` | 1031 | Partial update |
+| `replace_schema_enforcement(params)` | `workspace.rs` | 1039 | Full replacement |
+| `delete_schema_enforcement()` | `workspace.rs` | 1047 | Delete enforcement |
+| `run_audit()` | `workspace.rs` | 1052 | Full data audit |
+| `run_audit_events_only()` | `workspace.rs` | 1057 | Events-only audit |
+| `list_data_volume_anomalies(query_params)` | `workspace.rs` | 1062 | List anomalies |
+| `update_anomaly(params)` | `workspace.rs` | 1072 | Update anomaly status |
+| `bulk_update_anomalies(params)` | `workspace.rs` | 1077 | Bulk update anomalies |
+| `list_deletion_requests()` | `workspace.rs` | 1082 | List deletion requests |
+| `create_deletion_request(params)` | `workspace.rs` | 1087 | Create deletion request |
+| `cancel_deletion_request(id)` | `workspace.rs` | 1095 | Cancel pending deletion |
+| `preview_deletion_filters(params)` | `workspace.rs` | 1100 | Preview deletion filters |
+
+#### Rust API Client Methods
+
+| Method | HTTP | Endpoint | Rust File | Line |
+|--------|------|----------|-----------|------|
+| `get_schema_enforcement()` | GET | `data-definitions/schema/` | `api_client.rs` | 2294 |
+| `init_schema_enforcement()` | POST | `data-definitions/schema/` | `api_client.rs` | 2305 |
+| `update_schema_enforcement()` | PATCH | `data-definitions/schema/` | `api_client.rs` | 2316 |
+| `replace_schema_enforcement()` | PUT | `data-definitions/schema/` | `api_client.rs` | 2327 |
+| `delete_schema_enforcement()` | DELETE | `data-definitions/schema/` | `api_client.rs` | 2338 |
+| `run_audit()` | GET | `data-definitions/audit/` | `api_client.rs` | 2347 |
+| `run_audit_events_only()` | GET | `data-definitions/audit-events-only/` | `api_client.rs` | 2356 |
+| `list_data_volume_anomalies()` | GET | `data-definitions/data-volume-anomalies/` | `api_client.rs` | 2404 |
+| `update_anomaly()` | PATCH | `data-definitions/data-volume-anomalies/` | `api_client.rs` | 2428 |
+| `bulk_update_anomalies()` | PATCH | `data-definitions/data-volume-anomalies/bulk/` | `api_client.rs` | 2436 |
+| `list_deletion_requests()` | GET | `data-definitions/events/deletion-requests/` | `api_client.rs` | 2446 |
+| `create_deletion_request()` | POST | `data-definitions/events/deletion-requests/` | `api_client.rs` | 2452 |
+| `cancel_deletion_request()` | DELETE | `data-definitions/events/deletion-requests/` | `api_client.rs` | 2463 |
+| `preview_deletion_filters()` | POST | `data-definitions/events/deletion-requests/preview-filters/` | `api_client.rs` | 2471 |
+
+#### Rust Types to Port
+
+| Type | Rust File | Line | Key Fields |
+|------|-----------|------|------------|
+| `SchemaEnforcementConfig` | `types/data_definitions.rs` | 392 | enforcement config fields |
+| `InitSchemaEnforcementParams` | `types/data_definitions.rs` | 425 | init params |
+| `UpdateSchemaEnforcementParams` | `types/data_definitions.rs` | 432 | update params |
+| `ReplaceSchemaEnforcementParams` | `types/data_definitions.rs` | 446 | replace params |
+| `AuditResponse` | `types/data_definitions.rs` | 458 | audit violations |
+| `DataVolumeAnomaly` | `types/data_definitions.rs` | 484 | anomaly details |
+| `UpdateAnomalyParams` | `types/data_definitions.rs` | 517 | status update params |
+| `BulkUpdateAnomalyParams` | `types/data_definitions.rs` | 525 | bulk update params |
+| `EventDeletionRequest` | `types/data_definitions.rs` | 543 | deletion request details |
+| `CreateDeletionRequestParams` | `types/data_definitions.rs` | 560 | creation params |
+| `PreviewDeletionFiltersParams` | `types/data_definitions.rs` | 570 | preview params |
+
+#### CLI Commands
+
+| Command | Rust File | Line |
+|---------|-----------|------|
+| `mp lexicon enforcement get/init/update/replace/delete` | `commands/lexicon.rs` | 247 |
+| `mp lexicon audit` | `commands/lexicon.rs` | 34 |
+| `mp lexicon anomalies list/update/bulk-update` | `commands/lexicon.rs` | 305 |
+| `mp lexicon deletion-requests list/create/cancel/preview` | `commands/lexicon.rs` | 349 |
+
+---
+
+## Implementation Phases
+
+### Phase 0: Architectural Prerequisites (OAuth + App API Infrastructure)
+**Domains**: 0a + 0b | **Est. LOC**: ~1,500 impl + ~1,500 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `_internal/auth/__init__.py` | Create | `auth/mod.rs` |
+| `_internal/auth/pkce.py` | Create | `auth/pkce.rs` |
+| `_internal/auth/token.py` | Create | `auth/token.rs:54` |
+| `_internal/auth/storage.py` | Create | `auth/storage.rs:11` |
+| `_internal/auth/callback_server.py` | Create | `auth/callback_server.rs` |
+| `_internal/auth/client_registration.py` | Create | `auth/client_registration.rs:43` |
+| `_internal/auth/flow.py` | Create | `auth/flow.rs:44` |
+| `_internal/config.py` | Modify — add `AuthMethod` enum, extend `Credentials` | `config.rs` |
+| `_internal/api_client.py` | Modify — add `app_request()`, Bearer auth, workspace scoping | `api_client.rs:302-560` |
+| `_internal/pagination.py` | Create | `types/pagination.rs:8-44` |
+| `types.py` | Add `PublicWorkspace` | `types/common.rs:334` |
+| `workspace.py` | Add `list_workspaces()`, `resolve_workspace_id()` | `workspace.rs:304-309` |
+| `exceptions.py` | Add `OAuthError` | — |
+| `cli/main.py` | Add `--workspace-id` global option | `cli.rs:47` |
+| `cli/commands/auth.py` | Add `login`, `logout`, `status`, `token` subcommands | `commands/auth.rs:52-58` |
+
+### Phase 1: Core Entity CRUD (Dashboards + Reports + Cohorts)
+**Domains**: 1 + 2 + 3 | **Est. LOC**: ~2,500 impl + ~2,500 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `types.py` | Add Dashboard, Bookmark, Cohort types (~14 models) | `types/dashboard.rs`, `types/bookmark.rs`, `types/cohorts.rs` |
+| `_internal/api_client.py` | Add ~35 API methods | `api_client.rs:1160-1510` |
+| `workspace.py` | Add ~27 methods | `workspace.rs:407-578` |
+| `cli/commands/dashboards.py` | Create (17 subcommands) | `commands/dashboards.rs` |
+| `cli/commands/reports.py` | Create (10 subcommands) | `commands/reports.rs` |
+| `cli/commands/cohorts.py` | Create (7 subcommands) | `commands/cohorts.rs` |
+
+### Phase 2: Feature Management (Flags + Experiments)
+**Domains**: 4 + 5 | **Est. LOC**: ~2,000 impl + ~2,000 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `types.py` | Add FeatureFlag, Experiment types (~19 models) | `types/feature_flags.rs`, `types/experiments.rs` |
+| `_internal/api_client.py` | Add ~23 API methods | `api_client.rs:1528-1760` |
+| `workspace.py` | Add ~23 methods | `workspace.rs:592-732` |
+| `cli/commands/flags.py` | Create (11 subcommands) | `commands/flags.rs` |
+| `cli/commands/experiments.py` | Create (12 subcommands) | `commands/experiments.rs` |
+
+### Phase 3: Operational Tooling (Alerts + Annotations + Webhooks)
+**Domains**: 6 + 7 + 8 | **Est. LOC**: ~1,800 impl + ~1,800 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `types.py` | Add Alert, Annotation, Webhook types (~20 models) | `types/alerts.rs`, `types/annotations.rs`, `types/webhooks.rs` |
+| `_internal/api_client.py` | Add ~23 API methods | `api_client.rs:2759-3130` |
+| `workspace.py` | Add ~23 methods | `workspace.rs:743-886` |
+| `cli/commands/alerts.py` | Create (11 subcommands) | `commands/alerts.rs` |
+| `cli/commands/annotations.py` | Create (7 subcommands) | `commands/annotations.rs` |
+| `cli/commands/webhooks.py` | Create (5 subcommands) | `commands/webhooks.rs` |
+
+### Phase 4: Data Governance (Lexicon + Custom + Drop Filters + Lookup Tables)
+**Domains**: 9 + 10 + 11 + 12 + 13 | **Est. LOC**: ~2,500 impl + ~2,500 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `types.py` | Add definitions, custom property, drop filter, lookup table types (~25 models) | `types/data_definitions.rs`, `types/custom_properties.rs` |
+| `_internal/api_client.py` | Add ~38 API methods | `api_client.rs:1881-2530` |
+| `workspace.py` | Add ~38 methods | `workspace.rs:897-1462` |
+| `cli/commands/lexicon.py` | Create (15+ subcommands) | `commands/lexicon.rs` |
+| `cli/commands/custom_properties.py` | Create (6 subcommands) | `commands/custom_properties.rs` |
+| `cli/commands/custom_events.py` | Create (3 subcommands) | `commands/custom_events.rs` |
+| `cli/commands/drop_filters.py` | Create (4 subcommands) | `commands/drop_filters.rs` |
+| `cli/commands/lookup_tables.py` | Create (7 subcommands) | `commands/lookup_tables.rs` |
+
+### Phase 5: Schema & Advanced (Schema Registry + Governance + Workspaces)
+**Domains**: 14 + 15 | **Est. LOC**: ~1,200 impl + ~1,200 tests
+
+| File (Python) | Action | Rust Reference |
+|---------------|--------|----------------|
+| `types.py` | Add schema, governance types (~16 models) | `types/discovery.rs:66-118`, `types/data_definitions.rs:392-580` |
+| `_internal/api_client.py` | Add ~20 API methods | `api_client.rs:2294-2620` |
+| `workspace.py` | Add ~20 methods | `workspace.rs:1015-1181` |
+| `cli/commands/schemas.py` | Create (4 subcommands) | `commands/schemas.rs` |
+| `cli/commands/lexicon.py` | Add enforcement + governance subcommands | `commands/lexicon.rs:247-410` |
+
+---
+
+## Architectural Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | OAuth as `_internal/auth/` module (7 files) | Mirrors Rust's `auth/` module structure; isolates complexity |
+| 2 | Synchronous API (`httpx.Client`) | Python library is synchronous; OAuth callback server uses `threading` |
+| 3 | Extend `MixpanelAPIClient` (not new class) | `"app"` URLs already in `ENDPOINTS` dict (`api_client.py:92-104`) |
+| 4 | Credential resolution: env > OAuth > named > default | Extends existing order; OAuth becomes preferred when available |
+| 5 | Types stay in `types.py` until split needed | Start with single file; split to `types/` package if >5000 lines |
+| 6 | One CLI file per domain | `cli/commands/{domain}.py` — mirrors Rust's `commands/` structure |
+| 7 | `respx` for HTTP mocking | Python equivalent of Rust's `wiremock`; transport-level mocking for `httpx` |
+| 8 | Frozen Pydantic BaseModel for new types | Matches existing pattern in `types.py` for immutable result types |
+
+---
+
+## Cross-Cutting Concerns
+
+### Testing Strategy (per phase)
+- **Unit tests**: `tests/test_{module}.py` with `respx` mocks
+- **Integration tests**: End-to-end with mock transport
+- **CLI tests**: `subprocess` + `assert` (matches existing pattern)
+- **Property-based tests**: Hypothesis for type round-trips (serde equivalence)
+- **Coverage target**: 90% per `just test-cov`
+
+### Type Conventions
+- Frozen Pydantic `BaseModel` with `ConfigDict(frozen=True)`
+- `SecretStr` for sensitive fields (OAuth tokens, webhook passwords)
+- Optional `.to_dict()` for JSON serialization
+- Optional `.df` property for DataFrame conversion (query results only)
+- `Extra.allow` via `extra` HashMap catch-all for forward compatibility
+
+### Error Handling
+- New: `OAuthError(MixpanelDataError)` for auth failures
+- New: `WorkspaceScopeError(MixpanelDataError)` for workspace resolution failures
+- Existing `APIError` hierarchy handles 4xx/5xx from App API endpoints
+
+### Output Formatting
+- All 5 existing formatters (json, jsonl, table, csv, plain) apply to new commands
+- No new formatters needed
+
+---
+
+## Reference File Mapping
+
+| Rust Source | Python Target |
+|-------------|---------------|
+| `mixpanel_data/src/auth/` (7 files) | `_internal/auth/` (7 files, new) |
+| `mixpanel_data/src/types/dashboard.rs` | `types.py` (Dashboard models) |
+| `mixpanel_data/src/types/bookmark.rs` | `types.py` (Bookmark models) |
+| `mixpanel_data/src/types/cohorts.rs` | `types.py` (Cohort models) |
+| `mixpanel_data/src/types/feature_flags.rs` | `types.py` (FeatureFlag models) |
+| `mixpanel_data/src/types/experiments.rs` | `types.py` (Experiment models) |
+| `mixpanel_data/src/types/alerts.rs` | `types.py` (Alert models) |
+| `mixpanel_data/src/types/annotations.rs` | `types.py` (Annotation models) |
+| `mixpanel_data/src/types/webhooks.rs` | `types.py` (Webhook models) |
+| `mixpanel_data/src/types/custom_properties.rs` | `types.py` (CustomProperty models) |
+| `mixpanel_data/src/types/data_definitions.rs` | `types.py` (Lexicon/governance models) |
+| `mixpanel_data/src/types/pagination.rs` | `_internal/pagination.py` (new) |
+| `mixpanel_data/src/types/common.rs` | `types.py` (PublicWorkspace, Permissions) |
+| `mixpanel_data/src/internal/api_client.rs` | `_internal/api_client.py` |
+| `mixpanel_data/src/workspace.rs` | `workspace.py` |
+| `mp_cli/src/commands/dashboards.rs` | `cli/commands/dashboards.py` (new) |
+| `mp_cli/src/commands/reports.rs` | `cli/commands/reports.py` (new) |
+| `mp_cli/src/commands/cohorts.rs` | `cli/commands/cohorts.py` (new) |
+| `mp_cli/src/commands/flags.rs` | `cli/commands/flags.py` (new) |
+| `mp_cli/src/commands/experiments.rs` | `cli/commands/experiments.py` (new) |
+| `mp_cli/src/commands/alerts.rs` | `cli/commands/alerts.py` (new) |
+| `mp_cli/src/commands/annotations.rs` | `cli/commands/annotations.py` (new) |
+| `mp_cli/src/commands/webhooks.rs` | `cli/commands/webhooks.py` (new) |
+| `mp_cli/src/commands/lexicon.rs` | `cli/commands/lexicon.py` (new) |
+| `mp_cli/src/commands/custom_properties.rs` | `cli/commands/custom_properties.py` (new) |
+| `mp_cli/src/commands/custom_events.rs` | `cli/commands/custom_events.py` (new) |
+| `mp_cli/src/commands/drop_filters.rs` | `cli/commands/drop_filters.py` (new) |
+| `mp_cli/src/commands/lookup_tables.rs` | `cli/commands/lookup_tables.py` (new) |
+| `mp_cli/src/commands/schemas.rs` | `cli/commands/schemas.py` (new) |
+
+---
+
+## Totals
+
+| Category | Count |
+|----------|-------|
+| New Workspace methods | ~98 |
+| New API client methods | ~137 |
+| New Pydantic types | ~54 |
+| New CLI command groups | 15 |
+| New CLI subcommands | ~85 |
+| New Python files | ~24 (7 auth + 1 pagination + 15 CLI commands + 1 test fixtures) |
+| Modified Python files | ~5 (api_client.py, config.py, workspace.py, types.py, exceptions.py, cli/main.py) |
+| Est. implementation LOC | ~11,500 |
+| Est. test LOC | ~11,500 |
+| **Est. total LOC** | **~23,000** |

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,29 +1,33 @@
 # Auth Module
 
-The auth module provides credential management and configuration.
+The auth module provides credential management, configuration, and OAuth 2.0 authentication.
 
 !!! tip "Explore on DeepWiki"
     🤖 **[Configuration Reference →](https://deepwiki.com/jaredmcfarland/mixpanel_data/7.3-configuration-reference)**
 
-    Ask questions about credential management, ConfigManager, or account configuration.
+    Ask questions about credential management, ConfigManager, OAuth, or account configuration.
 
 ## Overview
 
 ```python
-from mixpanel_data.auth import ConfigManager, Credentials, AccountInfo
+from mixpanel_data.auth import ConfigManager, Credentials, AccountInfo, AuthMethod
 
-# Manage accounts
+# Manage service accounts
 config = ConfigManager()
 config.add_account("production", username="...", secret="...", project_id="...", region="us")
 accounts = config.list_accounts()
 
-# Resolve credentials
+# Resolve credentials (checks env vars → OAuth tokens → config file)
 creds = config.resolve_credentials(account="production")
+
+# Check auth method
+if creds.auth_method == AuthMethod.oauth:
+    print(f"Using OAuth: {creds.auth_header()[:20]}...")
 ```
 
 ## ConfigManager
 
-Manages accounts stored in the TOML config file (`~/.mp/config.toml`).
+Manages accounts stored in the TOML config file (`~/.mp/config.toml`) and resolves credentials from multiple sources including OAuth tokens.
 
 ::: mixpanel_data.auth.ConfigManager
     options:
@@ -39,9 +43,28 @@ Manages accounts stored in the TOML config file (`~/.mp/config.toml`).
         - set_default
         - get_account
 
+## AuthMethod
+
+Enum for authentication method selection.
+
+::: mixpanel_data._internal.config.AuthMethod
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Credentials
 
-Immutable container for authentication credentials.
+Immutable container for authentication credentials. Supports both Basic Auth (service accounts) and OAuth Bearer token authentication.
+
+**Key fields:**
+
+- `username`, `secret`, `project_id`, `region` — Standard credential fields
+- `auth_method` — `AuthMethod.basic` (default) or `AuthMethod.oauth`
+- `oauth_access_token` — OAuth access token (required when `auth_method` is `oauth`)
+
+**Key methods:**
+
+- `auth_header()` — Returns the appropriate `Authorization` header value (`"Basic <base64>"` or `"Bearer <token>"`)
 
 ::: mixpanel_data.auth.Credentials
     options:
@@ -56,3 +79,69 @@ Account metadata (without the secret).
     options:
       show_root_heading: true
       show_root_toc_entry: true
+
+## OAuth 2.0 Module
+
+The OAuth module (`mixpanel_data._internal.auth`) implements the OAuth 2.0 PKCE flow for interactive authentication.
+
+### OAuthFlow
+
+Orchestrates the complete OAuth 2.0 PKCE login flow: dynamic client registration, browser-based authorization, token exchange, and token refresh.
+
+```python
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.storage import OAuthStorage
+
+storage = OAuthStorage()
+flow = OAuthFlow(region="us", storage=storage)
+
+# Interactive login (opens browser)
+tokens = flow.login(project_id="12345")
+
+# Get valid token (auto-refreshes if expired)
+tokens = flow.get_valid_token(region="us")
+```
+
+### OAuthTokens
+
+Immutable model for OAuth access and refresh tokens.
+
+**Key fields:** `access_token`, `refresh_token`, `expires_at`, `scope`, `token_type`, `project_id`
+
+**Key methods:** `is_expired()` (includes 30-second safety buffer), `from_token_response(data, project_id)`
+
+### OAuthClientInfo
+
+Dynamic Client Registration metadata.
+
+**Key fields:** `client_id`, `client_secret`, `redirect_uris`, `created_at`, `expires_at`
+
+**Key methods:** `is_expired()`, `from_dcr_response(data)`
+
+### OAuthStorage
+
+Manages JSON persistence of tokens and client info at `~/.mp/oauth/`.
+
+```python
+from mixpanel_data._internal.auth.storage import OAuthStorage
+
+storage = OAuthStorage()
+tokens = storage.load_tokens(region="us")
+regions = storage.list_regions_with_tokens()
+storage.delete_all()  # Clear all regions
+```
+
+**Key methods:** `load_tokens(region)`, `save_tokens(tokens, region)`, `delete_tokens(region)`, `load_client_info(region)`, `save_client_info(client_info, region)`, `delete_all()`, `list_regions_with_tokens()`
+
+### PkceChallenge
+
+PKCE challenge generation (RFC 7636).
+
+```python
+from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+challenge = PkceChallenge.generate()
+# challenge.verifier — URL-safe random string (43-128 chars)
+# challenge.challenge — SHA256 hash, Base64URL encoded
+# challenge.challenge_method — Always "S256"
+```

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -114,9 +114,7 @@ Immutable model for OAuth access and refresh tokens.
 
 Dynamic Client Registration metadata.
 
-**Key fields:** `client_id`, `client_secret`, `redirect_uris`, `created_at`, `expires_at`
-
-**Key methods:** `is_expired()`, `from_dcr_response(data)`
+**Key fields:** `client_id`, `region`, `redirect_uri`, `scope`, `created_at`
 
 ### OAuthStorage
 
@@ -127,11 +125,11 @@ from mixpanel_data._internal.auth.storage import OAuthStorage
 
 storage = OAuthStorage()
 tokens = storage.load_tokens(region="us")
-regions = storage.list_regions_with_tokens()
+storage.delete_tokens(region="us")
 storage.delete_all()  # Clear all regions
 ```
 
-**Key methods:** `load_tokens(region)`, `save_tokens(tokens, region)`, `delete_tokens(region)`, `load_client_info(region)`, `save_client_info(client_info, region)`, `delete_all()`, `list_regions_with_tokens()`
+**Key methods:** `load_tokens(region)`, `save_tokens(tokens, region)`, `delete_tokens(region)`, `load_client_info(region)`, `save_client_info(info)`, `delete_all()`
 
 ### PkceChallenge
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -20,6 +20,8 @@ MixpanelDataError
 │   ├── QueryError
 │   ├── ServerError
 │   └── JQLSyntaxError
+├── OAuthError
+├── WorkspaceScopeError
 ├── TableExistsError
 ├── TableNotFoundError
 ├── DatabaseLockedError
@@ -38,6 +40,10 @@ except mp.AuthenticationError as e:
     print(f"Auth failed: {e.message}")
 except mp.RateLimitError as e:
     print(f"Rate limited, retry after {e.retry_after}s")
+except mp.OAuthError as e:
+    print(f"OAuth error [{e.code}]: {e.message}")
+except mp.WorkspaceScopeError as e:
+    print(f"Workspace error [{e.code}]: {e.message}")
 except mp.MixpanelDataError as e:
     print(f"Error [{e.code}]: {e.message}")
 ```
@@ -94,6 +100,39 @@ except mp.MixpanelDataError as e:
       show_root_toc_entry: true
 
 ::: mixpanel_data.AccountExistsError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+## OAuth Exceptions
+
+Raised during OAuth 2.0 PKCE authentication flows.
+
+| Error Code | Raised When |
+|------------|-------------|
+| `OAUTH_TOKEN_ERROR` | Token exchange fails |
+| `OAUTH_REFRESH_ERROR` | Token refresh fails |
+| `OAUTH_REGISTRATION_ERROR` | Dynamic client registration fails |
+| `OAUTH_TIMEOUT` | Callback server times out waiting for authorization |
+| `OAUTH_PORT_ERROR` | Cannot bind to a local port for the callback server |
+| `OAUTH_BROWSER_ERROR` | Cannot open the authorization URL in the browser |
+
+::: mixpanel_data.OAuthError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+## Workspace Exceptions
+
+Raised when workspace resolution fails for App API endpoints.
+
+| Error Code | Raised When |
+|------------|-------------|
+| `NO_WORKSPACES` | No workspaces found for the project |
+| `AMBIGUOUS_WORKSPACE` | Multiple workspaces found and none is marked as default |
+| `WORKSPACE_NOT_FOUND` | Specified workspace ID does not exist |
+
+::: mixpanel_data.WorkspaceScopeError
     options:
       show_root_heading: true
       show_root_toc_entry: true

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -20,7 +20,13 @@ result = ws.segmentation(...)
 from mixpanel_data import Workspace, FetchResult, MixpanelDataError
 
 # Auth utilities
-from mixpanel_data.auth import ConfigManager, Credentials
+from mixpanel_data.auth import ConfigManager, Credentials, AuthMethod
+
+# OAuth and workspace exceptions
+from mixpanel_data import OAuthError, WorkspaceScopeError
+
+# App API types
+from mixpanel_data import PublicWorkspace, CursorPagination, PaginatedResponse
 ```
 
 ## Core Components
@@ -43,8 +49,11 @@ The main entry point for all operations:
 Credential and account management:
 
 - **ConfigManager** — Manage accounts in config file
-- **Credentials** — Credential container with secrets
+- **Credentials** — Credential container with secrets (Basic Auth and OAuth)
+- **AuthMethod** — Authentication method enum (`basic`, `oauth`)
 - **AccountInfo** — Account metadata (without secrets)
+- **OAuthFlow** — OAuth 2.0 PKCE login flow orchestration
+- **OAuthStorage** — Local token and client info persistence
 
 [View Auth API](auth.md)
 
@@ -55,6 +64,8 @@ Structured error handling:
 - **MixpanelDataError** — Base exception
 - **APIError** — HTTP/API errors
 - **ConfigError** — Configuration errors
+- **OAuthError** — OAuth authentication errors
+- **WorkspaceScopeError** — Workspace resolution errors
 - **TableExistsError** / **TableNotFoundError** — Storage errors
 
 [View Exceptions](exceptions.md)

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -11,6 +11,25 @@ All result types are immutable frozen dataclasses with:
 - JSON serialization via the `.to_dict()` method
 - Full type hints for IDE/mypy support
 
+## App API Types
+
+Types for the Mixpanel App API infrastructure.
+
+::: mixpanel_data.PublicWorkspace
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.CursorPagination
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.PaginatedResponse
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Fetch Results
 
 ::: mixpanel_data.FetchResult

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -136,6 +136,10 @@ ws.fetch_profiles(
         - open
         - close
         - test_credentials
+        - workspace_id
+        - set_workspace_id
+        - list_workspaces
+        - resolve_workspace_id
         - events
         - properties
         - property_values

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -26,6 +26,7 @@ mp --version
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--account` | `-a` | Account name to use (overrides default) |
+| `--workspace-id` | | Workspace ID for App API operations (env: `MP_WORKSPACE_ID`) |
 | `--quiet` | `-q` | Suppress progress output |
 | `--verbose` | `-v` | Enable debug output |
 | `--version` | | Show version and exit |
@@ -33,18 +34,22 @@ mp --version
 
 ## Command Groups
 
-### auth — Account Management
+### auth — Account & Authentication Management
 
-Manage stored credentials and accounts.
+Manage stored credentials, accounts, and OAuth authentication.
 
 | Command | Description |
 |---------|-------------|
-| `mp auth list` | List configured accounts |
-| `mp auth add` | Add a new account |
-| `mp auth remove` | Remove an account |
+| `mp auth list` | List configured service accounts |
+| `mp auth add` | Add a new service account |
+| `mp auth remove` | Remove a service account |
 | `mp auth switch` | Set the default account |
 | `mp auth show` | Display account details |
 | `mp auth test` | Test account credentials |
+| `mp auth login` | OAuth 2.0 login via browser |
+| `mp auth logout` | Remove stored OAuth tokens |
+| `mp auth status` | Show OAuth authentication state per region |
+| `mp auth token` | Output raw OAuth access token (for piping) |
 
 ### fetch — Data Fetching
 
@@ -298,6 +303,9 @@ mp query sql "SELECT * FROM events" --format jsonl | python process.py
 | 5 | Rate limit exceeded | `RateLimitError` |
 | 130 | Interrupted | Ctrl+C |
 
+!!! note "OAuth and Workspace Errors"
+    `OAuthError` maps to exit code 2 (authentication error). `WorkspaceScopeError` maps to exit code 1 (general error).
+
 ## Environment Variables
 
 | Variable | Description |
@@ -306,6 +314,7 @@ mp query sql "SELECT * FROM events" --format jsonl | python process.py
 | `MP_SECRET` | Service account secret |
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency region |
+| `MP_WORKSPACE_ID` | Workspace ID for App API operations |
 | `MP_ACCOUNT` | Account name to use |
 | `MP_CONFIG_PATH` | Override config file path |
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,22 +1,32 @@
 # Configuration
 
-mixpanel_data uses Service Accounts for authentication and supports multiple configuration methods for credentials and settings.
+mixpanel_data supports two authentication methods: **Service Accounts** (Basic Auth) for server-side automation and **OAuth 2.0** for interactive use. Both methods support multiple configuration approaches.
 
 !!! tip "Explore on DeepWiki"
     🤖 **[Authentication Setup →](https://deepwiki.com/jaredmcfarland/mixpanel_data/2.2-authentication-setup)**
 
-    Ask questions about service accounts, environment variables, or multi-account configuration.
+    Ask questions about service accounts, OAuth, environment variables, or multi-account configuration.
+
+## Authentication Methods
+
+| Method | Best For | How It Works |
+|--------|----------|--------------|
+| **Service Account** (Basic Auth) | Scripts, CI/CD, automation | Username + secret from env vars or config file |
+| **OAuth 2.0** (PKCE) | Interactive use, personal access | Browser-based login, tokens stored locally |
+
+Service accounts are the default and work everywhere. OAuth is ideal when you want to authenticate as yourself without managing service account credentials.
 
 ## Environment Variables
 
-Set these environment variables to configure credentials:
+Set these environment variables to configure service account credentials:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `MP_USERNAME` | Service account username | Yes |
-| `MP_SECRET` | Service account secret | Yes |
+| `MP_USERNAME` | Service account username | Yes (Basic Auth) |
+| `MP_SECRET` | Service account secret | Yes (Basic Auth) |
 | `MP_PROJECT_ID` | Mixpanel project ID | Yes |
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) | No (default: `us`) |
+| `MP_WORKSPACE_ID` | Workspace ID for App API operations | No |
 | `MP_CONFIG_PATH` | Override config file location | No |
 | `MP_ACCOUNT` | Account name to use from config file | No |
 
@@ -130,14 +140,77 @@ config.set_default("production")
 config.remove_account("old_account")
 ```
 
+## OAuth Authentication
+
+OAuth 2.0 with PKCE provides browser-based login without managing service account credentials. Tokens are stored locally per region.
+
+### Login
+
+```bash
+# Login to your default region
+mp auth login
+
+# Login to a specific region and project
+mp auth login --region eu --project-id 12345
+```
+
+This opens your browser for Mixpanel authorization. After approval, tokens are saved to `~/.mp/oauth/{region}/`.
+
+### Check Status
+
+```bash
+mp auth status
+```
+
+Shows authentication state for each region (us, eu, in), including token expiry and scope.
+
+### Get a Token
+
+```bash
+# Output raw access token (useful for piping to other tools)
+mp auth token
+
+# Use with curl
+curl -H "Authorization: Bearer $(mp auth token)" https://mixpanel.com/api/app/...
+```
+
+### Logout
+
+```bash
+# Logout from a specific region
+mp auth logout --region us
+
+# Logout from all regions
+mp auth logout
+```
+
+### Token Storage
+
+OAuth tokens are stored as JSON files:
+
+```
+~/.mp/oauth/
+├── us/
+│   ├── tokens.json        # Access/refresh tokens, expiry, scope
+│   └── client_info.json   # Dynamic client registration data
+├── eu/
+│   └── ...
+└── in/
+    └── ...
+```
+
+Tokens are automatically refreshed when expired. The client registration is cached per region.
+
 ## Credential Resolution Order
 
 When creating a Workspace, credentials are resolved in this order:
 
-1. **Explicit arguments** — `Workspace(project_id=..., region=...)`
-2. **Environment variables** — `MP_USERNAME`, `MP_SECRET`, etc.
+1. **Environment variables** — `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION` (all four required)
+2. **OAuth tokens** — Valid (non-expired) tokens from `~/.mp/oauth/`
 3. **Named account** — `Workspace(account="staging")` or `MP_ACCOUNT=staging`
 4. **Default account** — The account marked as `default` in config.toml
+
+If environment variables provide all four values, they take priority. Otherwise, the system checks for a valid OAuth token before falling back to config file accounts.
 
 Example showing resolution:
 
@@ -151,7 +224,7 @@ ws = mp.Workspace(
     project_id="12345"
 )
 
-# Uses environment variables (if set)
+# Uses environment variables (if set), then OAuth, then config
 ws = mp.Workspace()
 
 # Uses named account from config file
@@ -170,6 +243,33 @@ Mixpanel stores data in regional data centers. Use the correct region for your p
 
 !!! warning "Region Mismatch"
     Using the wrong region will result in authentication errors or empty data.
+
+## Workspace ID
+
+Some App API endpoints are scoped to a workspace. You can set a workspace ID globally:
+
+```bash
+# CLI: global option
+mp --workspace-id 123 inspect events
+
+# Or via environment variable
+export MP_WORKSPACE_ID=123
+```
+
+```python
+import mixpanel_data as mp
+
+# Set at construction
+ws = mp.Workspace(workspace_id=123)
+
+# Or set later
+ws.set_workspace_id(123)
+
+# Auto-discover (uses default workspace)
+ws_id = ws.resolve_workspace_id()
+```
+
+If no workspace ID is set, workspace-scoped endpoints will auto-discover by listing available workspaces and selecting the default.
 
 ## Workspace Path
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -190,13 +190,12 @@ OAuth tokens are stored as JSON files:
 
 ```
 ~/.mp/oauth/
-├── us/
-│   ├── tokens.json        # Access/refresh tokens, expiry, scope
-│   └── client_info.json   # Dynamic client registration data
-├── eu/
-│   └── ...
-└── in/
-    └── ...
+├── tokens_us.json         # Access/refresh tokens, expiry, scope
+├── client_us.json         # Dynamic client registration data
+├── tokens_eu.json
+├── client_eu.json
+├── tokens_in.json
+└── client_in.json
 ```
 
 Tokens are automatically refreshed when expired. The client registration is cached per region.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,12 +12,12 @@ This guide walks you through your first queries with mixpanel_data in about 5 mi
 You'll need:
 
 - mixpanel_data installed (`pip install git+https://github.com/jaredmcfarland/mixpanel_data.git`)
-- A Mixpanel service account with username, secret, and project ID
+- **Either** a Mixpanel service account (username, secret, project ID) **or** a Mixpanel user account (for OAuth login)
 - Your project's data residency region (us, eu, or in)
 
-## Step 1: Set Up Service Account Credentials
+## Step 1: Set Up Credentials
 
-### Option A: Environment Variables
+### Option A: Environment Variables (Service Account)
 
 ```bash
 export MP_USERNAME="sa_abc123..."
@@ -26,7 +26,7 @@ export MP_PROJECT_ID="12345"
 export MP_REGION="us"
 ```
 
-### Option B: Using the CLI
+### Option B: Config File (Service Account)
 
 ```bash
 # Interactive prompt (secure, recommended)
@@ -48,6 +48,20 @@ MP_SECRET=your-secret mp auth add production --username sa_abc123... --project 1
 # Via stdin
 echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 --secret-stdin
 ```
+
+### Option C: OAuth Login (Interactive)
+
+For interactive use without managing service account credentials:
+
+```bash
+# Login via browser (opens Mixpanel authorization page)
+mp auth login --region us --project-id 12345
+
+# Check your auth status
+mp auth status
+```
+
+OAuth tokens are stored locally at `~/.mp/oauth/` and automatically refreshed when expired. See [Configuration](configuration.md#oauth-authentication) for details.
 
 ## Step 2: Test Your Connection
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # mixpanel_data
 
-A complete programmable interface to Mixpanel analytics—available as both a Python library and CLI.
+A complete programmable interface to Mixpanel analytics—available as both a Python library and CLI. Supports service account and OAuth 2.0 authentication.
 
 !!! tip "AI-Friendly Documentation"
     🤖 **[Explore on DeepWiki →](https://deepwiki.com/jaredmcfarland/mixpanel_data)**

--- a/mp_mcp/uv.lock
+++ b/mp_mcp/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1140,6 +1140,7 @@ dev = [
     { name = "click-man", specifier = ">=0.5.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "psutil", specifier = ">=7.2.0" },
+    { name = "ruff", specifier = ">=0.1" },
     { name = "types-psutil", specifier = ">=7.2.0.20251228" },
 ]
 
@@ -1153,7 +1154,7 @@ wheels = [
 ]
 
 [[package]]
-name = "mp_mcp"
+name = "mp-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [

--- a/specs/023-oauth-app-api-infra/checklists/requirements.md
+++ b/specs/023-oauth-app-api-infra/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: OAuth PKCE & App API Infrastructure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references specific RFC numbers (7636, 7591) which are standards, not implementation details.
+- File permission values (0o700, 0o600) are specified as requirements, not implementation — they define the security contract.
+- Port numbers (19284–19287) are specified as requirements matching the reference implementation's contract.

--- a/specs/023-oauth-app-api-infra/contracts/library-api.md
+++ b/specs/023-oauth-app-api-infra/contracts/library-api.md
@@ -1,0 +1,238 @@
+# Library API Contract: OAuth & App API Infrastructure
+
+**Feature**: 023-oauth-app-api-infra | **Date**: 2026-03-25
+
+This document defines the public API surface added by this feature. All methods below become part of the stable `mixpanel_data` public API.
+
+## Workspace Class Extensions
+
+### OAuth Authentication
+
+```python
+# No new public methods on Workspace for auth — auth is handled via:
+# 1. OAuthFlow class (for CLI login)
+# 2. Credential resolution (automatic for library users)
+```
+
+### Workspace Discovery
+
+```python
+class Workspace:
+    def list_workspaces(self) -> list[PublicWorkspace]:
+        """List all workspaces in the current project.
+
+        Returns:
+            List of PublicWorkspace objects with id, name, is_default.
+
+        Raises:
+            OAuthError: If OAuth tokens are missing or expired.
+            AuthenticationError: If credentials are invalid.
+            APIError: If the API request fails.
+        """
+
+    def resolve_workspace_id(self) -> int:
+        """Resolve the workspace ID for App API requests.
+
+        Resolution order:
+        1. Explicit workspace_id (set via constructor or set_workspace_id())
+        2. Auto-discover default workspace from project
+
+        Returns:
+            Integer workspace ID.
+
+        Raises:
+            WorkspaceScopeError: If no workspace can be resolved.
+            OAuthError: If OAuth tokens are missing or expired.
+        """
+
+    def set_workspace_id(self, workspace_id: int | None) -> None:
+        """Set explicit workspace ID for App API requests.
+
+        Args:
+            workspace_id: Workspace ID, or None to use auto-discovery.
+        """
+
+    @property
+    def workspace_id(self) -> int | None:
+        """Currently set workspace ID, or None if using auto-discovery."""
+```
+
+## New Public Types
+
+### PublicWorkspace
+
+```python
+class PublicWorkspace(BaseModel):
+    """A workspace within a Mixpanel project."""
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    id: int
+    name: str
+    project_id: int
+    is_default: bool
+    description: str | None = None
+    is_global: bool | None = None
+    is_restricted: bool | None = None
+    is_visible: bool | None = None
+    created_iso: str | None = None
+    creator_name: str | None = None
+```
+
+### PaginatedResponse (Generic)
+
+```python
+class CursorPagination(BaseModel):
+    """Cursor-based pagination metadata."""
+    model_config = ConfigDict(frozen=True)
+
+    page_size: int
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Paginated App API response wrapper."""
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    results: list[T]
+    pagination: CursorPagination | None = None
+```
+
+## New Exception Types
+
+```python
+class OAuthError(MixpanelDataError):
+    """OAuth authentication flow error."""
+    # code: str — one of OAUTH_TOKEN_ERROR, OAUTH_REFRESH_ERROR,
+    #   OAUTH_REGISTRATION_ERROR, OAUTH_TIMEOUT, OAUTH_PORT_ERROR, OAUTH_BROWSER_ERROR
+
+class WorkspaceScopeError(MixpanelDataError):
+    """Workspace resolution error."""
+    # code: str — one of NO_WORKSPACES, AMBIGUOUS_WORKSPACE, WORKSPACE_NOT_FOUND
+```
+
+## CLI Command Contract
+
+### `mp auth login`
+
+```
+Usage: mp auth login [OPTIONS]
+
+  Authenticate with Mixpanel via OAuth 2.0 PKCE flow.
+
+Options:
+  --region TEXT  Region (us, eu, in) [default: from config]
+  --help         Show this message and exit.
+
+Exit codes:
+  0  Login successful
+  1  General error
+  2  Authentication error (OAuth flow failed)
+
+Output (stderr): Progress messages during flow
+Output (stdout): JSON confirmation on success
+```
+
+### `mp auth logout`
+
+```
+Usage: mp auth logout [OPTIONS]
+
+  Remove stored OAuth tokens.
+
+Options:
+  --region TEXT  Region (us, eu, in) [default: all regions]
+  --help         Show this message and exit.
+
+Exit codes:
+  0  Tokens removed
+  1  General error
+```
+
+### `mp auth status`
+
+```
+Usage: mp auth status [OPTIONS]
+
+  Show current authentication status.
+
+Options:
+  --format TEXT  Output format (json, table, plain) [default: table]
+  --help         Show this message and exit.
+
+Exit codes:
+  0  Status displayed
+  1  General error
+
+Output (stdout): Auth method, token expiry, project ID, region
+```
+
+### `mp auth token`
+
+```
+Usage: mp auth token [OPTIONS]
+
+  Output current OAuth access token.
+
+Options:
+  --region TEXT  Region [default: from config]
+  --help         Show this message and exit.
+
+Exit codes:
+  0  Token printed to stdout
+  1  General error
+  2  No valid token available
+
+Output (stdout): Raw access token string (for piping to other tools)
+```
+
+### Global Option Addition
+
+```
+--workspace-id INTEGER  Workspace ID for App API operations [env: MP_WORKSPACE_ID]
+```
+
+Added to the `main()` callback, available to all commands.
+
+## Internal API Contract (for domain implementors)
+
+These methods are on `MixpanelAPIClient` (internal, but stable for domain extensions):
+
+```python
+class MixpanelAPIClient:
+    def app_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> Any:
+        """Make an authenticated App API request.
+
+        Handles auth header selection, workspace scoping, and result unwrapping.
+        """
+
+    def app_request_paginated(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        page_size: int = 100,
+    ) -> Iterator[T]:
+        """Make a paginated App API GET request, yielding all results."""
+
+    def maybe_scoped_path(self, domain_path: str) -> str:
+        """Optionally scope path with workspace ID (top-level pattern)."""
+
+    def require_scoped_path(self, domain_path: str) -> str:
+        """Always scope path with workspace ID (project-nested pattern).
+        Raises WorkspaceScopeError if workspace cannot be resolved.
+        """
+
+    def set_workspace_id(self, workspace_id: int | None) -> None:
+        """Set explicit workspace ID."""
+
+    def resolve_workspace_id(self) -> int:
+        """Resolve workspace ID (explicit or auto-discovered)."""
+```

--- a/specs/023-oauth-app-api-infra/data-model.md
+++ b/specs/023-oauth-app-api-infra/data-model.md
@@ -1,0 +1,216 @@
+# Data Model: OAuth PKCE & App API Infrastructure
+
+**Feature**: 023-oauth-app-api-infra | **Date**: 2026-03-25
+
+## Entities
+
+### 1. AuthMethod (Enum)
+
+Discriminator for authentication strategy.
+
+| Value | Description |
+|-------|-------------|
+| `basic` | Service account Basic Auth (username + secret) |
+| `oauth` | OAuth 2.0 Bearer token |
+
+**Relationships**: Referenced by `Credentials` to determine which auth header to generate.
+
+---
+
+### 2. Credentials (Extended)
+
+Immutable authentication container. Extended to support both Basic Auth and OAuth.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `username` | string | Yes (basic) | Service account username |
+| `secret` | secret string | Yes (basic) | Service account secret (redacted) |
+| `project_id` | string | Yes | Mixpanel project identifier |
+| `region` | "us" \| "eu" \| "in" | Yes | Data residency region |
+| `auth_method` | AuthMethod | Yes | Which auth strategy to use |
+| `oauth_tokens` | OAuthTokens \| None | No | OAuth tokens (when auth_method=oauth) |
+
+**Validation**:
+- `username` and `project_id` must be non-empty strings
+- `region` must be one of: us, eu, in
+- If `auth_method=basic`, `username` and `secret` are required
+- If `auth_method=oauth`, `oauth_tokens` must be present
+
+**State transitions**: None (immutable after construction)
+
+---
+
+### 3. OAuthTokens
+
+Immutable token set from an OAuth 2.0 token response.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `access_token` | secret string | Yes | Bearer token for API requests (redacted) |
+| `refresh_token` | secret string \| None | No | Token for refreshing access (redacted) |
+| `expires_at` | datetime (UTC) | Yes | When the access token expires |
+| `scope` | string | Yes | Space-separated list of granted scopes |
+| `token_type` | string | Yes | Always "Bearer" |
+| `project_id` | string \| None | No | Associated project (preserved through refresh) |
+
+**Validation**:
+- `access_token` must be non-empty
+- `expires_at` must be a valid UTC datetime
+- `token_type` must be "Bearer"
+
+**Derived behavior**:
+- `is_expired()`: Returns true if `now + 30 seconds >= expires_at`
+
+**State transitions**: Immutable. Token refresh produces a new `OAuthTokens` instance.
+
+**Persistence**: JSON file at `~/.mp/oauth/tokens_{region}.json`
+
+---
+
+### 4. PkceChallenge
+
+Single-use PKCE verifier/challenge pair for one authorization flow.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `verifier` | string | Yes | 86-char base64url string (from 64 random bytes) |
+| `challenge` | string | Yes | base64url SHA-256 hash of verifier |
+
+**Validation**:
+- `verifier` length must be 43–128 characters (RFC 7636)
+- `challenge` must be base64url-encoded
+
+**State transitions**: None (immutable, ephemeral — used once per flow, never persisted)
+
+---
+
+### 5. OAuthClientInfo
+
+Cached Dynamic Client Registration result.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `client_id` | string | Yes | Registered client identifier |
+| `region` | "us" \| "eu" \| "in" | Yes | Region this registration is for |
+| `redirect_uri` | string | Yes | Callback URI used during registration |
+| `scope` | string | Yes | Requested scope string |
+| `created_at` | datetime (UTC) | Yes | When registration occurred |
+
+**Validation**:
+- `client_id` must be non-empty
+- `redirect_uri` must start with `http://localhost:`
+
+**Persistence**: JSON file at `~/.mp/oauth/client_{region}.json`
+
+**Cache invalidation**: Re-register if `redirect_uri` doesn't match (port changed)
+
+---
+
+### 6. CallbackResult
+
+Result from the ephemeral OAuth callback server.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | string | Yes | Authorization code from Mixpanel |
+| `state` | string | Yes | State token for CSRF validation |
+
+**Validation**:
+- Both fields must be non-empty
+- `state` must match the value sent in the authorization request
+
+**State transitions**: None (ephemeral, consumed immediately by token exchange)
+
+---
+
+### 7. PublicWorkspace
+
+Organizational unit within a Mixpanel project.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | Yes | Workspace identifier |
+| `name` | string | Yes | Human-readable workspace name |
+| `project_id` | integer | Yes | Parent project identifier |
+| `is_default` | boolean | Yes | Whether this is the default workspace |
+| `description` | string \| None | No | Workspace description |
+| `is_global` | boolean \| None | No | Whether workspace is global |
+| `is_restricted` | boolean \| None | No | Whether workspace has restrictions |
+| `is_visible` | boolean \| None | No | Whether workspace is visible |
+| `created_iso` | string \| None | No | ISO 8601 creation timestamp |
+| `creator_name` | string \| None | No | Name of workspace creator |
+
+**Relationships**: A project has one or more workspaces. One workspace is `is_default=true`.
+
+---
+
+### 8. PaginatedResponse
+
+Generic wrapper for paginated App API responses.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | string | Yes | Response status (typically "ok") |
+| `results` | list[T] | Yes | Page of results |
+| `pagination` | CursorPagination \| None | No | Pagination metadata |
+
+---
+
+### 9. CursorPagination
+
+Cursor-based pagination metadata.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `page_size` | integer | Yes | Number of items per page |
+| `next_cursor` | string \| None | No | Cursor for next page (None = last page) |
+| `previous_cursor` | string \| None | No | Cursor for previous page |
+
+---
+
+## Entity Relationship Diagram
+
+```
+Credentials ──has──> AuthMethod
+    │
+    └──has (optional)──> OAuthTokens ──persisted as──> tokens_{region}.json
+
+OAuthFlow ──generates──> PkceChallenge (ephemeral)
+    │
+    ├──uses──> OAuthClientInfo ──persisted as──> client_{region}.json
+    │
+    ├──starts──> CallbackServer ──produces──> CallbackResult
+    │
+    └──exchanges──> authorization code ──for──> OAuthTokens
+
+MixpanelAPIClient ──uses──> Credentials
+    │
+    ├──discovers──> PublicWorkspace (via list_workspaces)
+    │
+    └──returns──> PaginatedResponse<T> ──contains──> CursorPagination
+```
+
+## Exception Types
+
+### OAuthError
+
+Inherits from `MixpanelDataError`. Raised for OAuth-specific failures.
+
+| Scenario | Error Code | Description |
+|----------|------------|-------------|
+| Token exchange fails | `OAUTH_TOKEN_ERROR` | Invalid grant, expired code |
+| Token refresh fails | `OAUTH_REFRESH_ERROR` | Refresh token expired/revoked |
+| DCR fails | `OAUTH_REGISTRATION_ERROR` | Client registration rejected |
+| Callback timeout | `OAUTH_TIMEOUT` | No callback received within timeout |
+| Port unavailable | `OAUTH_PORT_ERROR` | All callback ports occupied |
+| Browser open fails | `OAUTH_BROWSER_ERROR` | Could not open browser (URL printed as fallback) |
+
+### WorkspaceScopeError
+
+Inherits from `MixpanelDataError`. Raised when workspace resolution fails.
+
+| Scenario | Error Code | Description |
+|----------|------------|-------------|
+| No workspaces found | `NO_WORKSPACES` | Project has no accessible workspaces |
+| Multiple workspaces, none default | `AMBIGUOUS_WORKSPACE` | Must specify `--workspace-id` |
+| Workspace ID not found | `WORKSPACE_NOT_FOUND` | Explicit ID doesn't match any workspace |

--- a/specs/023-oauth-app-api-infra/plan.md
+++ b/specs/023-oauth-app-api-infra/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: OAuth PKCE & App API Infrastructure
+
+**Branch**: `023-oauth-app-api-infra` | **Date**: 2026-03-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/023-oauth-app-api-infra/spec.md`
+
+## Summary
+
+Add OAuth 2.0 PKCE authentication and App API request infrastructure to `mixpanel_data`, enabling all future CRUD operations across 15+ Mixpanel entity domains. This creates a 7-file `_internal/auth/` module (PKCE, token management, DCR, callback server, flow orchestrator), extends the API client with `app_request()` + workspace scoping + cursor pagination, adds `OAuthError`/`WorkspaceScopeError` exceptions, and provides `mp auth login/logout/status/token` CLI commands with a global `--workspace-id` option.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (mypy --strict)
+**Primary Dependencies**: httpx (HTTP client), Pydantic v2 (validation), Typer (CLI), Rich (output)
+**Storage**: JSON files at `~/.mp/oauth/` (token + client info persistence); DuckDB unchanged
+**Testing**: pytest + respx (HTTP mocking) + Hypothesis (PBT); 90% coverage target
+**Target Platform**: macOS / Linux (Unix file permissions)
+**Project Type**: Library + CLI
+**Performance Goals**: OAuth login < 60s; token refresh transparent; pagination fetches all pages
+**Constraints**: No new external dependencies (stdlib for crypto, threading, http.server)
+**Scale/Scope**: ~1,500 LOC implementation + ~1,500 LOC tests across ~15 new/modified files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Library-First** | PASS | All OAuth + App API methods exposed on Workspace class first. CLI delegates to library. |
+| **II. Agent-Native Design** | PASS | No interactive prompts in default path. `mp auth login` opens browser non-interactively. All output structured JSON. Exit codes follow convention. |
+| **III. Context Window Efficiency** | PASS | Workspace auto-discovery cached after first call. Pagination aggregates results. No raw data dumps. |
+| **IV. Two Data Paths** | PASS | App API is a new live query path. No local storage changes needed. Shares auth/config. |
+| **V. Explicit Over Implicit** | PASS | Auth method selection is explicit (endpoint category). Workspace ID settable explicitly. Token refresh is the one implicit behavior — justified by usability. |
+| **VI. Unix Philosophy** | PASS | `mp auth token` outputs raw token for piping. All commands support `--format json`. Errors to stderr. |
+| **VII. Secure by Default** | PASS | Tokens stored with 0o600 perms. Secrets use `SecretStr`. Never logged. `mp auth token` is intentional exception (explicit user action). |
+
+**Gate result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-oauth-app-api-infra/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: research findings
+├── data-model.md        # Phase 1: entity definitions
+├── quickstart.md        # Phase 1: usage guide
+├── contracts/
+│   └── library-api.md   # Phase 1: public API contract
+├── checklists/
+│   └── requirements.md  # Spec quality validation
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── __init__.py                          # Add: OAuthError, WorkspaceScopeError, PublicWorkspace exports
+├── workspace.py                         # Add: list_workspaces(), resolve_workspace_id(), set_workspace_id()
+├── exceptions.py                        # Add: OAuthError, WorkspaceScopeError
+├── types.py                             # Add: PublicWorkspace, CursorPagination, PaginatedResponse
+├── _internal/
+│   ├── config.py                        # Modify: AuthMethod enum, extend Credentials
+│   ├── api_client.py                    # Modify: app_request(), workspace scoping, pagination
+│   ├── pagination.py                    # NEW: paginate_all() helper
+│   └── auth/                            # NEW: OAuth module (7 files)
+│       ├── __init__.py                  # Module re-exports
+│       ├── pkce.py                      # PkceChallenge (S256)
+│       ├── token.py                     # OAuthTokens model
+│       ├── storage.py                   # OAuthStorage (JSON files, perms)
+│       ├── callback_server.py           # Ephemeral HTTP server
+│       ├── client_registration.py       # DCR (RFC 7591)
+│       └── flow.py                      # OAuthFlow orchestrator
+└── cli/
+    ├── main.py                          # Modify: --workspace-id global option
+    └── commands/
+        └── auth.py                      # Modify: add login, logout, status, token
+
+tests/
+├── test_auth_pkce.py                    # PKCE challenge generation
+├── test_auth_token.py                   # Token model, expiry logic
+├── test_auth_storage.py                 # Storage permissions, load/save
+├── test_auth_callback.py               # Callback server behavior
+├── test_auth_registration.py            # DCR request/response
+├── test_auth_flow.py                    # Full flow orchestration (mocked)
+├── test_app_api_client.py               # app_request(), workspace scoping
+├── test_pagination.py                   # Cursor pagination helper
+├── test_workspace_oauth.py              # Workspace OAuth integration
+├── test_cli_auth.py                     # CLI auth commands
+├── test_types_pbt.py                    # Update: PBT for new types
+└── test_config_oauth.py                 # Extended credential resolution
+```
+
+**Structure Decision**: Extends existing single-project layout. New `_internal/auth/` module mirrors Rust's `auth/` structure. All other changes are modifications to existing files.
+
+## Complexity Tracking
+
+> No constitution violations — this section is empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)* | — | — |

--- a/specs/023-oauth-app-api-infra/quickstart.md
+++ b/specs/023-oauth-app-api-infra/quickstart.md
@@ -1,0 +1,106 @@
+# Quickstart: OAuth PKCE & App API Infrastructure
+
+**Feature**: 023-oauth-app-api-infra | **Date**: 2026-03-25
+
+## Prerequisites
+
+- Python 3.10+ with `mixpanel_data` installed
+- A Mixpanel account with project access
+- A web browser (for OAuth consent screen)
+
+## 1. Authenticate via OAuth
+
+### CLI
+
+```bash
+# Login (opens browser for OAuth consent)
+mp auth login
+
+# Check authentication status
+mp auth status
+
+# Get raw access token (for debugging / external tools)
+mp auth token
+
+# Logout (remove stored tokens)
+mp auth logout
+```
+
+### Library
+
+```python
+from mixpanel_data._internal.auth.flow import OAuthFlow
+
+# Interactive login (opens browser)
+flow = OAuthFlow(region="us")
+tokens = flow.login()
+# Tokens are persisted automatically to ~/.mp/oauth/tokens_us.json
+```
+
+## 2. Use App API Endpoints
+
+### CLI (with workspace)
+
+```bash
+# Auto-discover workspace (single-workspace projects)
+mp auth status --format json
+
+# Explicit workspace ID
+mp --workspace-id 12345 auth status
+
+# Set via environment variable
+export MP_WORKSPACE_ID=12345
+```
+
+### Library
+
+```python
+from mixpanel_data import Workspace
+
+# Create workspace — OAuth tokens used automatically if available
+ws = Workspace()
+
+# List available workspaces
+workspaces = ws.list_workspaces()
+for w in workspaces:
+    print(f"{w.id}: {w.name} (default={w.is_default})")
+
+# Set explicit workspace for App API calls
+ws.set_workspace_id(12345)
+
+# Or let it auto-discover
+workspace_id = ws.resolve_workspace_id()
+```
+
+## 3. Credential Resolution Order
+
+The system resolves credentials in this order:
+
+1. **Environment variables**: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
+2. **OAuth tokens**: Stored at `~/.mp/oauth/tokens_{region}.json`
+3. **Named account**: `Workspace(account="staging")`
+4. **Default account**: From `~/.mp/config.toml`
+
+For App API endpoints, OAuth Bearer auth is preferred. For query/export endpoints, Basic Auth is used.
+
+## 4. Token Lifecycle
+
+Tokens are managed automatically:
+- **Access tokens** expire after ~10 hours. The library refreshes them transparently.
+- **Refresh tokens** are long-lived. If they expire, re-run `mp auth login`.
+- **Storage**: `~/.mp/oauth/` (override with `MP_OAUTH_STORAGE_DIR`)
+
+## 5. Error Handling
+
+```python
+from mixpanel_data.exceptions import OAuthError, WorkspaceScopeError
+
+try:
+    ws.list_workspaces()
+except OAuthError as e:
+    print(f"Auth issue: {e.message} (code: {e.code})")
+    # Re-authenticate: mp auth login
+except WorkspaceScopeError as e:
+    print(f"Workspace issue: {e.message}")
+    # Set workspace: ws.set_workspace_id(12345)
+```

--- a/specs/023-oauth-app-api-infra/research.md
+++ b/specs/023-oauth-app-api-infra/research.md
@@ -1,0 +1,241 @@
+# Research: OAuth PKCE & App API Infrastructure
+
+**Feature**: 023-oauth-app-api-infra | **Date**: 2026-03-25
+
+## R1: OAuth 2.0 PKCE Flow Implementation
+
+**Decision**: Implement RFC 7636 Authorization Code + PKCE using S256, with Dynamic Client Registration (RFC 7591).
+
+**Rationale**: The Rust reference implementation uses this exact flow. Mixpanel's OAuth provider (`/oauth/`) supports DCR at `/oauth/mcp/register/`. PKCE eliminates the need for a client secret, making it safe for CLI/desktop apps.
+
+**Alternatives considered**:
+- Device Authorization Grant (RFC 8628) — simpler UX but Mixpanel doesn't support it
+- Pre-registered client ID — would work but DCR allows per-installation registration and port flexibility
+
+### Flow Sequence (from Rust `auth/flow.rs`)
+
+1. Generate PKCE verifier (64 random bytes → base64url no-pad) and S256 challenge
+2. Generate state token (UUID v4) for CSRF protection
+3. Bind callback server to first available port in `[19284, 19285, 19286, 19287]`
+4. Register public client via DCR (`POST /oauth/mcp/register/`) — cache result per region
+5. Build authorization URL with params: `client_id`, `redirect_uri`, `response_type=code`, `code_challenge`, `code_challenge_method=S256`, `state` (omit `scope` to get all scopes)
+6. Open browser (fallback: print URL to stderr)
+7. Wait for callback (5 min timeout)
+8. Validate state matches (CSRF check)
+9. Exchange code for tokens (`POST /oauth/token/`)
+10. Save tokens with optional `project_id`
+
+### OAuth Endpoints (region-dependent)
+
+| Region | Base URL |
+|--------|----------|
+| US | `https://mixpanel.com/oauth/` |
+| EU | `https://eu.mixpanel.com/oauth/` |
+| IN | `https://in.mixpanel.com/oauth/` |
+
+### DCR Request
+
+```
+POST {base_url}mcp/register/
+Content-Type: application/json
+
+{
+  "redirect_uris": ["http://localhost:{port}/callback"],
+  "client_name": "Mixpanel CLI - {YYYY-MM-DD}",
+  "scope": "projects analysis events insights segmentation retention data:read funnels flows data_definitions dashboard_reports bookmarks",
+  "grant_types": ["authorization_code", "refresh_token"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+Response: `{ "client_id": "...", "client_id_issued_at": 1709568000, "redirect_uris": [...] }`
+
+**Critical**: Django OAuth Toolkit treats empty scope as "all scopes allowed" — omit `scope` from auth URL.
+
+### Token Exchange
+
+```
+POST {base_url}token/
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code={code}&redirect_uri={redirect_uri}&client_id={client_id}&code_verifier={code_verifier}
+```
+
+Response: `{ "access_token": "...", "token_type": "Bearer", "expires_in": 36000, "refresh_token": "...", "scope": "..." }`
+
+### Token Refresh
+
+```
+POST {base_url}token/
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token&refresh_token={refresh_token}&client_id={client_id}
+```
+
+---
+
+## R2: PKCE Algorithm
+
+**Decision**: 64 random bytes → base64url (no padding) for verifier; SHA-256 of verifier → base64url (no padding) for challenge.
+
+**Rationale**: Matches Rust implementation exactly. 64 bytes → 86 base64url chars (within RFC 7636's 43-128 range).
+
+**Python implementation**: `secrets.token_bytes(64)` → `base64.urlsafe_b64encode().rstrip(b'=')` → `hashlib.sha256(verifier).digest()` → `base64.urlsafe_b64encode().rstrip(b'=')`
+
+---
+
+## R3: Token Storage
+
+**Decision**: JSON files at `~/.mp/oauth/` with Unix permissions (dir: 0o700, files: 0o600).
+
+**Rationale**: Matches Rust implementation. JSON is human-readable and debuggable.
+
+**File naming**:
+- `tokens_{region}.json` — OAuth tokens per region
+- `client_{region}.json` — Cached DCR client info per region
+
+**Token JSON format**:
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_at": "2026-03-25T10:30:00Z",
+  "scope": "projects analysis ...",
+  "token_type": "Bearer",
+  "project_id": "optional"
+}
+```
+
+**Client info JSON format**:
+```json
+{
+  "client_id": "...",
+  "region": "us",
+  "redirect_uri": "http://localhost:19284/callback",
+  "scope": "projects analysis ...",
+  "created_at": "2026-03-25T10:30:00Z"
+}
+```
+
+**Override**: `MP_OAUTH_STORAGE_DIR` environment variable.
+
+---
+
+## R4: Callback Server
+
+**Decision**: Ephemeral `http.server`-based TCP listener on localhost, trying ports 19284–19287.
+
+**Rationale**: stdlib `http.server` + `threading` avoids external dependencies. Port list matches Rust.
+
+**Key details**:
+- Bind to `127.0.0.1` but use `localhost` in redirect URI (Mixpanel webapp regex expects `localhost`)
+- 5-minute timeout for callback
+- Parse query params: `code`, `state`, `error`, `error_description`
+- Validate `state` matches (CSRF protection)
+- Respond with HTML success/error page, then shut down
+- 8KB buffer for HTTP request parsing
+
+---
+
+## R5: Credential Resolution Extension
+
+**Decision**: Extend resolution order to: env vars > OAuth tokens > named account > default.
+
+**Rationale**: Backward compatible — env vars still win. OAuth slots in naturally for users who've run `mp auth login`.
+
+**Auth method selection**:
+- Query/Export/Engage endpoints → Basic Auth (service accounts)
+- App API endpoints → Bearer token (OAuth) preferred, Basic Auth accepted as fallback
+- The `@auth_required` decorator in Mixpanel's Django accepts both
+
+**Implementation**: Add `AuthMethod` enum (`basic`, `oauth`) to `Credentials` or create parallel `OAuthCredentials` type. The API client selects auth header based on endpoint category.
+
+---
+
+## R6: App API Request Infrastructure
+
+**Decision**: Extend `MixpanelAPIClient` with `app_request()` method using Bearer auth, workspace scoping, and automatic result unwrapping.
+
+**Rationale**: The `"app"` URLs already exist in `ENDPOINTS` dict. Extending the existing client avoids duplication.
+
+### Workspace Scoping Patterns
+
+Two URL patterns exist in the Rust implementation:
+
+1. **Top-level (optional workspace)** — `maybe_scoped_path()`:
+   - With workspace: `/api/app/workspaces/{wid}/{domain}/...`
+   - Without workspace: `/api/app/projects/{pid}/{domain}/...`
+   - Used by: dashboards, cohorts, alerts, annotations, bookmarks, webhooks, lexicon, etc.
+
+2. **Project-nested (required workspace)** — `require_scoped_path()`:
+   - Always: `/api/app/projects/{pid}/workspaces/{wid}/{domain}/...`
+   - Auto-discovers workspace ID if not set
+   - Used by: feature flags only
+
+### Workspace Resolution
+
+1. Return explicit workspace ID if set (via `--workspace-id` or `set_workspace_id()`)
+2. Auto-discover: `GET /api/app/projects/{pid}/workspaces/public` → find `is_default: true`
+3. Cache result for lifetime of client instance (Python: simple instance variable with sentinel)
+
+### Result Unwrapping
+
+App API responses have two shapes:
+- `{ "status": "ok", "results": [...] }` — unwrap `results`
+- `{ "status": "ok", ... }` — return full response (for non-list endpoints)
+
+### Error Handling
+
+- 204 No Content → synthetic `{"status": "ok"}`
+- 404 → `ResourceNotFoundError` (new, or reuse existing `QueryError`)
+- 422 → `ValidationError` (for bad request bodies)
+- Other 4xx/5xx → existing `APIError` hierarchy
+
+---
+
+## R7: Cursor-Based Pagination
+
+**Decision**: Generic `PaginatedResponse` model with `CursorPagination` support.
+
+**Rationale**: Matches Rust's `PaginatedResponse<T>` pattern. All App API list endpoints use consistent pagination.
+
+**Response format**:
+```json
+{
+  "status": "ok",
+  "results": [...],
+  "pagination": {
+    "page_size": 100,
+    "next_cursor": "abc123",
+    "previous_cursor": "xyz789"
+  }
+}
+```
+
+**Pagination helper**: `paginate_all()` generator that follows `next_cursor` until `None`.
+
+---
+
+## R8: Token Expiry Buffer
+
+**Decision**: 30-second buffer before expiry (tokens considered expired if within 30s of `expires_at`).
+
+**Rationale**: Matches Rust implementation. Prevents race conditions where a token expires mid-request.
+
+**Implementation**: `is_expired()` checks `datetime.now(UTC) + timedelta(seconds=30) >= expires_at`
+
+---
+
+## R9: Existing Python Patterns to Follow
+
+**API Client**: `_build_url(api_type, path)` + `_request(method, url, params, ...)` with `_execute_with_retry()` for rate limiting.
+
+**Workspace**: Lazy service initialization via properties. Dependency injection for testing (`_api_client`, `_config_manager` params).
+
+**Types**: `@dataclass(frozen=True)` inheriting `ResultWithDataFrame` for query results. Pydantic `BaseModel` with `ConfigDict(frozen=True)` for API response models.
+
+**CLI**: Typer command groups via `app.add_typer()`. `@handle_errors` decorator. `get_workspace(ctx)` helper. `output_result(ctx, data, format=format)` for output.
+
+**Docstrings**: Google-style with Args/Returns/Raises/Example sections. Markdown code fences (not doctest `>>>`).
+
+**Strict typing**: `mypy --strict` compliant. No untyped `Any`. `Literal` for constrained strings.

--- a/specs/023-oauth-app-api-infra/spec.md
+++ b/specs/023-oauth-app-api-infra/spec.md
@@ -1,0 +1,195 @@
+# Feature Specification: OAuth PKCE & App API Infrastructure
+
+**Feature Branch**: `023-oauth-app-api-infra`
+**Created**: 2026-03-25
+**Status**: Draft
+**Input**: Phase 0 architectural prerequisites — OAuth 2.0 PKCE authentication and App API request infrastructure enabling all future CRUD operations across 15+ Mixpanel entity domains.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Interactive OAuth Login (Priority: P1)
+
+A developer using the `mp` CLI wants to authenticate with their Mixpanel account so they can access App API endpoints (dashboards, reports, cohorts, flags, etc.) that require OAuth credentials rather than service account Basic Auth.
+
+**Why this priority**: Without OAuth authentication, no App API CRUD operation is possible. This is the foundational prerequisite for all subsequent features (Phases 1–5).
+
+**Independent Test**: Can be fully tested by running `mp auth login`, completing the browser-based OAuth flow, and verifying that tokens are persisted locally. Delivers value by unlocking App API access.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has no stored OAuth tokens, **When** they run `mp auth login`, **Then** the system opens their default browser to Mixpanel's authorization page, starts a local callback server, and waits for the redirect.
+2. **Given** the browser redirect completes with an authorization code, **When** the system exchanges the code for tokens, **Then** access and refresh tokens are securely stored on disk with restricted file permissions.
+3. **Given** the user completes login successfully, **When** they run `mp auth status`, **Then** they see confirmation of their authenticated state including token expiry information.
+4. **Given** the user is already authenticated, **When** they run `mp auth login` again, **Then** the system refreshes their existing tokens (or re-authenticates if refresh fails).
+5. **Given** the user wants to switch accounts or clear tokens, **When** they run `mp auth logout`, **Then** all stored OAuth tokens are removed from disk.
+
+---
+
+### User Story 2 - Automatic Token Lifecycle Management (Priority: P1)
+
+A developer using the library programmatically wants token refresh and expiry to be handled automatically so they don't need to manage OAuth token lifecycle themselves.
+
+**Why this priority**: Without transparent token management, every API call would require manual token checks, making the library impractical for automation and scripting.
+
+**Independent Test**: Can be tested by authenticating once, waiting for token expiry (or simulating it), and verifying that a subsequent API call automatically refreshes the token without user intervention.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid access token exists, **When** the user makes an App API request, **Then** the system uses the stored Bearer token without prompting.
+2. **Given** the access token has expired but the refresh token is valid, **When** the user makes an App API request, **Then** the system automatically refreshes the access token and retries the request transparently.
+3. **Given** both access and refresh tokens are expired or invalid, **When** the user makes an App API request, **Then** the system raises a clear error indicating re-authentication is needed.
+4. **Given** a token refresh is in progress, **When** the refreshed token is obtained, **Then** the new tokens are persisted to disk so other processes can use them.
+
+---
+
+### User Story 3 - App API Requests with Workspace Scoping (Priority: P1)
+
+A developer wants to make requests to Mixpanel's App API endpoints (e.g., list dashboards, create cohorts) with automatic workspace scoping so that API calls target the correct organizational context.
+
+**Why this priority**: App API infrastructure (request method, Bearer auth, workspace scoping, pagination) is required by every domain that follows. Without it, no CRUD operations can be built.
+
+**Independent Test**: Can be tested by calling `list_workspaces()` to discover available workspaces, then making a workspace-scoped App API request (e.g., listing dashboards) and verifying the correct workspace context is applied.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid OAuth credentials and a project ID, **When** the user calls `list_workspaces()`, **Then** the system returns a list of workspaces available in the project.
+2. **Given** no explicit workspace ID is set, **When** the user makes an App API request for a domain that requires workspace scoping, **Then** the system auto-discovers the workspace ID from the project's available workspaces.
+3. **Given** the user provides an explicit workspace ID (via parameter or CLI flag), **When** they make an App API request, **Then** the system uses the provided workspace ID for scoping.
+4. **Given** App API results span multiple pages, **When** the user requests all results, **Then** the system automatically follows cursor-based pagination and aggregates all pages.
+5. **Given** a workspace cannot be resolved (no workspaces found or ambiguous), **When** the user makes a workspace-scoped request, **Then** the system raises a clear error explaining the issue and how to resolve it.
+
+---
+
+### User Story 4 - Credential Resolution with OAuth Support (Priority: P2)
+
+A developer wants the existing credential resolution system to seamlessly support OAuth as an additional authentication method alongside Basic Auth, so they can use whichever method is appropriate for their use case.
+
+**Why this priority**: Backward compatibility with existing Basic Auth workflows is essential. OAuth should augment, not replace, the existing auth system.
+
+**Independent Test**: Can be tested by verifying that existing Basic Auth workflows continue working unchanged, and that OAuth credentials are preferred when available for App API endpoints.
+
+**Acceptance Scenarios**:
+
+1. **Given** environment variables (`MP_USERNAME`, `MP_SECRET`, etc.) are set, **When** the user creates a Workspace, **Then** Basic Auth credentials resolve exactly as before (no regression).
+2. **Given** stored OAuth tokens exist and no environment variables are set, **When** the user makes an App API request, **Then** OAuth Bearer auth is used automatically.
+3. **Given** both Basic Auth credentials and OAuth tokens are available, **When** the user makes a request to a query/export endpoint, **Then** Basic Auth is used (as before). **When** they make a request to an App API endpoint, **Then** the appropriate auth method is selected based on endpoint type.
+4. **Given** OAuth tokens exist but are for a different project, **When** the user makes a request, **Then** the system handles the mismatch gracefully with a clear error.
+
+---
+
+### User Story 5 - CLI Workspace Selection (Priority: P2)
+
+A CLI user wants to specify which workspace to target for App API operations, either via a global flag or automatic discovery, so they can manage multi-workspace projects.
+
+**Why this priority**: Many Mixpanel projects have multiple workspaces. CLI users need a way to target the correct one without hardcoding.
+
+**Independent Test**: Can be tested by running any App API CLI command with and without `--workspace-id` and verifying correct workspace targeting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user provides `--workspace-id 12345` as a global CLI flag, **When** they run an App API command, **Then** the system uses workspace 12345 for scoping.
+2. **Given** the user does not provide `--workspace-id`, **When** they run an App API command on a single-workspace project, **Then** the system auto-discovers and uses the sole workspace.
+3. **Given** the user does not provide `--workspace-id` on a multi-workspace project, **When** they run an App API command, **Then** the system informs them of available workspaces and asks them to specify one.
+4. **Given** the user runs `mp auth token`, **When** the command executes, **Then** it outputs the current access token (useful for debugging and external tool integration).
+
+---
+
+### User Story 6 - Secure Token Storage (Priority: P2)
+
+A developer wants OAuth tokens to be stored securely on their local filesystem with appropriate access controls so that credentials are not exposed to other users or processes.
+
+**Why this priority**: OAuth tokens grant broad access to Mixpanel project data. Secure storage is essential for preventing unauthorized access.
+
+**Independent Test**: Can be tested by verifying file permissions on token storage files and confirming tokens are not logged or exposed in CLI output.
+
+**Acceptance Scenarios**:
+
+1. **Given** OAuth tokens are saved, **When** the storage directory and files are created, **Then** the directory has 0o700 permissions and files have 0o600 permissions (owner-only access).
+2. **Given** the default storage location (`~/.mp/oauth/`), **When** the user wants a custom location, **Then** they can set the `MP_OAUTH_STORAGE_DIR` environment variable to override it.
+3. **Given** token data is stored as JSON, **When** any part of the system logs or displays credential information, **Then** access tokens and refresh tokens are redacted (never shown in plain text).
+4. **Given** tokens are persisted on disk, **When** the user runs `mp auth logout`, **Then** all token files are securely deleted.
+
+---
+
+### Edge Cases
+
+- What happens when the local callback server port is already in use? The system tries multiple fallback ports (19284, 19285, 19286, 19287) before failing with a clear error.
+- What happens when the browser fails to open? The system displays the authorization URL in the terminal so the user can manually navigate to it.
+- What happens when the OAuth callback times out? The system fails gracefully with a clear timeout message after a reasonable wait period.
+- What happens when the user's network drops mid-token-exchange? The system reports a clear connection error, not a cryptic OAuth error.
+- What happens when the token storage directory has incorrect permissions? The system attempts to fix permissions or warns the user.
+- What happens when pagination returns an empty cursor? The system treats this as the final page and stops paginating.
+- What happens when a workspace-scoped endpoint is called without any auth? The system raises an error explaining that OAuth login is required for App API operations.
+- What happens when the PKCE verifier or challenge fails validation? The system raises a clear error (this would indicate a bug in the implementation).
+- What happens when Dynamic Client Registration fails? The system provides a clear error message about the registration failure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**OAuth 2.0 PKCE Authentication**
+
+- **FR-001**: System MUST implement OAuth 2.0 Authorization Code flow with PKCE (RFC 7636) using S256 challenge method.
+- **FR-002**: System MUST generate cryptographically secure PKCE verifiers (64 random bytes, base64url-encoded) and compute SHA-256 challenges.
+- **FR-003**: System MUST support Dynamic Client Registration (RFC 7591) for registering the CLI application with Mixpanel's OAuth provider.
+- **FR-004**: System MUST start an ephemeral local HTTP server to receive the OAuth redirect callback, trying ports 19284–19287 in sequence.
+- **FR-005**: System MUST exchange authorization codes for access/refresh token pairs and persist them securely.
+- **FR-006**: System MUST automatically refresh expired access tokens using the refresh token, with a 30-second expiry buffer.
+- **FR-007**: System MUST store tokens in JSON format at `~/.mp/oauth/` (or `MP_OAUTH_STORAGE_DIR`) with restricted Unix permissions (directory: 0o700, files: 0o600).
+- **FR-008**: System MUST provide `login`, `logout`, `status`, and `token` subcommands under `mp auth`.
+- **FR-009**: System MUST never expose raw token values in logs, error messages, or standard output (except `mp auth token` which intentionally outputs the access token).
+
+**App API Infrastructure**
+
+- **FR-010**: System MUST support HTTP requests to Mixpanel's App API (`/api/app/...`) endpoints using OAuth Bearer token authentication.
+- **FR-011**: System MUST support workspace scoping for App API requests, with both explicit workspace ID and auto-discovery modes.
+- **FR-012**: System MUST implement cursor-based pagination for App API responses, automatically fetching all pages when requested.
+- **FR-013**: System MUST provide a `--workspace-id` global CLI option for specifying the workspace context.
+- **FR-014**: System MUST expose `list_workspaces()` and `resolve_workspace_id()` methods on the Workspace class.
+- **FR-015**: System MUST support both optional workspace scoping (top-level URL pattern) and required workspace scoping (project-nested URL pattern) for different App API endpoint styles.
+
+**Credential Resolution**
+
+- **FR-016**: System MUST extend the credential resolution order to: environment variables > OAuth tokens > named account > default account.
+- **FR-017**: System MUST preserve full backward compatibility with existing Basic Auth credential resolution.
+- **FR-018**: System MUST select the appropriate authentication method (Basic Auth vs. Bearer) based on the API endpoint category (query/export vs. app).
+
+**Error Handling**
+
+- **FR-019**: System MUST define `OAuthError` and `WorkspaceScopeError` exception types within the existing exception hierarchy.
+- **FR-020**: System MUST map OAuth-specific HTTP errors (invalid grant, expired token, invalid scope) to structured exception types with actionable messages.
+- **FR-021**: System MUST handle App API 4xx/5xx errors through the existing error hierarchy.
+
+### Key Entities
+
+- **Credentials**: Extended to support both Basic Auth (username/secret) and OAuth (access/refresh tokens) authentication methods. Includes an auth method indicator.
+- **OAuth Tokens**: Access token, refresh token, expiry timestamp, and scope. Immutable after creation; refreshed tokens produce a new token object.
+- **PKCE Challenge**: A verifier/challenge pair used once per authorization flow. The verifier is a cryptographic random string; the challenge is its SHA-256 hash.
+- **Workspace**: An organizational unit within a Mixpanel project. Has an ID, name, and project association. Used for scoping App API requests.
+- **Paginated Response**: A generic wrapper for App API responses containing a page of results and cursor-based pagination metadata (next cursor, has more).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can complete the full OAuth login flow (browser auth + token storage) in under 60 seconds on a standard connection.
+- **SC-002**: Existing Basic Auth workflows (environment variables, named accounts, config file) continue working with zero changes required by users.
+- **SC-003**: Token refresh happens transparently — users making sequential App API calls never see an authentication interruption for expired tokens when a valid refresh token exists.
+- **SC-004**: All App API requests correctly target the intended workspace, with auto-discovery succeeding on first attempt for single-workspace projects.
+- **SC-005**: Paginated App API responses return complete result sets — no data is lost due to pagination boundaries.
+- **SC-006**: Token storage files are created with owner-only permissions (verified by file permission checks on the storage directory and files).
+- **SC-007**: The system handles all edge cases (port conflicts, browser failures, network errors, timeout) with user-actionable error messages rather than stack traces or cryptic errors.
+- **SC-008**: All new code achieves 90%+ test coverage, consistent with the project's existing quality gate.
+
+## Assumptions
+
+- Users have a modern web browser available for the OAuth authorization flow (the browser-based consent step cannot be bypassed).
+- Mixpanel's OAuth provider supports Dynamic Client Registration (RFC 7591) for CLI applications. If not, a pre-registered client ID will be hardcoded.
+- The existing synchronous HTTP client is sufficient for all OAuth and App API operations; no async HTTP client is needed.
+- Token storage uses the local filesystem (`~/.mp/oauth/`). Keychain/credential-store integration is out of scope for this phase.
+- The App API's cursor-based pagination uses a consistent scheme across all domains (consistent `next` cursor field and `has_more` indicator).
+- Workspace auto-discovery uses the `list_workspaces()` endpoint, which is available to all authenticated users.
+- Only Unix-style file permissions (0o700/0o600) are enforced; Windows ACL support is out of scope.
+- The OAuth callback server runs on localhost only; it does not need to be accessible from external networks.
+- The `mp auth token` command intentionally outputs the raw access token for debugging and external tool integration — this is by design, not a security gap.
+- App API endpoints accept both Basic Auth (service accounts) and OAuth Bearer tokens, as indicated by the reference codebase's auth decorators.

--- a/specs/023-oauth-app-api-infra/tasks.md
+++ b/specs/023-oauth-app-api-infra/tasks.md
@@ -1,0 +1,301 @@
+# Tasks: OAuth PKCE & App API Infrastructure
+
+**Input**: Design documents from `/specs/023-oauth-app-api-infra/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/library-api.md
+
+**Tests**: Included — project CLAUDE.md mandates strict TDD (tests FIRST, then implementation).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Library**: `src/mixpanel_data/`
+- **Internal**: `src/mixpanel_data/_internal/`
+- **Auth module**: `src/mixpanel_data/_internal/auth/`
+- **CLI**: `src/mixpanel_data/cli/`
+- **Tests**: `tests/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create auth module structure and new exception types
+
+- [x] T001 Create auth module package with `__init__.py` in `src/mixpanel_data/_internal/auth/__init__.py`
+- [x] T002 [P] Add `OAuthError` exception class to `src/mixpanel_data/exceptions.py` (inherits `MixpanelDataError`, codes: OAUTH_TOKEN_ERROR, OAUTH_REFRESH_ERROR, OAUTH_REGISTRATION_ERROR, OAUTH_TIMEOUT, OAUTH_PORT_ERROR, OAUTH_BROWSER_ERROR)
+- [x] T003 [P] Add `WorkspaceScopeError` exception class to `src/mixpanel_data/exceptions.py` (inherits `MixpanelDataError`, codes: NO_WORKSPACES, AMBIGUOUS_WORKSPACE, WORKSPACE_NOT_FOUND)
+- [x] T004 [P] Add `PublicWorkspace` frozen Pydantic model to `src/mixpanel_data/types.py` (fields: id, name, project_id, is_default, description, is_global, is_restricted, is_visible, created_iso, creator_name; `extra="allow"`)
+- [x] T005 [P] Add `CursorPagination` and `PaginatedResponse[T]` frozen Pydantic models to `src/mixpanel_data/types.py` (CursorPagination: page_size, next_cursor, previous_cursor; PaginatedResponse: status, results, pagination)
+- [x] T006 Export new types (`OAuthError`, `WorkspaceScopeError`, `PublicWorkspace`) from `src/mixpanel_data/__init__.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: PKCE, token model, and storage — core building blocks all OAuth stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests for Foundational Phase
+
+- [x] T007 [P] Write tests for PKCE challenge generation in `tests/test_auth_pkce.py` — verify: verifier is 86 chars, base64url no-pad, challenge is SHA-256 of verifier in base64url no-pad, deterministic for same input, different per generation
+- [x] T008 [P] Write tests for OAuthTokens model in `tests/test_auth_token.py` — verify: frozen immutable, `is_expired()` returns True when within 30s of expires_at, `is_expired()` returns False when >30s from expires_at, SecretStr redaction in repr, JSON round-trip serialization/deserialization, project_id preservation
+- [x] T009 [P] Write tests for OAuthStorage in `tests/test_auth_storage.py` — verify: save/load token round-trip, save/load client info round-trip, file permissions (0o600 for files, 0o700 for dir), `MP_OAUTH_STORAGE_DIR` override, region-specific file naming (`tokens_{region}.json`, `client_{region}.json`), missing file returns None, delete removes files
+- [x] T010 [P] Write tests for `AuthMethod` enum and extended credential resolution in `tests/test_config_oauth.py` — verify: existing Basic Auth resolution unchanged, `AuthMethod.basic` and `AuthMethod.oauth` values, `auth_header()` returns correct header for each method
+
+### Implementation for Foundational Phase
+
+- [x] T011 [P] Implement `PkceChallenge` class in `src/mixpanel_data/_internal/auth/pkce.py` — `generate()` classmethod: 64 random bytes → base64url no-pad verifier, SHA-256 → base64url no-pad challenge. Use stdlib `secrets`, `hashlib`, `base64`
+- [x] T012 [P] Implement `OAuthTokens` frozen Pydantic model in `src/mixpanel_data/_internal/auth/token.py` — fields: access_token (SecretStr), refresh_token (Optional[SecretStr]), expires_at (datetime UTC), scope (str), token_type (str), project_id (Optional[str]). Method: `is_expired()` with 30s buffer. Class method: `from_token_response(data, project_id)` to compute `expires_at` from `expires_in`
+- [x] T013 [P] Implement `OAuthClientInfo` frozen Pydantic model in `src/mixpanel_data/_internal/auth/token.py` — fields: client_id, region, redirect_uri, scope, created_at
+- [x] T014 Implement `OAuthStorage` class in `src/mixpanel_data/_internal/auth/storage.py` — methods: `save_tokens(tokens, region)`, `load_tokens(region)`, `save_client_info(info)`, `load_client_info(region)`, `delete_tokens(region)`, `delete_all()`. Path: `~/.mp/oauth/` or `MP_OAUTH_STORAGE_DIR`. Permissions: dir 0o700, files 0o600
+- [x] T015 Add `AuthMethod` enum (`basic`, `oauth`) to `src/mixpanel_data/_internal/config.py` and add `auth_header()` method to `Credentials` that returns `"Basic ..."` or `"Bearer ..."` based on auth method. Preserve all existing credential resolution behavior unchanged
+- [x] T016 Update auth module `__init__.py` in `src/mixpanel_data/_internal/auth/__init__.py` — re-export: PkceChallenge, OAuthTokens, OAuthClientInfo, OAuthStorage
+
+**Checkpoint**: Foundation ready — PKCE, tokens, storage, and auth method dispatch all working and tested
+
+---
+
+## Phase 3: User Story 1 — Interactive OAuth Login (Priority: P1) MVP
+
+**Goal**: Users can run `mp auth login` to authenticate via browser-based OAuth PKCE flow, storing tokens locally
+
+**Independent Test**: Run `mp auth login`, complete browser flow, verify tokens saved at `~/.mp/oauth/tokens_{region}.json` with correct permissions
+
+### Tests for User Story 1
+
+- [x] T017 [P] [US1] Write tests for callback server in `tests/test_auth_callback.py` — verify: binds to first available port in [19284-19287], returns code+state from query params, validates state match, handles error params, times out after configured duration, sends HTML response to browser, uses `localhost` in redirect URI
+- [x] T018 [P] [US1] Write tests for Dynamic Client Registration in `tests/test_auth_registration.py` — verify: POST to `{base_url}mcp/register/` with correct body (redirect_uris, client_name, scope, grant_types, token_endpoint_auth_method), parses client_id from response, caches result per region, re-registers if redirect_uri changes, handles 429 rate limit
+- [x] T019 [P] [US1] Write tests for OAuthFlow orchestrator in `tests/test_auth_flow.py` — verify: full login sequence (generate PKCE → bind callback → register client → build auth URL → exchange code → save tokens), token exchange POST with correct form params, handles missing refresh_token, preserves project_id through flow, region-specific OAuth base URLs (us/eu/in)
+
+### Implementation for User Story 1
+
+- [x] T020 [US1] Implement callback server in `src/mixpanel_data/_internal/auth/callback_server.py` — function: `start_callback_server(state, timeout=300)` returns `(CallbackResult, port)`. Uses stdlib `http.server` + `threading`. Tries ports [19284, 19285, 19286, 19287]. Validates state. Returns HTML success/error page. Binds `127.0.0.1`, uses `localhost` in redirect URI
+- [x] T021 [US1] Implement Dynamic Client Registration in `src/mixpanel_data/_internal/auth/client_registration.py` — function: `ensure_client_registered(http_client, region, redirect_uri)` returns `OAuthClientInfo`. POST to `{oauth_base}/mcp/register/`. Cache via `OAuthStorage`. Scope: "projects analysis events insights segmentation retention data:read funnels flows data_definitions dashboard_reports bookmarks"
+- [x] T022 [US1] Implement `OAuthFlow` orchestrator in `src/mixpanel_data/_internal/auth/flow.py` — class with methods: `login(project_id=None)` → full PKCE flow, `exchange_code(code, verifier, client_id, redirect_uri)` → OAuthTokens, `refresh_tokens(tokens, client_id)` → OAuthTokens. OAuth base URLs: US `https://mixpanel.com/oauth/`, EU `https://eu.mixpanel.com/oauth/`, IN `https://in.mixpanel.com/oauth/`. Wrap `httpx` calls in try/except to catch `httpx.ConnectError`, `httpx.TimeoutException` → raise `OAuthError(code="OAUTH_TOKEN_ERROR", message="Network error during token exchange: {details}")` with actionable message. Map token endpoint error responses to specific OAuthError codes: `{"error": "invalid_grant"}` → `OAuthError(code="OAUTH_TOKEN_ERROR")`, `{"error": "invalid_scope"}` → `OAuthError(code="OAUTH_TOKEN_ERROR", details={"scope_error": ...})`, `{"error": "unauthorized_client"}` → `OAuthError(code="OAUTH_REGISTRATION_ERROR")`. Parse `error_description` from response into exception message
+- [x] T023 [US1] Update auth module exports in `src/mixpanel_data/_internal/auth/__init__.py` — add: OAuthFlow, CallbackResult, ensure_client_registered
+
+**Checkpoint**: OAuth login flow works end-to-end (PKCE → browser → callback → token exchange → storage)
+
+---
+
+## Phase 4: User Story 2 — Automatic Token Lifecycle Management (Priority: P1)
+
+**Goal**: Token refresh happens transparently — expired access tokens are automatically refreshed using the refresh token before API requests
+
+**Independent Test**: Authenticate, simulate token expiry (set expires_at to past), make an App API request, verify token was auto-refreshed and new tokens persisted
+
+### Tests for User Story 2
+
+- [x] T024 [P] [US2] Write tests for `get_valid_token()` in `tests/test_auth_flow.py` (extend existing) — verify: returns current token if not expired, auto-refreshes if expired, persists refreshed tokens, raises OAuthError if refresh fails, raises OAuthError if no tokens exist
+
+### Implementation for User Story 2
+
+- [x] T025 [US2] Add `get_valid_token(region)` method to `OAuthFlow` in `src/mixpanel_data/_internal/auth/flow.py` — loads tokens from storage, checks `is_expired()`, refreshes if needed via `refresh_tokens()`, saves new tokens, returns valid access token string. Raises `OAuthError(code="OAUTH_REFRESH_ERROR")` if refresh fails
+
+**Checkpoint**: Token lifecycle is fully automatic — expired tokens refresh transparently
+
+---
+
+## Phase 5: User Story 3 — App API Requests with Workspace Scoping (Priority: P1)
+
+**Goal**: API client can make App API requests with Bearer auth, workspace scoping (optional and required patterns), and cursor-based pagination
+
+**Independent Test**: Call `list_workspaces()` via the API client, verify it returns workspace data with correct auth headers and URL construction
+
+### Tests for User Story 3
+
+- [x] T026 [P] [US3] Write tests for `app_request()` in `tests/test_app_api_client.py` — verify: uses Bearer auth header, builds correct URL from ENDPOINTS["app"], unwraps `results` field from response, handles 204 No Content, maps 404 to error, maps 422 to error, passes through existing 4xx/5xx error handling
+- [x] T027 [P] [US3] Write tests for workspace scoping in `tests/test_app_api_client.py` — verify: `maybe_scoped_path()` returns unscoped path when no workspace set, returns `/workspaces/{wid}/{path}` when workspace set; `require_scoped_path()` auto-discovers workspace ID via `list_workspaces()`, raises WorkspaceScopeError if no workspaces found, caches resolved workspace ID
+- [x] T028 [P] [US3] Write tests for cursor pagination in `tests/test_pagination.py` — verify: `paginate_all()` yields all results across pages, follows next_cursor until None, handles empty results, handles missing pagination field (single page), respects page_size parameter
+
+### Implementation for User Story 3
+
+- [x] T029 [US3] Add `app_request()` method to `MixpanelAPIClient` in `src/mixpanel_data/_internal/api_client.py` — method signature: `app_request(method, path, *, params=None, json_body=None)`. Uses Bearer auth from OAuth tokens. Builds URL via `_build_url("app", scoped_path)`. Unwraps `results` from response JSON. Handles 204 → `{"status": "ok"}`
+- [x] T030 [US3] Add workspace scoping methods to `MixpanelAPIClient` in `src/mixpanel_data/_internal/api_client.py` — methods: `set_workspace_id(id)`, `resolve_workspace_id()` (explicit → auto-discover default → error), `maybe_scoped_path(path)` (optional workspace, top-level pattern), `require_scoped_path(path)` (required workspace, project-nested pattern). Add `workspace_id` and `_cached_workspace_id` instance variables
+- [x] T031 [US3] Add `list_workspaces()` method to `MixpanelAPIClient` in `src/mixpanel_data/_internal/api_client.py` — `GET /api/app/projects/{pid}/workspaces/public` → `list[PublicWorkspace]`
+- [x] T032 [US3] Create pagination helper in `src/mixpanel_data/_internal/pagination.py` — function: `paginate_all(client, path, *, params=None, page_size=100)` → `Iterator[T]`. Follows `next_cursor` until None. Uses `app_request("GET", path, params={..., "cursor": next_cursor})`
+
+**Checkpoint**: App API infrastructure complete — Bearer auth, workspace scoping, and pagination all working
+
+---
+
+## Phase 6: User Story 4 — Credential Resolution with OAuth Support (Priority: P2)
+
+**Goal**: Credential resolution seamlessly supports OAuth alongside Basic Auth, selecting the appropriate method per endpoint category
+
+**Independent Test**: Set env vars for Basic Auth AND have OAuth tokens stored — verify query endpoints use Basic Auth, App API endpoints use Bearer
+
+### Tests for User Story 4
+
+- [x] T033 [P] [US4] Write tests for extended credential resolution in `tests/test_config_oauth.py` (extend existing) — verify: env vars still resolve to Basic Auth (no regression), stored OAuth tokens resolve when no env vars set, resolution order: env > OAuth > named > default, auth method selection by endpoint type (query/export → Basic, app → Bearer)
+- [x] T034 [P] [US4] Write integration tests in `tests/test_workspace_oauth.py` — verify: Workspace construction with OAuth tokens, `list_workspaces()` on Workspace class, `resolve_workspace_id()` on Workspace class, backward compatibility with existing Basic Auth Workspace usage
+
+### Implementation for User Story 4
+
+- [x] T035 [US4] Extend credential resolution in `src/mixpanel_data/_internal/config.py` — update `ConfigManager.resolve_credentials()` to check for stored OAuth tokens (via `OAuthStorage.load_tokens(region)`) after env vars. If OAuth tokens found, return Credentials with `auth_method=AuthMethod.oauth`. Preserve existing env var and named account resolution unchanged
+- [x] T036 [US4] Add Workspace OAuth integration in `src/mixpanel_data/workspace.py` — add `list_workspaces()`, `resolve_workspace_id()`, `set_workspace_id()`, `workspace_id` property. Wire through to `MixpanelAPIClient` methods. Add `workspace_id` parameter to constructor (optional)
+- [x] T037 [US4] Update `MixpanelAPIClient` in `src/mixpanel_data/_internal/api_client.py` to use `credentials.auth_header()` for auth header dispatch instead of hardcoded Basic Auth in `_get_auth_header()`. Ensure `_request()` (existing) uses Basic Auth, `app_request()` (new) uses `auth_header()` from credentials
+
+**Checkpoint**: Both auth methods work seamlessly — existing workflows unaffected, OAuth available for App API
+
+---
+
+## Phase 7: User Story 5 — CLI Workspace Selection (Priority: P2)
+
+**Goal**: CLI users can specify `--workspace-id` globally and use `mp auth login/logout/status/token` commands
+
+**Independent Test**: Run `mp auth status` to see auth state, run `mp --workspace-id 123 auth status` to verify workspace targeting
+
+### Tests for User Story 5
+
+- [x] T038 [P] [US5] Write CLI auth command tests in `tests/test_cli_auth.py` — verify: `mp auth login` triggers OAuth flow (mocked), `mp auth logout` removes tokens, `mp auth status` shows auth state (authenticated/not authenticated), `mp auth token` outputs raw access token to stdout, exit codes (0 success, 2 auth error)
+- [x] T039 [P] [US5] Write CLI workspace option tests in `tests/test_cli_auth.py` (extend) — verify: `--workspace-id` global option is available, value passes through `ctx.obj` to Workspace construction, `MP_WORKSPACE_ID` env var works as alternative
+
+### Implementation for User Story 5
+
+- [x] T040 [US5] Add `--workspace-id` global option to `src/mixpanel_data/cli/main.py` — add to `main()` callback as `typer.Option("--workspace-id", envvar="MP_WORKSPACE_ID", help="Workspace ID for App API operations")`, store in `ctx.obj["workspace_id"]`
+- [x] T041 [US5] Implement `mp auth login` command in `src/mixpanel_data/cli/commands/auth.py` — creates `OAuthFlow(region)`, calls `flow.login(project_id)`, outputs JSON success confirmation. Opens browser via `webbrowser.open()`, prints fallback URL to stderr if browser fails
+- [x] T042 [US5] Implement `mp auth logout` command in `src/mixpanel_data/cli/commands/auth.py` — creates `OAuthStorage()`, calls `storage.delete_tokens(region)` or `storage.delete_all()` if no region specified. Outputs JSON confirmation
+- [x] T043 [US5] Implement `mp auth status` command in `src/mixpanel_data/cli/commands/auth.py` — checks for stored tokens per region, displays: auth method, token expiry, project_id, region, is_expired. Supports `--format` (json/table/plain)
+- [x] T044 [US5] Implement `mp auth token` command in `src/mixpanel_data/cli/commands/auth.py` — loads tokens via `OAuthFlow.get_valid_token(region)`, prints raw access token to stdout (for piping). Exit code 2 if no valid token
+
+**Checkpoint**: Full CLI auth workflow operational — login, logout, status, token, workspace selection
+
+---
+
+## Phase 8: User Story 6 — Secure Token Storage (Priority: P2)
+
+**Goal**: Token files have correct Unix permissions, secrets are redacted everywhere except `mp auth token`
+
+**Independent Test**: Run `mp auth login`, check file permissions with `stat`, verify no tokens in logs/stderr
+
+### Tests for User Story 6
+
+- [x] T045 [P] [US6] Write security tests in `tests/test_auth_storage.py` (extend existing) — verify: directory created with 0o700, files created with 0o600, `repr()` of OAuthTokens redacts access_token and refresh_token, `str()` of OAuthTokens redacts secrets, token values never appear in log output (mock logger, check messages)
+
+### Implementation for User Story 6
+
+- [x] T046 [US6] Audit and harden `OAuthStorage` in `src/mixpanel_data/_internal/auth/storage.py` — ensure `os.chmod()` called after every file write, ensure `os.makedirs()` with `mode=0o700` for directory, add `umask` handling for new file creation, verify `delete_tokens()` removes files completely. Add `_check_and_fix_permissions()` helper: on `load_tokens()`, check directory/file permissions; if incorrect, attempt `os.chmod()` to repair; if repair fails (e.g., not owner), log warning to stderr with actionable message ("Token storage permissions are too open: {path} has {actual}, expected {expected}. Run: chmod 600 {path}")
+- [x] T047 [US6] Audit `OAuthTokens` repr/str in `src/mixpanel_data/_internal/auth/token.py` — ensure `__repr__` shows `access_token=***`, `refresh_token=***`. Verify Pydantic `SecretStr` integration works for JSON serialization (expose value only in `save_tokens()`)
+- [x] T048 [US6] Audit logging across auth module — grep all auth files for any logging of token values. Ensure `logger.debug/info/warning/error` calls never include raw token strings. Add redaction where needed
+
+**Checkpoint**: All token handling passes security audit — correct permissions, no secret leaks
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates, type checking, full test coverage verification
+
+- [x] T049 Run `ruff format` and `ruff check` on all new and modified files
+- [x] T050 Run `mypy --strict` on all new and modified files — fix any type errors
+- [x] T051 Run `just test-cov` to verify 90%+ coverage on new code
+- [x] T052 [P] Add property-based tests (Hypothesis) for PKCE and OAuthTokens round-trip in `tests/test_types_pbt.py`
+- [x] T053 Run `just check` (full lint + typecheck + test suite) — ensure zero failures
+- [x] T054 Validate quickstart.md scenarios work end-to-end (manual/mocked verification)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — can start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — BLOCKS all user stories
+- **Phase 3 (US1 - OAuth Login)**: Depends on Phase 2
+- **Phase 4 (US2 - Token Lifecycle)**: Depends on Phase 3 (needs OAuthFlow)
+- **Phase 5 (US3 - App API)**: Depends on Phase 2 (needs token model, not full flow)
+- **Phase 6 (US4 - Credential Resolution)**: Depends on Phase 3 + Phase 5 (needs both auth and app_request)
+- **Phase 7 (US5 - CLI)**: Depends on Phase 3 + Phase 4 (needs OAuthFlow with get_valid_token)
+- **Phase 8 (US6 - Security)**: Depends on Phase 3 (audits existing auth code)
+- **Phase 9 (Polish)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (OAuth Login)**: No story dependencies — first implementable after foundation
+- **US2 (Token Lifecycle)**: Depends on US1 (extends OAuthFlow)
+- **US3 (App API)**: Independent of US1/US2 — only needs foundational token model
+- **US4 (Credential Resolution)**: Depends on US1 + US3 (integrates both)
+- **US5 (CLI)**: Depends on US1 + US2 (needs full auth flow + auto-refresh)
+- **US6 (Security)**: Depends on US1 (audits auth module)
+
+### Parallel Opportunities
+
+**After Phase 2 completes, these can run in parallel:**
+- US1 (OAuth Login) and US3 (App API) — completely independent code paths
+
+**After US1 completes:**
+- US2 (Token Lifecycle), US6 (Security), and US3 (if not started) — all independent
+
+**Within each phase**, tasks marked [P] can run in parallel.
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch all tests in parallel (different files):
+Task: T007 "PKCE tests in tests/test_auth_pkce.py"
+Task: T008 "Token model tests in tests/test_auth_token.py"
+Task: T009 "Storage tests in tests/test_auth_storage.py"
+Task: T010 "Config OAuth tests in tests/test_config_oauth.py"
+
+# Then launch parallel implementations:
+Task: T011 "PkceChallenge in _internal/auth/pkce.py"
+Task: T012 "OAuthTokens in _internal/auth/token.py"
+Task: T013 "OAuthClientInfo in _internal/auth/token.py"  # same file as T012, sequence after
+```
+
+## Parallel Example: US1 + US3 (after Phase 2)
+
+```bash
+# These two stories can run completely in parallel:
+# Agent A: US1 (OAuth Login)
+Task: T017-T023 "Callback server, DCR, OAuthFlow"
+
+# Agent B: US3 (App API)
+Task: T026-T032 "app_request, workspace scoping, pagination"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US3 = OAuth + App API)
+
+1. Complete Phase 1: Setup (T001-T006)
+2. Complete Phase 2: Foundational (T007-T016)
+3. Complete Phase 3: US1 OAuth Login (T017-T023)
+4. Complete Phase 5: US3 App API (T026-T032) — can parallel with US1
+5. **STOP and VALIDATE**: OAuth login works, App API requests work with workspace scoping
+6. This is the minimum viable infrastructure for all future CRUD phases
+
+### Incremental Delivery
+
+1. Setup + Foundational → Core building blocks ready
+2. US1 (OAuth Login) → Can authenticate (**MVP auth**)
+3. US3 (App API) → Can make App API requests (**MVP infra**)
+4. US2 (Token Lifecycle) → Auto-refresh works
+5. US4 (Credential Resolution) → Seamless auth selection
+6. US5 (CLI) → Full CLI workflow
+7. US6 (Security) → Hardened storage
+8. Polish → Quality gates pass
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- TDD is mandatory: write tests FIRST, ensure they FAIL, then implement
+- Commit after each task or logical group
+- Run `just check` at each checkpoint
+- Total: 54 tasks across 9 phases

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -18,11 +18,13 @@ from mixpanel_data.exceptions import (
     EventNotFoundError,
     JQLSyntaxError,
     MixpanelDataError,
+    OAuthError,
     QueryError,
     RateLimitError,
     ServerError,
     TableExistsError,
     TableNotFoundError,
+    WorkspaceScopeError,
 )
 from mixpanel_data.types import (
     ActivityFeedResult,
@@ -34,6 +36,7 @@ from mixpanel_data.types import (
     ColumnInfo,
     ColumnStatsResult,
     ColumnSummary,
+    CursorPagination,
     DailyCount,
     DailyCountsResult,
     EngagementBucket,
@@ -57,6 +60,7 @@ from mixpanel_data.types import (
     NumericBucketResult,
     NumericPropertySummaryResult,
     NumericSumResult,
+    PaginatedResponse,
     ParallelFetchResult,
     ParallelProfileResult,
     ProfilePageResult,
@@ -66,6 +70,7 @@ from mixpanel_data.types import (
     PropertyCoverageResult,
     PropertyDistributionResult,
     PropertyValueCount,
+    PublicWorkspace,
     RetentionResult,
     SavedCohort,
     SavedReportResult,
@@ -109,6 +114,8 @@ __all__ = [
     "DatabaseNotFoundError",
     "EventNotFoundError",
     "DateRangeTooLargeError",
+    "OAuthError",
+    "WorkspaceScopeError",
     # Result types
     "FetchResult",
     "ParallelFetchResult",
@@ -172,4 +179,8 @@ __all__ = [
     "EngagementBucket",
     "PropertyCoverageResult",
     "PropertyCoverage",
+    # App API types (Phase 023)
+    "PublicWorkspace",
+    "CursorPagination",
+    "PaginatedResponse",
 ]

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -1,7 +1,7 @@
 """Mixpanel API Client.
 
 Low-level HTTP client for all Mixpanel APIs. Handles:
-- Service account authentication via HTTP Basic auth
+- Authentication via HTTP Basic auth (service accounts) or OAuth 2.0 Bearer tokens
 - Regional endpoint routing (US, EU, India)
 - Automatic rate limit handling with exponential backoff
 - Streaming JSONL parsing for large exports
@@ -169,7 +169,7 @@ class MixpanelAPIClient:
         """Build full URL for the given API type and path.
 
         Args:
-            api_type: One of "query", "export", or "engage".
+            api_type: One of "query", "export", "engage", or "app".
             path: API endpoint path (e.g., "/segmentation").
 
         Returns:
@@ -709,8 +709,7 @@ class MixpanelAPIClient:
         client = self._ensure_client()
 
         # Build params with query_origin
-        request_params: dict[str, str] = {}
-        request_params["query_origin"] = "mixpanel-data-cli"
+        request_params: dict[str, str] = {"query_origin": "mixpanel-data-cli"}
         if params:
             request_params.update(params)
 
@@ -719,7 +718,7 @@ class MixpanelAPIClient:
                 response = client.request(
                     method,
                     url,
-                    params=request_params if request_params else None,
+                    params=request_params,
                     json=json_body,
                     headers=headers,
                     timeout=self._timeout,
@@ -786,7 +785,7 @@ class MixpanelAPIClient:
                     response,
                     request_method=method,
                     request_url=url,
-                    request_params=request_params if request_params else None,
+                    request_params=request_params,
                     request_body=json_body,
                 )
 

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -31,8 +31,9 @@ from mixpanel_data.exceptions import (
     QueryError,
     RateLimitError,
     ServerError,
+    WorkspaceScopeError,
 )
-from mixpanel_data.types import ProfilePageResult
+from mixpanel_data.types import ProfilePageResult, PublicWorkspace
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -150,6 +151,8 @@ class MixpanelAPIClient:
         self._max_retries = max_retries
         self._client: httpx.Client | None = None
         self._transport = _transport
+        self._workspace_id: int | None = None
+        self._cached_workspace_id: int | None = None
 
     def _get_auth_header(self) -> str:
         """Generate HTTP Basic auth header value.
@@ -653,6 +656,326 @@ class MixpanelAPIClient:
             except ValueError:
                 pass
         return None
+
+    # =========================================================================
+    # App API - OAuth/Bearer requests with workspace scoping
+    # =========================================================================
+
+    def app_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> Any:
+        """Make an authenticated request to the Mixpanel App API.
+
+        Uses Bearer auth (OAuth) or Basic auth depending on credentials.
+        Builds the URL from the ``app`` endpoint for the configured region.
+        Unwraps the ``results`` field from the response JSON when present.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, DELETE, etc.).
+            path: API path (e.g., ``/projects/12345/dashboards``).
+            params: Optional query parameters.
+            json_body: Optional JSON request body.
+
+        Returns:
+            The ``results`` field from the response JSON if present,
+            otherwise the full response body. For 204 No Content responses,
+            returns ``{"status": "ok"}``.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            RateLimitError: Rate limit exceeded after max retries (429).
+            QueryError: Invalid parameters or resource not found (400, 404, 422).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors.
+
+        Example:
+            ```python
+            client = MixpanelAPIClient(oauth_credentials)
+            with client:
+                dashboards = client.app_request(
+                    "GET", "/projects/12345/dashboards"
+                )
+            ```
+        """
+        url = self._build_url("app", path)
+        auth_header = self._credentials.auth_header()
+        headers = {"Authorization": auth_header}
+
+        client = self._ensure_client()
+
+        # Build params with query_origin
+        request_params: dict[str, str] = {}
+        if params:
+            request_params.update(params)
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = client.request(
+                    method,
+                    url,
+                    params=request_params if request_params else None,
+                    json=json_body,
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+
+                # Handle 204 No Content
+                if response.status_code == 204:
+                    return {"status": "ok"}
+
+                # Handle 429 rate limiting with retry
+                if response.status_code == 429:
+                    if attempt >= self._max_retries:
+                        retry_after = self._parse_retry_after(response)
+                        response_body: str | dict[str, Any] | None = None
+                        try:
+                            response_body = response.json()
+                        except json.JSONDecodeError:
+                            response_body = (
+                                response.text[:500] if response.text else None
+                            )
+                        raise RateLimitError(
+                            "Rate limit exceeded after max retries",
+                            retry_after=retry_after,
+                            status_code=response.status_code,
+                            response_body=response_body,
+                            request_method=method,
+                            request_url=url,
+                        )
+                    retry_after = self._parse_retry_after(response)
+                    if retry_after is not None:
+                        wait_time = float(retry_after)
+                    else:
+                        wait_time = self._calculate_backoff(attempt)
+                    logger.warning(
+                        "Rate limited, retrying in %.1f seconds (attempt %d/%d)",
+                        wait_time,
+                        attempt + 1,
+                        self._max_retries,
+                    )
+                    time.sleep(wait_time)
+                    continue
+
+                # Handle 422 as QueryError
+                if response.status_code == 422:
+                    err_body: str | dict[str, Any] | None = None
+                    try:
+                        err_body = response.json()
+                    except json.JSONDecodeError:
+                        err_body = response.text[:500] if response.text else None
+                    error_msg = "Unprocessable entity"
+                    if isinstance(err_body, dict):
+                        error_msg = str(err_body.get("error", error_msg))
+                    raise QueryError(
+                        error_msg,
+                        status_code=422,
+                        response_body=err_body,
+                        request_method=method,
+                        request_url=url,
+                        request_body=json_body,
+                    )
+
+                # Delegate other error codes to _handle_response
+                result = self._handle_response(
+                    response,
+                    request_method=method,
+                    request_url=url,
+                    request_params=request_params if request_params else None,
+                    request_body=json_body,
+                )
+
+                # Unwrap results field if present
+                if isinstance(result, dict) and "results" in result:
+                    return result["results"]
+                return result
+
+            except httpx.HTTPError as e:
+                raise MixpanelDataError(
+                    f"HTTP error: {e}",
+                    code="HTTP_ERROR",
+                    details={
+                        "error": str(e),
+                        "request_method": method,
+                        "request_url": url,
+                    },
+                ) from e
+
+        # Should not reach here, but satisfy type checker
+        raise RateLimitError(
+            "Rate limit exceeded after max retries",
+            request_method=method,
+            request_url=url,
+        )
+
+    def set_workspace_id(self, workspace_id: int | None) -> None:
+        """Set or clear the explicit workspace ID for scoped requests.
+
+        When set, ``maybe_scoped_path()`` will use workspace-scoped paths.
+        Setting to ``None`` clears both the explicit ID and the cached
+        auto-discovered ID, reverting to project-scoped paths.
+
+        Args:
+            workspace_id: Workspace ID to use, or None to clear.
+
+        Example:
+            ```python
+            client.set_workspace_id(789)
+            path = client.maybe_scoped_path("dashboards")
+            # "/workspaces/789/dashboards"
+
+            client.set_workspace_id(None)
+            path = client.maybe_scoped_path("dashboards")
+            # "/projects/12345/dashboards"
+            ```
+        """
+        self._workspace_id = workspace_id
+        if workspace_id is None:
+            self._cached_workspace_id = None
+
+    def resolve_workspace_id(self) -> int:
+        """Resolve the workspace ID to use for scoped requests.
+
+        Resolution order:
+        1. Explicit workspace ID (set via ``set_workspace_id()``)
+        2. Cached auto-discovered workspace ID
+        3. Auto-discover by calling ``list_workspaces()`` and finding
+           the default workspace (``is_default=True``), falling back
+           to the first workspace.
+
+        Returns:
+            The resolved workspace ID.
+
+        Raises:
+            WorkspaceScopeError: If no workspaces are found for the project.
+
+        Example:
+            ```python
+            client.set_workspace_id(42)
+            assert client.resolve_workspace_id() == 42
+
+            # Or auto-discover:
+            ws_id = client.resolve_workspace_id()
+            ```
+        """
+        if self._workspace_id is not None:
+            return self._workspace_id
+
+        if self._cached_workspace_id is not None:
+            return self._cached_workspace_id
+
+        workspaces = self.list_workspaces()
+        if not workspaces:
+            raise WorkspaceScopeError(
+                "No workspaces found for project "
+                f"'{self._credentials.project_id}'. "
+                "Ensure you have access to at least one workspace.",
+                code="NO_WORKSPACES",
+                details={"project_id": self._credentials.project_id},
+            )
+
+        # Prefer the default workspace
+        for ws in workspaces:
+            if ws.is_default:
+                self._cached_workspace_id = ws.id
+                return ws.id
+
+        # Fall back to first workspace
+        self._cached_workspace_id = workspaces[0].id
+        return workspaces[0].id
+
+    def maybe_scoped_path(self, domain_path: str) -> str:
+        """Build an optionally workspace-scoped API path.
+
+        If a workspace ID is set (via ``set_workspace_id()``), returns a
+        workspace-scoped path. Otherwise returns a project-scoped path.
+
+        Args:
+            domain_path: Domain-relative path (e.g., ``"dashboards"``).
+
+        Returns:
+            Workspace-scoped path ``/workspaces/{wid}/{domain_path}`` if
+            workspace is set, otherwise ``/projects/{pid}/{domain_path}``.
+
+        Example:
+            ```python
+            # No workspace set:
+            client.maybe_scoped_path("dashboards")
+            # "/projects/12345/dashboards"
+
+            # With workspace:
+            client.set_workspace_id(789)
+            client.maybe_scoped_path("dashboards")
+            # "/workspaces/789/dashboards"
+            ```
+        """
+        if self._workspace_id is not None:
+            return f"/workspaces/{self._workspace_id}/{domain_path}"
+        return f"/projects/{self._credentials.project_id}/{domain_path}"
+
+    def require_scoped_path(self, domain_path: str) -> str:
+        """Build a workspace-scoped API path, auto-discovering if needed.
+
+        Always returns a path scoped to both project and workspace. If no
+        workspace ID is set, auto-discovers one via ``resolve_workspace_id()``.
+
+        Args:
+            domain_path: Domain-relative path (e.g., ``"feature-flags"``).
+
+        Returns:
+            Path in format ``/projects/{pid}/workspaces/{wid}/{domain_path}``.
+
+        Raises:
+            WorkspaceScopeError: If no workspaces are found for the project.
+
+        Example:
+            ```python
+            client.set_workspace_id(789)
+            client.require_scoped_path("feature-flags")
+            # "/projects/12345/workspaces/789/feature-flags"
+
+            # Auto-discovers workspace if not set:
+            client.require_scoped_path("experiments")
+            # "/projects/12345/workspaces/100/experiments"
+            ```
+        """
+        ws_id = self.resolve_workspace_id()
+        pid = self._credentials.project_id
+        return f"/projects/{pid}/workspaces/{ws_id}/{domain_path}"
+
+    def list_workspaces(self) -> list[PublicWorkspace]:
+        """List all public workspaces for the current project.
+
+        Calls ``GET /api/app/projects/{pid}/workspaces/public``.
+
+        Returns:
+            List of PublicWorkspace models for the project.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400, 404).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(credentials) as client:
+                workspaces = client.list_workspaces()
+                for ws in workspaces:
+                    print(f"{ws.name} (id={ws.id}, default={ws.is_default})")
+            ```
+        """
+        pid = self._credentials.project_id
+        path = f"/projects/{pid}/workspaces/public"
+        results = self.app_request("GET", path)
+
+        if isinstance(results, list):
+            return [PublicWorkspace.model_validate(ws) for ws in results]
+        return []
 
     # =========================================================================
     # Export API - Streaming

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -710,6 +710,7 @@ class MixpanelAPIClient:
 
         # Build params with query_origin
         request_params: dict[str, str] = {}
+        request_params["query_origin"] = "mixpanel-data-cli"
         if params:
             request_params.update(params)
 
@@ -811,6 +812,15 @@ class MixpanelAPIClient:
             request_method=method,
             request_url=url,
         )
+
+    @property
+    def workspace_id(self) -> int | None:
+        """Return the explicit workspace ID, if set.
+
+        Returns:
+            The workspace ID set via ``set_workspace_id()``, or None.
+        """
+        return self._workspace_id
 
     def set_workspace_id(self, workspace_id: int | None) -> None:
         """Set or clear the explicit workspace ID for scoped requests.
@@ -973,9 +983,12 @@ class MixpanelAPIClient:
         path = f"/projects/{pid}/workspaces/public"
         results = self.app_request("GET", path)
 
-        if isinstance(results, list):
-            return [PublicWorkspace.model_validate(ws) for ws in results]
-        return []
+        if not isinstance(results, list):
+            raise MixpanelDataError(
+                f"Unexpected response format from list_workspaces: "
+                f"expected list, got {type(results).__name__}",
+            )
+        return [PublicWorkspace.model_validate(ws) for ws in results]
 
     # =========================================================================
     # Export API - Streaming

--- a/src/mixpanel_data/_internal/auth/__init__.py
+++ b/src/mixpanel_data/_internal/auth/__init__.py
@@ -1,0 +1,48 @@
+"""OAuth 2.0 PKCE authentication module.
+
+Implements the OAuth 2.0 Authorization Code + PKCE flow for Mixpanel,
+including Dynamic Client Registration (RFC 7591), token management,
+and secure local storage.
+
+Components:
+- PkceChallenge: PKCE verifier/challenge generation (RFC 7636)
+- OAuthTokens: Immutable token model with expiry tracking
+- OAuthClientInfo: Cached DCR client registration info
+- OAuthStorage: Secure JSON file storage for tokens and client info
+- OAuthFlow: Flow orchestrator (login, token exchange, refresh)
+- CallbackResult: Authorization callback result model
+- ensure_client_registered: Dynamic Client Registration helper
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth import (
+        PkceChallenge,
+        OAuthTokens,
+        OAuthClientInfo,
+        OAuthStorage,
+        OAuthFlow,
+        CallbackResult,
+    )
+
+    challenge = PkceChallenge.generate()
+    storage = OAuthStorage()
+    flow = OAuthFlow(region="us", storage=storage)
+    ```
+"""
+
+from mixpanel_data._internal.auth.callback_server import CallbackResult
+from mixpanel_data._internal.auth.client_registration import ensure_client_registered
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.pkce import PkceChallenge
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+
+__all__ = [
+    "CallbackResult",
+    "OAuthFlow",
+    "OAuthClientInfo",
+    "OAuthStorage",
+    "OAuthTokens",
+    "PkceChallenge",
+    "ensure_client_registered",
+]

--- a/src/mixpanel_data/_internal/auth/callback_server.py
+++ b/src/mixpanel_data/_internal/auth/callback_server.py
@@ -78,25 +78,33 @@ class CallbackResult:
 def start_callback_server(
     state: str,
     timeout: float = 300.0,
+    port: int | None = None,
 ) -> tuple[CallbackResult, int]:
     """Start a local HTTP server to receive the OAuth callback.
 
-    Tries to bind to ports 19284-19287 on ``127.0.0.1``. Once bound, it waits
-    for a single GET request containing ``code`` and ``state`` query parameters.
-    The ``state`` must match the provided value (CSRF protection). An HTML
-    page is returned to the browser indicating success or failure.
+    When ``port`` is provided, binds only to that specific port (no scanning).
+    This avoids TOCTOU races when the caller has already probed for an
+    available port. When ``port`` is ``None``, tries ports 19284-19287 on
+    ``127.0.0.1`` in order. Once bound, the server waits for a single GET
+    request containing ``code`` and ``state`` query parameters. The ``state``
+    must match the provided value (CSRF protection). An HTML page is returned
+    to the browser indicating success or failure.
 
     Args:
         state: The expected state parameter for CSRF validation.
         timeout: Maximum seconds to wait for the callback (default 300).
+        port: Specific port to bind to. When provided, only this port is
+            attempted and no scanning occurs. When ``None``, ports
+            19284-19287 are tried in order.
 
     Returns:
         A tuple of ``(CallbackResult, port)`` where ``port`` is the bound port.
 
     Raises:
-        OAuthError: If all ports are busy (``OAUTH_PORT_ERROR``), the callback
-            times out (``OAUTH_TIMEOUT``), the state doesn't match, or the
-            provider returns an error parameter.
+        OAuthError: If all ports are busy (``OAUTH_PORT_ERROR``), the
+            requested port is unavailable, the callback times out
+            (``OAUTH_TIMEOUT``), the state doesn't match, or the provider
+            returns an error parameter.
 
     Example:
         ```python
@@ -108,13 +116,26 @@ def start_callback_server(
     server: HTTPServer | None = None
     bound_port: int = 0
 
-    for port in CALLBACK_PORTS:
+    if port is not None:
+        # Bind to the exact requested port — no scanning
         try:
             server = _create_server(port)
             bound_port = port
-            break
-        except OSError:
-            continue
+        except OSError as exc:
+            raise OAuthError(
+                f"OAuth callback port {port} is no longer available. "
+                "Another process may have claimed it. Please try again.",
+                code="OAUTH_PORT_ERROR",
+                details={"port": port},
+            ) from exc
+    else:
+        for candidate in CALLBACK_PORTS:
+            try:
+                server = _create_server(candidate)
+                bound_port = candidate
+                break
+            except OSError:
+                continue
 
     if server is None:
         raise OAuthError(

--- a/src/mixpanel_data/_internal/auth/callback_server.py
+++ b/src/mixpanel_data/_internal/auth/callback_server.py
@@ -20,6 +20,7 @@ Example:
 
 from __future__ import annotations
 
+import html as html_mod
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
@@ -220,8 +221,9 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             if error_desc:
                 message += f" - {error_desc}"
 
+            # Escape provider-supplied values to prevent HTML injection
             self._send_html(
-                _ERROR_HTML.format(message=message),
+                _ERROR_HTML.format(message=html_mod.escape(message)),
                 status=400,
             )
             handler_state["error"] = OAuthError(
@@ -237,7 +239,9 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
         if not code_list or not state_list:
             message = "Missing 'code' or 'state' parameter in callback"
-            self._send_html(_ERROR_HTML.format(message=message), status=400)
+            self._send_html(
+                _ERROR_HTML.format(message=html_mod.escape(message)), status=400
+            )
             handler_state["error"] = OAuthError(
                 message,
                 code="OAUTH_TOKEN_ERROR",
@@ -246,13 +250,15 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
         received_state = state_list[0]
         if received_state != expected_state:
-            message = (
-                f"State mismatch: expected '{expected_state}', "
-                f"got '{received_state}'. Possible CSRF attack."
+            # Don't leak the expected state to the browser — keep details
+            # only in the server-side exception for debugging.
+            browser_message = "State parameter mismatch. Authorization failed."
+            self._send_html(
+                _ERROR_HTML.format(message=html_mod.escape(browser_message)),
+                status=400,
             )
-            self._send_html(_ERROR_HTML.format(message=message), status=400)
             handler_state["error"] = OAuthError(
-                message,
+                "State mismatch: possible CSRF attack.",
                 code="OAUTH_TOKEN_ERROR",
                 details={
                     "expected_state": expected_state,

--- a/src/mixpanel_data/_internal/auth/callback_server.py
+++ b/src/mixpanel_data/_internal/auth/callback_server.py
@@ -1,0 +1,272 @@
+"""OAuth callback server for receiving authorization codes.
+
+Implements a minimal HTTP server that listens for the OAuth 2.0 authorization
+code redirect from the browser. The server binds to ``127.0.0.1`` on the first
+available port in ``[19284, 19285, 19286, 19287]`` and waits for the
+authorization server to redirect the browser with ``code`` and ``state``
+query parameters.
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.callback_server import (
+        CallbackResult,
+        start_callback_server,
+    )
+
+    result, port = start_callback_server(state="random-state", timeout=300.0)
+    print(f"Got code: {result.code} on port {port}")
+    ```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from mixpanel_data.exceptions import OAuthError
+
+#: Ports to attempt binding to, in order.
+CALLBACK_PORTS: list[int] = [19284, 19285, 19286, 19287]
+
+_SUCCESS_HTML = """<!DOCTYPE html>
+<html>
+<head><title>Authorization Successful</title></head>
+<body style="font-family: sans-serif; text-align: center; padding: 2em;">
+<h1>&#10004; Successfully Authorized</h1>
+<p>You can close this browser tab and return to the terminal.</p>
+</body>
+</html>"""
+
+_ERROR_HTML = """<!DOCTYPE html>
+<html>
+<head><title>Authorization Error</title></head>
+<body style="font-family: sans-serif; text-align: center; padding: 2em;">
+<h1>&#10008; Authorization Error</h1>
+<p>{message}</p>
+<p>Please close this tab and try again.</p>
+</body>
+</html>"""
+
+
+@dataclass(frozen=True)
+class CallbackResult:
+    """Immutable result from an OAuth authorization callback.
+
+    Contains the authorization code and state parameter received from
+    the OAuth provider's redirect.
+
+    Attributes:
+        code: The authorization code from the OAuth provider.
+        state: The state parameter for CSRF validation.
+
+    Example:
+        ```python
+        result = CallbackResult(code="abc123", state="xyz789")
+        assert result.code == "abc123"
+        ```
+    """
+
+    code: str
+    """The authorization code from the OAuth provider."""
+
+    state: str
+    """The state parameter for CSRF validation."""
+
+
+def start_callback_server(
+    state: str,
+    timeout: float = 300.0,
+) -> tuple[CallbackResult, int]:
+    """Start a local HTTP server to receive the OAuth callback.
+
+    Tries to bind to ports 19284-19287 on ``127.0.0.1``. Once bound, it waits
+    for a single GET request containing ``code`` and ``state`` query parameters.
+    The ``state`` must match the provided value (CSRF protection). An HTML
+    page is returned to the browser indicating success or failure.
+
+    Args:
+        state: The expected state parameter for CSRF validation.
+        timeout: Maximum seconds to wait for the callback (default 300).
+
+    Returns:
+        A tuple of ``(CallbackResult, port)`` where ``port`` is the bound port.
+
+    Raises:
+        OAuthError: If all ports are busy (``OAUTH_PORT_ERROR``), the callback
+            times out (``OAUTH_TIMEOUT``), the state doesn't match, or the
+            provider returns an error parameter.
+
+    Example:
+        ```python
+        result, port = start_callback_server(state="my-state", timeout=60.0)
+        redirect_uri = f"http://localhost:{port}/callback"
+        ```
+    """
+    # Try to bind to the first available port
+    server: HTTPServer | None = None
+    bound_port: int = 0
+
+    for port in CALLBACK_PORTS:
+        try:
+            server = _create_server(port)
+            bound_port = port
+            break
+        except OSError:
+            continue
+
+    if server is None:
+        raise OAuthError(
+            "All OAuth callback ports (19284-19287) are busy. "
+            "Close other applications using these ports and try again.",
+            code="OAUTH_PORT_ERROR",
+            details={"ports": CALLBACK_PORTS},
+        )
+
+    server.timeout = timeout
+
+    # The handler stores results on the server instance
+    handler_state: dict[str, Any] = {
+        "result": None,
+        "error": None,
+    }
+    # Attach to server so handler can access it
+    server._handler_state = handler_state  # type: ignore[attr-defined]
+    server._expected_state = state  # type: ignore[attr-defined]
+
+    # Handle one request (blocking, with timeout)
+    server.handle_request()
+    server.server_close()
+
+    error = handler_state.get("error")
+    if error is not None:
+        raise error
+
+    result = handler_state.get("result")
+    if result is None:
+        raise OAuthError(
+            f"OAuth callback timed out after {timeout} seconds. "
+            "Please try again and complete the authorization in your browser.",
+            code="OAUTH_TIMEOUT",
+            details={"timeout_seconds": timeout},
+        )
+
+    return result, bound_port
+
+
+def _create_server(port: int) -> HTTPServer:
+    """Create an HTTPServer bound to the given port.
+
+    Args:
+        port: Port number to bind to on 127.0.0.1.
+
+    Returns:
+        Configured HTTPServer instance.
+
+    Raises:
+        OSError: If the port is already in use.
+    """
+    server = HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    return server
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the OAuth callback redirect.
+
+    Parses the authorization code and state from query parameters,
+    validates the state, and sends an HTML response to the browser.
+    """
+
+    def do_GET(self) -> None:  # noqa: N802
+        """Handle GET request from OAuth redirect.
+
+        Parses query parameters, validates state, and stores the result
+        on the server's ``_handler_state`` dict.
+        """
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        handler_state: dict[str, Any] = self.server._handler_state  # type: ignore[attr-defined]
+        expected_state: str = self.server._expected_state  # type: ignore[attr-defined]
+
+        # Check for error from provider
+        error_param = params.get("error")
+        if error_param:
+            error_desc = params.get("error_description", [""])[0]
+            error_code = error_param[0]
+            message = f"OAuth provider returned error: {error_code}"
+            if error_desc:
+                message += f" - {error_desc}"
+
+            self._send_html(
+                _ERROR_HTML.format(message=message),
+                status=400,
+            )
+            handler_state["error"] = OAuthError(
+                message,
+                code="OAUTH_TOKEN_ERROR",
+                details={"error": error_code, "error_description": error_desc},
+            )
+            return
+
+        # Extract code and state
+        code_list = params.get("code")
+        state_list = params.get("state")
+
+        if not code_list or not state_list:
+            message = "Missing 'code' or 'state' parameter in callback"
+            self._send_html(_ERROR_HTML.format(message=message), status=400)
+            handler_state["error"] = OAuthError(
+                message,
+                code="OAUTH_TOKEN_ERROR",
+            )
+            return
+
+        received_state = state_list[0]
+        if received_state != expected_state:
+            message = (
+                f"State mismatch: expected '{expected_state}', "
+                f"got '{received_state}'. Possible CSRF attack."
+            )
+            self._send_html(_ERROR_HTML.format(message=message), status=400)
+            handler_state["error"] = OAuthError(
+                message,
+                code="OAUTH_TOKEN_ERROR",
+                details={
+                    "expected_state": expected_state,
+                    "received_state": received_state,
+                },
+            )
+            return
+
+        # Success
+        self._send_html(_SUCCESS_HTML, status=200)
+        handler_state["result"] = CallbackResult(
+            code=code_list[0],
+            state=received_state,
+        )
+
+    def _send_html(self, html: str, *, status: int = 200) -> None:
+        """Send an HTML response to the browser.
+
+        Args:
+            html: HTML content to send.
+            status: HTTP status code.
+        """
+        body = html.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Suppress default stderr logging from BaseHTTPRequestHandler.
+
+        Args:
+            format: Log format string (unused).
+            *args: Log arguments (unused).
+        """
+        # Silence the default access log to avoid polluting terminal output
+        pass

--- a/src/mixpanel_data/_internal/auth/client_registration.py
+++ b/src/mixpanel_data/_internal/auth/client_registration.py
@@ -1,0 +1,165 @@
+"""Dynamic Client Registration for Mixpanel OAuth.
+
+Implements RFC 7591 Dynamic Client Registration to obtain a client_id
+from the Mixpanel authorization server. Client registrations are cached
+per-region via OAuthStorage to avoid redundant network calls.
+
+Example:
+    ```python
+    import httpx
+    from mixpanel_data._internal.auth.client_registration import (
+        ensure_client_registered,
+    )
+    from mixpanel_data._internal.auth.storage import OAuthStorage
+
+    storage = OAuthStorage()
+    client = httpx.Client()
+    info = ensure_client_registered(
+        http_client=client,
+        region="us",
+        redirect_uri="http://localhost:19284/callback",
+        storage=storage,
+    )
+    print(f"Client ID: {info.client_id}")
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import httpx
+
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo
+from mixpanel_data.exceptions import OAuthError
+
+#: OAuth base URLs keyed by Mixpanel region.
+OAUTH_BASE_URLS: dict[str, str] = {
+    "us": "https://mixpanel.com/oauth/",
+    "eu": "https://eu.mixpanel.com/oauth/",
+    "in": "https://in.mixpanel.com/oauth/",
+}
+
+#: Scopes sent in the DCR request body for server-side validation.
+#: Advisory only — DCR does NOT store these on the application model.
+#: The created app has an empty scope field, meaning all scopes are allowed.
+#: See: mixpanel_data_rust/docs/016-webapp-oauth-plan.md
+_DEFAULT_SCOPE: str = (
+    "projects analysis events insights segmentation retention "
+    "data:read funnels flows data_definitions dashboard_reports bookmarks"
+)
+
+
+def ensure_client_registered(
+    http_client: httpx.Client,
+    region: str,
+    redirect_uri: str,
+    storage: OAuthStorage,
+) -> OAuthClientInfo:
+    """Ensure a Dynamic Client Registration exists for the given region.
+
+    Checks the local cache (via OAuthStorage) first. If a cached client
+    exists with a matching ``redirect_uri``, it is returned immediately.
+    Otherwise, a new registration is performed via POST to the Mixpanel
+    ``mcp/register/`` endpoint and the result is cached.
+
+    Args:
+        http_client: An httpx.Client instance for making HTTP requests.
+        region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+        redirect_uri: The OAuth redirect URI to register.
+        storage: OAuthStorage instance for caching client info.
+
+    Returns:
+        The registered (or cached) OAuthClientInfo.
+
+    Raises:
+        OAuthError: If the registration request fails (network error,
+            non-200 status, or rate limiting with ``OAUTH_REGISTRATION_ERROR``).
+
+    Example:
+        ```python
+        info = ensure_client_registered(
+            http_client=httpx.Client(),
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=OAuthStorage(),
+        )
+        print(info.client_id)
+        ```
+    """
+    # Check cache
+    cached = storage.load_client_info(region)
+    if cached is not None and cached.redirect_uri == redirect_uri:
+        return cached
+
+    # Register new client
+    base_url = OAUTH_BASE_URLS.get(region, OAUTH_BASE_URLS["us"])
+    register_url = f"{base_url}mcp/register/"
+
+    body: dict[str, object] = {
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": _DEFAULT_SCOPE,
+    }
+
+    try:
+        response = http_client.post(register_url, json=body)
+    except httpx.HTTPError as exc:
+        raise OAuthError(
+            f"Client registration request failed: {exc}",
+            code="OAUTH_REGISTRATION_ERROR",
+            details={"region": region, "url": register_url},
+        ) from exc
+
+    if response.status_code == 429:
+        raise OAuthError(
+            "Client registration rate limited. Please try again later.",
+            code="OAUTH_REGISTRATION_ERROR",
+            details={
+                "region": region,
+                "status_code": 429,
+                "retry_after": response.headers.get("Retry-After"),
+            },
+        )
+
+    if not response.is_success:
+        raise OAuthError(
+            f"Client registration failed with status {response.status_code}: "
+            f"{response.text}",
+            code="OAUTH_REGISTRATION_ERROR",
+            details={
+                "region": region,
+                "status_code": response.status_code,
+                "response_body": response.text,
+            },
+        )
+
+    try:
+        data = response.json()
+        client_id = str(data["client_id"])
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise OAuthError(
+            f"Invalid registration response: {exc}",
+            code="OAUTH_REGISTRATION_ERROR",
+            details={
+                "region": region,
+                "response_body": response.text,
+            },
+        ) from exc
+
+    client_info = OAuthClientInfo(
+        client_id=client_id,
+        region=region,
+        redirect_uri=redirect_uri,
+        scope=_DEFAULT_SCOPE,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    # Cache for future use
+    storage.save_client_info(client_info)
+
+    return client_info

--- a/src/mixpanel_data/_internal/auth/client_registration.py
+++ b/src/mixpanel_data/_internal/auth/client_registration.py
@@ -95,7 +95,13 @@ def ensure_client_registered(
         return cached
 
     # Register new client
-    base_url = OAUTH_BASE_URLS.get(region, OAUTH_BASE_URLS["us"])
+    if region not in OAUTH_BASE_URLS:
+        raise OAuthError(
+            f"Unknown region: {region!r}. Must be one of: "
+            f"{', '.join(sorted(OAUTH_BASE_URLS.keys()))}",
+            code="OAUTH_REGISTRATION_ERROR",
+        )
+    base_url = OAUTH_BASE_URLS[region]
     register_url = f"{base_url}mcp/register/"
 
     body: dict[str, object] = {

--- a/src/mixpanel_data/_internal/auth/flow.py
+++ b/src/mixpanel_data/_internal/auth/flow.py
@@ -20,13 +20,18 @@ Example:
 
 from __future__ import annotations
 
+import json
 import secrets
+import socket
+import threading
+import time
 import webbrowser
 from urllib.parse import urlencode
 
 import httpx
 
 from mixpanel_data._internal.auth.callback_server import (
+    CALLBACK_PORTS,
     CallbackResult,
     start_callback_server,
 )
@@ -82,10 +87,16 @@ class OAuthFlow:
             flow = OAuthFlow(region="us", storage=OAuthStorage(Path("/tmp")))
             ```
         """
+        if region not in OAUTH_BASE_URLS:
+            raise OAuthError(
+                f"Unknown region: {region!r}. Must be one of: "
+                f"{', '.join(sorted(OAUTH_BASE_URLS.keys()))}",
+                code="OAUTH_CONFIG_ERROR",
+            )
         self._region = region
         self._storage = storage or OAuthStorage()
         self._http_client = http_client or httpx.Client()
-        self._base_url = OAUTH_BASE_URLS.get(region, OAUTH_BASE_URLS["us"])
+        self._base_url = OAUTH_BASE_URLS[region]
 
     @property
     def region(self) -> str:
@@ -176,29 +187,11 @@ class OAuthFlow:
         pkce = PkceChallenge.generate()
         state = secrets.token_urlsafe(32)
 
-        # Step 2: Start callback server (gets port)
-        # We need to start the server first to know which port we got,
-        # then use that port for registration and the authorize URL.
-        # But start_callback_server blocks... so we need a different approach.
-        # We'll register with a predicted port, then start the server.
-
-        # Try to find an available port by attempting registration with each
-        import socket
-
-        bound_port: int | None = None
-        for port in [19284, 19285, 19286, 19287]:
-            try:
-                test_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                test_sock.bind(("127.0.0.1", port))
-                test_sock.close()
-                bound_port = port
-                break
-            except OSError:
-                continue
-
+        # Step 2: Find an available callback port by probing before binding
+        bound_port = _find_available_port()
         if bound_port is None:
             raise OAuthError(
-                "All OAuth callback ports (19284-19287) are busy.",
+                f"All OAuth callback ports ({CALLBACK_PORTS}) are busy.",
                 code="OAUTH_PORT_ERROR",
             )
 
@@ -221,9 +214,6 @@ class OAuthFlow:
         )
 
         # Step 5: Start callback server in background, then open browser
-        # The callback server needs to be running before the browser redirects
-        import threading
-
         callback_result_holder: list[tuple[CallbackResult, int]] = []
         callback_error_holder: list[Exception] = []
 
@@ -240,9 +230,7 @@ class OAuthFlow:
         callback_thread = threading.Thread(target=_run_callback, daemon=True)
         callback_thread.start()
 
-        # Small delay to ensure server is listening
-        import time
-
+        # Small delay to ensure server is listening before opening browser
         time.sleep(0.1)
 
         # Open browser
@@ -325,8 +313,6 @@ class OAuthFlow:
             )
             ```
         """
-        token_url = f"{self._base_url}token/"
-
         form_data: dict[str, str] = {
             "grant_type": "authorization_code",
             "code": code,
@@ -334,45 +320,12 @@ class OAuthFlow:
             "client_id": client_id,
             "code_verifier": verifier,
         }
-
-        try:
-            response = self._http_client.post(token_url, data=form_data)
-        except httpx.HTTPError as exc:
-            raise OAuthError(
-                f"Token exchange request failed: {exc}",
-                code="OAUTH_TOKEN_ERROR",
-                details={"url": token_url},
-            ) from exc
-
-        if response.status_code != 200:
-            raise OAuthError(
-                f"Token exchange failed with status {response.status_code}: "
-                f"{response.text}",
-                code="OAUTH_TOKEN_ERROR",
-                details={
-                    "status_code": response.status_code,
-                    "response_body": response.text,
-                },
-            )
-
-        try:
-            data: dict[str, object] = response.json()
-        except Exception as exc:
-            raise OAuthError(
-                f"Token exchange returned non-JSON response: "
-                f"{response.headers.get('content-type', 'unknown')}",
-                code="OAUTH_TOKEN_ERROR",
-                details={"response_body": response.text},
-            ) from exc
-
-        try:
-            return OAuthTokens.from_token_response(data, project_id=project_id)
-        except (KeyError, TypeError, ValueError) as exc:
-            raise OAuthError(
-                f"Token exchange response missing required fields: {exc}",
-                code="OAUTH_TOKEN_ERROR",
-                details={"response_data": str(data)},
-            ) from exc
+        return self._post_token_request(
+            form_data,
+            operation="Token exchange",
+            error_code="OAUTH_TOKEN_ERROR",
+            project_id=project_id,
+        )
 
     def refresh_tokens(
         self,
@@ -406,28 +359,61 @@ class OAuthFlow:
                 code="OAUTH_REFRESH_ERROR",
             )
 
-        token_url = f"{self._base_url}token/"
-
         form_data: dict[str, str] = {
             "grant_type": "refresh_token",
             "refresh_token": tokens.refresh_token.get_secret_value(),
             "client_id": client_id,
         }
+        return self._post_token_request(
+            form_data,
+            operation="Token refresh",
+            error_code="OAUTH_REFRESH_ERROR",
+            project_id=tokens.project_id,
+        )
+
+    def _post_token_request(
+        self,
+        form_data: dict[str, str],
+        *,
+        operation: str,
+        error_code: str,
+        project_id: str | None = None,
+    ) -> OAuthTokens:
+        """POST form data to the token endpoint and parse the response.
+
+        Shared implementation for both token exchange and token refresh
+        requests, which follow the same request/response pattern.
+
+        Args:
+            form_data: Form-encoded body to POST.
+            operation: Human-readable name for error messages
+                (e.g., ``"Token exchange"`` or ``"Token refresh"``).
+            error_code: OAuthError code to use on failure.
+            project_id: Optional project ID to attach to the returned tokens.
+
+        Returns:
+            Parsed OAuthTokens from the token endpoint response.
+
+        Raises:
+            OAuthError: If the request fails, returns a non-200 status,
+                returns non-JSON, or is missing required fields.
+        """
+        token_url = f"{self._base_url}token/"
 
         try:
             response = self._http_client.post(token_url, data=form_data)
         except httpx.HTTPError as exc:
             raise OAuthError(
-                f"Token refresh request failed: {exc}",
-                code="OAUTH_REFRESH_ERROR",
+                f"{operation} request failed: {exc}",
+                code=error_code,
                 details={"url": token_url},
             ) from exc
 
         if response.status_code != 200:
             raise OAuthError(
-                f"Token refresh failed with status {response.status_code}: "
+                f"{operation} failed with status {response.status_code}: "
                 f"{response.text}",
-                code="OAUTH_REFRESH_ERROR",
+                code=error_code,
                 details={
                     "status_code": response.status_code,
                     "response_body": response.text,
@@ -436,20 +422,20 @@ class OAuthFlow:
 
         try:
             data: dict[str, object] = response.json()
-        except Exception as exc:
+        except (json.JSONDecodeError, ValueError) as exc:
             raise OAuthError(
-                f"Token refresh returned non-JSON response: "
+                f"{operation} returned non-JSON response: "
                 f"{response.headers.get('content-type', 'unknown')}",
-                code="OAUTH_REFRESH_ERROR",
+                code=error_code,
                 details={"response_body": response.text},
             ) from exc
 
         try:
-            return OAuthTokens.from_token_response(data, project_id=tokens.project_id)
+            return OAuthTokens.from_token_response(data, project_id=project_id)
         except (KeyError, TypeError, ValueError) as exc:
             raise OAuthError(
-                f"Token refresh response missing required fields: {exc}",
-                code="OAUTH_REFRESH_ERROR",
+                f"{operation} response missing required fields: {exc}",
+                code=error_code,
                 details={"response_data": str(data)},
             ) from exc
 
@@ -484,3 +470,22 @@ class OAuthFlow:
             "code_challenge_method": "S256",
         }
         return f"{self._base_url}authorize/?{urlencode(params)}"
+
+
+def _find_available_port() -> int | None:
+    """Probe CALLBACK_PORTS to find one that is not currently in use.
+
+    Binds and immediately releases each candidate port on 127.0.0.1.
+    Returns the first available port, or None if all are occupied.
+
+    Returns:
+        An available port number, or None.
+    """
+    for port in CALLBACK_PORTS:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as test_sock:
+                test_sock.bind(("127.0.0.1", port))
+            return port
+        except OSError:
+            continue
+    return None

--- a/src/mixpanel_data/_internal/auth/flow.py
+++ b/src/mixpanel_data/_internal/auth/flow.py
@@ -1,0 +1,484 @@
+"""OAuth 2.0 PKCE flow orchestrator for Mixpanel.
+
+Coordinates the full OAuth 2.0 Authorization Code + PKCE flow:
+1. Dynamic Client Registration (via ``ensure_client_registered``)
+2. PKCE challenge generation
+3. Browser-based authorization
+4. Local callback server to receive the authorization code
+5. Token exchange
+6. Token refresh
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.flow import OAuthFlow
+
+    flow = OAuthFlow(region="us")
+    tokens = flow.login(project_id="12345")
+    print(f"Access token: {tokens.access_token.get_secret_value()[:8]}...")
+    ```
+"""
+
+from __future__ import annotations
+
+import secrets
+import webbrowser
+from urllib.parse import urlencode
+
+import httpx
+
+from mixpanel_data._internal.auth.callback_server import (
+    CallbackResult,
+    start_callback_server,
+)
+from mixpanel_data._internal.auth.client_registration import (
+    OAUTH_BASE_URLS,
+    ensure_client_registered,
+)
+from mixpanel_data._internal.auth.pkce import PkceChallenge
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data.exceptions import OAuthError
+
+
+class OAuthFlow:
+    """Orchestrator for the OAuth 2.0 Authorization Code + PKCE flow.
+
+    Manages the full interactive login sequence: client registration,
+    PKCE challenge generation, browser authorization, callback handling,
+    and token exchange. Also supports token refresh.
+
+    Attributes:
+        region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+    Example:
+        ```python
+        flow = OAuthFlow(region="us")
+        tokens = flow.login(project_id="12345")
+        # Later, refresh tokens:
+        new_tokens = flow.refresh_tokens(tokens, client_id="my-client")
+        ```
+    """
+
+    def __init__(
+        self,
+        region: str = "us",
+        *,
+        storage: OAuthStorage | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        """Initialize the OAuth flow orchestrator.
+
+        Args:
+            region: Mixpanel data residency region (default ``"us"``).
+                Must be one of ``"us"``, ``"eu"``, or ``"in"``.
+            storage: OAuthStorage instance for caching tokens and client info.
+                Uses the default storage location if not provided.
+            http_client: httpx.Client for making HTTP requests. A default
+                client is created if not provided.
+
+        Example:
+            ```python
+            flow = OAuthFlow(region="eu")
+            flow = OAuthFlow(region="us", storage=OAuthStorage(Path("/tmp")))
+            ```
+        """
+        self._region = region
+        self._storage = storage or OAuthStorage()
+        self._http_client = http_client or httpx.Client()
+        self._base_url = OAUTH_BASE_URLS.get(region, OAUTH_BASE_URLS["us"])
+
+    @property
+    def region(self) -> str:
+        """Mixpanel data residency region.
+
+        Returns:
+            The region string (``us``, ``eu``, or ``in``).
+        """
+        return self._region
+
+    def get_valid_token(self, region: str) -> str:
+        """Return a valid access token, refreshing if expired.
+
+        Loads tokens from storage, checks if expired, auto-refreshes if
+        needed, persists refreshed tokens, and returns the access token string.
+
+        Args:
+            region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+        Returns:
+            A valid OAuth access token string.
+
+        Raises:
+            OAuthError: If no tokens exist (``OAUTH_TOKEN_ERROR``),
+                no client info exists for refresh (``OAUTH_REFRESH_ERROR``),
+                or the refresh request fails (``OAUTH_REFRESH_ERROR``).
+
+        Example:
+            ```python
+            flow = OAuthFlow(region="us")
+            token = flow.get_valid_token(region="us")
+            headers = {"Authorization": f"Bearer {token}"}
+            ```
+        """
+        tokens = self._storage.load_tokens(region=region)
+        if tokens is None:
+            raise OAuthError(
+                "No OAuth tokens found. Please log in first with `mp auth login`.",
+                code="OAUTH_TOKEN_ERROR",
+            )
+
+        if not tokens.is_expired():
+            return tokens.access_token.get_secret_value()
+
+        # Token is expired — refresh it
+        client_info = self._storage.load_client_info(region=region)
+        if client_info is None:
+            raise OAuthError(
+                "No OAuth client info found for refresh. "
+                "Please log in again with `mp auth login`.",
+                code="OAUTH_REFRESH_ERROR",
+            )
+
+        new_tokens = self.refresh_tokens(tokens=tokens, client_id=client_info.client_id)
+        self._storage.save_tokens(new_tokens, region=region)
+        return new_tokens.access_token.get_secret_value()
+
+    def login(self, project_id: str | None = None) -> OAuthTokens:
+        """Execute the full interactive OAuth PKCE login flow.
+
+        Performs the following steps:
+        1. Register (or load cached) OAuth client via DCR
+        2. Generate PKCE challenge
+        3. Start local callback server
+        4. Open browser to Mixpanel authorization URL
+        5. Wait for callback with authorization code
+        6. Exchange code for tokens
+        7. Save tokens to local storage
+
+        Args:
+            project_id: Optional Mixpanel project ID to associate with tokens.
+
+        Returns:
+            The obtained OAuthTokens with access and optional refresh tokens.
+
+        Raises:
+            OAuthError: If any step of the flow fails (registration, browser,
+                callback, token exchange).
+
+        Example:
+            ```python
+            flow = OAuthFlow(region="us")
+            tokens = flow.login(project_id="12345")
+            print(tokens.access_token.get_secret_value()[:8])
+            ```
+        """
+        # Step 1: Generate PKCE challenge and state
+        pkce = PkceChallenge.generate()
+        state = secrets.token_urlsafe(32)
+
+        # Step 2: Start callback server (gets port)
+        # We need to start the server first to know which port we got,
+        # then use that port for registration and the authorize URL.
+        # But start_callback_server blocks... so we need a different approach.
+        # We'll register with a predicted port, then start the server.
+
+        # Try to find an available port by attempting registration with each
+        import socket
+
+        bound_port: int | None = None
+        for port in [19284, 19285, 19286, 19287]:
+            try:
+                test_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                test_sock.bind(("127.0.0.1", port))
+                test_sock.close()
+                bound_port = port
+                break
+            except OSError:
+                continue
+
+        if bound_port is None:
+            raise OAuthError(
+                "All OAuth callback ports (19284-19287) are busy.",
+                code="OAUTH_PORT_ERROR",
+            )
+
+        redirect_uri = f"http://localhost:{bound_port}/callback"
+
+        # Step 3: Ensure client registration
+        client_info = ensure_client_registered(
+            http_client=self._http_client,
+            region=self._region,
+            redirect_uri=redirect_uri,
+            storage=self._storage,
+        )
+
+        # Step 4: Build authorize URL and open browser
+        authorize_url = self._build_authorize_url(
+            client_id=client_info.client_id,
+            redirect_uri=redirect_uri,
+            challenge=pkce.challenge,
+            state=state,
+        )
+
+        # Step 5: Start callback server in background, then open browser
+        # The callback server needs to be running before the browser redirects
+        import threading
+
+        callback_result_holder: list[tuple[CallbackResult, int]] = []
+        callback_error_holder: list[Exception] = []
+
+        def _run_callback() -> None:
+            """Run the callback server in a thread."""
+            try:
+                result = start_callback_server(state=state, timeout=300.0)
+                callback_result_holder.append(result)
+            except Exception as exc:
+                callback_error_holder.append(exc)
+
+        callback_thread = threading.Thread(target=_run_callback, daemon=True)
+        callback_thread.start()
+
+        # Small delay to ensure server is listening
+        import time
+
+        time.sleep(0.1)
+
+        # Open browser
+        try:
+            webbrowser.open(authorize_url)
+        except Exception as exc:
+            raise OAuthError(
+                f"Could not open browser for authorization: {exc}",
+                code="OAUTH_BROWSER_ERROR",
+                details={"authorize_url": authorize_url},
+            ) from exc
+
+        # Step 6: Wait for callback
+        callback_thread.join(timeout=310.0)
+
+        if callback_error_holder:
+            err = callback_error_holder[0]
+            if isinstance(err, OAuthError):
+                raise err
+            raise OAuthError(
+                f"Callback server error: {err}",
+                code="OAUTH_TOKEN_ERROR",
+            ) from err
+
+        if not callback_result_holder:
+            raise OAuthError(
+                "Callback server did not receive a response.",
+                code="OAUTH_TIMEOUT",
+            )
+
+        callback_result, _ = callback_result_holder[0]
+
+        # Step 7: Exchange code for tokens
+        tokens = self.exchange_code(
+            code=callback_result.code,
+            verifier=pkce.verifier,
+            client_id=client_info.client_id,
+            redirect_uri=redirect_uri,
+            project_id=project_id,
+        )
+
+        # Step 8: Save tokens
+        self._storage.save_tokens(tokens, region=self._region)
+
+        return tokens
+
+    def exchange_code(
+        self,
+        code: str,
+        verifier: str,
+        client_id: str,
+        redirect_uri: str,
+        project_id: str | None = None,
+    ) -> OAuthTokens:
+        """Exchange an authorization code for OAuth tokens.
+
+        Sends a POST request to the token endpoint with the authorization
+        code and PKCE verifier.
+
+        Args:
+            code: The authorization code from the callback.
+            verifier: The PKCE code verifier.
+            client_id: The registered OAuth client ID.
+            redirect_uri: The redirect URI used in the authorization request.
+            project_id: Optional Mixpanel project ID to associate with tokens.
+
+        Returns:
+            The obtained OAuthTokens.
+
+        Raises:
+            OAuthError: If the token exchange fails (``OAUTH_TOKEN_ERROR``).
+
+        Example:
+            ```python
+            tokens = flow.exchange_code(
+                code="auth-code",
+                verifier="pkce-verifier",
+                client_id="my-client",
+                redirect_uri="http://localhost:19284/callback",
+            )
+            ```
+        """
+        token_url = f"{self._base_url}token/"
+
+        form_data: dict[str, str] = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        }
+
+        try:
+            response = self._http_client.post(token_url, data=form_data)
+        except httpx.HTTPError as exc:
+            raise OAuthError(
+                f"Token exchange request failed: {exc}",
+                code="OAUTH_TOKEN_ERROR",
+                details={"url": token_url},
+            ) from exc
+
+        if response.status_code != 200:
+            raise OAuthError(
+                f"Token exchange failed with status {response.status_code}: "
+                f"{response.text}",
+                code="OAUTH_TOKEN_ERROR",
+                details={
+                    "status_code": response.status_code,
+                    "response_body": response.text,
+                },
+            )
+
+        try:
+            data: dict[str, object] = response.json()
+        except Exception as exc:
+            raise OAuthError(
+                f"Token exchange returned non-JSON response: "
+                f"{response.headers.get('content-type', 'unknown')}",
+                code="OAUTH_TOKEN_ERROR",
+                details={"response_body": response.text},
+            ) from exc
+
+        try:
+            return OAuthTokens.from_token_response(data, project_id=project_id)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise OAuthError(
+                f"Token exchange response missing required fields: {exc}",
+                code="OAUTH_TOKEN_ERROR",
+                details={"response_data": str(data)},
+            ) from exc
+
+    def refresh_tokens(
+        self,
+        tokens: OAuthTokens,
+        client_id: str,
+    ) -> OAuthTokens:
+        """Refresh OAuth tokens using a refresh token.
+
+        Sends a POST request to the token endpoint with the refresh token
+        to obtain new access and refresh tokens.
+
+        Args:
+            tokens: Current OAuthTokens containing the refresh token.
+            client_id: The OAuth client ID.
+
+        Returns:
+            New OAuthTokens with a fresh access token.
+
+        Raises:
+            OAuthError: If no refresh token is available
+                (``OAUTH_REFRESH_ERROR``) or the refresh request fails.
+
+        Example:
+            ```python
+            new_tokens = flow.refresh_tokens(tokens, client_id="my-client")
+            ```
+        """
+        if tokens.refresh_token is None:
+            raise OAuthError(
+                "Cannot refresh: no refresh token available. Please log in again.",
+                code="OAUTH_REFRESH_ERROR",
+            )
+
+        token_url = f"{self._base_url}token/"
+
+        form_data: dict[str, str] = {
+            "grant_type": "refresh_token",
+            "refresh_token": tokens.refresh_token.get_secret_value(),
+            "client_id": client_id,
+        }
+
+        try:
+            response = self._http_client.post(token_url, data=form_data)
+        except httpx.HTTPError as exc:
+            raise OAuthError(
+                f"Token refresh request failed: {exc}",
+                code="OAUTH_REFRESH_ERROR",
+                details={"url": token_url},
+            ) from exc
+
+        if response.status_code != 200:
+            raise OAuthError(
+                f"Token refresh failed with status {response.status_code}: "
+                f"{response.text}",
+                code="OAUTH_REFRESH_ERROR",
+                details={
+                    "status_code": response.status_code,
+                    "response_body": response.text,
+                },
+            )
+
+        try:
+            data: dict[str, object] = response.json()
+        except Exception as exc:
+            raise OAuthError(
+                f"Token refresh returned non-JSON response: "
+                f"{response.headers.get('content-type', 'unknown')}",
+                code="OAUTH_REFRESH_ERROR",
+                details={"response_body": response.text},
+            ) from exc
+
+        try:
+            return OAuthTokens.from_token_response(data, project_id=tokens.project_id)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise OAuthError(
+                f"Token refresh response missing required fields: {exc}",
+                code="OAUTH_REFRESH_ERROR",
+                details={"response_data": str(data)},
+            ) from exc
+
+    def _build_authorize_url(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        challenge: str,
+        state: str,
+    ) -> str:
+        """Build the OAuth authorization URL with PKCE parameters.
+
+        Args:
+            client_id: The registered OAuth client ID.
+            redirect_uri: The callback redirect URI.
+            challenge: The PKCE code challenge.
+            state: The CSRF state parameter.
+
+        Returns:
+            The full authorization URL to open in the browser.
+        """
+        # scope intentionally omitted — DCR creates apps with an empty scope
+        # field, so Django OAuth Toolkit defaults to ["__all__"], granting
+        # every scope in OAUTH2_PROVIDER["SCOPES"] (~63 total).
+        # See: mixpanel_data_rust/docs/016-webapp-oauth-plan.md
+        params: dict[str, str] = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+        return f"{self._base_url}authorize/?{urlencode(params)}"

--- a/src/mixpanel_data/_internal/auth/flow.py
+++ b/src/mixpanel_data/_internal/auth/flow.py
@@ -230,7 +230,9 @@ class OAuthFlow:
         def _run_callback() -> None:
             """Run the callback server in a thread."""
             try:
-                result = start_callback_server(state=state, timeout=300.0)
+                result = start_callback_server(
+                    state=state, timeout=300.0, port=bound_port
+                )
                 callback_result_holder.append(result)
             except Exception as exc:
                 callback_error_holder.append(exc)

--- a/src/mixpanel_data/_internal/auth/pkce.py
+++ b/src/mixpanel_data/_internal/auth/pkce.py
@@ -1,0 +1,73 @@
+"""PKCE (Proof Key for Code Exchange) challenge generation.
+
+Implements RFC 7636 PKCE for OAuth 2.0 Authorization Code flow.
+Generates cryptographically secure code verifier and code challenge pairs
+using SHA-256 hashing and base64url encoding.
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+    challenge = PkceChallenge.generate()
+    # challenge.verifier  -> 86-char base64url string
+    # challenge.challenge  -> 43-char base64url SHA-256 hash
+    ```
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PkceChallenge:
+    """Immutable PKCE code verifier and challenge pair.
+
+    A frozen dataclass containing a cryptographically secure code verifier
+    and its corresponding SHA-256 code challenge, as specified in RFC 7636.
+
+    The verifier is 86 characters of base64url-encoded random bytes (64 bytes).
+    The challenge is the base64url-encoded SHA-256 hash of the verifier.
+
+    Attributes:
+        verifier: Base64url-encoded code verifier (86 chars, no padding).
+        challenge: Base64url-encoded SHA-256 hash of the verifier (43 chars, no padding).
+    """
+
+    verifier: str
+    """Base64url-encoded code verifier (86 chars, no padding)."""
+
+    challenge: str
+    """Base64url-encoded SHA-256 hash of the verifier (43 chars, no padding)."""
+
+    @classmethod
+    def generate(cls) -> PkceChallenge:
+        """Generate a new PKCE verifier/challenge pair.
+
+        Creates 64 cryptographically secure random bytes, encodes them as
+        a base64url string (no padding) for the verifier, then computes
+        the SHA-256 hash of the verifier encoded as base64url (no padding)
+        for the challenge.
+
+        Returns:
+            A new PkceChallenge with verifier and challenge fields set.
+
+        Example:
+            ```python
+            pkce = PkceChallenge.generate()
+            assert len(pkce.verifier) == 86
+            assert len(pkce.challenge) == 43
+            ```
+        """
+        random_bytes = secrets.token_bytes(64)
+        verifier = base64.urlsafe_b64encode(random_bytes).rstrip(b"=").decode("ascii")
+
+        challenge_hash = hashlib.sha256(verifier.encode("ascii")).digest()
+        challenge = (
+            base64.urlsafe_b64encode(challenge_hash).rstrip(b"=").decode("ascii")
+        )
+
+        return cls(verifier=verifier, challenge=challenge)

--- a/src/mixpanel_data/_internal/auth/storage.py
+++ b/src/mixpanel_data/_internal/auth/storage.py
@@ -212,8 +212,7 @@ class OAuthStorage:
                 type(parsed).__name__,
             )
             return None
-        raw: dict[str, Any] = parsed
-        return raw
+        return parsed
 
     def _tokens_path(self, region: str) -> Path:
         """Return the file path for tokens of a given region.

--- a/src/mixpanel_data/_internal/auth/storage.py
+++ b/src/mixpanel_data/_internal/auth/storage.py
@@ -1,0 +1,401 @@
+"""Secure local storage for OAuth tokens and client registration info.
+
+Persists OAuth tokens and client metadata as JSON files in a
+permission-restricted directory (``~/.mp/oauth/`` by default).
+Directory permissions are set to ``0o700`` and file permissions to ``0o600``
+to protect sensitive credential material.
+
+The storage directory can be overridden via the ``MP_OAUTH_STORAGE_DIR``
+environment variable for testing or custom deployments.
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.storage import OAuthStorage
+    from mixpanel_data._internal.auth.token import OAuthTokens
+
+    storage = OAuthStorage()
+    storage.save_tokens(tokens, region="us")
+    loaded = storage.load_tokens(region="us")
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any
+
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+
+logger = logging.getLogger(__name__)
+
+
+class OAuthStorage:
+    """Secure file-based storage for OAuth tokens and client info.
+
+    Stores tokens and client registration data as JSON files under
+    a permission-restricted directory. Each region gets its own pair
+    of files (``tokens_{region}.json`` and ``client_{region}.json``).
+
+    The storage directory defaults to ``~/.mp/oauth/`` but can be
+    overridden via the ``MP_OAUTH_STORAGE_DIR`` environment variable
+    or the ``storage_dir`` constructor parameter.
+
+    Security:
+        - Directory permissions: ``0o700`` (owner-only access)
+        - File permissions: ``0o600`` (owner-only read/write)
+
+    Attributes:
+        storage_dir: Path to the storage directory.
+    """
+
+    DEFAULT_STORAGE_DIR: Path = Path.home() / ".mp" / "oauth"
+
+    def __init__(self, storage_dir: Path | None = None) -> None:
+        """Initialize OAuthStorage.
+
+        Args:
+            storage_dir: Override the storage directory. If not provided,
+                uses ``MP_OAUTH_STORAGE_DIR`` env var or ``~/.mp/oauth/``.
+
+        Example:
+            ```python
+            storage = OAuthStorage()  # uses default
+            storage = OAuthStorage(Path("/tmp/test-oauth"))  # custom dir
+            ```
+        """
+        if storage_dir is not None:
+            self._storage_dir = storage_dir
+        elif "MP_OAUTH_STORAGE_DIR" in os.environ:
+            self._storage_dir = Path(os.environ["MP_OAUTH_STORAGE_DIR"])
+        else:
+            self._storage_dir = self.DEFAULT_STORAGE_DIR
+
+    @property
+    def storage_dir(self) -> Path:
+        """Return the storage directory path.
+
+        Returns:
+            The resolved storage directory path.
+        """
+        return self._storage_dir
+
+    @staticmethod
+    def _validate_region(region: str) -> None:
+        """Validate that the region string is safe for use in file paths.
+
+        Prevents path traversal attacks by ensuring the region is exactly
+        a 2-letter lowercase ASCII string (e.g., ``us``, ``eu``, ``in``).
+
+        Args:
+            region: The region string to validate.
+
+        Raises:
+            ValueError: If the region is not a 2-letter lowercase string.
+
+        Example:
+            ```python
+            OAuthStorage._validate_region("us")   # OK
+            OAuthStorage._validate_region("../x")  # raises ValueError
+            ```
+        """
+        if not re.fullmatch(r"[a-z]{2}", region):
+            raise ValueError(
+                f"Invalid region: {region!r}. Must be a 2-letter lowercase string."
+            )
+
+    def _ensure_dir(self) -> None:
+        """Create storage directory with restricted permissions if it doesn't exist.
+
+        Sets directory permissions to ``0o700`` (owner-only access).
+        """
+        old_umask = os.umask(0o077)
+        try:
+            self._storage_dir.mkdir(parents=True, exist_ok=True)
+        finally:
+            os.umask(old_umask)
+        self._storage_dir.chmod(stat.S_IRWXU)
+
+    def _check_and_fix_permissions(self, path: Path) -> None:
+        """Check and repair file/directory permissions.
+
+        Verifies that the storage directory has ``0o700`` permissions and
+        the specified file has ``0o600`` permissions. Attempts to repair
+        incorrect permissions via ``os.chmod()``. Logs a warning to stderr
+        if repair fails.
+
+        Args:
+            path: File path whose permissions (and parent directory) to check.
+        """
+        # Check directory permissions
+        if self._storage_dir.exists():
+            dir_mode = stat.S_IMODE(self._storage_dir.stat().st_mode)
+            if dir_mode != 0o700:
+                try:
+                    self._storage_dir.chmod(stat.S_IRWXU)
+                except OSError:
+                    logger.warning(
+                        "Cannot repair directory permissions on %s. "
+                        "Expected 0o700, got %s. "
+                        "Run: chmod 700 %s",
+                        self._storage_dir,
+                        oct(dir_mode),
+                        self._storage_dir,
+                    )
+
+        # Check file permissions
+        if path.exists():
+            file_mode = stat.S_IMODE(path.stat().st_mode)
+            if file_mode != 0o600:
+                try:
+                    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+                except OSError:
+                    logger.warning(
+                        "Cannot repair file permissions on %s. "
+                        "Expected 0o600, got %s. "
+                        "Run: chmod 600 %s",
+                        path,
+                        oct(file_mode),
+                        path,
+                    )
+
+    def _write_file(self, path: Path, data: dict[str, Any]) -> None:
+        """Write JSON data to a file with restricted permissions.
+
+        Sets umask before writing to ensure no group/other bits leak,
+        then explicitly sets ``0o600`` after write.
+
+        Args:
+            path: File path to write to.
+            data: Dictionary to serialize as JSON.
+        """
+        self._ensure_dir()
+        old_umask = os.umask(0o177)
+        try:
+            path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        finally:
+            os.umask(old_umask)
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    def _read_file(self, path: Path) -> dict[str, Any] | None:
+        """Read JSON data from a file.
+
+        Checks and repairs file/directory permissions before reading.
+        Returns None and logs a warning if the file contains invalid JSON.
+
+        Args:
+            path: File path to read from.
+
+        Returns:
+            Parsed dictionary, or None if the file does not exist or
+            contains invalid/non-JSON data.
+        """
+        if not path.exists():
+            return None
+        self._check_and_fix_permissions(path)
+        try:
+            content = path.read_text(encoding="utf-8")
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            logger.warning("Corrupted or invalid JSON in %s — ignoring file.", path)
+            return None
+        if not isinstance(parsed, dict):
+            logger.warning(
+                "Expected JSON object in %s, got %s — ignoring file.",
+                path,
+                type(parsed).__name__,
+            )
+            return None
+        raw: dict[str, Any] = parsed
+        return raw
+
+    def _tokens_path(self, region: str) -> Path:
+        """Return the file path for tokens of a given region.
+
+        Args:
+            region: Mixpanel data residency region.
+
+        Returns:
+            Path to the tokens JSON file.
+        """
+        return self._storage_dir / f"tokens_{region}.json"
+
+    def _client_path(self, region: str) -> Path:
+        """Return the file path for client info of a given region.
+
+        Args:
+            region: Mixpanel data residency region.
+
+        Returns:
+            Path to the client info JSON file.
+        """
+        return self._storage_dir / f"client_{region}.json"
+
+    def save_tokens(self, tokens: OAuthTokens, region: str) -> None:
+        """Persist OAuth tokens to disk.
+
+        Serializes the token model to JSON, converting ``SecretStr`` fields
+        to their plain-text values for storage. The file is written with
+        ``0o600`` permissions.
+
+        Args:
+            tokens: The OAuth tokens to save.
+            region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            storage.save_tokens(tokens, region="us")
+            ```
+        """
+        self._validate_region(region)
+        data: dict[str, Any] = {
+            "access_token": tokens.access_token.get_secret_value(),
+            "expires_at": tokens.expires_at.isoformat(),
+            "scope": tokens.scope,
+            "token_type": tokens.token_type,
+            "project_id": tokens.project_id,
+        }
+        if tokens.refresh_token is not None:
+            data["refresh_token"] = tokens.refresh_token.get_secret_value()
+        self._write_file(self._tokens_path(region), data)
+
+    def load_tokens(self, region: str) -> OAuthTokens | None:
+        """Load OAuth tokens from disk.
+
+        Reads the tokens JSON file for the given region and reconstructs
+        the ``OAuthTokens`` model, wrapping secret fields back into
+        ``SecretStr`` instances.
+
+        Args:
+            region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+        Returns:
+            The loaded OAuthTokens, or None if no tokens file exists.
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            tokens = storage.load_tokens(region="us")
+            if tokens and not tokens.is_expired():
+                print("Using cached tokens")
+            ```
+        """
+        self._validate_region(region)
+        data = self._read_file(self._tokens_path(region))
+        if data is None:
+            return None
+
+        try:
+            refresh_token: SecretStr | None = None
+            raw_refresh = data.get("refresh_token")
+            if raw_refresh is not None:
+                refresh_token = SecretStr(str(raw_refresh))
+
+            return OAuthTokens(
+                access_token=SecretStr(str(data["access_token"])),
+                refresh_token=refresh_token,
+                expires_at=data["expires_at"],
+                scope=str(data["scope"]),
+                token_type=str(data["token_type"]),
+                project_id=data.get("project_id"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to parse tokens from %s: %s — ignoring file.",
+                self._tokens_path(region),
+                exc,
+            )
+            return None
+
+    def save_client_info(self, info: OAuthClientInfo) -> None:
+        """Persist OAuth client registration info to disk.
+
+        Uses the client's ``region`` field to determine the file path.
+
+        Args:
+            info: The client registration info to save.
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            storage.save_client_info(client_info)
+            ```
+        """
+        self._validate_region(info.region)
+        data = info.model_dump(mode="json")
+        self._write_file(self._client_path(info.region), data)
+
+    def load_client_info(self, region: str) -> OAuthClientInfo | None:
+        """Load OAuth client registration info from disk.
+
+        Args:
+            region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+        Returns:
+            The loaded OAuthClientInfo, or None if no client file exists.
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            client = storage.load_client_info(region="us")
+            if client:
+                print(f"Cached client: {client.client_id}")
+            ```
+        """
+        self._validate_region(region)
+        data = self._read_file(self._client_path(region))
+        if data is None:
+            return None
+        try:
+            return OAuthClientInfo.model_validate(data)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to parse client info from %s: %s — ignoring file.",
+                self._client_path(region),
+                exc,
+            )
+            return None
+
+    def delete_tokens(self, region: str) -> None:
+        """Delete stored tokens for a region.
+
+        Silently succeeds if the tokens file does not exist.
+
+        Args:
+            region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            storage.delete_tokens(region="us")
+            ```
+        """
+        self._validate_region(region)
+        path = self._tokens_path(region)
+        if path.exists():
+            path.unlink()
+
+    def delete_all(self) -> None:
+        """Delete all stored tokens and client info files.
+
+        Removes all JSON files in the storage directory. The directory
+        itself is preserved. Silently succeeds if the directory does
+        not exist.
+
+        Example:
+            ```python
+            storage = OAuthStorage()
+            storage.delete_all()
+            ```
+        """
+        if not self._storage_dir.exists():
+            return
+        for path in self._storage_dir.glob("*.json"):
+            path.unlink()

--- a/src/mixpanel_data/_internal/auth/token.py
+++ b/src/mixpanel_data/_internal/auth/token.py
@@ -1,0 +1,167 @@
+"""OAuth token and client info models.
+
+Immutable Pydantic models for OAuth 2.0 token management and
+Dynamic Client Registration (DCR) client metadata.
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.token import OAuthTokens, OAuthClientInfo
+
+    tokens = OAuthTokens.from_token_response(
+        {"access_token": "abc", "refresh_token": "def", "expires_in": 3600,
+         "scope": "read", "token_type": "Bearer"},
+        project_id="12345",
+    )
+    if tokens.is_expired():
+        print("Token needs refresh")
+    ```
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+
+class OAuthTokens(BaseModel):
+    """Immutable OAuth 2.0 token set with expiry tracking.
+
+    Stores access and optional refresh tokens along with metadata
+    from the token response. The ``is_expired`` method includes a
+    30-second safety buffer to avoid using tokens that are about to expire.
+
+    Attributes:
+        access_token: The OAuth access token (redacted in output).
+        refresh_token: The OAuth refresh token, if provided (redacted in output).
+        expires_at: UTC datetime when the access token expires.
+        scope: Space-separated list of granted scopes.
+        token_type: Token type, typically ``"Bearer"``.
+        project_id: Associated Mixpanel project ID, if known.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    access_token: SecretStr
+    """The OAuth access token (redacted in output)."""
+
+    refresh_token: SecretStr | None = None
+    """The OAuth refresh token, if provided (redacted in output)."""
+
+    expires_at: datetime
+    """UTC datetime when the access token expires."""
+
+    scope: str
+    """Space-separated list of granted scopes."""
+
+    token_type: str
+    """Token type, typically ``'Bearer'``."""
+
+    project_id: str | None = None
+    """Associated Mixpanel project ID, if known."""
+
+    def is_expired(self) -> bool:
+        """Check whether the access token is expired or about to expire.
+
+        Uses a 30-second safety buffer to avoid sending tokens that are
+        about to expire during in-flight requests.
+
+        Returns:
+            True if the token is expired or will expire within 30 seconds.
+
+        Example:
+            ```python
+            tokens = OAuthTokens.from_token_response(
+                {"access_token": "x", "expires_in": 10,
+                 "scope": "read", "token_type": "Bearer"}
+            )
+            assert tokens.is_expired()  # 10s < 30s buffer
+            ```
+        """
+        return datetime.now(timezone.utc) + timedelta(seconds=30) >= self.expires_at
+
+    @classmethod
+    def from_token_response(
+        cls,
+        data: dict[str, object],
+        project_id: str | None = None,
+    ) -> OAuthTokens:
+        """Create an OAuthTokens instance from a raw token endpoint response.
+
+        Computes ``expires_at`` by adding the ``expires_in`` value (in seconds)
+        to the current UTC time.
+
+        Args:
+            data: Raw JSON response from the token endpoint. Must contain
+                ``access_token``, ``expires_in``, ``scope``, and ``token_type``.
+                May contain ``refresh_token``.
+            project_id: Optional Mixpanel project ID to associate with the tokens.
+
+        Returns:
+            A new frozen OAuthTokens instance.
+
+        Raises:
+            KeyError: If required keys are missing from ``data``.
+            TypeError: If ``expires_in`` is not an int.
+
+        Example:
+            ```python
+            response = {
+                "access_token": "eyJ...",
+                "refresh_token": "dGhp...",
+                "expires_in": 3600,
+                "scope": "read:project",
+                "token_type": "Bearer",
+            }
+            tokens = OAuthTokens.from_token_response(response, project_id="123")
+            ```
+        """
+        expires_in_raw = data["expires_in"]
+        expires_in = int(str(expires_in_raw))
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+        raw_refresh = data.get("refresh_token")
+        refresh_token: SecretStr | None = None
+        if raw_refresh is not None:
+            refresh_token = SecretStr(str(raw_refresh))
+
+        return cls(
+            access_token=SecretStr(str(data["access_token"])),
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            scope=str(data.get("scope", "")),
+            token_type=str(data["token_type"]),
+            project_id=project_id,
+        )
+
+
+class OAuthClientInfo(BaseModel):
+    """Immutable OAuth client registration metadata.
+
+    Stores client information from Dynamic Client Registration (RFC 7591)
+    for reuse across sessions without re-registering.
+
+    Attributes:
+        client_id: The OAuth client identifier.
+        region: Mixpanel data residency region (``us``, ``eu``, or ``in``).
+        redirect_uri: The redirect URI registered with the authorization server.
+        scope: Space-separated list of requested scopes.
+        created_at: UTC datetime when the client was registered.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    client_id: str
+    """The OAuth client identifier."""
+
+    region: str
+    """Mixpanel data residency region (``us``, ``eu``, or ``in``)."""
+
+    redirect_uri: str
+    """The redirect URI registered with the authorization server."""
+
+    scope: str
+    """Space-separated list of requested scopes."""
+
+    created_at: datetime
+    """UTC datetime when the client was registered."""

--- a/src/mixpanel_data/_internal/auth/token.py
+++ b/src/mixpanel_data/_internal/auth/token.py
@@ -102,7 +102,7 @@ class OAuthTokens(BaseModel):
 
         Raises:
             KeyError: If required keys are missing from ``data``.
-            TypeError: If ``expires_in`` is not an int.
+            ValueError: If ``expires_in`` cannot be converted to an int.
 
         Example:
             ```python

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import sys
 from dataclasses import dataclass
+from enum import Enum
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -18,7 +19,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import tomli_w
-from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, SecretStr, field_validator, model_validator
 
 from mixpanel_data.exceptions import (
     AccountExistsError,
@@ -31,6 +32,31 @@ VALID_REGIONS = ("us", "eu", "in")
 RegionType = Literal["us", "eu", "in"]
 
 
+class AuthMethod(str, Enum):
+    """Authentication method for Mixpanel API requests.
+
+    Determines how the ``Authorization`` header is constructed:
+
+    - ``basic``: Uses HTTP Basic Auth with service account username/secret.
+    - ``oauth``: Uses OAuth 2.0 Bearer token.
+
+    Example:
+        ```python
+        method = AuthMethod.basic
+        assert method.value == "basic"
+
+        method = AuthMethod.oauth
+        assert method.value == "oauth"
+        ```
+    """
+
+    basic = "basic"
+    """HTTP Basic Auth with service account credentials."""
+
+    oauth = "oauth"
+    """OAuth 2.0 Bearer token authentication."""
+
+
 class Credentials(BaseModel):
     """Immutable credentials for Mixpanel API authentication.
 
@@ -38,21 +64,31 @@ class Credentials(BaseModel):
     - All fields are validated on construction
     - The secret is never exposed in repr/str output
     - The object cannot be modified after creation
+
+    Supports both Basic Auth (service account) and OAuth 2.0 Bearer token
+    authentication. When ``auth_method`` is ``oauth``, the ``username`` and
+    ``secret`` fields may be empty strings.
     """
 
     model_config = ConfigDict(frozen=True)
 
     username: str
-    """Service account username."""
+    """Service account username (may be empty for OAuth)."""
 
     secret: SecretStr
-    """Service account secret (redacted in output)."""
+    """Service account secret (redacted in output; may be empty for OAuth)."""
 
     project_id: str
     """Mixpanel project identifier."""
 
     region: RegionType
     """Data residency region (us, eu, or in)."""
+
+    auth_method: AuthMethod = AuthMethod.basic
+    """Authentication method (basic or oauth). Defaults to basic."""
+
+    oauth_access_token: SecretStr | None = None
+    """OAuth 2.0 access token, required when auth_method is oauth."""
 
     @field_validator("region", mode="before")
     @classmethod
@@ -66,13 +102,72 @@ class Credentials(BaseModel):
             raise ValueError(f"Region must be one of: {valid}. Got: {v}")
         return v_lower
 
-    @field_validator("username", "project_id")
-    @classmethod
-    def validate_non_empty(cls, v: str) -> str:
-        """Validate string fields are non-empty."""
-        if not v or not v.strip():
-            raise ValueError("Field cannot be empty")
-        return v
+    @model_validator(mode="after")
+    def validate_credentials(self) -> Credentials:
+        """Validate credential fields based on auth method.
+
+        For basic auth, username and project_id must be non-empty.
+        For OAuth, username may be empty but project_id must still be non-empty,
+        and oauth_access_token must be provided.
+
+        Returns:
+            The validated Credentials instance.
+
+        Raises:
+            ValueError: If required fields are missing for the auth method.
+        """
+        if not self.project_id or not self.project_id.strip():
+            raise ValueError("project_id cannot be empty")
+
+        if self.auth_method == AuthMethod.basic:
+            if not self.username or not self.username.strip():
+                raise ValueError("username cannot be empty for basic auth")
+            if not self.secret.get_secret_value():
+                raise ValueError("secret cannot be empty for basic auth")
+        elif self.auth_method == AuthMethod.oauth:
+            if self.oauth_access_token is None:
+                raise ValueError(
+                    "oauth_access_token is required when auth_method is oauth"
+                )
+        return self
+
+    def auth_header(self) -> str:
+        """Build the Authorization header value for API requests.
+
+        Returns:
+            For basic auth: ``"Basic <base64(username:secret)>"``.
+            For OAuth: ``"Bearer <access_token>"``.
+
+        Raises:
+            ValueError: If auth_method is oauth but no access token is set.
+
+        Example:
+            ```python
+            creds = Credentials(
+                username="sa-user", secret=SecretStr("sa-secret"),
+                project_id="123", region="us",
+            )
+            assert creds.auth_header().startswith("Basic ")
+
+            oauth_creds = Credentials(
+                username="", secret=SecretStr(""),
+                project_id="123", region="us",
+                auth_method=AuthMethod.oauth,
+                oauth_access_token=SecretStr("my-token"),
+            )
+            assert oauth_creds.auth_header() == "Bearer my-token"
+            ```
+        """
+        if self.auth_method == AuthMethod.oauth:
+            if self.oauth_access_token is None:
+                raise ValueError("No OAuth access token available")
+            return f"Bearer {self.oauth_access_token.get_secret_value()}"
+
+        import base64
+
+        raw = f"{self.username}:{self.secret.get_secret_value()}"
+        encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
+        return f"Basic {encoded}"
 
     def __repr__(self) -> str:
         """Return string representation with redacted secret."""
@@ -178,16 +273,32 @@ class ConfigManager:
         accounts = config.get("accounts", {})
         return list(accounts.keys())
 
-    def resolve_credentials(self, account: str | None = None) -> Credentials:
+    def resolve_credentials(
+        self,
+        account: str | None = None,
+        *,
+        _oauth_storage_dir: Path | None = None,
+    ) -> Credentials:
         """Resolve credentials using priority order.
 
         Resolution order:
         1. Environment variables (MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION)
-        2. Named account from config file (if account parameter provided)
-        3. Default account from config file
+        2. OAuth tokens from local storage (if no explicit account requested)
+        3. Named account from config file (if account parameter provided)
+        4. Default account from config file
+
+        For OAuth resolution, the region and project_id are determined from:
+        - ``MP_PROJECT_ID`` / ``MP_REGION`` env vars (partial env mode), or
+        - The default account in the config file.
+
+        Expired OAuth tokens are skipped, falling through to config file
+        resolution.
 
         Args:
             account: Optional account name to use instead of default.
+                When provided, OAuth resolution is skipped.
+            _oauth_storage_dir: Override OAuth storage directory for testing.
+                If ``None``, uses the default ``OAuthStorage`` directory.
 
         Returns:
             Immutable Credentials object.
@@ -195,13 +306,28 @@ class ConfigManager:
         Raises:
             ConfigError: If no credentials can be resolved.
             AccountNotFoundError: If named account doesn't exist.
+
+        Example:
+            ```python
+            config = ConfigManager()
+            creds = config.resolve_credentials()
+            print(creds.auth_method)  # AuthMethod.basic or AuthMethod.oauth
+            ```
         """
-        # Priority 1: Environment variables
+        # Priority 1: Environment variables (all four must be set)
         env_creds = self._resolve_from_env()
         if env_creds is not None:
             return env_creds
 
-        # Priority 2 & 3: Config file (named account or default)
+        # Priority 2: OAuth tokens (only when no explicit account requested)
+        if account is None:
+            oauth_creds = self._resolve_from_oauth(
+                _oauth_storage_dir=_oauth_storage_dir,
+            )
+            if oauth_creds is not None:
+                return oauth_creds
+
+        # Priority 3 & 4: Config file (named account or default)
         config = self._read_config()
         accounts = config.get("accounts", {})
 
@@ -237,6 +363,89 @@ class ConfigManager:
             project_id=account_data["project_id"],
             region=account_data["region"],
         )
+
+    def _resolve_from_oauth(
+        self,
+        *,
+        _oauth_storage_dir: Path | None = None,
+    ) -> Credentials | None:
+        """Attempt to resolve credentials from stored OAuth tokens.
+
+        Checks for valid (non-expired) OAuth tokens in local storage.
+        The region for token lookup is determined from ``MP_REGION`` env var
+        or the default account in the config file.
+
+        Args:
+            _oauth_storage_dir: Override OAuth storage directory for testing.
+
+        Returns:
+            Credentials with ``auth_method=AuthMethod.oauth`` if valid tokens
+            are found, ``None`` otherwise.
+        """
+        from mixpanel_data._internal.auth.storage import OAuthStorage
+
+        # Determine region and project_id for token lookup
+        region, project_id = self._resolve_region_and_project_for_oauth()
+        if region is None:
+            return None
+
+        storage = OAuthStorage(storage_dir=_oauth_storage_dir)
+        tokens = storage.load_tokens(region)
+        if tokens is None:
+            return None
+
+        # Skip expired tokens
+        if tokens.is_expired():
+            return None
+
+        # Use project_id from token if available, otherwise from config/env
+        resolved_project_id = tokens.project_id or project_id
+        if resolved_project_id is None:
+            return None
+
+        return Credentials(
+            username="",
+            secret=SecretStr(""),
+            project_id=resolved_project_id,
+            region=cast(RegionType, region),
+            auth_method=AuthMethod.oauth,
+            oauth_access_token=SecretStr(tokens.access_token.get_secret_value()),
+        )
+
+    def _resolve_region_and_project_for_oauth(
+        self,
+    ) -> tuple[str | None, str | None]:
+        """Determine region and project_id for OAuth token lookup.
+
+        Checks in order:
+        1. ``MP_REGION`` / ``MP_PROJECT_ID`` environment variables
+        2. Default account from config file
+
+        Returns:
+            Tuple of ``(region, project_id)``. Either or both may be
+            ``None`` if not determinable.
+        """
+        # Check env vars first (partial env mode)
+        env_region = os.environ.get("MP_REGION")
+        env_project_id = os.environ.get("MP_PROJECT_ID")
+
+        if env_region and env_region in VALID_REGIONS:
+            return env_region, env_project_id
+
+        # Fall back to config file default account
+        config = self._read_config()
+        accounts = config.get("accounts", {})
+        if not accounts:
+            return None, None
+
+        default_name = config.get("default")
+        if default_name and isinstance(default_name, str) and default_name in accounts:
+            account_data = accounts[default_name]
+            return account_data.get("region"), account_data.get("project_id")
+
+        # Use first account as fallback
+        first_account = next(iter(accounts.values()))
+        return first_account.get("region"), first_account.get("project_id")
 
     def _resolve_from_env(self) -> Credentials | None:
         """Attempt to resolve credentials from environment variables.

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -6,6 +6,8 @@ Configuration is stored in TOML format at ~/.mp/config.toml by default.
 
 from __future__ import annotations
 
+import base64
+import logging
 import os
 import sys
 from dataclasses import dataclass
@@ -26,6 +28,8 @@ from mixpanel_data.exceptions import (
     AccountNotFoundError,
     ConfigError,
 )
+
+logger = logging.getLogger(__name__)
 
 # Valid regions for Mixpanel data residency
 VALID_REGIONS = ("us", "eu", "in")
@@ -129,6 +133,8 @@ class Credentials(BaseModel):
                 raise ValueError(
                     "oauth_access_token is required when auth_method is oauth"
                 )
+            if not self.oauth_access_token.get_secret_value():
+                raise ValueError("oauth_access_token cannot be empty for oauth auth")
         return self
 
     def auth_header(self) -> str:
@@ -162,8 +168,6 @@ class Credentials(BaseModel):
             if self.oauth_access_token is None:
                 raise ValueError("No OAuth access token available")
             return f"Bearer {self.oauth_access_token.get_secret_value()}"
-
-        import base64
 
         raw = f"{self.username}:{self.secret.get_secret_value()}"
         encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
@@ -394,8 +398,13 @@ class ConfigManager:
         if tokens is None:
             return None
 
-        # Skip expired tokens
+        # Skip expired tokens — fall through to config file resolution
         if tokens.is_expired():
+            logger.debug(
+                "OAuth token for region '%s' is expired. "
+                "Run 'mp auth login' to refresh.",
+                region,
+            )
             return None
 
         # Use project_id from token if available, otherwise from config/env

--- a/src/mixpanel_data/_internal/pagination.py
+++ b/src/mixpanel_data/_internal/pagination.py
@@ -1,0 +1,186 @@
+"""Cursor-based pagination helper for Mixpanel App API.
+
+Provides a generic paginator that follows cursor-based pagination
+through App API responses. Used by domain-specific methods to iterate
+through all pages of results.
+
+This is a private implementation detail. Users should use the Workspace
+class methods instead of accessing this module directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    MixpanelDataError,
+    RateLimitError,
+    ServerError,
+)
+
+if TYPE_CHECKING:
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+logger = logging.getLogger(__name__)
+
+#: Maximum number of pages to fetch before raising an error.
+#: Prevents infinite loops when the server returns a non-null cursor indefinitely.
+MAX_PAGES: int = 10000
+
+
+def paginate_all(
+    client: MixpanelAPIClient,
+    path: str,
+    *,
+    params: dict[str, str] | None = None,
+    page_size: int = 100,
+) -> Iterator[Any]:
+    """Iterate through all pages of a paginated App API response.
+
+    Makes repeated calls to ``client.app_request("GET", path, ...)`` following
+    the ``next_cursor`` field in pagination metadata until all pages are
+    exhausted.
+
+    The App API returns paginated responses in this shape::
+
+        {
+            "status": "ok",
+            "results": [...],
+            "pagination": {
+                "page_size": 100,
+                "next_cursor": "abc123" | null
+            }
+        }
+
+    Since ``app_request()`` unwraps the ``results`` field, this function
+    makes a raw request to get the full response including pagination metadata.
+
+    Args:
+        client: MixpanelAPIClient instance to use for requests.
+        path: App API path (e.g., ``/projects/12345/dashboards``).
+        params: Optional additional query parameters to include in each request.
+        page_size: Number of items per page (default 100).
+
+    Yields:
+        Individual items from across all pages of results.
+
+    Raises:
+        AuthenticationError: Invalid credentials (401).
+        RateLimitError: Rate limit exceeded after max retries (429).
+        QueryError: Invalid parameters (400, 404, 422).
+        ServerError: Server-side errors (5xx).
+        MixpanelDataError: Network/connection errors.
+
+    Example:
+        ```python
+        with MixpanelAPIClient(credentials) as client:
+            all_dashboards = list(paginate_all(
+                client,
+                "/projects/12345/dashboards",
+                page_size=50,
+            ))
+        ```
+    """
+    next_cursor: str | None = None
+    is_first_page = True
+    page_count = 0
+
+    while is_first_page or next_cursor is not None:
+        is_first_page = False
+        page_count += 1
+
+        if page_count > MAX_PAGES:
+            raise MixpanelDataError(
+                "Pagination exceeded maximum page limit",
+                code="PAGINATION_LIMIT",
+                details={"max_pages": MAX_PAGES, "path": path},
+            )
+
+        # Build request params
+        request_params: dict[str, str] = {"page_size": str(page_size)}
+        if params:
+            request_params.update(params)
+        if next_cursor is not None:
+            request_params["cursor"] = next_cursor
+
+        # Make the raw request to get full response with pagination
+        url = client._build_url("app", path)
+        auth_header = client._credentials.auth_header()
+        headers = {"Authorization": auth_header}
+
+        http_client = client._ensure_client()
+        try:
+            response = http_client.request(
+                "GET",
+                url,
+                params=request_params,
+                headers=headers,
+                timeout=client._timeout,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            body = exc.response.text
+            if status == 401:
+                raise AuthenticationError(
+                    f"Authentication failed during pagination: {body}",
+                    status_code=status,
+                    response_body=body,
+                    request_method="GET",
+                    request_url=url,
+                ) from exc
+            if status == 429:
+                retry_after_raw = exc.response.headers.get("Retry-After")
+                retry_after = int(retry_after_raw) if retry_after_raw else None
+                raise RateLimitError(
+                    f"Rate limited during pagination: {body}",
+                    retry_after=retry_after,
+                    status_code=status,
+                    response_body=body,
+                    request_method="GET",
+                    request_url=url,
+                ) from exc
+            if status >= 500:
+                raise ServerError(
+                    f"Server error during pagination: {body}",
+                    status_code=status,
+                    response_body=body,
+                    request_method="GET",
+                    request_url=url,
+                ) from exc
+            raise MixpanelDataError(
+                f"HTTP {status} during pagination: {body}",
+                code="API_ERROR",
+                details={"status_code": status, "response_body": body},
+            ) from exc
+
+        try:
+            data = response.json()
+        except Exception as exc:
+            raise MixpanelDataError(
+                f"Non-JSON response during pagination (content-type: "
+                f"{response.headers.get('content-type', 'unknown')})",
+                code="INVALID_RESPONSE",
+                details={"content_type": response.headers.get("content-type")},
+            ) from exc
+
+        # Extract results
+        results: list[Any] = []
+        if isinstance(data, dict):
+            results = data.get("results", [])
+        elif isinstance(data, list):
+            results = data
+
+        yield from results
+
+        # Check for next page
+        pagination = data.get("pagination") if isinstance(data, dict) else None
+        if pagination and isinstance(pagination, dict):
+            next_cursor = pagination.get("next_cursor")
+        else:
+            next_cursor = None

--- a/src/mixpanel_data/_internal/pagination.py
+++ b/src/mixpanel_data/_internal/pagination.py
@@ -11,6 +11,7 @@ class methods instead of accessing this module directly.
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,15 @@ logger = logging.getLogger(__name__)
 #: Maximum number of pages to fetch before raising an error.
 #: Prevents infinite loops when the server returns a non-null cursor indefinitely.
 MAX_PAGES: int = 10000
+
+#: Maximum number of retries for rate-limited (429) responses per page request.
+MAX_RATE_LIMIT_RETRIES: int = 3
+
+#: Base delay in seconds for exponential backoff on 429 retries.
+_BACKOFF_BASE: float = 1.0
+
+#: Maximum backoff delay in seconds.
+_BACKOFF_MAX: float = 60.0
 
 
 def paginate_all(
@@ -101,8 +111,9 @@ def paginate_all(
                 details={"max_pages": MAX_PAGES, "path": path},
             )
 
-        # Build request params
+        # Build request params with query_origin
         request_params: dict[str, str] = {"page_size": str(page_size)}
+        request_params["query_origin"] = "mixpanel-data-cli"
         if params:
             request_params.update(params)
         if next_cursor is not None:
@@ -114,14 +125,59 @@ def paginate_all(
         headers = {"Authorization": auth_header}
 
         http_client = client._ensure_client()
+        response: httpx.Response | None = None
+
+        for attempt in range(MAX_RATE_LIMIT_RETRIES + 1):
+            try:
+                response = http_client.request(
+                    "GET",
+                    url,
+                    params=request_params,
+                    headers=headers,
+                    timeout=client._timeout,
+                )
+            except httpx.HTTPError as exc:
+                raise MixpanelDataError(
+                    f"Network error during pagination: {exc}",
+                    code="NETWORK_ERROR",
+                    details={"path": path, "error": str(exc)},
+                ) from exc
+
+            # Handle 429 with retry/backoff
+            if response.status_code == 429:
+                if attempt >= MAX_RATE_LIMIT_RETRIES:
+                    retry_after_raw = response.headers.get("Retry-After")
+                    retry_after = int(retry_after_raw) if retry_after_raw else None
+                    raise RateLimitError(
+                        "Rate limit exceeded after max retries during pagination",
+                        retry_after=retry_after,
+                        status_code=429,
+                        response_body=response.text,
+                        request_method="GET",
+                        request_url=url,
+                    )
+                retry_after_raw = response.headers.get("Retry-After")
+                if retry_after_raw:
+                    wait_time = float(retry_after_raw)
+                else:
+                    wait_time = min(_BACKOFF_BASE * (2**attempt), _BACKOFF_MAX)
+                logger.warning(
+                    "Rate limited during pagination, retrying in %.1f seconds "
+                    "(attempt %d/%d)",
+                    wait_time,
+                    attempt + 1,
+                    MAX_RATE_LIMIT_RETRIES,
+                )
+                time.sleep(wait_time)
+                continue
+
+            # Not a 429 — break out of retry loop
+            break
+
+        # At this point response is guaranteed non-None
+        assert response is not None  # noqa: S101
+
         try:
-            response = http_client.request(
-                "GET",
-                url,
-                params=request_params,
-                headers=headers,
-                timeout=client._timeout,
-            )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
@@ -129,17 +185,6 @@ def paginate_all(
             if status == 401:
                 raise AuthenticationError(
                     f"Authentication failed during pagination: {body}",
-                    status_code=status,
-                    response_body=body,
-                    request_method="GET",
-                    request_url=url,
-                ) from exc
-            if status == 429:
-                retry_after_raw = exc.response.headers.get("Retry-After")
-                retry_after = int(retry_after_raw) if retry_after_raw else None
-                raise RateLimitError(
-                    f"Rate limited during pagination: {body}",
-                    retry_after=retry_after,
                     status_code=status,
                     response_body=body,
                     request_method="GET",

--- a/src/mixpanel_data/_internal/pagination.py
+++ b/src/mixpanel_data/_internal/pagination.py
@@ -10,6 +10,7 @@ class methods instead of accessing this module directly.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from collections.abc import Iterator
@@ -82,9 +83,9 @@ def paginate_all(
     Raises:
         AuthenticationError: Invalid credentials (401).
         RateLimitError: Rate limit exceeded after max retries (429).
-        QueryError: Invalid parameters (400, 404, 422).
         ServerError: Server-side errors (5xx).
-        MixpanelDataError: Network/connection errors.
+        MixpanelDataError: Client errors (400, 404, 422), network/connection
+            errors, or pagination limit exceeded.
 
     Example:
         ```python
@@ -97,11 +98,9 @@ def paginate_all(
         ```
     """
     next_cursor: str | None = None
-    is_first_page = True
     page_count = 0
 
-    while is_first_page or next_cursor is not None:
-        is_first_page = False
+    while True:
         page_count += 1
 
         if page_count > MAX_PAGES:
@@ -112,8 +111,10 @@ def paginate_all(
             )
 
         # Build request params with query_origin
-        request_params: dict[str, str] = {"page_size": str(page_size)}
-        request_params["query_origin"] = "mixpanel-data-cli"
+        request_params: dict[str, str] = {
+            "page_size": str(page_size),
+            "query_origin": "mixpanel-data-cli",
+        }
         if params:
             request_params.update(params)
         if next_cursor is not None:
@@ -147,7 +148,10 @@ def paginate_all(
             if response.status_code == 429:
                 if attempt >= MAX_RATE_LIMIT_RETRIES:
                     retry_after_raw = response.headers.get("Retry-After")
-                    retry_after = int(retry_after_raw) if retry_after_raw else None
+                    retry_after: int | None = None
+                    if retry_after_raw:
+                        with contextlib.suppress(ValueError):
+                            retry_after = int(retry_after_raw)
                     raise RateLimitError(
                         "Rate limit exceeded after max retries during pagination",
                         retry_after=retry_after,
@@ -157,8 +161,12 @@ def paginate_all(
                         request_url=url,
                     )
                 retry_after_raw = response.headers.get("Retry-After")
+                wait_time: float
                 if retry_after_raw:
-                    wait_time = float(retry_after_raw)
+                    try:
+                        wait_time = float(retry_after_raw)
+                    except ValueError:
+                        wait_time = min(_BACKOFF_BASE * (2**attempt), _BACKOFF_MAX)
                 else:
                     wait_time = min(_BACKOFF_BASE * (2**attempt), _BACKOFF_MAX)
                 logger.warning(
@@ -229,3 +237,6 @@ def paginate_all(
             next_cursor = pagination.get("next_cursor")
         else:
             next_cursor = None
+
+        if next_cursor is None:
+            break

--- a/src/mixpanel_data/auth.py
+++ b/src/mixpanel_data/auth.py
@@ -7,12 +7,13 @@ Re-exported classes:
     ConfigManager: TOML-based account management (~/.mp/config.toml).
     Credentials: Immutable credential container with SecretStr for secrets.
     AccountInfo: Named account metadata (name, username, project_id, region).
+    AuthMethod: Enum for authentication method selection (basic, oauth).
 
 For full documentation of these classes, see:
     mixpanel_data._internal.config
 
 Example usage:
-    from mixpanel_data.auth import ConfigManager, Credentials
+    from mixpanel_data.auth import ConfigManager, Credentials, AuthMethod
 
     config = ConfigManager()
     creds = config.resolve_credentials()
@@ -20,11 +21,13 @@ Example usage:
 
 from mixpanel_data._internal.config import (
     AccountInfo,
+    AuthMethod,
     ConfigManager,
     Credentials,
 )
 
 __all__ = [
+    "AuthMethod",
     "ConfigManager",
     "Credentials",
     "AccountInfo",

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -7,6 +7,10 @@ This module provides commands for managing Mixpanel accounts:
 - switch: Set default account
 - show: Display account details
 - test: Test account credentials
+- login: OAuth 2.0 PKCE login
+- logout: Remove OAuth tokens
+- status: Show OAuth auth state
+- token: Output raw access token
 """
 
 from __future__ import annotations
@@ -17,6 +21,8 @@ from typing import Annotated
 
 import typer
 
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.storage import OAuthStorage
 from mixpanel_data._internal.config import AccountInfo, ConfigManager
 from mixpanel_data.cli.options import FormatOption
 from mixpanel_data.cli.utils import (
@@ -325,3 +331,201 @@ def test_account(
     # and API testing. Exceptions are handled by @handle_errors decorator.
     result = Workspace.test_credentials(name)
     output_result(ctx, result, format=format)
+
+
+def _resolve_region(ctx: typer.Context, region: str | None) -> str:
+    """Resolve the region from option, config default account, or fallback.
+
+    Priority order:
+    1. Explicit ``--region`` option
+    2. Default account's region from config
+    3. ``"us"`` fallback
+
+    Args:
+        ctx: Typer context with global options in obj dict.
+        region: Explicit region from ``--region`` option, or None.
+
+    Returns:
+        Resolved region string (``us``, ``eu``, or ``in``).
+    """
+    if region is not None:
+        return region
+    try:
+        config = get_config(ctx)
+        default_account = _find_default_account(config)
+        if default_account is not None:
+            return default_account.region
+    except Exception:  # noqa: BLE001
+        pass
+    return "us"
+
+
+@auth_app.command("login")
+@handle_errors
+def login(
+    ctx: typer.Context,
+    region: Annotated[
+        str | None,
+        typer.Option("--region", help="Region (us, eu, in)."),
+    ] = None,
+    project_id: Annotated[
+        str | None,
+        typer.Option(
+            "--project-id", help="Mixpanel project ID to associate with tokens."
+        ),
+    ] = None,
+    format: FormatOption = "json",
+) -> None:
+    """Log in via OAuth 2.0 PKCE flow.
+
+    Opens a browser for Mixpanel authorization. After approving,
+    tokens are saved locally for subsequent API calls.
+
+    Examples:
+
+        mp auth login
+        mp auth login --region eu
+        mp auth login --project-id 12345
+    """
+    resolved_region = _resolve_region(ctx, region)
+    flow = OAuthFlow(region=resolved_region)
+    tokens = flow.login(project_id=project_id)
+
+    output_result(
+        ctx,
+        {
+            "status": "login_success",
+            "region": resolved_region,
+            "scope": tokens.scope,
+            "expires_at": tokens.expires_at.isoformat(),
+        },
+        format=format,
+    )
+
+
+@auth_app.command("logout")
+@handle_errors
+def logout(
+    ctx: typer.Context,
+    region: Annotated[
+        str | None,
+        typer.Option("--region", help="Region (us, eu, in)."),
+    ] = None,
+    format: FormatOption = "json",
+) -> None:
+    """Remove stored OAuth tokens.
+
+    With ``--region``, removes tokens for that region only. Without
+    ``--region``, removes all stored tokens and client info.
+
+    Examples:
+
+        mp auth logout
+        mp auth logout --region us
+    """
+    storage = OAuthStorage()
+    if region is not None:
+        storage.delete_tokens(region)
+        output_result(
+            ctx,
+            {"status": "logout_success", "region": region, "removed": "tokens"},
+            format=format,
+        )
+    else:
+        storage.delete_all()
+        output_result(
+            ctx,
+            {"status": "logout_success", "region": "all", "removed": "all"},
+            format=format,
+        )
+
+
+@auth_app.command("status")
+@handle_errors
+def auth_status(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+) -> None:
+    """Show OAuth authentication state per region.
+
+    Checks for stored tokens across all regions (us, eu, in) and
+    displays authentication status, token expiry, and project ID.
+
+    Examples:
+
+        mp auth status
+        mp auth status --format table
+    """
+    storage = OAuthStorage()
+    regions: list[str] = ["us", "eu", "in"]
+    statuses: list[dict[str, object]] = []
+
+    for rgn in regions:
+        tokens = storage.load_tokens(region=rgn)
+        if tokens is not None:
+            is_expired = tokens.is_expired()
+            statuses.append(
+                {
+                    "region": rgn,
+                    "authenticated": True,
+                    "token_type": tokens.token_type,
+                    "scope": tokens.scope,
+                    "expires_at": tokens.expires_at.isoformat(),
+                    "is_expired": is_expired,
+                    "project_id": tokens.project_id,
+                }
+            )
+        else:
+            statuses.append(
+                {
+                    "region": rgn,
+                    "authenticated": False,
+                    "token_type": None,
+                    "scope": None,
+                    "expires_at": None,
+                    "is_expired": None,
+                    "project_id": None,
+                }
+            )
+
+    output_result(
+        ctx,
+        statuses,
+        columns=[
+            "region",
+            "authenticated",
+            "token_type",
+            "expires_at",
+            "is_expired",
+            "project_id",
+        ],
+        format=format,
+    )
+
+
+@auth_app.command("token")
+@handle_errors
+def auth_token(
+    ctx: typer.Context,
+    region: Annotated[
+        str | None,
+        typer.Option("--region", help="Region (us, eu, in)."),
+    ] = None,
+) -> None:
+    """Output a valid OAuth access token to stdout.
+
+    Loads the stored token, refreshes if expired, and prints the
+    raw access token string. Suitable for piping to other tools.
+
+    Exit code 2 if no valid token is available.
+
+    Examples:
+
+        mp auth token
+        mp auth token --region eu
+        curl -H "Authorization: Bearer $(mp auth token)" https://...
+    """
+    resolved_region = _resolve_region(ctx, region)
+    flow = OAuthFlow(region=resolved_region)
+    token = flow.get_valid_token(region=resolved_region)
+    print(token)

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -356,8 +356,16 @@ def _resolve_region(ctx: typer.Context, region: str | None) -> str:
         default_account = _find_default_account(config)
         if default_account is not None:
             return default_account.region
-    except (ConfigError, AccountNotFoundError, OSError):
-        pass
+    except (ConfigError, AccountNotFoundError) as exc:
+        err_console.print(
+            f"[yellow]Warning:[/yellow] Could not determine region from config: {exc}. "
+            "Defaulting to 'us'."
+        )
+    except OSError as exc:
+        err_console.print(
+            f"[yellow]Warning:[/yellow] Could not read config file: {exc}. "
+            "Defaulting to region 'us'."
+        )
     return "us"
 
 

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -31,6 +31,7 @@ from mixpanel_data.cli.utils import (
     handle_errors,
     output_result,
 )
+from mixpanel_data.exceptions import AccountNotFoundError, ConfigError
 
 auth_app = typer.Typer(
     name="auth",
@@ -355,7 +356,7 @@ def _resolve_region(ctx: typer.Context, region: str | None) -> str:
         default_account = _find_default_account(config)
         if default_account is not None:
             return default_account.region
-    except Exception:  # noqa: BLE001
+    except (ConfigError, AccountNotFoundError, OSError):
         pass
     return "us"
 

--- a/src/mixpanel_data/cli/main.py
+++ b/src/mixpanel_data/cli/main.py
@@ -88,6 +88,14 @@ def main(
             envvar="MP_ACCOUNT",
         ),
     ] = None,
+    workspace_id: Annotated[
+        int | None,
+        typer.Option(
+            "--workspace-id",
+            envvar="MP_WORKSPACE_ID",
+            help="Workspace ID for App API operations.",
+        ),
+    ] = None,
     quiet: Annotated[
         bool,
         typer.Option(
@@ -121,6 +129,7 @@ def main(
     """
     ctx.ensure_object(dict)
     ctx.obj["account"] = account
+    ctx.obj["workspace_id"] = workspace_id
     ctx.obj["quiet"] = quiet
     ctx.obj["verbose"] = verbose
     ctx.obj["workspace"] = None

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -34,11 +34,13 @@ from mixpanel_data.exceptions import (
     EventNotFoundError,
     JQLSyntaxError,
     MixpanelDataError,
+    OAuthError,
     QueryError,
     RateLimitError,
     ServerError,
     TableExistsError,
     TableNotFoundError,
+    WorkspaceScopeError,
 )
 
 if TYPE_CHECKING:
@@ -254,6 +256,16 @@ def handle_errors(func: F) -> F:
                 "Try again in a few moments."
             )
             raise typer.Exit(ExitCode.GENERAL_ERROR) from None
+        except OAuthError as e:
+            err_console.print(f"[red]OAuth error:[/red] {e.message}")
+            if e.code:
+                err_console.print(f"  [dim]Code:[/dim] {e.code}")
+            raise typer.Exit(ExitCode.AUTH_ERROR) from None
+        except WorkspaceScopeError as e:
+            err_console.print(f"[red]Workspace error:[/red] {e.message}")
+            if e.code:
+                err_console.print(f"  [dim]Code:[/dim] {e.code}")
+            raise typer.Exit(ExitCode.GENERAL_ERROR) from None
         except ConfigError as e:
             err_console.print(f"[red]Configuration error:[/red] {e.message}")
             raise typer.Exit(ExitCode.GENERAL_ERROR) from None
@@ -298,7 +310,10 @@ def get_workspace(ctx: typer.Context, *, read_only: bool = False) -> Workspace:
 
     if "workspace" not in ctx.obj or ctx.obj["workspace"] is None:
         account = ctx.obj.get("account")
-        ctx.obj["workspace"] = Workspace(account=account, read_only=read_only)
+        workspace_id: int | None = ctx.obj.get("workspace_id")
+        ctx.obj["workspace"] = Workspace(
+            account=account, read_only=read_only, workspace_id=workspace_id
+        )
     workspace: Workspace = ctx.obj["workspace"]
     return workspace
 

--- a/src/mixpanel_data/exceptions.py
+++ b/src/mixpanel_data/exceptions.py
@@ -971,3 +971,88 @@ class DateRangeTooLargeError(MixpanelDataError):
     def max_days(self) -> int:
         """Maximum allowed days."""
         return self._max_days
+
+
+# OAuth Exceptions
+
+
+class OAuthError(MixpanelDataError):
+    """OAuth authentication flow error.
+
+    Raised for failures during the OAuth 2.0 PKCE flow, including token
+    exchange, token refresh, client registration, callback timeout,
+    port unavailability, and browser launch failures.
+
+    Error codes:
+    - OAUTH_TOKEN_ERROR: Token exchange or validation failed
+    - OAUTH_REFRESH_ERROR: Token refresh failed
+    - OAUTH_REGISTRATION_ERROR: Dynamic Client Registration failed
+    - OAUTH_TIMEOUT: Callback server timed out waiting for authorization
+    - OAUTH_PORT_ERROR: All callback ports are occupied
+    - OAUTH_BROWSER_ERROR: Could not open browser for authorization
+
+    Example:
+        ```python
+        try:
+            flow = OAuthFlow(region="us")
+            tokens = flow.login()
+        except OAuthError as e:
+            print(f"OAuth failed: {e.message} (code: {e.code})")
+        ```
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "OAUTH_TOKEN_ERROR",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize OAuthError.
+
+        Args:
+            message: Human-readable error message.
+            code: Machine-readable error code. One of: OAUTH_TOKEN_ERROR,
+                OAUTH_REFRESH_ERROR, OAUTH_REGISTRATION_ERROR, OAUTH_TIMEOUT,
+                OAUTH_PORT_ERROR, OAUTH_BROWSER_ERROR.
+            details: Additional structured data about the error.
+        """
+        super().__init__(message, code=code, details=details)
+
+
+class WorkspaceScopeError(MixpanelDataError):
+    """Workspace resolution error.
+
+    Raised when workspace resolution fails during App API requests.
+    This can occur when no workspaces are found, multiple workspaces
+    exist without a clear default, or an explicit workspace ID doesn't
+    match any available workspace.
+
+    Error codes:
+    - NO_WORKSPACES: Project has no accessible workspaces
+    - AMBIGUOUS_WORKSPACE: Multiple workspaces, none default; must specify --workspace-id
+    - WORKSPACE_NOT_FOUND: Explicit workspace ID doesn't match any workspace
+
+    Example:
+        ```python
+        try:
+            workspace_id = ws.resolve_workspace_id()
+        except WorkspaceScopeError as e:
+            print(f"Workspace issue: {e.message} (code: {e.code})")
+        ```
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "NO_WORKSPACES",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize WorkspaceScopeError.
+
+        Args:
+            message: Human-readable error message.
+            code: Machine-readable error code. One of: NO_WORKSPACES,
+                AMBIGUOUS_WORKSPACE, WORKSPACE_NOT_FOUND.
+            details: Additional structured data about the error.
+        """
+        super().__init__(message, code=code, details=details)

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -21,9 +21,12 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Generic, Literal, TypeVar
 
 import pandas as pd
+from pydantic import BaseModel, ConfigDict
+
+T = TypeVar("T")
 
 # =============================================================================
 # Base Class for Result Types with DataFrame Conversion
@@ -3315,3 +3318,130 @@ class ParallelProfileResult:
             "fetched_at": self.fetched_at.isoformat(),
             "has_failures": self.has_failures,
         }
+
+
+# =============================================================================
+# App API Types (OAuth & Workspace Scoping)
+# =============================================================================
+
+
+class PublicWorkspace(BaseModel):
+    """A workspace within a Mixpanel project.
+
+    Represents a workspace as returned by the Mixpanel App API
+    ``GET /api/app/projects/{pid}/workspaces/public`` endpoint.
+    Extra fields from the API response are preserved via ``extra="allow"``.
+
+    Attributes:
+        id: Workspace identifier.
+        name: Human-readable workspace name.
+        project_id: Parent project identifier.
+        is_default: Whether this is the default workspace.
+        description: Workspace description, if set.
+        is_global: Whether workspace is global.
+        is_restricted: Whether workspace has restrictions.
+        is_visible: Whether workspace is visible.
+        created_iso: ISO 8601 creation timestamp.
+        creator_name: Name of workspace creator.
+
+    Example:
+        ```python
+        ws = PublicWorkspace(
+            id=1, name="Main", project_id=12345, is_default=True
+        )
+        assert ws.is_default is True
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    id: int
+    """Workspace identifier."""
+
+    name: str
+    """Human-readable workspace name."""
+
+    project_id: int
+    """Parent project identifier."""
+
+    is_default: bool
+    """Whether this is the default workspace."""
+
+    description: str | None = None
+    """Workspace description, if set."""
+
+    is_global: bool | None = None
+    """Whether workspace is global."""
+
+    is_restricted: bool | None = None
+    """Whether workspace has restrictions."""
+
+    is_visible: bool | None = None
+    """Whether workspace is visible."""
+
+    created_iso: str | None = None
+    """ISO 8601 creation timestamp."""
+
+    creator_name: str | None = None
+    """Name of workspace creator."""
+
+
+class CursorPagination(BaseModel):
+    """Cursor-based pagination metadata from App API responses.
+
+    Attributes:
+        page_size: Number of items per page.
+        next_cursor: Cursor for next page, or None if last page.
+        previous_cursor: Cursor for previous page.
+
+    Example:
+        ```python
+        pagination = CursorPagination(page_size=100, next_cursor="abc123")
+        assert pagination.next_cursor == "abc123"
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    page_size: int
+    """Number of items per page."""
+
+    next_cursor: str | None = None
+    """Cursor for next page (None = last page)."""
+
+    previous_cursor: str | None = None
+    """Cursor for previous page."""
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Paginated App API response wrapper.
+
+    Generic wrapper for paginated responses from the Mixpanel App API.
+    Contains the results list, status, and optional pagination metadata.
+
+    Attributes:
+        status: Response status (typically "ok").
+        results: Page of results.
+        pagination: Pagination metadata, or None for single-page responses.
+
+    Example:
+        ```python
+        response = PaginatedResponse[dict](
+            status="ok",
+            results=[{"id": 1}],
+            pagination=CursorPagination(page_size=100),
+        )
+        assert len(response.results) == 1
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    """Response status (typically "ok")."""
+
+    results: list[Any]
+    """Page of results."""
+
+    pagination: CursorPagination | None = None
+    """Pagination metadata, or None for single-page responses."""

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -3440,7 +3440,7 @@ class PaginatedResponse(BaseModel, Generic[T]):
     status: str
     """Response status (typically "ok")."""
 
-    results: list[Any]
+    results: list[T]
     """Page of results."""
 
     pagination: CursorPagination | None = None

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -82,6 +82,7 @@ from mixpanel_data.types import (
     PropertyCountsResult,
     PropertyCoverageResult,
     PropertyDistributionResult,
+    PublicWorkspace,
     RetentionResult,
     SavedCohort,
     SavedReportResult,
@@ -188,6 +189,7 @@ class Workspace:
         region: str | None = None,
         path: str | Path | None = None,
         read_only: bool = False,
+        workspace_id: int | None = None,
         # Dependency injection for testing
         _config_manager: ConfigManager | None = None,
         _api_client: MixpanelAPIClient | None = None,
@@ -197,8 +199,9 @@ class Workspace:
 
         Credentials are resolved in priority order:
         1. Environment variables (MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION)
-        2. Named account from config file (if account parameter specified)
-        3. Default account from config file
+        2. OAuth tokens from local storage (if available and not expired)
+        3. Named account from config file (if account parameter specified)
+        4. Default account from config file
 
         Args:
             account: Named account from config file to use.
@@ -207,6 +210,8 @@ class Workspace:
             path: Path to database file. If None, uses default location.
             read_only: If True, open database in read-only mode allowing
                 concurrent reads. Defaults to False (write access).
+            workspace_id: Optional workspace ID for scoped App API requests.
+                If provided, the API client will use workspace-scoped paths.
             _config_manager: Injected ConfigManager for testing.
             _api_client: Injected MixpanelAPIClient for testing.
             _storage: Injected StorageEngine for testing.
@@ -266,6 +271,11 @@ class Workspace:
         self._discovery: DiscoveryService | None = None
         self._fetcher: FetcherService | None = None
         self._live_query: LiveQueryService | None = None
+
+        # Set workspace_id on the api_client if provided
+        self._initial_workspace_id = workspace_id
+        if workspace_id is not None and self._api_client is not None:
+            self._api_client.set_workspace_id(workspace_id)
 
     @classmethod
     @contextmanager
@@ -528,6 +538,8 @@ class Workspace:
                     "Use Workspace() with credentials instead of Workspace.open()."
                 )
             self._api_client = MixpanelAPIClient(self._credentials)
+            if self._initial_workspace_id is not None:
+                self._api_client.set_workspace_id(self._initial_workspace_id)
         return self._api_client
 
     def _require_api_client(self) -> MixpanelAPIClient:
@@ -545,6 +557,108 @@ class Workspace:
                 "Use Workspace() with credentials instead of Workspace.open()."
             )
         return self._get_api_client()
+
+    # =========================================================================
+    # WORKSPACE MANAGEMENT
+    # =========================================================================
+
+    @property
+    def workspace_id(self) -> int | None:
+        """Return the currently set workspace ID, or None if not set.
+
+        This returns the explicit workspace ID set via ``set_workspace_id()``
+        or the constructor's ``workspace_id`` parameter. It does NOT
+        auto-discover a workspace ID (use ``resolve_workspace_id()`` for that).
+
+        Returns:
+            The workspace ID if explicitly set, ``None`` otherwise.
+
+        Example:
+            ```python
+            ws = Workspace(workspace_id=42)
+            assert ws.workspace_id == 42
+
+            ws2 = Workspace()
+            assert ws2.workspace_id is None
+            ```
+        """
+        client = self._get_api_client()
+        return client._workspace_id
+
+    def set_workspace_id(self, workspace_id: int | None) -> None:
+        """Set or clear the workspace ID for scoped App API requests.
+
+        When set, App API requests that use ``maybe_scoped_path()`` or
+        ``require_scoped_path()`` will target the specified workspace.
+        Setting to ``None`` clears the workspace scope.
+
+        Args:
+            workspace_id: Workspace ID to use, or ``None`` to clear.
+
+        Example:
+            ```python
+            ws = Workspace()
+            ws.set_workspace_id(789)
+            assert ws.workspace_id == 789
+
+            ws.set_workspace_id(None)
+            assert ws.workspace_id is None
+            ```
+        """
+        self._initial_workspace_id = workspace_id
+        client = self._get_api_client()
+        client.set_workspace_id(workspace_id)
+
+    def list_workspaces(self) -> list[PublicWorkspace]:
+        """List all public workspaces for the current project.
+
+        Delegates to the API client's ``list_workspaces()`` method, which
+        calls ``GET /api/app/projects/{pid}/workspaces/public``.
+
+        Returns:
+            List of ``PublicWorkspace`` models for the project.
+
+        Raises:
+            ConfigError: If credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400, 404).
+            ServerError: Server-side errors (5xx).
+
+        Example:
+            ```python
+            ws = Workspace()
+            workspaces = ws.list_workspaces()
+            for w in workspaces:
+                print(f"{w.name} (id={w.id}, default={w.is_default})")
+            ```
+        """
+        client = self._require_api_client()
+        return client.list_workspaces()
+
+    def resolve_workspace_id(self) -> int:
+        """Resolve the workspace ID for scoped requests.
+
+        Resolution order:
+        1. Explicit workspace ID (set via ``set_workspace_id()``)
+        2. Cached auto-discovered workspace ID
+        3. Auto-discover by listing workspaces and finding the default
+
+        Returns:
+            The resolved workspace ID.
+
+        Raises:
+            ConfigError: If credentials are not available.
+            WorkspaceScopeError: If no workspaces are found for the project.
+
+        Example:
+            ```python
+            ws = Workspace()
+            ws_id = ws.resolve_workspace_id()
+            print(f"Using workspace {ws_id}")
+            ```
+        """
+        client = self._require_api_client()
+        return client.resolve_workspace_id()
 
     @staticmethod
     def _try_float(value: Any) -> float | None:

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -583,7 +583,7 @@ class Workspace:
             ```
         """
         client = self._get_api_client()
-        return client._workspace_id
+        return client.workspace_id
 
     def set_workspace_id(self, workspace_id: int | None) -> None:
         """Set or clear the workspace ID for scoped App API requests.

--- a/tests/integration/test_config_file.py
+++ b/tests/integration/test_config_file.py
@@ -177,7 +177,10 @@ class TestEnvironmentVariableIntegration:
             monkeypatch.setenv("MP_USERNAME", "env_user")
             # MP_SECRET, MP_PROJECT_ID, MP_REGION not set
 
-            creds = config.resolve_credentials()
+            # Use empty temp dir for OAuth storage to avoid picking up real tokens
+            oauth_dir = Path(tmpdir) / "oauth_empty"
+            oauth_dir.mkdir()
+            creds = config.resolve_credentials(_oauth_storage_dir=oauth_dir)
 
             # Should use file credentials since env vars are incomplete
             assert creds.username == "file_user"

--- a/tests/integration/test_foundation.py
+++ b/tests/integration/test_foundation.py
@@ -49,8 +49,10 @@ class TestFoundationLayerWorkflow:
             assert len(accounts) == 1
             assert accounts[0].name == "production"
 
-            # Retrieve credentials
-            creds = config.resolve_credentials()
+            # Retrieve credentials (use empty OAuth dir to avoid real tokens)
+            oauth_dir = Path(tmpdir) / "oauth_empty"
+            oauth_dir.mkdir()
+            creds = config.resolve_credentials(_oauth_storage_dir=oauth_dir)
             assert creds.username == "sa_test_user"
             assert creds.project_id == "12345"
 

--- a/tests/integration/test_storage_integration.py
+++ b/tests/integration/test_storage_integration.py
@@ -1003,7 +1003,9 @@ class TestInMemoryIntegration:
                 }
                 for i in range(100)
             ]
-            events_meta = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            events_meta = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
             storage.create_events_table("events", iter(events), events_meta)
 
             # Create profiles table
@@ -1015,7 +1017,9 @@ class TestInMemoryIntegration:
                 }
                 for i in range(50)
             ]
-            profiles_meta = TableMetadata(type="profiles", fetched_at=datetime.now(timezone.utc))
+            profiles_meta = TableMetadata(
+                type="profiles", fetched_at=datetime.now(timezone.utc)
+            )
             storage.create_profiles_table("profiles", iter(profiles), profiles_meta)
 
             # Verify row counts
@@ -1101,7 +1105,9 @@ class TestInMemoryIntegration:
         with StorageEngine.memory() as storage:
             # Create empty events table
             events: list[dict[str, object]] = []
-            metadata = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
             row_count = storage.create_events_table(
                 "empty_events", iter(events), metadata
             )
@@ -1134,7 +1140,9 @@ class TestInMemoryIntegration:
                     "properties": {},
                 }
             ]
-            metadata = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
 
             # Create table
             storage.create_events_table("test_table", iter(events), metadata)

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -1,0 +1,481 @@
+"""Unit tests for CLI auth OAuth commands (login, logout, status, token).
+
+Tests cover:
+- T038: OAuth CLI commands (login, logout, status, token)
+- T039: --workspace-id global option and MP_WORKSPACE_ID env var
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from pydantic import SecretStr
+from typer.testing import CliRunner
+
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data.cli.main import app
+from mixpanel_data.cli.utils import ExitCode
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_tokens() -> OAuthTokens:
+    """Create mock OAuth tokens for testing."""
+    return OAuthTokens(
+        access_token=SecretStr("test-access-token-abc123"),
+        refresh_token=SecretStr("test-refresh-token-def456"),
+        expires_at=datetime(2099, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+        scope="projects analysis events",
+        token_type="Bearer",
+        project_id="12345",
+    )
+
+
+@pytest.fixture
+def expired_tokens() -> OAuthTokens:
+    """Create expired OAuth tokens for testing."""
+    return OAuthTokens(
+        access_token=SecretStr("expired-access-token"),
+        refresh_token=SecretStr("expired-refresh-token"),
+        expires_at=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        scope="projects analysis events",
+        token_type="Bearer",
+        project_id="12345",
+    )
+
+
+class TestAuthLogin:
+    """Tests for mp auth login command."""
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_login_triggers_oauth_flow(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner, mock_tokens: OAuthTokens
+    ) -> None:
+        """Test that mp auth login triggers the OAuth flow."""
+        mock_flow = MagicMock()
+        mock_flow.login.return_value = mock_tokens
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == 0
+        mock_flow_cls.assert_called_once()
+        mock_flow.login.assert_called_once()
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_login_with_region(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner, mock_tokens: OAuthTokens
+    ) -> None:
+        """Test that mp auth login --region eu passes region to OAuthFlow."""
+        mock_flow = MagicMock()
+        mock_flow.login.return_value = mock_tokens
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "login", "--region", "eu"])
+
+        assert result.exit_code == 0
+        mock_flow_cls.assert_called_once_with(region="eu")
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_login_success_outputs_json(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner, mock_tokens: OAuthTokens
+    ) -> None:
+        """Test that successful login outputs JSON confirmation."""
+        mock_flow = MagicMock()
+        mock_flow.login.return_value = mock_tokens
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == 0
+        assert "login" in result.stdout.lower() or "success" in result.stdout.lower()
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_login_oauth_error_exits_2(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that OAuthError during login results in exit code 2."""
+        from mixpanel_data.exceptions import OAuthError
+
+        mock_flow = MagicMock()
+        mock_flow.login.side_effect = OAuthError(
+            "Login failed", code="OAUTH_TOKEN_ERROR"
+        )
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == ExitCode.AUTH_ERROR
+
+
+class TestAuthLogout:
+    """Tests for mp auth logout command."""
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_logout_with_region(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that mp auth logout --region us deletes tokens for that region."""
+        mock_storage = MagicMock()
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "logout", "--region", "us"])
+
+        assert result.exit_code == 0
+        mock_storage.delete_tokens.assert_called_once_with("us")
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_logout_without_region_deletes_all(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that mp auth logout without region deletes all tokens."""
+        mock_storage = MagicMock()
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        mock_storage.delete_all.assert_called_once()
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_logout_outputs_confirmation(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that logout outputs JSON confirmation."""
+        mock_storage = MagicMock()
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "logout" in result.stdout.lower() or "removed" in result.stdout.lower()
+
+
+class TestAuthStatus:
+    """Tests for mp auth status command."""
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_status_authenticated(
+        self,
+        mock_storage_cls: MagicMock,
+        cli_runner: CliRunner,
+        mock_tokens: OAuthTokens,
+    ) -> None:
+        """Test that status shows authenticated when tokens exist."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = mock_tokens
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "status"])
+
+        assert result.exit_code == 0
+        assert "authenticated" in result.stdout.lower() or "Bearer" in result.stdout
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_status_not_authenticated(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that status shows not authenticated when no tokens exist."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = None
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "status"])
+
+        assert result.exit_code == 0
+        assert "false" in result.stdout.lower() or "null" in result.stdout.lower()
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_status_shows_expiry(
+        self,
+        mock_storage_cls: MagicMock,
+        cli_runner: CliRunner,
+        mock_tokens: OAuthTokens,
+    ) -> None:
+        """Test that status shows token expiry information."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = mock_tokens
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "status"])
+
+        assert result.exit_code == 0
+        # Should include expiry info
+        assert "expires" in result.stdout.lower() or "2099" in result.stdout
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_status_shows_expired_flag(
+        self,
+        mock_storage_cls: MagicMock,
+        cli_runner: CliRunner,
+        expired_tokens: OAuthTokens,
+    ) -> None:
+        """Test that status indicates when tokens are expired."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = expired_tokens
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "status"])
+
+        assert result.exit_code == 0
+        assert "expired" in result.stdout.lower() or "true" in result.stdout.lower()
+
+
+class TestAuthToken:
+    """Tests for mp auth token command."""
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_token_outputs_raw_token(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that mp auth token outputs raw access token to stdout."""
+        mock_flow = MagicMock()
+        mock_flow.get_valid_token.return_value = "raw-access-token-value"
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "token"])
+
+        assert result.exit_code == 0
+        assert "raw-access-token-value" in result.stdout.strip()
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_token_with_region(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that mp auth token --region eu passes region correctly."""
+        mock_flow = MagicMock()
+        mock_flow.get_valid_token.return_value = "eu-token-value"
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "token", "--region", "eu"])
+
+        assert result.exit_code == 0
+        mock_flow.get_valid_token.assert_called_once_with(region="eu")
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_token_no_token_exits_2(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that missing token results in exit code 2."""
+        from mixpanel_data.exceptions import OAuthError
+
+        mock_flow = MagicMock()
+        mock_flow.get_valid_token.side_effect = OAuthError(
+            "No OAuth tokens found.", code="OAUTH_TOKEN_ERROR"
+        )
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "token"])
+
+        assert result.exit_code == ExitCode.AUTH_ERROR
+
+
+class TestWorkspaceIdOption:
+    """Tests for --workspace-id global option."""
+
+    def test_workspace_id_option_available(self, cli_runner: CliRunner) -> None:
+        """Test that --workspace-id is available as a global option."""
+        result = cli_runner.invoke(app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "workspace-id" in result.stdout
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_workspace_id_stored_in_context(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that --workspace-id value is passed through context."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = None
+        mock_storage_cls.return_value = mock_storage
+
+        # Using auth status as a simple command that doesn't need workspace
+        result = cli_runner.invoke(app, ["--workspace-id", "999", "auth", "status"])
+
+        assert result.exit_code == 0
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_workspace_id_env_var(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that MP_WORKSPACE_ID env var works."""
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = None
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(
+            app,
+            ["auth", "status"],
+            env={"MP_WORKSPACE_ID": "888"},
+        )
+
+        assert result.exit_code == 0
+
+    @patch("mixpanel_data.workspace.Workspace")
+    def test_workspace_id_passed_to_workspace_constructor(
+        self, mock_ws_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Test that workspace_id is passed to Workspace constructor."""
+        from pathlib import Path
+
+        from mixpanel_data.types import WorkspaceInfo
+
+        mock_ws = MagicMock()
+        mock_ws.events.return_value = ["Event1"]
+        mock_ws.info.return_value = WorkspaceInfo(
+            path=Path("/tmp/test.db"),
+            account="default",
+            project_id="12345",
+            region="us",
+            tables=[],
+            size_mb=0.0,
+            created_at=None,
+        )
+        mock_ws_cls.return_value = mock_ws
+
+        # Patch at the point where get_workspace imports Workspace
+        with patch("mixpanel_data.cli.utils.Workspace", mock_ws_cls, create=True):
+            # Patch the local import inside get_workspace
+            import mixpanel_data.cli.utils as utils_mod
+
+            def patched_get_workspace(
+                ctx: typer.Context,
+                *,
+                read_only: bool = False,  # noqa: ARG001
+            ) -> MagicMock:
+                """Patched get_workspace that captures constructor args."""
+                if "workspace" not in ctx.obj or ctx.obj["workspace"] is None:
+                    account = ctx.obj.get("account")
+                    workspace_id_val: int | None = ctx.obj.get("workspace_id")
+                    ctx.obj["workspace"] = mock_ws_cls(
+                        account=account,
+                        read_only=read_only,
+                        workspace_id=workspace_id_val,
+                    )
+                return ctx.obj["workspace"]
+
+            with patch.object(utils_mod, "get_workspace", patched_get_workspace):
+                cli_runner.invoke(app, ["--workspace-id", "777", "inspect", "info"])
+
+        # Verify workspace_id was passed
+        mock_ws_cls.assert_called_once()
+        call_kwargs = mock_ws_cls.call_args
+        assert call_kwargs.kwargs.get("workspace_id") == 777
+
+
+class TestHandleErrorsOAuth:
+    """Tests for OAuthError and WorkspaceScopeError handling in handle_errors."""
+
+    def test_oauth_error_exits_2(self) -> None:
+        """Test that OAuthError maps to exit code 2."""
+        import click.exceptions
+
+        from mixpanel_data.cli.utils import handle_errors
+        from mixpanel_data.exceptions import OAuthError
+
+        @handle_errors
+        def failing_func() -> None:
+            """Raise OAuthError."""
+            raise OAuthError("Token expired", code="OAUTH_TOKEN_ERROR")
+
+        with pytest.raises(click.exceptions.Exit) as exc_info:
+            failing_func()
+
+        assert exc_info.value.exit_code == ExitCode.AUTH_ERROR
+
+    def test_workspace_scope_error_exits_1(self) -> None:
+        """Test that WorkspaceScopeError maps to exit code 1."""
+        import click.exceptions
+
+        from mixpanel_data.cli.utils import handle_errors
+        from mixpanel_data.exceptions import WorkspaceScopeError
+
+        @handle_errors
+        def failing_func() -> None:
+            """Raise WorkspaceScopeError."""
+            raise WorkspaceScopeError(
+                "Multiple workspaces found", code="AMBIGUOUS_WORKSPACE"
+            )
+
+        with pytest.raises(click.exceptions.Exit) as exc_info:
+            failing_func()
+
+        assert exc_info.value.exit_code == ExitCode.GENERAL_ERROR
+
+
+class TestCliAuthSmoke:
+    """Smoke tests verifying help output for all auth subcommands."""
+
+    def test_auth_help(self, cli_runner: CliRunner) -> None:
+        """Verify mp auth --help exits 0 and lists login/logout subcommands."""
+        result = cli_runner.invoke(app, ["auth", "--help"])
+        assert result.exit_code == 0
+        assert "login" in result.stdout
+        assert "logout" in result.stdout
+
+    def test_auth_login_help(self, cli_runner: CliRunner) -> None:
+        """Verify mp auth login --help exits 0 and shows --region option."""
+        result = cli_runner.invoke(app, ["auth", "login", "--help"])
+        assert result.exit_code == 0
+        assert "--region" in result.stdout
+
+    def test_auth_logout_help(self, cli_runner: CliRunner) -> None:
+        """Verify mp auth logout --help exits 0."""
+        result = cli_runner.invoke(app, ["auth", "logout", "--help"])
+        assert result.exit_code == 0
+
+    def test_auth_status_help(self, cli_runner: CliRunner) -> None:
+        """Verify mp auth status --help exits 0."""
+        result = cli_runner.invoke(app, ["auth", "status", "--help"])
+        assert result.exit_code == 0
+
+    def test_auth_token_help(self, cli_runner: CliRunner) -> None:
+        """Verify mp auth token --help exits 0."""
+        result = cli_runner.invoke(app, ["auth", "token", "--help"])
+        assert result.exit_code == 0
+
+    def test_workspace_id_in_main_help(self, cli_runner: CliRunner) -> None:
+        """Verify --workspace-id appears in the main mp --help output."""
+        result = cli_runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "workspace-id" in result.stdout
+
+
+class TestCliAuthExtended:
+    """Extended CLI tests for auth token and logout region behaviour."""
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthFlow")
+    def test_auth_token_only_raw_token(
+        self, mock_flow_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Verify mp auth token outputs only the raw token string, no JSON wrapper."""
+        mock_flow = MagicMock()
+        mock_flow.get_valid_token.return_value = "my_raw_token_value"
+        mock_flow_cls.return_value = mock_flow
+
+        result = cli_runner.invoke(app, ["auth", "token"])
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "my_raw_token_value"
+
+    @patch("mixpanel_data.cli.commands.auth.OAuthStorage")
+    def test_auth_logout_region_preserves_others(
+        self, mock_storage_cls: MagicMock, cli_runner: CliRunner
+    ) -> None:
+        """Verify mp auth logout --region us calls delete_tokens, not delete_all."""
+        mock_storage = MagicMock()
+        mock_storage_cls.return_value = mock_storage
+
+        result = cli_runner.invoke(app, ["auth", "logout", "--region", "us"])
+
+        assert result.exit_code == 0
+        mock_storage.delete_tokens.assert_called_once_with("us")
+        mock_storage.delete_all.assert_not_called()

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -360,7 +360,8 @@ class TestWorkspaceIdOption:
                         read_only=read_only,
                         workspace_id=workspace_id_val,
                     )
-                return ctx.obj["workspace"]
+                result: MagicMock = ctx.obj["workspace"]
+                return result
 
             with patch.object(utils_mod, "get_workspace", patched_get_workspace):
                 cli_runner.invoke(app, ["--workspace-id", "777", "inspect", "info"])

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -454,7 +454,9 @@ class TestGetWorkspace:
 
             result = get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account=None, read_only=False)
+            MockWorkspace.assert_called_once_with(
+                account=None, read_only=False, workspace_id=None
+            )
             assert result == mock_ws
             assert ctx.obj["workspace"] == mock_ws
 
@@ -478,7 +480,9 @@ class TestGetWorkspace:
         with patch("mixpanel_data.workspace.Workspace") as MockWorkspace:
             get_workspace(ctx)
 
-            MockWorkspace.assert_called_once_with(account="staging", read_only=False)
+            MockWorkspace.assert_called_once_with(
+                account="staging", read_only=False, workspace_id=None
+            )
 
 
 class TestGetConfig:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1529,11 +1529,19 @@ class TestPublicRequest:
             client.request(
                 "POST",
                 "https://mixpanel.com/api/app/projects/12345/data",
-                json_body={"name": "test", "value": 123, "query_origin": "mixpanel-data-cli"},
+                json_body={
+                    "name": "test",
+                    "value": 123,
+                    "query_origin": "mixpanel-data-cli",
+                },
             )
 
         assert "application/json" in captured_content_type
-        assert captured_body == {"name": "test", "value": 123, "query_origin": "mixpanel-data-cli"}
+        assert captured_body == {
+            "name": "test",
+            "value": 123,
+            "query_origin": "mixpanel-data-cli",
+        }
 
     def test_request_with_custom_headers(self, test_credentials: Credentials) -> None:
         """request() should merge custom headers with auth."""

--- a/tests/unit/test_api_client_pbt.py
+++ b/tests/unit/test_api_client_pbt.py
@@ -512,15 +512,19 @@ def _collect_lines_from_chunks(chunks: list[bytes]) -> list[str]:
 
 # Strategy for JSON-like line content (no newlines, no leading/trailing whitespace)
 # Use printable characters excluding newlines
-json_line_content = st.text(
-    alphabet=st.characters(
-        whitelist_categories=("L", "N", "P", "S"),
-        whitelist_characters='{}[]":, ',
-        blacklist_characters="\n\r",
-    ),
-    min_size=1,
-    max_size=100,
-).map(lambda s: s.strip()).filter(bool)
+json_line_content = (
+    st.text(
+        alphabet=st.characters(
+            whitelist_categories=("L", "N", "P", "S"),
+            whitelist_characters='{}[]":, ',
+            blacklist_characters="\n\r",
+        ),
+        min_size=1,
+        max_size=100,
+    )
+    .map(lambda s: s.strip())
+    .filter(bool)
+)
 
 # Strategy for JSONL documents (list of non-empty lines)
 jsonl_documents = st.lists(json_line_content, min_size=1, max_size=10)
@@ -648,7 +652,5 @@ class TestIterJsonlLinesProperties:
 
         # Should match input
         assert output_lines == lines, (
-            f"Byte-by-byte chunking failed!\n"
-            f"Input: {lines}\n"
-            f"Output: {output_lines}"
+            f"Byte-by-byte chunking failed!\nInput: {lines}\nOutput: {output_lines}"
         )

--- a/tests/unit/test_app_api_client.py
+++ b/tests/unit/test_app_api_client.py
@@ -21,6 +21,7 @@ from mixpanel_data._internal.api_client import ENDPOINTS, MixpanelAPIClient
 from mixpanel_data._internal.config import AuthMethod, Credentials
 from mixpanel_data.exceptions import (
     AuthenticationError,
+    MixpanelDataError,
     QueryError,
     ServerError,
     WorkspaceScopeError,
@@ -604,13 +605,11 @@ class TestListWorkspacesEdgeCases:
     def test_list_workspaces_string_response(
         self, oauth_credentials: Credentials
     ) -> None:
-        """Verify list_workspaces() returns empty list when results is a string.
+        """Verify list_workspaces() raises on non-list results.
 
-        Bug B6: When the API returns ``{"results": "unexpected_string"}``,
+        When the API returns ``{"results": "unexpected_string"}``,
         ``app_request()`` unwraps results to the string ``"unexpected_string"``.
-        ``list_workspaces()`` then checks ``isinstance(results, list)`` which
-        is False, so it silently returns ``[]``. This documents the current
-        behavior — the string response is swallowed without error.
+        ``list_workspaces()`` validates the type and raises ``MixpanelDataError``.
         """
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -620,11 +619,11 @@ class TestListWorkspacesEdgeCases:
             )
 
         client = create_mock_client(oauth_credentials, handler)
-        with client:
-            workspaces = client.list_workspaces()
-
-        # Bug B6: silently returns empty list instead of raising
-        assert workspaces == []
+        with (
+            client,
+            pytest.raises(MixpanelDataError, match="Unexpected response format"),
+        ):
+            client.list_workspaces()
 
     def test_list_workspaces_missing_required_fields(
         self, oauth_credentials: Credentials

--- a/tests/unit/test_app_api_client.py
+++ b/tests/unit/test_app_api_client.py
@@ -1,0 +1,652 @@
+"""Unit tests for App API request methods and workspace scoping.
+
+Tests for:
+- app_request() method: Bearer auth, URL building, response unwrapping
+- Workspace scoping: maybe_scoped_path(), require_scoped_path()
+- Workspace resolution: list_workspaces(), resolve_workspace_id()
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.api_client import ENDPOINTS, MixpanelAPIClient
+from mixpanel_data._internal.config import AuthMethod, Credentials
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    QueryError,
+    ServerError,
+    WorkspaceScopeError,
+)
+from mixpanel_data.types import PublicWorkspace
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def oauth_credentials() -> Credentials:
+    """Create OAuth credentials for App API testing."""
+    return Credentials(
+        username="",
+        secret=SecretStr(""),
+        project_id="12345",
+        region="us",
+        auth_method=AuthMethod.oauth,
+        oauth_access_token=SecretStr("test-oauth-token"),
+    )
+
+
+@pytest.fixture
+def basic_credentials() -> Credentials:
+    """Create Basic Auth credentials for App API testing."""
+    return Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id="12345",
+        region="us",
+    )
+
+
+def create_mock_client(
+    credentials: Credentials,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> MixpanelAPIClient:
+    """Create a client with mock transport.
+
+    Args:
+        credentials: Authentication credentials.
+        handler: Mock HTTP handler function.
+
+    Returns:
+        MixpanelAPIClient configured with mock transport.
+    """
+    transport = httpx.MockTransport(handler)
+    return MixpanelAPIClient(credentials, _transport=transport)
+
+
+# =============================================================================
+# T026: app_request() method tests
+# =============================================================================
+
+
+class TestAppRequest:
+    """Test app_request() method for App API calls."""
+
+    def test_uses_bearer_auth_header(self, oauth_credentials: Credentials) -> None:
+        """app_request() should use Bearer auth from credentials.auth_header()."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.app_request("GET", "/dashboards")
+
+        assert captured_headers["authorization"] == "Bearer test-oauth-token"
+
+    def test_uses_basic_auth_when_configured(
+        self, basic_credentials: Credentials
+    ) -> None:
+        """app_request() should use Basic auth when credentials use basic method."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(basic_credentials, handler)
+        with client:
+            client.app_request("GET", "/dashboards")
+
+        assert captured_headers["authorization"].startswith("Basic ")
+
+    def test_builds_correct_url(self, oauth_credentials: Credentials) -> None:
+        """app_request() should build URL from ENDPOINTS['app'] + path."""
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.app_request("GET", "/projects/12345/dashboards")
+
+        expected_base = ENDPOINTS["us"]["app"]
+        assert captured_urls[0].startswith(f"{expected_base}/projects/12345/dashboards")
+
+    def test_unwraps_results_field(self, oauth_credentials: Credentials) -> None:
+        """app_request() should unwrap 'results' field from response."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1, "name": "Dashboard 1"}],
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            result = client.app_request("GET", "/projects/12345/dashboards")
+
+        assert result == [{"id": 1, "name": "Dashboard 1"}]
+
+    def test_returns_full_response_when_no_results_key(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """app_request() should return full body when no 'results' key."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"status": "ok", "data": "something"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            result = client.app_request("GET", "/projects/12345/some-endpoint")
+
+        assert result == {"status": "ok", "data": "something"}
+
+    def test_handles_204_no_content(self, oauth_credentials: Credentials) -> None:
+        """app_request() should return {'status': 'ok'} for 204 No Content."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(204)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            result = client.app_request("DELETE", "/projects/12345/dashboards/1")
+
+        assert result == {"status": "ok"}
+
+    def test_maps_404_to_query_error(self, oauth_credentials: Credentials) -> None:
+        """app_request() should raise QueryError on 404."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"error": "Not found"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(QueryError) as exc_info:
+            client.app_request("GET", "/projects/12345/dashboards/999")
+
+        assert exc_info.value.status_code == 404
+
+    def test_maps_422_to_query_error(self, oauth_credentials: Credentials) -> None:
+        """app_request() should raise QueryError on 422."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                422, json={"error": "Unprocessable entity", "details": "bad field"}
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(QueryError) as exc_info:
+            client.app_request("GET", "/projects/12345/dashboards")
+
+        assert exc_info.value.status_code == 422
+
+    def test_maps_401_to_authentication_error(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """app_request() should raise AuthenticationError on 401."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "Unauthorized"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(AuthenticationError):
+            client.app_request("GET", "/projects/12345/dashboards")
+
+    def test_maps_5xx_to_server_error(self, oauth_credentials: Credentials) -> None:
+        """app_request() should raise ServerError on 5xx."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "Internal server error"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(ServerError):
+            client.app_request("GET", "/projects/12345/dashboards")
+
+    def test_passes_query_params(self, oauth_credentials: Credentials) -> None:
+        """app_request() should pass query params through."""
+        captured_params: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.update(dict(request.url.params))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.app_request(
+                "GET", "/projects/12345/dashboards", params={"page_size": "50"}
+            )
+
+        assert captured_params["page_size"] == "50"
+
+    def test_passes_json_body(self, oauth_credentials: Credentials) -> None:
+        """app_request() should pass JSON body for POST/PATCH."""
+        captured_body: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content.decode())
+            captured_body.update(body)
+            return httpx.Response(
+                200, json={"status": "ok", "results": {"id": 1, "name": "New"}}
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.app_request(
+                "POST",
+                "/projects/12345/dashboards",
+                json_body={"name": "New Dashboard"},
+            )
+
+        assert captured_body["name"] == "New Dashboard"
+
+    def test_eu_region_uses_eu_endpoint(self) -> None:
+        """app_request() should use EU endpoint for EU credentials."""
+        eu_creds = Credentials(
+            username="",
+            secret=SecretStr(""),
+            project_id="12345",
+            region="eu",
+            auth_method=AuthMethod.oauth,
+            oauth_access_token=SecretStr("eu-token"),
+        )
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(eu_creds, handler)
+        with client:
+            client.app_request("GET", "/projects/12345/dashboards")
+
+        assert captured_urls[0].startswith(ENDPOINTS["eu"]["app"])
+
+
+# =============================================================================
+# T027: Workspace scoping tests
+# =============================================================================
+
+
+class TestWorkspaceScoping:
+    """Test workspace scoping path helpers."""
+
+    def test_maybe_scoped_path_without_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """maybe_scoped_path() returns project-scoped path when no workspace set."""
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        path = client.maybe_scoped_path("dashboards")
+        assert path == "/projects/12345/dashboards"
+
+    def test_maybe_scoped_path_with_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """maybe_scoped_path() returns workspace-scoped path when workspace set."""
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(789)
+        path = client.maybe_scoped_path("dashboards")
+        assert path == "/workspaces/789/dashboards"
+
+    def test_maybe_scoped_path_with_workspace_none_resets(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """set_workspace_id(None) should reset to project-scoped paths."""
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(789)
+        client.set_workspace_id(None)
+        path = client.maybe_scoped_path("dashboards")
+        assert path == "/projects/12345/dashboards"
+
+    def test_require_scoped_path_with_explicit_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """require_scoped_path() uses explicit workspace ID if set."""
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(789)
+        path = client.require_scoped_path("feature-flags")
+        assert path == "/projects/12345/workspaces/789/feature-flags"
+
+    def test_require_scoped_path_auto_discovers_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """require_scoped_path() auto-discovers workspace when not set."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {"id": 100, "name": "Main", "project_id": 12345, "is_default": True},
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            path = client.require_scoped_path("feature-flags")
+
+        assert path == "/projects/12345/workspaces/100/feature-flags"
+
+    def test_require_scoped_path_raises_on_no_workspaces(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """require_scoped_path() raises WorkspaceScopeError if no workspaces."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(WorkspaceScopeError):
+            client.require_scoped_path("feature-flags")
+
+    def test_require_scoped_path_caches_resolved_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """require_scoped_path() caches resolved workspace ID."""
+        call_count = 0
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {"id": 100, "name": "Main", "project_id": 12345, "is_default": True},
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.require_scoped_path("feature-flags")
+            client.require_scoped_path("experiments")
+
+        # Only one HTTP call for workspace resolution
+        assert call_count == 1
+
+
+# =============================================================================
+# Workspace resolution tests
+# =============================================================================
+
+
+class TestResolveWorkspaceId:
+    """Test resolve_workspace_id() method."""
+
+    def test_returns_explicit_workspace_id(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """resolve_workspace_id() returns explicit ID when set."""
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(42)
+        assert client.resolve_workspace_id() == 42
+
+    def test_auto_discovers_default_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """resolve_workspace_id() finds is_default=True workspace."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {"id": 10, "name": "Other", "project_id": 12345, "is_default": False},
+                {"id": 20, "name": "Main", "project_id": 12345, "is_default": True},
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            ws_id = client.resolve_workspace_id()
+
+        assert ws_id == 20
+
+    def test_falls_back_to_first_workspace(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """resolve_workspace_id() uses first workspace when none is default."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {"id": 10, "name": "First", "project_id": 12345, "is_default": False},
+                {"id": 20, "name": "Second", "project_id": 12345, "is_default": False},
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            ws_id = client.resolve_workspace_id()
+
+        assert ws_id == 10
+
+    def test_raises_on_empty_workspaces(self, oauth_credentials: Credentials) -> None:
+        """resolve_workspace_id() raises WorkspaceScopeError when no workspaces."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(WorkspaceScopeError) as exc_info:
+            client.resolve_workspace_id()
+
+        assert exc_info.value.code == "NO_WORKSPACES"
+
+    def test_caches_resolved_id(self, oauth_credentials: Credentials) -> None:
+        """resolve_workspace_id() caches the resolved ID for subsequent calls."""
+        call_count = 0
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {"id": 100, "name": "Main", "project_id": 12345, "is_default": True},
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            first = client.resolve_workspace_id()
+            second = client.resolve_workspace_id()
+
+        assert first == second == 100
+        assert call_count == 1
+
+
+class TestListWorkspaces:
+    """Test list_workspaces() method."""
+
+    def test_returns_public_workspace_list(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """list_workspaces() returns list of PublicWorkspace models."""
+        workspaces_response = {
+            "status": "ok",
+            "results": [
+                {
+                    "id": 1,
+                    "name": "Default",
+                    "project_id": 12345,
+                    "is_default": True,
+                },
+                {
+                    "id": 2,
+                    "name": "Staging",
+                    "project_id": 12345,
+                    "is_default": False,
+                },
+            ],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=workspaces_response)
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            workspaces = client.list_workspaces()
+
+        assert len(workspaces) == 2
+        assert isinstance(workspaces[0], PublicWorkspace)
+        assert workspaces[0].id == 1
+        assert workspaces[0].name == "Default"
+        assert workspaces[0].is_default is True
+        assert workspaces[1].id == 2
+        assert workspaces[1].is_default is False
+
+    def test_calls_correct_endpoint(self, oauth_credentials: Credentials) -> None:
+        """list_workspaces() calls /api/app/projects/{pid}/workspaces/public."""
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            client.list_workspaces()
+
+        expected = f"{ENDPOINTS['us']['app']}/projects/12345/workspaces/public"
+        assert captured_urls[0].startswith(expected)
+
+
+# =============================================================================
+# Phase 3B: Empty/None parameter edge cases
+# =============================================================================
+
+
+class TestAppApiEdgeCases:
+    """Tests for edge-case parameter values in App API client methods.
+
+    Verifies behavior when workspace IDs are zero or negative, which
+    are technically valid integers but may indicate misconfiguration.
+    """
+
+    def test_set_workspace_id_zero(self, oauth_credentials: Credentials) -> None:
+        """Verify that workspace ID 0 is accepted and included in scoped paths.
+
+        While workspace ID 0 is unusual, the client should not reject it.
+        ``maybe_scoped_path()`` should produce ``/workspaces/0/dashboards``.
+        """
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(0)
+        path = client.maybe_scoped_path("dashboards")
+        assert "/workspaces/0/" in path
+
+    def test_set_workspace_id_negative(self, oauth_credentials: Credentials) -> None:
+        """Verify that a negative workspace ID is accepted and included in scoped paths.
+
+        While workspace ID -1 is invalid in practice, the client does not
+        validate IDs — it delegates validation to the server. The path
+        should contain ``/workspaces/-1/``.
+        """
+        client = create_mock_client(
+            oauth_credentials, lambda _r: httpx.Response(200, json={})
+        )
+        client.set_workspace_id(-1)
+        path = client.maybe_scoped_path("dashboards")
+        assert "/workspaces/-1/" in path
+
+
+# =============================================================================
+# Phase 3D: list_workspaces non-list response (Bug B6)
+# =============================================================================
+
+
+class TestListWorkspacesEdgeCases:
+    """Tests for list_workspaces() handling of unexpected response shapes.
+
+    Documents behavior when the API returns non-list ``results`` or
+    results missing required fields — edge cases that may occur with
+    API version mismatches or server bugs.
+    """
+
+    def test_list_workspaces_string_response(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """Verify list_workspaces() returns empty list when results is a string.
+
+        Bug B6: When the API returns ``{"results": "unexpected_string"}``,
+        ``app_request()`` unwraps results to the string ``"unexpected_string"``.
+        ``list_workspaces()`` then checks ``isinstance(results, list)`` which
+        is False, so it silently returns ``[]``. This documents the current
+        behavior — the string response is swallowed without error.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a response with string results instead of list."""
+            return httpx.Response(
+                200, json={"results": "unexpected_string", "status": "ok"}
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            workspaces = client.list_workspaces()
+
+        # Bug B6: silently returns empty list instead of raising
+        assert workspaces == []
+
+    def test_list_workspaces_missing_required_fields(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """Verify list_workspaces() raises ValidationError when fields are missing.
+
+        When the API returns workspace objects missing required fields
+        (like ``id``), Pydantic's ``model_validate()`` should raise
+        ``ValidationError`` during deserialization.
+        """
+        from pydantic import ValidationError
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return workspace data missing the required 'id' field."""
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"name": "missing_id"}],
+                    "status": "ok",
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(ValidationError):
+            client.list_workspaces()

--- a/tests/unit/test_auth_callback.py
+++ b/tests/unit/test_auth_callback.py
@@ -1,0 +1,277 @@
+"""Unit tests for OAuth callback server (T017).
+
+Tests the callback server that receives the OAuth authorization code
+from the browser redirect during the PKCE flow.
+
+Verifies:
+- Binds to first available port in [19284-19287]
+- Returns code+state from query params
+- Validates state match
+- Handles error params from provider
+- Times out after configured duration
+- Sends HTML response to browser
+- Uses ``localhost`` in redirect URI
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import threading
+import time
+
+import httpx
+import pytest
+
+from mixpanel_data._internal.auth.callback_server import (
+    CallbackResult,
+    start_callback_server,
+)
+from mixpanel_data.exceptions import OAuthError
+
+
+class TestCallbackResult:
+    """Tests for the CallbackResult frozen dataclass."""
+
+    def test_fields_accessible(self) -> None:
+        """Verify code and state fields are accessible on the frozen dataclass."""
+        result = CallbackResult(code="abc123", state="xyz789")
+        assert result.code == "abc123"
+        assert result.state == "xyz789"
+
+    def test_frozen(self) -> None:
+        """Verify that CallbackResult is immutable (frozen dataclass)."""
+        result = CallbackResult(code="abc", state="def")
+        with pytest.raises(AttributeError):
+            result.code = "new"  # type: ignore[misc]
+
+
+class TestStartCallbackServer:
+    """Tests for the start_callback_server function."""
+
+    def test_returns_code_and_state_from_query_params(self) -> None:
+        """Verify the server parses code and state from the redirect query params.
+
+        Starts the server in a background thread, simulates a browser redirect
+        with code and state query parameters, and checks the returned result.
+        """
+        state = "test-state-123"
+        result_holder: list[tuple[CallbackResult, int]] = []
+        error_holder: list[Exception] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            try:
+                result = start_callback_server(state=state, timeout=10.0)
+                result_holder.append(result)
+            except Exception as exc:
+                error_holder.append(exc)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        # Give the server time to bind
+        time.sleep(0.3)
+
+        # Simulate the OAuth redirect
+        resp = httpx.get(
+            "http://localhost:19284/callback",
+            params={"code": "auth-code-456", "state": state},
+            follow_redirects=False,
+        )
+
+        thread.join(timeout=5.0)
+        assert not error_holder, f"Server raised: {error_holder[0]}"
+        assert len(result_holder) == 1
+        cb_result, port = result_holder[0]
+        assert cb_result.code == "auth-code-456"
+        assert cb_result.state == state
+        assert port == 19284
+        assert resp.status_code == 200
+
+    def test_html_response_sent_to_browser(self) -> None:
+        """Verify the server sends an HTML page back to the browser on success."""
+        state = "html-test"
+        result_holder: list[tuple[CallbackResult, int]] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            result_holder.append(start_callback_server(state=state, timeout=10.0))
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        resp = httpx.get(
+            "http://localhost:19284/callback",
+            params={"code": "code1", "state": state},
+            follow_redirects=False,
+        )
+
+        thread.join(timeout=5.0)
+        assert "text/html" in resp.headers.get("content-type", "")
+        assert "success" in resp.text.lower() or "authorized" in resp.text.lower()
+
+    def test_state_mismatch_raises_oauth_error(self) -> None:
+        """Verify that a state mismatch causes OAuthError with OAUTH_TOKEN_ERROR code."""
+        state = "expected-state"
+        result_holder: list[tuple[CallbackResult, int]] = []
+        error_holder: list[Exception] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            try:
+                result_holder.append(start_callback_server(state=state, timeout=10.0))
+            except Exception as exc:
+                error_holder.append(exc)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        # Send mismatched state
+        httpx.get(
+            "http://localhost:19284/callback",
+            params={"code": "code1", "state": "wrong-state"},
+            follow_redirects=False,
+        )
+
+        thread.join(timeout=5.0)
+        assert len(error_holder) == 1
+        assert isinstance(error_holder[0], OAuthError)
+        assert "state" in str(error_holder[0]).lower()
+
+    def test_error_param_raises_oauth_error(self) -> None:
+        """Verify that an error param from the provider raises OAuthError."""
+        state = "error-test"
+        error_holder: list[Exception] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            try:
+                start_callback_server(state=state, timeout=10.0)
+            except Exception as exc:
+                error_holder.append(exc)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        httpx.get(
+            "http://localhost:19284/callback",
+            params={
+                "error": "access_denied",
+                "error_description": "User denied access",
+            },
+            follow_redirects=False,
+        )
+
+        thread.join(timeout=5.0)
+        assert len(error_holder) == 1
+        assert isinstance(error_holder[0], OAuthError)
+        assert "access_denied" in str(error_holder[0])
+
+    def test_timeout_raises_oauth_error(self) -> None:
+        """Verify that exceeding the timeout raises OAuthError with OAUTH_TIMEOUT code."""
+        state = "timeout-test"
+        error_holder: list[Exception] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            try:
+                start_callback_server(state=state, timeout=0.5)
+            except Exception as exc:
+                error_holder.append(exc)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        thread.join(timeout=5.0)
+
+        assert len(error_holder) == 1
+        err = error_holder[0]
+        assert isinstance(err, OAuthError)
+        assert err.code == "OAUTH_TIMEOUT"
+
+    def test_tries_next_port_when_first_is_busy(self) -> None:
+        """Verify the server tries ports 19284-19287 and uses the first available."""
+        import socket
+
+        # Occupy port 19284
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 19284))
+        sock.listen(1)
+
+        try:
+            state = "port-fallback"
+            result_holder: list[tuple[CallbackResult, int]] = []
+
+            def run_server() -> None:
+                """Run the callback server in a thread."""
+                result_holder.append(start_callback_server(state=state, timeout=10.0))
+
+            thread = threading.Thread(target=run_server, daemon=True)
+            thread.start()
+            time.sleep(0.3)
+
+            # Must be on port 19285 since 19284 is occupied
+            httpx.get(
+                "http://localhost:19285/callback",
+                params={"code": "fallback-code", "state": state},
+                follow_redirects=False,
+            )
+
+            thread.join(timeout=5.0)
+            assert len(result_holder) == 1
+            cb_result, port = result_holder[0]
+            assert port == 19285
+            assert cb_result.code == "fallback-code"
+        finally:
+            sock.close()
+
+    def test_all_ports_busy_raises_oauth_error(self) -> None:
+        """Verify OAuthError with OAUTH_PORT_ERROR if all ports are occupied."""
+        import socket
+
+        socks: list[socket.socket] = []
+        ports = [19284, 19285, 19286, 19287]
+        try:
+            for p in ports:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind(("127.0.0.1", p))
+                s.listen(1)
+                socks.append(s)
+
+            with pytest.raises(OAuthError) as exc_info:
+                start_callback_server(state="all-busy", timeout=5.0)
+            assert exc_info.value.code == "OAUTH_PORT_ERROR"
+        finally:
+            for s in socks:
+                s.close()
+
+    def test_redirect_uri_uses_localhost(self) -> None:
+        """Verify the redirect URI uses 'localhost' (not 127.0.0.1).
+
+        OAuth providers require consistent redirect URIs. We use localhost
+        for the redirect URI while binding to 127.0.0.1.
+        """
+        state = "localhost-test"
+        result_holder: list[tuple[CallbackResult, int]] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            result_holder.append(start_callback_server(state=state, timeout=10.0))
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        # Use localhost (not 127.0.0.1) to match the redirect URI
+        resp = httpx.get(
+            "http://localhost:19284/callback",
+            params={"code": "local-code", "state": state},
+            follow_redirects=False,
+        )
+
+        thread.join(timeout=5.0)
+        assert len(result_holder) == 1
+        assert resp.status_code == 200

--- a/tests/unit/test_auth_callback.py
+++ b/tests/unit/test_auth_callback.py
@@ -16,6 +16,7 @@ Verifies:
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import time
 
@@ -275,3 +276,66 @@ class TestStartCallbackServer:
         thread.join(timeout=5.0)
         assert len(result_holder) == 1
         assert resp.status_code == 200
+
+
+class TestCallbackHtmlSecurity:
+    """Tests for HTML security in callback responses."""
+
+    def test_state_mismatch_does_not_leak_expected_state(self) -> None:
+        """Verify that the browser HTML does NOT contain the expected state value."""
+        state = "secret-csrf-state-12345"
+        response_holder: list[httpx.Response] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            with contextlib.suppress(OAuthError):
+                start_callback_server(state=state, timeout=10.0)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        resp = httpx.get(
+            "http://localhost:19284/callback",
+            params={"code": "code1", "state": "wrong-state"},
+            follow_redirects=False,
+        )
+        response_holder.append(resp)
+
+        thread.join(timeout=5.0)
+        html_body = resp.text
+        # The expected state must NOT appear in the browser HTML
+        assert state not in html_body
+        # But the error page should still indicate a failure
+        assert "Authorization" in html_body or "mismatch" in html_body
+
+    def test_provider_error_description_is_html_escaped(self) -> None:
+        """Verify that provider error_description is HTML-escaped in the response."""
+        state = "escape-test"
+        response_holder: list[httpx.Response] = []
+
+        def run_server() -> None:
+            """Run the callback server in a thread."""
+            with contextlib.suppress(OAuthError):
+                start_callback_server(state=state, timeout=10.0)
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(0.3)
+
+        xss_payload = '<script>alert("xss")</script>'
+        resp = httpx.get(
+            "http://localhost:19284/callback",
+            params={
+                "error": "server_error",
+                "error_description": xss_payload,
+            },
+            follow_redirects=False,
+        )
+        response_holder.append(resp)
+
+        thread.join(timeout=5.0)
+        html_body = resp.text
+        # Raw script tag must NOT appear in HTML — it should be escaped
+        assert "<script>" not in html_body
+        assert "&lt;script&gt;" in html_body

--- a/tests/unit/test_auth_flow.py
+++ b/tests/unit/test_auth_flow.py
@@ -756,3 +756,32 @@ class TestOAuthFlowNetworkErrors:
         with pytest.raises(OAuthError) as exc_info:
             flow.refresh_tokens(tokens=tokens, client_id="cid")
         assert exc_info.value.code == "OAUTH_REFRESH_ERROR"
+
+
+class TestOAuthFlowRegionValidation:
+    """Tests for region validation in OAuthFlow.__init__."""
+
+    def test_invalid_region_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that an invalid region raises OAuthError with OAUTH_CONFIG_ERROR."""
+        with pytest.raises(OAuthError) as exc_info:
+            OAuthFlow(region="uk", storage=OAuthStorage(storage_dir=tmp_path))
+        assert exc_info.value.code == "OAUTH_CONFIG_ERROR"
+        assert "uk" in str(exc_info.value)
+
+    def test_uppercase_region_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that an uppercase region is rejected (case-sensitive)."""
+        with pytest.raises(OAuthError) as exc_info:
+            OAuthFlow(region="US", storage=OAuthStorage(storage_dir=tmp_path))
+        assert exc_info.value.code == "OAUTH_CONFIG_ERROR"
+
+    def test_empty_region_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that an empty region is rejected."""
+        with pytest.raises(OAuthError) as exc_info:
+            OAuthFlow(region="", storage=OAuthStorage(storage_dir=tmp_path))
+        assert exc_info.value.code == "OAUTH_CONFIG_ERROR"
+
+    @pytest.mark.parametrize("region", ["us", "eu", "in"])
+    def test_valid_regions_accepted(self, tmp_path: Path, region: str) -> None:
+        """Verify that valid regions are accepted without error."""
+        flow = OAuthFlow(region=region, storage=OAuthStorage(storage_dir=tmp_path))
+        assert flow.region == region

--- a/tests/unit/test_auth_flow.py
+++ b/tests/unit/test_auth_flow.py
@@ -1,0 +1,752 @@
+"""Unit tests for OAuthFlow orchestrator (T019).
+
+Tests the OAuthFlow class which orchestrates the full OAuth 2.0 PKCE
+authorization flow for Mixpanel.
+
+Verifies:
+- Full login sequence (mock all external deps)
+- Token exchange POST with correct form params
+- Handles missing refresh_token
+- Preserves project_id through flow
+- Region-specific OAuth base URLs (us/eu/in)
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.callback_server import CallbackResult
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+from mixpanel_data.exceptions import OAuthError
+
+
+def _make_token_response(
+    *,
+    access_token: str = "access-tok-123",
+    refresh_token: str | None = "refresh-tok-456",
+    expires_in: int = 3600,
+    scope: str = "projects analysis",
+    token_type: str = "Bearer",
+) -> dict[str, object]:
+    """Create a mock token endpoint response dict.
+
+    Args:
+        access_token: Access token value.
+        refresh_token: Refresh token value, or None to omit.
+        expires_in: Token lifetime in seconds.
+        scope: Granted scopes.
+        token_type: Token type string.
+
+    Returns:
+        Dictionary matching the OAuth token endpoint response shape.
+    """
+    data: dict[str, object] = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+        "scope": scope,
+        "token_type": token_type,
+    }
+    if refresh_token is not None:
+        data["refresh_token"] = refresh_token
+    return data
+
+
+def _make_client_info(
+    *,
+    client_id: str = "test-client-id",
+    region: str = "us",
+    redirect_uri: str = "http://localhost:19284/callback",
+) -> OAuthClientInfo:
+    """Create an OAuthClientInfo fixture.
+
+    Args:
+        client_id: Client identifier.
+        region: Mixpanel region.
+        redirect_uri: Registered redirect URI.
+
+    Returns:
+        Configured OAuthClientInfo instance.
+    """
+    return OAuthClientInfo(
+        client_id=client_id,
+        region=region,
+        redirect_uri=redirect_uri,
+        scope="projects analysis",
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class TestOAuthFlowLogin:
+    """Tests for OAuthFlow.login() full sequence."""
+
+    @patch("mixpanel_data._internal.auth.flow.webbrowser")
+    @patch("mixpanel_data._internal.auth.flow.start_callback_server")
+    @patch("mixpanel_data._internal.auth.flow.ensure_client_registered")
+    def test_full_login_sequence(
+        self,
+        mock_register: MagicMock,
+        mock_callback: MagicMock,
+        mock_browser: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the full login flow: register -> browser -> callback -> exchange.
+
+        Mocks client registration, callback server, browser open, and token exchange.
+        """
+        # Setup mocks
+        client_info = _make_client_info()
+        mock_register.return_value = client_info
+        mock_callback.return_value = (
+            CallbackResult(code="auth-code-xyz", state="any"),
+            19284,
+        )
+        mock_browser.open.return_value = True
+
+        token_response = _make_token_response()
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            """Handle token exchange request.
+
+            Args:
+                request: The incoming HTTP request.
+
+            Returns:
+                Mock token response.
+            """
+            return httpx.Response(200, json=token_response)
+
+        transport = httpx.MockTransport(handle_request)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        tokens = flow.login(project_id="12345")
+
+        assert tokens.access_token.get_secret_value() == "access-tok-123"
+        assert tokens.refresh_token is not None
+        assert tokens.refresh_token.get_secret_value() == "refresh-tok-456"
+        assert tokens.project_id == "12345"
+        mock_browser.open.assert_called_once()
+
+    @patch("mixpanel_data._internal.auth.flow.webbrowser")
+    @patch("mixpanel_data._internal.auth.flow.start_callback_server")
+    @patch("mixpanel_data._internal.auth.flow.ensure_client_registered")
+    def test_preserves_project_id(
+        self,
+        mock_register: MagicMock,
+        mock_callback: MagicMock,
+        mock_browser: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Verify that project_id is passed through to the resulting tokens."""
+        mock_register.return_value = _make_client_info()
+        mock_callback.return_value = (
+            CallbackResult(code="code1", state="s"),
+            19284,
+        )
+        mock_browser.open.return_value = True
+
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        tokens = flow.login(project_id="proj-999")
+
+        assert tokens.project_id == "proj-999"
+
+    @patch("mixpanel_data._internal.auth.flow.webbrowser")
+    @patch("mixpanel_data._internal.auth.flow.start_callback_server")
+    @patch("mixpanel_data._internal.auth.flow.ensure_client_registered")
+    def test_handles_missing_refresh_token(
+        self,
+        mock_register: MagicMock,
+        mock_callback: MagicMock,
+        mock_browser: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Verify login succeeds when the token response has no refresh_token."""
+        mock_register.return_value = _make_client_info()
+        mock_callback.return_value = (
+            CallbackResult(code="code1", state="s"),
+            19284,
+        )
+        mock_browser.open.return_value = True
+
+        token_resp = _make_token_response(refresh_token=None)
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=token_resp)
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        tokens = flow.login()
+
+        assert tokens.access_token.get_secret_value() == "access-tok-123"
+        assert tokens.refresh_token is None
+
+
+class TestOAuthFlowTokenExchange:
+    """Tests for the token exchange step."""
+
+    def test_exchange_posts_correct_form_params(self, tmp_path: Path) -> None:
+        """Verify the token exchange POST contains the correct form parameters.
+
+        Must include grant_type, code, redirect_uri, client_id, code_verifier.
+        """
+        captured_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture request and return token response.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock token response.
+            """
+            captured_requests.append(request)
+            return httpx.Response(200, json=_make_token_response())
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        flow.exchange_code(
+            code="auth-code",
+            verifier="test-verifier-string",
+            client_id="my-client",
+            redirect_uri="http://localhost:19284/callback",
+        )
+
+        assert len(captured_requests) == 1
+        req = captured_requests[0]
+        assert req.method == "POST"
+        # Parse form body
+        body = req.content.decode("utf-8")
+        assert "grant_type=authorization_code" in body
+        assert "code=auth-code" in body
+        assert "client_id=my-client" in body
+        assert "code_verifier=test-verifier-string" in body
+        assert "redirect_uri=" in body
+
+    def test_exchange_uses_correct_url_for_region(self, tmp_path: Path) -> None:
+        """Verify the token exchange URL is region-specific."""
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL and return token response.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock token response.
+            """
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, json=_make_token_response())
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+
+        for region, expected_host in [
+            ("us", "mixpanel.com"),
+            ("eu", "eu.mixpanel.com"),
+            ("in", "in.mixpanel.com"),
+        ]:
+            captured_urls.clear()
+            storage = OAuthStorage(storage_dir=tmp_path / region)
+            flow = OAuthFlow(region=region, storage=storage, http_client=http_client)
+            flow.exchange_code(
+                code="c",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+            assert expected_host in captured_urls[0]
+            assert (
+                "/oauth/token/" in captured_urls[0]
+                or "/oauth/token" in captured_urls[0]
+            )
+
+    def test_exchange_error_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that a failed token exchange raises OAuthError."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(
+                400, json={"error": "invalid_grant", "error_description": "Bad code"}
+            )
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.exchange_code(
+                code="bad-code",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+
+class TestOAuthFlowRefresh:
+    """Tests for OAuthFlow.refresh_tokens()."""
+
+    def test_refresh_posts_correct_params(self, tmp_path: Path) -> None:
+        """Verify the refresh POST contains grant_type=refresh_token and client_id."""
+        captured_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture request and return token response.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock token response.
+            """
+            captured_requests.append(request)
+            return httpx.Response(200, json=_make_token_response())
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        tokens = OAuthTokens(
+            access_token=SecretStr("old-access"),
+            refresh_token=SecretStr("old-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects",
+            token_type="Bearer",
+            project_id="123",
+        )
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        new_tokens = flow.refresh_tokens(tokens=tokens, client_id="cid")
+
+        assert len(captured_requests) == 1
+        body = captured_requests[0].content.decode("utf-8")
+        assert "grant_type=refresh_token" in body
+        assert "refresh_token=old-refresh" in body
+        assert "client_id=cid" in body
+        assert new_tokens.access_token.get_secret_value() == "access-tok-123"
+
+    def test_refresh_error_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that a failed refresh raises OAuthError with OAUTH_REFRESH_ERROR."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(400, json={"error": "invalid_grant"})
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        tokens = OAuthTokens(
+            access_token=SecretStr("old"),
+            refresh_token=SecretStr("bad-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects",
+            token_type="Bearer",
+        )
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.refresh_tokens(tokens=tokens, client_id="cid")
+        assert exc_info.value.code == "OAUTH_REFRESH_ERROR"
+
+    def test_refresh_without_refresh_token_raises(self, tmp_path: Path) -> None:
+        """Verify that refreshing without a refresh_token raises OAuthError."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        tokens = OAuthTokens(
+            access_token=SecretStr("old"),
+            refresh_token=None,
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects",
+            token_type="Bearer",
+        )
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.refresh_tokens(tokens=tokens, client_id="cid")
+        assert exc_info.value.code == "OAUTH_REFRESH_ERROR"
+
+
+class TestOAuthFlowGetValidToken:
+    """Tests for OAuthFlow.get_valid_token() token lifecycle management."""
+
+    def test_returns_current_token_if_not_expired(self, tmp_path: Path) -> None:
+        """Verify that a non-expired token is returned immediately without refresh."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(500, text="should not be called")
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+        valid_tokens = OAuthTokens(
+            access_token=SecretStr("valid-access-token"),
+            refresh_token=SecretStr("valid-refresh-token"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scope="projects analysis",
+            token_type="Bearer",
+            project_id="12345",
+        )
+        client_info = _make_client_info()
+        storage.save_tokens(valid_tokens, region="us")
+        storage.save_client_info(client_info)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        result = flow.get_valid_token(region="us")
+
+        assert result == "valid-access-token"
+
+    def test_auto_refreshes_expired_token(self, tmp_path: Path) -> None:
+        """Verify that an expired token triggers a refresh and returns the new token."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+        expired_tokens = OAuthTokens(
+            access_token=SecretStr("expired-access"),
+            refresh_token=SecretStr("valid-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects analysis",
+            token_type="Bearer",
+            project_id="12345",
+        )
+        client_info = _make_client_info()
+        storage.save_tokens(expired_tokens, region="us")
+        storage.save_client_info(client_info)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        result = flow.get_valid_token(region="us")
+
+        assert result == "access-tok-123"
+
+    def test_persists_refreshed_tokens(self, tmp_path: Path) -> None:
+        """Verify that refreshed tokens are saved back to storage."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+        expired_tokens = OAuthTokens(
+            access_token=SecretStr("expired-access"),
+            refresh_token=SecretStr("valid-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects analysis",
+            token_type="Bearer",
+            project_id="12345",
+        )
+        client_info = _make_client_info()
+        storage.save_tokens(expired_tokens, region="us")
+        storage.save_client_info(client_info)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        flow.get_valid_token(region="us")
+
+        # Verify the new token was persisted
+        reloaded = storage.load_tokens(region="us")
+        assert reloaded is not None
+        assert reloaded.access_token.get_secret_value() == "access-tok-123"
+
+    def test_raises_oauth_error_if_refresh_fails(self, tmp_path: Path) -> None:
+        """Verify that a failed refresh raises OAuthError with OAUTH_REFRESH_ERROR."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(400, json={"error": "invalid_grant"})
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+        expired_tokens = OAuthTokens(
+            access_token=SecretStr("expired-access"),
+            refresh_token=SecretStr("bad-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects analysis",
+            token_type="Bearer",
+        )
+        client_info = _make_client_info()
+        storage.save_tokens(expired_tokens, region="us")
+        storage.save_client_info(client_info)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.get_valid_token(region="us")
+        assert exc_info.value.code == "OAUTH_REFRESH_ERROR"
+
+    def test_raises_oauth_error_if_no_tokens_exist(self, tmp_path: Path) -> None:
+        """Verify that missing tokens raises OAuthError with OAUTH_TOKEN_ERROR."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(500, text="should not be called")
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.get_valid_token(region="us")
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+    def test_raises_oauth_error_if_no_client_info_for_refresh(
+        self, tmp_path: Path
+    ) -> None:
+        """Verify error when tokens are expired but no client info exists for refresh."""
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+
+        storage = OAuthStorage(storage_dir=tmp_path)
+        expired_tokens = OAuthTokens(
+            access_token=SecretStr("expired-access"),
+            refresh_token=SecretStr("valid-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects analysis",
+            token_type="Bearer",
+        )
+        storage.save_tokens(expired_tokens, region="us")
+        # Intentionally NOT saving client_info
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.get_valid_token(region="us")
+        assert exc_info.value.code == "OAUTH_REFRESH_ERROR"
+
+
+class TestOAuthFlowRegionUrls:
+    """Tests for region-specific OAuth base URLs."""
+
+    @patch("mixpanel_data._internal.auth.flow.webbrowser")
+    @patch("mixpanel_data._internal.auth.flow.start_callback_server")
+    @patch("mixpanel_data._internal.auth.flow.ensure_client_registered")
+    def test_eu_region_authorize_url(
+        self,
+        mock_register: MagicMock,
+        mock_callback: MagicMock,
+        mock_browser: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the EU region uses eu.mixpanel.com for the authorize URL."""
+        mock_register.return_value = _make_client_info(region="eu")
+        mock_callback.return_value = (
+            CallbackResult(code="c", state="s"),
+            19284,
+        )
+        mock_browser.open.return_value = True
+
+        opened_urls: list[str] = []
+        mock_browser.open.side_effect = lambda url: opened_urls.append(url) or True
+
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(200, json=_make_token_response())
+        )
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="eu", storage=storage, http_client=http_client)
+        flow.login()
+
+        assert len(opened_urls) == 1
+        assert "eu.mixpanel.com" in opened_urls[0]
+
+
+class TestOAuthFlowNetworkErrors:
+    """Tests for network error handling in exchange_code and refresh_tokens."""
+
+    def test_exchange_code_timeout(self, tmp_path: Path) -> None:
+        """Verify exchange_code raises OAuthError on timeout.
+
+        A network timeout during token exchange should be wrapped in
+        OAuthError with OAUTH_TOKEN_ERROR code.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Raise TimeoutException.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Never returns.
+
+            Raises:
+                httpx.TimeoutException: Always.
+            """
+            raise httpx.TimeoutException("test timeout")
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.exchange_code(
+                code="c",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+    def test_exchange_code_connection_error(self, tmp_path: Path) -> None:
+        """Verify exchange_code raises OAuthError on connection failure.
+
+        A connection error (e.g. DNS resolution failure) should be wrapped
+        in OAuthError with OAUTH_TOKEN_ERROR code.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Raise ConnectError.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Never returns.
+
+            Raises:
+                httpx.ConnectError: Always.
+            """
+            raise httpx.ConnectError("test connection error")
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.exchange_code(
+                code="c",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+    def test_exchange_code_non_json_response(self, tmp_path: Path) -> None:
+        """Verify exchange_code raises OAuthError for non-JSON 200 response.
+
+        A proxy or misconfigured server might return HTML on success.
+        The function should raise OAuthError, not a raw exception.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return HTML body.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                HTML response.
+            """
+            return httpx.Response(
+                200,
+                content=b"<html>error</html>",
+                headers={"content-type": "text/html"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.exchange_code(
+                code="c",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+    def test_exchange_code_missing_access_token_in_response(
+        self, tmp_path: Path
+    ) -> None:
+        """Verify exchange_code raises OAuthError when access_token is missing.
+
+        A valid JSON response missing ``access_token`` should raise
+        OAuthError, not a raw KeyError.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return JSON with missing access_token.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                JSON response without access_token.
+            """
+            return httpx.Response(200, json={"scope": "x"})
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.exchange_code(
+                code="c",
+                verifier="v",
+                client_id="cid",
+                redirect_uri="http://localhost:19284/callback",
+            )
+        assert exc_info.value.code == "OAUTH_TOKEN_ERROR"
+
+    def test_refresh_tokens_timeout(self, tmp_path: Path) -> None:
+        """Verify refresh_tokens raises OAuthError on timeout.
+
+        A network timeout during token refresh should be wrapped in
+        OAuthError with OAUTH_REFRESH_ERROR code.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Raise TimeoutException.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Never returns.
+
+            Raises:
+                httpx.TimeoutException: Always.
+            """
+            raise httpx.TimeoutException("test timeout")
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        tokens = OAuthTokens(
+            access_token=SecretStr("old"),
+            refresh_token=SecretStr("old-refresh"),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            scope="projects",
+            token_type="Bearer",
+        )
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+        with pytest.raises(OAuthError) as exc_info:
+            flow.refresh_tokens(tokens=tokens, client_id="cid")
+        assert exc_info.value.code == "OAUTH_REFRESH_ERROR"

--- a/tests/unit/test_auth_flow.py
+++ b/tests/unit/test_auth_flow.py
@@ -555,7 +555,13 @@ class TestOAuthFlowRegionUrls:
         mock_browser.open.return_value = True
 
         opened_urls: list[str] = []
-        mock_browser.open.side_effect = lambda url: opened_urls.append(url) or True
+
+        def _capture_url(url: str) -> bool:
+            """Capture opened URL and return True to indicate success."""
+            opened_urls.append(url)
+            return True
+
+        mock_browser.open.side_effect = _capture_url
 
         transport = httpx.MockTransport(
             lambda _req: httpx.Response(200, json=_make_token_response())

--- a/tests/unit/test_auth_pkce.py
+++ b/tests/unit/test_auth_pkce.py
@@ -1,0 +1,141 @@
+"""Unit tests for PKCE challenge generation (T007).
+
+Tests the PkceChallenge class which implements RFC 7636 PKCE
+(Proof Key for Code Exchange) for OAuth 2.0 authorization.
+
+Verifies:
+- Verifier is 86 characters, base64url no-pad encoded
+- Challenge is SHA-256 of verifier in base64url no-pad encoding
+- Challenge computation is deterministic for the same verifier input
+- Each generation produces a different verifier (randomness)
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+
+from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+# Base64url alphabet: A-Z, a-z, 0-9, -, _ (no padding =)
+BASE64URL_NO_PAD_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class TestPkceChallenge:
+    """Tests for PkceChallenge.generate() and its attributes."""
+
+    def test_verifier_length_is_86_chars(self) -> None:
+        """Verify that the generated verifier is exactly 86 characters.
+
+        RFC 7636 specifies that 64 random bytes base64url-encoded without
+        padding produces an 86-character string, which is within the
+        required 43-128 character range.
+        """
+        challenge = PkceChallenge.generate()
+        assert len(challenge.verifier) == 86
+
+    def test_verifier_is_base64url_no_pad(self) -> None:
+        """Verify that the verifier uses only base64url characters without padding.
+
+        The verifier must contain only characters from the base64url alphabet
+        (A-Z, a-z, 0-9, '-', '_') and must not include '=' padding.
+        """
+        challenge = PkceChallenge.generate()
+        assert BASE64URL_NO_PAD_PATTERN.match(challenge.verifier), (
+            f"Verifier contains invalid characters: {challenge.verifier}"
+        )
+        assert "=" not in challenge.verifier
+
+    def test_challenge_is_base64url_no_pad(self) -> None:
+        """Verify that the challenge uses only base64url characters without padding.
+
+        The challenge (code_challenge) is the base64url-encoded SHA-256 hash
+        of the verifier, without padding.
+        """
+        challenge = PkceChallenge.generate()
+        assert BASE64URL_NO_PAD_PATTERN.match(challenge.challenge), (
+            f"Challenge contains invalid characters: {challenge.challenge}"
+        )
+        assert "=" not in challenge.challenge
+
+    def test_challenge_is_sha256_of_verifier(self) -> None:
+        """Verify that the challenge is the SHA-256 hash of the verifier, base64url-encoded.
+
+        Per RFC 7636 Section 4.2:
+            code_challenge = BASE64URL(SHA256(code_verifier))
+
+        We independently compute the expected challenge and compare.
+        """
+        challenge = PkceChallenge.generate()
+
+        # Independently compute SHA-256 of the verifier
+        verifier_bytes = challenge.verifier.encode("ascii")
+        sha256_digest = hashlib.sha256(verifier_bytes).digest()
+        expected_challenge = (
+            base64.urlsafe_b64encode(sha256_digest).rstrip(b"=").decode("ascii")
+        )
+
+        assert challenge.challenge == expected_challenge
+
+    def test_challenge_computation_is_deterministic(self) -> None:
+        """Verify that the same verifier always produces the same challenge.
+
+        Given a fixed verifier string, the SHA-256 hash and base64url encoding
+        should always produce the same challenge value.
+        """
+        challenge = PkceChallenge.generate()
+
+        # Recompute challenge from the verifier twice
+        verifier_bytes = challenge.verifier.encode("ascii")
+        digest1 = hashlib.sha256(verifier_bytes).digest()
+        digest2 = hashlib.sha256(verifier_bytes).digest()
+
+        result1 = base64.urlsafe_b64encode(digest1).rstrip(b"=").decode("ascii")
+        result2 = base64.urlsafe_b64encode(digest2).rstrip(b"=").decode("ascii")
+
+        assert result1 == result2
+        assert result1 == challenge.challenge
+
+    def test_each_generation_produces_different_verifier(self) -> None:
+        """Verify that successive calls to generate() produce different verifiers.
+
+        The verifier is derived from cryptographically random bytes, so each
+        generation should be unique. We generate multiple and check they
+        are all distinct.
+        """
+        verifiers = {PkceChallenge.generate().verifier for _ in range(10)}
+        assert len(verifiers) == 10, (
+            "Expected 10 unique verifiers from 10 generations, "
+            f"got {len(verifiers)} unique values"
+        )
+
+    def test_each_generation_produces_different_challenge(self) -> None:
+        """Verify that successive calls to generate() produce different challenges.
+
+        Since each verifier is unique, the corresponding challenges must also
+        be unique.
+        """
+        challenges = {PkceChallenge.generate().challenge for _ in range(10)}
+        assert len(challenges) == 10, (
+            "Expected 10 unique challenges from 10 generations, "
+            f"got {len(challenges)} unique values"
+        )
+
+    def test_challenge_length_is_43_chars(self) -> None:
+        """Verify that the challenge is exactly 43 characters.
+
+        SHA-256 produces 32 bytes. Base64url-encoded without padding:
+        ceil(32 * 4 / 3) = 43 characters.
+        """
+        challenge = PkceChallenge.generate()
+        assert len(challenge.challenge) == 43
+
+    def test_verifier_and_challenge_are_strings(self) -> None:
+        """Verify that verifier and challenge attributes are plain strings.
+
+        Both attributes should be regular str instances, not bytes or other types.
+        """
+        challenge = PkceChallenge.generate()
+        assert isinstance(challenge.verifier, str)
+        assert isinstance(challenge.challenge, str)

--- a/tests/unit/test_auth_registration.py
+++ b/tests/unit/test_auth_registration.py
@@ -1,0 +1,438 @@
+"""Unit tests for Dynamic Client Registration (T018).
+
+Tests the ensure_client_registered function which implements
+Dynamic Client Registration (RFC 7591) for Mixpanel OAuth.
+
+Verifies:
+- POST to ``{base_url}mcp/register/`` with correct body
+- Parses client_id from response
+- Caches result per region (checks OAuthStorage)
+- Re-registers if redirect_uri changes
+- Handles 429 rate limit
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from mixpanel_data._internal.auth.client_registration import (
+    ensure_client_registered,
+)
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo
+from mixpanel_data.exceptions import OAuthError
+
+
+def _make_register_transport(
+    *,
+    client_id: str = "registered-client-id",
+    status_code: int = 201,
+) -> httpx.MockTransport:
+    """Create a mock transport that simulates the registration endpoint.
+
+    Args:
+        client_id: The client_id to return in the response.
+        status_code: HTTP status code to return.
+
+    Returns:
+        An httpx.MockTransport configured for registration responses.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Handle mock HTTP request.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            Mock HTTP response.
+        """
+        if status_code == 429:
+            return httpx.Response(
+                status_code=429,
+                json={"error": "rate_limited"},
+                headers={"Retry-After": "60"},
+            )
+        return httpx.Response(
+            status_code=status_code,
+            json={"client_id": client_id},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+class TestEnsureClientRegistered:
+    """Tests for the ensure_client_registered function."""
+
+    def test_posts_to_register_endpoint(self, tmp_path: Path) -> None:
+        """Verify that a POST is made to ``{base_url}mcp/register/``.
+
+        Captures the request URL and method to verify correct endpoint usage.
+        """
+        captured_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture request and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response.
+            """
+            captured_requests.append(request)
+            return httpx.Response(201, json={"client_id": "cid-1"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert len(captured_requests) == 1
+        req = captured_requests[0]
+        assert req.method == "POST"
+        assert str(req.url) == "https://mixpanel.com/oauth/mcp/register/"
+
+    def test_correct_request_body(self, tmp_path: Path) -> None:
+        """Verify the registration POST body contains required fields.
+
+        The body must include redirect_uris, grant_types, response_types,
+        token_endpoint_auth_method, and scope.
+        """
+        import json
+
+        captured_body: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture request body and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response.
+            """
+            body: dict[str, object] = json.loads(request.content)
+            captured_body.append(body)
+            return httpx.Response(201, json={"client_id": "cid-1"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert len(captured_body) == 1
+        body = captured_body[0]
+        assert body["redirect_uris"] == ["http://localhost:19284/callback"]
+        assert body["grant_types"] == ["authorization_code", "refresh_token"]
+        assert body["response_types"] == ["code"]
+        assert body["token_endpoint_auth_method"] == "none"
+        assert isinstance(body.get("scope"), str)
+        # Scope should contain key scopes
+        scope_str = str(body["scope"])
+        assert "projects" in scope_str
+        assert "analysis" in scope_str
+
+    def test_parses_client_id_from_response(self, tmp_path: Path) -> None:
+        """Verify client_id is correctly parsed from the registration response."""
+        transport = _make_register_transport(client_id="parsed-client-id")
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        result = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert isinstance(result, OAuthClientInfo)
+        assert result.client_id == "parsed-client-id"
+        assert result.region == "us"
+        assert result.redirect_uri == "http://localhost:19284/callback"
+
+    def test_caches_result_per_region(self, tmp_path: Path) -> None:
+        """Verify that a cached client is returned without making a new request.
+
+        After the first registration, subsequent calls for the same region
+        should return the cached client without hitting the network.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Count calls and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response.
+            """
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(201, json={"client_id": "cached-cid"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        # First call registers
+        result1 = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+        assert call_count == 1
+
+        # Second call uses cache
+        result2 = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+        assert call_count == 1  # No new request
+        assert result2.client_id == result1.client_id
+
+    def test_re_registers_if_redirect_uri_changes(self, tmp_path: Path) -> None:
+        """Verify re-registration occurs when the redirect_uri changes.
+
+        If the cached client has a different redirect_uri than requested,
+        a new registration must be performed.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Count calls and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response with incremented client_id.
+            """
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(201, json={"client_id": f"cid-{call_count}"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        # First registration
+        result1 = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+        assert call_count == 1
+        assert result1.client_id == "cid-1"
+
+        # Changed redirect_uri triggers re-registration
+        result2 = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19285/callback",
+            storage=storage,
+        )
+        assert call_count == 2
+        assert result2.client_id == "cid-2"
+        assert result2.redirect_uri == "http://localhost:19285/callback"
+
+    def test_handles_429_rate_limit(self, tmp_path: Path) -> None:
+        """Verify that HTTP 429 raises OAuthError with OAUTH_REGISTRATION_ERROR code."""
+        transport = _make_register_transport(status_code=429)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        with pytest.raises(OAuthError) as exc_info:
+            ensure_client_registered(
+                http_client=client,
+                region="us",
+                redirect_uri="http://localhost:19284/callback",
+                storage=storage,
+            )
+        assert exc_info.value.code == "OAUTH_REGISTRATION_ERROR"
+
+    def test_eu_region_uses_eu_base_url(self, tmp_path: Path) -> None:
+        """Verify that EU region uses eu.mixpanel.com base URL."""
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response.
+            """
+            captured_urls.append(str(request.url))
+            return httpx.Response(201, json={"client_id": "eu-cid"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        ensure_client_registered(
+            http_client=client,
+            region="eu",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert captured_urls[0] == "https://eu.mixpanel.com/oauth/mcp/register/"
+
+    def test_in_region_uses_in_base_url(self, tmp_path: Path) -> None:
+        """Verify that IN region uses in.mixpanel.com base URL."""
+        captured_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL and return success.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Mock success response.
+            """
+            captured_urls.append(str(request.url))
+            return httpx.Response(201, json={"client_id": "in-cid"})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        ensure_client_registered(
+            http_client=client,
+            region="in",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert captured_urls[0] == "https://in.mixpanel.com/oauth/mcp/register/"
+
+    def test_accepts_200_status_code(self, tmp_path: Path) -> None:
+        """Verify that HTTP 200 is also accepted for backward compatibility.
+
+        The real DCR endpoint returns 201, but some servers may return 200.
+        Both are valid success responses.
+        """
+        transport = _make_register_transport(client_id="cid-200", status_code=200)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        result = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert result.client_id == "cid-200"
+
+    def test_accepts_201_status_code(self, tmp_path: Path) -> None:
+        """Verify that HTTP 201 Created is accepted.
+
+        The Mixpanel DCR endpoint returns 201 for newly registered clients.
+        """
+        transport = _make_register_transport(client_id="cid-201", status_code=201)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        result = ensure_client_registered(
+            http_client=client,
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            storage=storage,
+        )
+
+        assert result.client_id == "cid-201"
+
+
+class TestEnsureClientRegisteredRobustness:
+    """Tests for handling malformed registration responses."""
+
+    def test_registration_response_missing_client_id(self, tmp_path: Path) -> None:
+        """Verify OAuthError when the 200 response body is missing client_id.
+
+        A successful HTTP status but an empty JSON body should raise
+        OAuthError with OAUTH_REGISTRATION_ERROR code.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return 200 with empty JSON body.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Response with no client_id field.
+            """
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        with pytest.raises(OAuthError) as exc_info:
+            ensure_client_registered(
+                http_client=client,
+                region="us",
+                redirect_uri="http://localhost:19284/callback",
+                storage=storage,
+            )
+        assert exc_info.value.code == "OAUTH_REGISTRATION_ERROR"
+
+    def test_registration_non_json_response(self, tmp_path: Path) -> None:
+        """Verify OAuthError when the 200 response body is HTML, not JSON.
+
+        Some proxies or error pages may return HTML even with a 200 status.
+        The function should raise OAuthError, not JSONDecodeError.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return 200 with HTML body.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                HTML response instead of JSON.
+            """
+            return httpx.Response(
+                200,
+                content=b"<html><body>Oops</body></html>",
+                headers={"content-type": "text/html"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        with pytest.raises(OAuthError) as exc_info:
+            ensure_client_registered(
+                http_client=client,
+                region="us",
+                redirect_uri="http://localhost:19284/callback",
+                storage=storage,
+            )
+        assert exc_info.value.code == "OAUTH_REGISTRATION_ERROR"

--- a/tests/unit/test_auth_registration.py
+++ b/tests/unit/test_auth_registration.py
@@ -436,3 +436,26 @@ class TestEnsureClientRegisteredRobustness:
                 storage=storage,
             )
         assert exc_info.value.code == "OAUTH_REGISTRATION_ERROR"
+
+
+class TestEnsureClientRegisteredRegionValidation:
+    """Tests for region validation in ensure_client_registered."""
+
+    def test_invalid_region_raises_oauth_error(self, tmp_path: Path) -> None:
+        """Verify that an invalid region raises OAuthError before making any request."""
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                lambda _req: httpx.Response(200, json={"client_id": "nope"})
+            )
+        )
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        with pytest.raises(OAuthError) as exc_info:
+            ensure_client_registered(
+                http_client=client,
+                region="xx",
+                redirect_uri="http://localhost:19284/callback",
+                storage=storage,
+            )
+        assert exc_info.value.code == "OAUTH_REGISTRATION_ERROR"
+        assert "xx" in str(exc_info.value)

--- a/tests/unit/test_auth_storage.py
+++ b/tests/unit/test_auth_storage.py
@@ -1,0 +1,923 @@
+"""Unit tests for OAuthStorage (T009).
+
+Tests the OAuthStorage class which provides secure local file storage
+for OAuth tokens and client registration info.
+
+Verifies:
+- Save/load token round-trip
+- Save/load client info round-trip
+- File permissions (0o600 for files, 0o700 for directories)
+- MP_OAUTH_STORAGE_DIR environment variable override
+- Region-specific file naming (tokens_{region}.json, client_{region}.json)
+- Missing file returns None
+- Delete removes files
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+
+
+def _utcnow() -> datetime:
+    """Return current UTC datetime.
+
+    Returns:
+        Current datetime with UTC timezone.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _make_tokens(
+    *,
+    access_token: str = "access_abc123",
+    refresh_token: str | None = "refresh_xyz789",
+    scope: str = "projects analysis",
+    project_id: str | None = "12345",
+) -> OAuthTokens:
+    """Create an OAuthTokens instance with sensible defaults for testing.
+
+    Args:
+        access_token: OAuth access token string.
+        refresh_token: OAuth refresh token string, or None.
+        scope: OAuth scope string.
+        project_id: Associated Mixpanel project ID.
+
+    Returns:
+        Configured OAuthTokens instance.
+    """
+    return OAuthTokens(
+        access_token=SecretStr(access_token),
+        refresh_token=SecretStr(refresh_token) if refresh_token is not None else None,
+        expires_at=_utcnow() + timedelta(hours=1),
+        scope=scope,
+        token_type="Bearer",
+        project_id=project_id,
+    )
+
+
+def _make_client_info(
+    *,
+    client_id: str = "client_abc123",
+    region: str = "us",
+) -> OAuthClientInfo:
+    """Create an OAuthClientInfo instance with sensible defaults for testing.
+
+    Args:
+        client_id: DCR client identifier.
+        region: Mixpanel data residency region.
+
+    Returns:
+        Configured OAuthClientInfo instance.
+    """
+    return OAuthClientInfo(
+        client_id=client_id,
+        region=region,
+        redirect_uri="http://localhost:19284/callback",
+        scope="projects analysis",
+        created_at=_utcnow(),
+    )
+
+
+class TestOAuthStorageSecurityHardening:
+    """Tests for security hardening of OAuthStorage (T045)."""
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_directory_created_with_0o700(self, temp_dir: Path) -> None:
+        """Verify that the storage directory is always created with 0o700 permissions."""
+        storage_dir = temp_dir / "secure_oauth"
+        storage = OAuthStorage(storage_dir=storage_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        dir_mode = stat.S_IMODE(storage_dir.stat().st_mode)
+        assert dir_mode == 0o700, f"Expected 0o700, got {oct(dir_mode)}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_files_created_with_0o600(self, temp_dir: Path) -> None:
+        """Verify that token and client files are created with 0o600 permissions."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+        storage.save_client_info(_make_client_info())
+
+        token_file = temp_dir / "tokens_us.json"
+        client_file = temp_dir / "client_us.json"
+
+        for f in (token_file, client_file):
+            file_mode = stat.S_IMODE(f.stat().st_mode)
+            assert file_mode == 0o600, (
+                f"Expected 0o600 for {f.name}, got {oct(file_mode)}"
+            )
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_check_and_fix_permissions_repairs_directory(self, temp_dir: Path) -> None:
+        """Verify that _check_and_fix_permissions repairs directory permissions."""
+        storage_dir = temp_dir / "fixable_oauth"
+        storage_dir.mkdir(parents=True)
+        storage_dir.chmod(0o755)  # Intentionally wrong
+
+        storage = OAuthStorage(storage_dir=storage_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        dir_mode = stat.S_IMODE(storage_dir.stat().st_mode)
+        assert dir_mode == 0o700, f"Expected 0o700 after repair, got {oct(dir_mode)}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_check_and_fix_permissions_repairs_files_on_load(
+        self, temp_dir: Path
+    ) -> None:
+        """Verify that load_tokens repairs file permissions if incorrect."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        # Deliberately break file permissions
+        token_file = temp_dir / "tokens_us.json"
+        token_file.chmod(0o644)
+
+        # Loading should repair permissions
+        storage.load_tokens(region="us")
+        file_mode = stat.S_IMODE(token_file.stat().st_mode)
+        assert file_mode == 0o600, f"Expected 0o600 after repair, got {oct(file_mode)}"
+
+    def test_repr_redacts_access_token(self) -> None:
+        """Verify that repr() of OAuthTokens redacts access_token."""
+        tokens = _make_tokens()
+        r = repr(tokens)
+        assert "access_abc123" not in r
+        assert "**********" in r
+
+    def test_repr_redacts_refresh_token(self) -> None:
+        """Verify that repr() of OAuthTokens redacts refresh_token."""
+        tokens = _make_tokens()
+        r = repr(tokens)
+        assert "refresh_xyz789" not in r
+
+    def test_str_redacts_secrets(self) -> None:
+        """Verify that str() of OAuthTokens does not leak secret values."""
+        tokens = _make_tokens()
+        s = str(tokens)
+        assert "access_abc123" not in s
+        assert "refresh_xyz789" not in s
+
+    def test_token_values_never_in_log_output(self) -> None:
+        """Verify that token values never appear in logger output.
+
+        Mocks the logger used by the storage module and ensures no raw
+        token values are emitted in any log messages.
+        """
+        tokens = _make_tokens()
+        # Check that formatting the tokens for potential log output doesn't leak
+        formatted = f"Loaded tokens: {tokens}"
+        assert "access_abc123" not in formatted
+        assert "refresh_xyz789" not in formatted
+
+        # Also verify that repr is safe
+        formatted_repr = f"Token info: {tokens!r}"
+        assert "access_abc123" not in formatted_repr
+        assert "refresh_xyz789" not in formatted_repr
+
+
+class TestOAuthStorageTokenRoundTrip:
+    """Tests for saving and loading OAuth tokens."""
+
+    def test_save_and_load_tokens(self, temp_dir: Path) -> None:
+        """Verify tokens can be saved and loaded back with all fields preserved.
+
+        The storage should serialize OAuthTokens to JSON and deserialize
+        back to an equivalent OAuthTokens instance.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        original = _make_tokens()
+
+        storage.save_tokens(original, region="us")
+        loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        assert loaded.access_token.get_secret_value() == "access_abc123"
+        assert loaded.refresh_token is not None
+        assert loaded.refresh_token.get_secret_value() == "refresh_xyz789"
+        assert loaded.scope == "projects analysis"
+        assert loaded.token_type == "Bearer"
+        assert loaded.project_id == "12345"
+
+    def test_save_and_load_tokens_without_refresh_token(self, temp_dir: Path) -> None:
+        """Verify tokens without a refresh token survive round-trip."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        original = _make_tokens(refresh_token=None)
+
+        storage.save_tokens(original, region="us")
+        loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        assert loaded.refresh_token is None
+
+    def test_save_and_load_tokens_without_project_id(self, temp_dir: Path) -> None:
+        """Verify tokens without a project_id survive round-trip."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        original = _make_tokens(project_id=None)
+
+        storage.save_tokens(original, region="eu")
+        loaded = storage.load_tokens(region="eu")
+
+        assert loaded is not None
+        assert loaded.project_id is None
+
+    def test_expires_at_preserved_through_round_trip(self, temp_dir: Path) -> None:
+        """Verify that the expires_at datetime is preserved through save/load.
+
+        JSON serialization may lose sub-microsecond precision, but the
+        datetime should be within 1 second of the original.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        original = _make_tokens()
+
+        storage.save_tokens(original, region="us")
+        loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        delta = abs((loaded.expires_at - original.expires_at).total_seconds())
+        assert delta < 1, f"expires_at drift: {delta}s"
+
+
+class TestOAuthStorageClientInfoRoundTrip:
+    """Tests for saving and loading client registration info."""
+
+    def test_save_and_load_client_info(self, temp_dir: Path) -> None:
+        """Verify client info can be saved and loaded with all fields preserved."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        original = _make_client_info()
+
+        storage.save_client_info(original)
+        loaded = storage.load_client_info(region="us")
+
+        assert loaded is not None
+        assert loaded.client_id == "client_abc123"
+        assert loaded.region == "us"
+        assert loaded.redirect_uri == "http://localhost:19284/callback"
+        assert loaded.scope == "projects analysis"
+
+    def test_save_and_load_client_info_different_regions(self, temp_dir: Path) -> None:
+        """Verify client info is stored per-region and doesn't cross-contaminate."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        us_info = _make_client_info(client_id="us_client", region="us")
+        eu_info = _make_client_info(client_id="eu_client", region="eu")
+
+        storage.save_client_info(us_info)
+        storage.save_client_info(eu_info)
+
+        loaded_us = storage.load_client_info(region="us")
+        loaded_eu = storage.load_client_info(region="eu")
+
+        assert loaded_us is not None
+        assert loaded_us.client_id == "us_client"
+        assert loaded_eu is not None
+        assert loaded_eu.client_id == "eu_client"
+
+
+class TestOAuthStorageFilePermissions:
+    """Tests for secure file and directory permissions."""
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_storage_directory_has_0o700_permissions(self, temp_dir: Path) -> None:
+        """Verify that the storage directory is created with 0o700 permissions.
+
+        Only the owning user should have read/write/execute access to the
+        directory containing OAuth tokens.
+        """
+        storage_dir = temp_dir / "oauth_perms"
+        storage = OAuthStorage(storage_dir=storage_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        dir_mode = stat.S_IMODE(storage_dir.stat().st_mode)
+        assert dir_mode == 0o700, f"Expected 0o700, got {oct(dir_mode)}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_token_file_has_0o600_permissions(self, temp_dir: Path) -> None:
+        """Verify that token files are created with 0o600 permissions.
+
+        Only the owning user should have read/write access to token files.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        token_file = temp_dir / "tokens_us.json"
+        file_mode = stat.S_IMODE(token_file.stat().st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX file permissions not available on Windows",
+    )
+    def test_client_info_file_has_0o600_permissions(self, temp_dir: Path) -> None:
+        """Verify that client info files are created with 0o600 permissions."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_client_info(_make_client_info(region="eu"))
+
+        client_file = temp_dir / "client_eu.json"
+        file_mode = stat.S_IMODE(client_file.stat().st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+class TestOAuthStorageEnvOverride:
+    """Tests for MP_OAUTH_STORAGE_DIR environment variable override."""
+
+    def test_mp_oauth_storage_dir_override(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that MP_OAUTH_STORAGE_DIR overrides the default storage path.
+
+        When set, OAuthStorage should use the specified directory instead
+        of the default ~/.mp/oauth/.
+        """
+        custom_dir = temp_dir / "custom_oauth"
+        custom_dir.mkdir(parents=True)
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(custom_dir))
+
+        storage = OAuthStorage()
+        storage.save_tokens(_make_tokens(), region="us")
+
+        assert (custom_dir / "tokens_us.json").exists()
+
+    def test_explicit_storage_dir_takes_precedence_over_env(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that an explicit storage_dir parameter overrides the env var.
+
+        When both are set, the explicit constructor argument should win.
+        """
+        env_dir = temp_dir / "env_dir"
+        env_dir.mkdir()
+        explicit_dir = temp_dir / "explicit_dir"
+        explicit_dir.mkdir()
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(env_dir))
+
+        storage = OAuthStorage(storage_dir=explicit_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        assert (explicit_dir / "tokens_us.json").exists()
+        assert not (env_dir / "tokens_us.json").exists()
+
+
+class TestOAuthStorageRegionNaming:
+    """Tests for region-specific file naming conventions."""
+
+    def test_tokens_file_named_by_region(self, temp_dir: Path) -> None:
+        """Verify that token files are named tokens_{region}.json.
+
+        Each region's tokens are stored in a separate file to support
+        multi-region authentication.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        for region in ("us", "eu", "in"):
+            storage.save_tokens(_make_tokens(), region=region)
+            expected_file = temp_dir / f"tokens_{region}.json"
+            assert expected_file.exists(), f"Expected {expected_file} to exist"
+
+    def test_client_file_named_by_region(self, temp_dir: Path) -> None:
+        """Verify that client info files are named client_{region}.json."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        for region in ("us", "eu", "in"):
+            storage.save_client_info(_make_client_info(region=region))
+            expected_file = temp_dir / f"client_{region}.json"
+            assert expected_file.exists(), f"Expected {expected_file} to exist"
+
+    def test_different_regions_are_independent(self, temp_dir: Path) -> None:
+        """Verify that saving tokens for one region doesn't affect another.
+
+        US and EU tokens should be stored and loaded independently.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        us_tokens = _make_tokens(access_token="us_token")
+        eu_tokens = _make_tokens(access_token="eu_token")
+
+        storage.save_tokens(us_tokens, region="us")
+        storage.save_tokens(eu_tokens, region="eu")
+
+        loaded_us = storage.load_tokens(region="us")
+        loaded_eu = storage.load_tokens(region="eu")
+
+        assert loaded_us is not None
+        assert loaded_us.access_token.get_secret_value() == "us_token"
+        assert loaded_eu is not None
+        assert loaded_eu.access_token.get_secret_value() == "eu_token"
+
+
+class TestOAuthStorageMissingFile:
+    """Tests for behavior when storage files do not exist."""
+
+    def test_load_tokens_returns_none_when_missing(self, temp_dir: Path) -> None:
+        """Verify that load_tokens() returns None when no token file exists.
+
+        This is the expected state before any OAuth login has occurred.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        result = storage.load_tokens(region="us")
+        assert result is None
+
+    def test_load_client_info_returns_none_when_missing(self, temp_dir: Path) -> None:
+        """Verify that load_client_info() returns None when no client file exists."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        result = storage.load_client_info(region="us")
+        assert result is None
+
+    def test_load_tokens_returns_none_for_different_region(
+        self, temp_dir: Path
+    ) -> None:
+        """Verify that tokens saved for US are not found when loading for EU."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        result = storage.load_tokens(region="eu")
+        assert result is None
+
+
+class TestOAuthStorageDelete:
+    """Tests for deleting stored tokens and client info."""
+
+    def test_delete_tokens_removes_file(self, temp_dir: Path) -> None:
+        """Verify that delete_tokens() removes the token file for the region."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        assert (temp_dir / "tokens_us.json").exists()
+
+        storage.delete_tokens(region="us")
+
+        assert not (temp_dir / "tokens_us.json").exists()
+
+    def test_delete_tokens_only_affects_specified_region(self, temp_dir: Path) -> None:
+        """Verify that deleting tokens for one region doesn't affect others."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+        storage.save_tokens(_make_tokens(), region="eu")
+
+        storage.delete_tokens(region="us")
+
+        assert not (temp_dir / "tokens_us.json").exists()
+        assert (temp_dir / "tokens_eu.json").exists()
+
+    def test_delete_tokens_when_no_file_exists(self, temp_dir: Path) -> None:
+        """Verify that delete_tokens() does not raise when no file exists.
+
+        Deleting tokens that don't exist should be a no-op.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        # Should not raise
+        storage.delete_tokens(region="us")
+
+    def test_load_tokens_returns_none_after_delete(self, temp_dir: Path) -> None:
+        """Verify that load_tokens() returns None after tokens are deleted."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        storage.save_tokens(_make_tokens(), region="us")
+
+        storage.delete_tokens(region="us")
+        result = storage.load_tokens(region="us")
+
+        assert result is None
+
+    def test_delete_all_removes_all_files(self, temp_dir: Path) -> None:
+        """Verify that delete_all() removes all token and client files."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        # Save tokens and client info for multiple regions
+        for region in ("us", "eu", "in"):
+            storage.save_tokens(_make_tokens(), region=region)
+            storage.save_client_info(_make_client_info(region=region))
+
+        storage.delete_all()
+
+        for region in ("us", "eu", "in"):
+            assert storage.load_tokens(region=region) is None
+            assert storage.load_client_info(region=region) is None
+
+
+class TestOAuthStorageCorruptedFiles:
+    """Tests for handling corrupted or malformed files on disk."""
+
+    def test_load_tokens_invalid_json(self, temp_dir: Path) -> None:
+        """Verify load_tokens returns None when file contains truncated JSON.
+
+        A corrupted file (e.g. from a partial write) should not crash
+        the application with JSONDecodeError.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens_file = temp_dir / "tokens_us.json"
+        tokens_file.parent.mkdir(parents=True, exist_ok=True)
+        tokens_file.write_text('{"truncated', encoding="utf-8")
+
+        result = storage.load_tokens(region="us")
+        assert result is None
+
+    def test_load_tokens_empty_file(self, temp_dir: Path) -> None:
+        """Verify load_tokens returns None when the file is empty.
+
+        An empty file is invalid JSON and should be handled gracefully.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens_file = temp_dir / "tokens_us.json"
+        tokens_file.parent.mkdir(parents=True, exist_ok=True)
+        tokens_file.write_text("", encoding="utf-8")
+
+        result = storage.load_tokens(region="us")
+        assert result is None
+
+    def test_load_tokens_binary_data(self, temp_dir: Path) -> None:
+        """Verify load_tokens returns None when file contains binary data.
+
+        Binary garbage in the token file should not crash with
+        UnicodeDecodeError or JSONDecodeError.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens_file = temp_dir / "tokens_us.json"
+        tokens_file.parent.mkdir(parents=True, exist_ok=True)
+        tokens_file.write_bytes(b"\x80\x81\x82\xff\xfe\x00\x01")
+
+        result = storage.load_tokens(region="us")
+        assert result is None
+
+    def test_load_tokens_wrong_schema(self, temp_dir: Path) -> None:
+        """Verify load_tokens returns None when JSON is valid but missing required fields.
+
+        A file with ``{"foo": "bar"}`` (no ``access_token``) should not
+        raise KeyError.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens_file = temp_dir / "tokens_us.json"
+        tokens_file.parent.mkdir(parents=True, exist_ok=True)
+        tokens_file.write_text('{"foo": "bar"}', encoding="utf-8")
+
+        result = storage.load_tokens(region="us")
+        assert result is None
+
+    def test_load_tokens_wrong_types(self, temp_dir: Path) -> None:
+        """Verify load_tokens returns None when field types are incorrect.
+
+        Writing ``access_token`` as an integer and ``expires_at`` as a
+        non-date string should be handled gracefully.
+        """
+        import json
+
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens_file = temp_dir / "tokens_us.json"
+        tokens_file.parent.mkdir(parents=True, exist_ok=True)
+        bad_data = {
+            "access_token": 42,
+            "expires_at": "not-a-date",
+            "scope": 123,
+            "token_type": None,
+        }
+        tokens_file.write_text(json.dumps(bad_data), encoding="utf-8")
+
+        result = storage.load_tokens(region="us")
+        # Should return None (validation error), not crash
+        assert result is None
+
+    def test_load_client_info_corrupted(self, temp_dir: Path) -> None:
+        """Verify load_client_info returns None when file contains invalid JSON.
+
+        Corrupted client info files should be handled the same as
+        corrupted token files.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        client_file = temp_dir / "client_us.json"
+        client_file.parent.mkdir(parents=True, exist_ok=True)
+        client_file.write_text("not valid json {{{", encoding="utf-8")
+
+        result = storage.load_client_info(region="us")
+        assert result is None
+
+
+class TestOAuthStoragePathTraversal:
+    """Tests for path traversal prevention in region parameters."""
+
+    def test_tokens_path_traversal_rejected(self, temp_dir: Path) -> None:
+        """Verify that save_tokens rejects region with path traversal characters.
+
+        A region like ``../../../tmp`` would escape the storage directory
+        if not validated. The storage must raise ``ValueError``.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.save_tokens(_make_tokens(), region="../../../tmp")
+
+    def test_tokens_path_with_slashes(self, temp_dir: Path) -> None:
+        """Verify that a region containing slashes is rejected.
+
+        A region like ``us/eu`` is not a valid 2-letter region code and
+        could be used to create files in unexpected subdirectories.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.save_tokens(_make_tokens(), region="us/eu")
+
+    def test_client_path_traversal_rejected(self, temp_dir: Path) -> None:
+        """Verify that save_client_info rejects region with traversal characters.
+
+        Uses a client info object whose region contains path traversal
+        sequences. The storage must raise ``ValueError``.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        malicious_info = OAuthClientInfo(
+            client_id="test_client",
+            region="../../../etc",
+            redirect_uri="http://localhost:19284/callback",
+            scope="projects analysis",
+            created_at=_utcnow(),
+        )
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.save_client_info(malicious_info)
+
+    def test_valid_regions_accepted(self, temp_dir: Path) -> None:
+        """Verify that valid 2-letter region codes are accepted without error.
+
+        The standard Mixpanel regions ``us``, ``eu``, and ``in`` must all
+        pass validation and successfully save/load tokens.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        for region in ("us", "eu", "in"):
+            storage.save_tokens(_make_tokens(), region=region)
+            loaded = storage.load_tokens(region=region)
+            assert loaded is not None
+
+    def test_load_tokens_traversal_rejected(self, temp_dir: Path) -> None:
+        """Verify that load_tokens rejects traversal regions."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.load_tokens(region="../../../tmp")
+
+    def test_load_client_info_traversal_rejected(self, temp_dir: Path) -> None:
+        """Verify that load_client_info rejects traversal regions."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.load_client_info(region="../../../tmp")
+
+    def test_delete_tokens_traversal_rejected(self, temp_dir: Path) -> None:
+        """Verify that delete_tokens rejects traversal regions."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.delete_tokens(region="../../../tmp")
+
+    def test_uppercase_region_rejected(self, temp_dir: Path) -> None:
+        """Verify that uppercase region codes are rejected.
+
+        Only lowercase 2-letter codes are valid.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.save_tokens(_make_tokens(), region="US")
+
+    def test_three_letter_region_rejected(self, temp_dir: Path) -> None:
+        """Verify that region codes longer than 2 characters are rejected."""
+        storage = OAuthStorage(storage_dir=temp_dir)
+        with pytest.raises(ValueError, match="Invalid region"):
+            storage.save_tokens(_make_tokens(), region="usa")
+
+
+# =============================================================================
+# Phase 3C: Unicode & Special Characters
+# =============================================================================
+
+
+class TestOAuthStorageUnicode:
+    """Tests for Unicode and special character handling in token storage.
+
+    Verifies that tokens with non-ASCII scope values and special characters
+    in access tokens survive the save/load round-trip without corruption.
+    """
+
+    def test_save_load_tokens_unicode_scope(self, temp_dir: Path) -> None:
+        """Verify that tokens with Unicode scope values survive round-trip.
+
+        OAuth scopes are typically ASCII, but the storage layer should
+        not corrupt Unicode characters if they appear (e.g. localized
+        scope descriptions from non-standard servers).
+
+        Args:
+            temp_dir: Temporary directory fixture for isolated storage.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens = _make_tokens(scope="événements données")
+        storage.save_tokens(tokens, region="us")
+        loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        assert loaded.scope == "événements données"
+
+    def test_save_load_tokens_special_chars_in_token(self, temp_dir: Path) -> None:
+        """Verify that tokens with URL-special characters survive round-trip.
+
+        Access tokens may contain ``+``, ``/``, ``=`` from base64 encoding.
+        These must not be corrupted by JSON serialization.
+
+        Args:
+            temp_dir: Temporary directory fixture for isolated storage.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+        tokens = _make_tokens(access_token="tok+en/with=special")
+        storage.save_tokens(tokens, region="us")
+        loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        assert loaded.access_token.get_secret_value() == "tok+en/with=special"
+
+
+# =============================================================================
+# Phase 4: Concurrency Tests
+# =============================================================================
+
+
+class TestOAuthStorageConcurrency:
+    """Tests for concurrent access to OAuthStorage.
+
+    Verifies that simultaneous reads and writes do not produce corrupted
+    JSON files or raise unexpected exceptions. Uses threading to simulate
+    real-world concurrent access patterns.
+    """
+
+    def test_concurrent_saves_produce_valid_json(self, temp_dir: Path) -> None:
+        """Verify that 10 concurrent saves all produce valid JSON on disk.
+
+        Launches 10 threads, each saving tokens with a unique access_token.
+        After all complete, ``load_tokens()`` must return a valid token
+        (one of the 10 values) — not corrupted JSON.
+
+        Args:
+            temp_dir: Temporary directory fixture for isolated storage.
+        """
+        import concurrent.futures
+
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        def save_with_id(thread_id: int) -> None:
+            """Save tokens with a thread-specific access token.
+
+            Args:
+                thread_id: Unique identifier for this thread's token.
+            """
+            tokens = _make_tokens(access_token=f"token_{thread_id}")
+            storage.save_tokens(tokens, region="us")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(save_with_id, i) for i in range(10)]
+            concurrent.futures.wait(futures)
+
+        # Verify no exceptions were raised
+        for f in futures:
+            f.result()  # Raises if the thread raised
+
+        # After all writes, the file should contain valid JSON
+        loaded = storage.load_tokens(region="us")
+        assert loaded is not None
+        # The token should be one of the 10 written values
+        token_value = loaded.access_token.get_secret_value()
+        valid_tokens = {f"token_{i}" for i in range(10)}
+        assert token_value in valid_tokens
+
+    def test_concurrent_read_during_write(self, temp_dir: Path) -> None:
+        """Verify that concurrent reads and writes do not crash.
+
+        A writer thread saves tokens in a loop (20 iterations), while
+        a reader thread loads tokens in a loop (20 iterations). After
+        both complete, no exceptions should have been raised. The reader
+        should get either ``None`` or a valid ``OAuthTokens`` instance.
+
+        Args:
+            temp_dir: Temporary directory fixture for isolated storage.
+        """
+        import concurrent.futures
+        import threading
+
+        storage = OAuthStorage(storage_dir=temp_dir)
+        read_results: list[OAuthTokens | None] = []
+        read_errors: list[Exception] = []
+        write_errors: list[Exception] = []
+        read_lock = threading.Lock()
+
+        def writer() -> None:
+            """Write tokens in a loop, recording any errors."""
+            for i in range(20):
+                try:
+                    tokens = _make_tokens(access_token=f"write_{i}")
+                    storage.save_tokens(tokens, region="us")
+                except Exception as exc:
+                    write_errors.append(exc)
+
+        def reader() -> None:
+            """Read tokens in a loop, recording results and any errors.
+
+            PermissionError is expected during concurrent access because
+            the storage temporarily changes file permissions via umask
+            during writes. These are tolerated as known race conditions.
+            """
+            for _ in range(20):
+                try:
+                    result = storage.load_tokens(region="us")
+                    with read_lock:
+                        read_results.append(result)
+                except PermissionError:
+                    # Expected: writer temporarily restricts permissions
+                    pass
+                except Exception as exc:
+                    read_errors.append(exc)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            write_future = executor.submit(writer)
+            read_future = executor.submit(reader)
+            concurrent.futures.wait([write_future, read_future])
+
+        # No exceptions in either thread (PermissionError already handled)
+        write_future.result()
+        read_future.result()
+        assert len(write_errors) == 0, f"Writer errors: {write_errors}"
+        assert len(read_errors) == 0, f"Reader errors: {read_errors}"
+
+        # Reader results should all be None or valid OAuthTokens
+        for result in read_results:
+            assert result is None or isinstance(result, OAuthTokens)
+
+
+class TestOAuthStorageUmaskRestoration:
+    """Tests for umask restoration after write operations."""
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX umask not available on Windows",
+    )
+    def test_umask_restored_after_write_exception(self, temp_dir: Path) -> None:
+        """Verify umask is restored when write_text raises an exception.
+
+        Sets a known umask, mocks ``Path.write_text`` to raise ``OSError``,
+        then verifies the original umask is restored after the failure.
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        os.umask(0o022)
+        try:
+            with (
+                patch.object(Path, "write_text", side_effect=OSError("disk full")),
+                pytest.raises(OSError, match="disk full"),
+            ):
+                storage.save_tokens(_make_tokens(), region="us")
+        finally:
+            restored = os.umask(0o022)
+            os.umask(restored)
+
+        assert restored == 0o022, (
+            f"Expected umask 0o022 after failed write, got {oct(restored)}"
+        )
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX umask not available on Windows",
+    )
+    def test_umask_restored_after_successful_write(self, temp_dir: Path) -> None:
+        """Verify umask is restored to original value after successful write.
+
+        Sets umask to ``0o022``, performs a successful save, then checks
+        that the umask is still ``0o022`` (not stuck at the restrictive
+        ``0o177`` used internally).
+        """
+        storage = OAuthStorage(storage_dir=temp_dir)
+
+        os.umask(0o022)
+        try:
+            storage.save_tokens(_make_tokens(), region="us")
+        finally:
+            restored = os.umask(0o022)
+            os.umask(restored)
+
+        assert restored == 0o022, (
+            f"Expected umask 0o022 after successful write, got {oct(restored)}"
+        )

--- a/tests/unit/test_auth_token.py
+++ b/tests/unit/test_auth_token.py
@@ -1,0 +1,584 @@
+"""Unit tests for OAuthTokens and OAuthClientInfo models (T008).
+
+Tests the OAuth token model and client info model which provide
+immutable, validated containers for OAuth 2.0 token data and
+Dynamic Client Registration (DCR) client metadata.
+
+Verifies:
+- OAuthTokens: frozen immutable, is_expired() with 30s buffer, SecretStr
+  redaction, JSON round-trip, project_id preservation, from_token_response()
+- OAuthClientInfo: frozen immutable, field validation, created_at tracking
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+
+
+def _utcnow() -> datetime:
+    """Return current UTC datetime.
+
+    Returns:
+        Current datetime with UTC timezone.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _make_tokens(
+    *,
+    access_token: str = "access_abc123",
+    refresh_token: str | None = "refresh_xyz789",
+    expires_at: datetime | None = None,
+    scope: str = "projects analysis",
+    token_type: str = "Bearer",
+    project_id: str | None = "12345",
+) -> OAuthTokens:
+    """Create an OAuthTokens instance with sensible defaults for testing.
+
+    Args:
+        access_token: OAuth access token string.
+        refresh_token: OAuth refresh token string, or None.
+        expires_at: Token expiry datetime. Defaults to 1 hour from now.
+        scope: OAuth scope string.
+        token_type: Token type (typically 'Bearer').
+        project_id: Associated Mixpanel project ID.
+
+    Returns:
+        Configured OAuthTokens instance.
+    """
+    if expires_at is None:
+        from datetime import timedelta
+
+        expires_at = _utcnow() + timedelta(hours=1)
+
+    return OAuthTokens(
+        access_token=SecretStr(access_token),
+        refresh_token=SecretStr(refresh_token) if refresh_token is not None else None,
+        expires_at=expires_at,
+        scope=scope,
+        token_type=token_type,
+        project_id=project_id,
+    )
+
+
+class TestOAuthTokensImmutability:
+    """Tests that OAuthTokens is a frozen (immutable) Pydantic model."""
+
+    def test_frozen_cannot_modify_access_token(self) -> None:
+        """Verify that access_token cannot be modified after construction.
+
+        OAuthTokens is a frozen Pydantic model, so attribute assignment
+        should raise a ValidationError.
+        """
+        tokens = _make_tokens()
+        with pytest.raises(ValidationError):
+            tokens.access_token = SecretStr("new_token")  # type: ignore[misc]
+
+    def test_frozen_cannot_modify_scope(self) -> None:
+        """Verify that scope cannot be modified after construction."""
+        tokens = _make_tokens()
+        with pytest.raises(ValidationError):
+            tokens.scope = "different_scope"  # type: ignore[misc]
+
+    def test_frozen_cannot_modify_project_id(self) -> None:
+        """Verify that project_id cannot be modified after construction."""
+        tokens = _make_tokens()
+        with pytest.raises(ValidationError):
+            tokens.project_id = "99999"  # type: ignore[misc]
+
+
+class TestOAuthTokensExpiry:
+    """Tests for the is_expired() method with 30-second buffer."""
+
+    def test_is_expired_true_when_past_expires_at(self) -> None:
+        """Verify is_expired() returns True when expires_at is in the past."""
+        from datetime import timedelta
+
+        past = _utcnow() - timedelta(minutes=5)
+        tokens = _make_tokens(expires_at=past)
+        assert tokens.is_expired() is True
+
+    def test_is_expired_true_within_30s_buffer(self) -> None:
+        """Verify is_expired() returns True when within 30 seconds of expiry.
+
+        The 30-second buffer prevents using tokens that are about to expire
+        during an in-flight request.
+        """
+        from datetime import timedelta
+
+        # 15 seconds from now — within the 30s buffer
+        almost_expired = _utcnow() + timedelta(seconds=15)
+        tokens = _make_tokens(expires_at=almost_expired)
+        assert tokens.is_expired() is True
+
+    def test_is_expired_true_at_exactly_30s(self) -> None:
+        """Verify is_expired() returns True when exactly at the 30s boundary.
+
+        At exactly 30 seconds remaining, the token should be considered expired
+        (boundary condition).
+        """
+        from datetime import timedelta
+
+        boundary = _utcnow() + timedelta(seconds=30)
+        tokens = _make_tokens(expires_at=boundary)
+        # At exactly 30s, should be expired (<=30s means expired)
+        assert tokens.is_expired() is True
+
+    def test_is_expired_false_when_well_in_future(self) -> None:
+        """Verify is_expired() returns False when >30s from expires_at."""
+        from datetime import timedelta
+
+        future = _utcnow() + timedelta(hours=1)
+        tokens = _make_tokens(expires_at=future)
+        assert tokens.is_expired() is False
+
+    def test_is_expired_false_just_outside_buffer(self) -> None:
+        """Verify is_expired() returns False when just beyond the 30s buffer.
+
+        At 60 seconds from expiry, the token should still be considered valid.
+        """
+        from datetime import timedelta
+
+        outside_buffer = _utcnow() + timedelta(seconds=60)
+        tokens = _make_tokens(expires_at=outside_buffer)
+        assert tokens.is_expired() is False
+
+
+class TestOAuthTokensSecretRedaction:
+    """Tests that SecretStr fields are properly redacted in output."""
+
+    def test_access_token_redacted_in_repr(self) -> None:
+        """Verify that the access token value does not appear in repr().
+
+        SecretStr should display as '**********' in repr output, never
+        exposing the actual token value.
+        """
+        tokens = _make_tokens(access_token="super_secret_access_token")
+        repr_str = repr(tokens)
+        assert "super_secret_access_token" not in repr_str
+
+    def test_refresh_token_redacted_in_repr(self) -> None:
+        """Verify that the refresh token value does not appear in repr()."""
+        tokens = _make_tokens(refresh_token="super_secret_refresh_token")
+        repr_str = repr(tokens)
+        assert "super_secret_refresh_token" not in repr_str
+
+    def test_access_token_redacted_in_str(self) -> None:
+        """Verify that the access token value does not appear in str()."""
+        tokens = _make_tokens(access_token="super_secret_access_token")
+        str_str = str(tokens)
+        assert "super_secret_access_token" not in str_str
+
+    def test_secret_values_accessible_via_get_secret_value(self) -> None:
+        """Verify that the actual token values can be retrieved when needed.
+
+        While redacted in repr/str, the actual values must be accessible
+        via get_secret_value() for use in HTTP headers.
+        """
+        tokens = _make_tokens(access_token="my_access", refresh_token="my_refresh")
+        assert tokens.access_token.get_secret_value() == "my_access"
+        assert tokens.refresh_token is not None
+        assert tokens.refresh_token.get_secret_value() == "my_refresh"
+
+
+class TestOAuthTokensSerialization:
+    """Tests for JSON round-trip serialization/deserialization."""
+
+    def test_json_round_trip(self) -> None:
+        """Verify that OAuthTokens survives JSON serialization and deserialization.
+
+        The model should be serializable to JSON and reconstructable from
+        that JSON, with all field values preserved.
+        """
+        from datetime import timedelta
+
+        expires = _utcnow() + timedelta(hours=1)
+        original = _make_tokens(
+            access_token="rt_access",
+            refresh_token="rt_refresh",
+            expires_at=expires,
+            scope="projects analysis events",
+            token_type="Bearer",
+            project_id="54321",
+        )
+
+        # Use model_dump with mode="json" to get JSON-serializable dict,
+        # exposing SecretStr values for round-trip (mirrors OAuthStorage pattern)
+        import json
+
+        data = original.model_dump(mode="json")
+        # SecretStr values are redacted by default in model_dump, so we must
+        # manually expose them for round-trip fidelity
+        data["access_token"] = original.access_token.get_secret_value()
+        if original.refresh_token is not None:
+            data["refresh_token"] = original.refresh_token.get_secret_value()
+        json_str = json.dumps(data, default=str)
+        restored = OAuthTokens.model_validate_json(json_str)
+
+        assert restored.access_token.get_secret_value() == "rt_access"
+        assert restored.refresh_token is not None
+        assert restored.refresh_token.get_secret_value() == "rt_refresh"
+        assert restored.scope == "projects analysis events"
+        assert restored.token_type == "Bearer"
+        assert restored.project_id == "54321"
+        # Datetime comparison (may lose sub-microsecond precision in JSON)
+        assert abs((restored.expires_at - original.expires_at).total_seconds()) < 1
+
+    def test_json_round_trip_without_refresh_token(self) -> None:
+        """Verify JSON round-trip works when refresh_token is None.
+
+        Some OAuth flows may not return a refresh token. The model must
+        handle None correctly through serialization.
+        """
+        original = _make_tokens(refresh_token=None)
+
+        json_str = original.model_dump_json()
+        restored = OAuthTokens.model_validate_json(json_str)
+
+        assert restored.refresh_token is None
+
+    def test_json_round_trip_without_project_id(self) -> None:
+        """Verify JSON round-trip works when project_id is None."""
+        original = _make_tokens(project_id=None)
+
+        json_str = original.model_dump_json()
+        restored = OAuthTokens.model_validate_json(json_str)
+
+        assert restored.project_id is None
+
+
+class TestOAuthTokensProjectId:
+    """Tests for project_id field preservation."""
+
+    def test_project_id_preserved(self) -> None:
+        """Verify that project_id is stored and retrievable."""
+        tokens = _make_tokens(project_id="98765")
+        assert tokens.project_id == "98765"
+
+    def test_project_id_none_allowed(self) -> None:
+        """Verify that project_id can be None.
+
+        During initial OAuth login, project_id may not yet be known.
+        """
+        tokens = _make_tokens(project_id=None)
+        assert tokens.project_id is None
+
+    def test_project_id_preserved_through_different_values(self) -> None:
+        """Verify that different project_id values are independently preserved."""
+        tokens_a = _make_tokens(project_id="111")
+        tokens_b = _make_tokens(project_id="222")
+
+        assert tokens_a.project_id == "111"
+        assert tokens_b.project_id == "222"
+
+
+class TestOAuthTokensFromTokenResponse:
+    """Tests for the from_token_response() class method."""
+
+    def test_from_token_response_basic(self) -> None:
+        """Verify from_token_response() creates tokens from API response data.
+
+        The token endpoint returns a dict with 'access_token', 'refresh_token',
+        'expires_in', 'scope', 'token_type'. The class method should parse
+        this and compute expires_at from expires_in.
+        """
+        data = {
+            "access_token": "new_access",
+            "refresh_token": "new_refresh",
+            "expires_in": 3600,
+            "scope": "projects analysis",
+            "token_type": "Bearer",
+        }
+
+        tokens = OAuthTokens.from_token_response(data, project_id="12345")
+
+        assert tokens.access_token.get_secret_value() == "new_access"
+        assert tokens.refresh_token is not None
+        assert tokens.refresh_token.get_secret_value() == "new_refresh"
+        assert tokens.scope == "projects analysis"
+        assert tokens.token_type == "Bearer"
+        assert tokens.project_id == "12345"
+
+    def test_from_token_response_computes_expires_at(self) -> None:
+        """Verify that expires_at is computed from expires_in seconds.
+
+        The expires_at should be approximately now + expires_in seconds.
+        """
+        from datetime import timedelta
+
+        data = {
+            "access_token": "tok",
+            "expires_in": 7200,
+            "scope": "projects",
+            "token_type": "Bearer",
+        }
+
+        before = _utcnow()
+        tokens = OAuthTokens.from_token_response(data, project_id=None)
+        after = _utcnow()
+
+        expected_min = before + timedelta(seconds=7200)
+        expected_max = after + timedelta(seconds=7200)
+
+        assert expected_min <= tokens.expires_at <= expected_max
+
+    def test_from_token_response_without_refresh_token(self) -> None:
+        """Verify from_token_response() handles missing refresh_token."""
+        data = {
+            "access_token": "tok",
+            "expires_in": 3600,
+            "scope": "projects",
+            "token_type": "Bearer",
+        }
+
+        tokens = OAuthTokens.from_token_response(data, project_id="123")
+
+        assert tokens.refresh_token is None
+
+    def test_from_token_response_project_id_none(self) -> None:
+        """Verify from_token_response() accepts None project_id."""
+        data = {
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "expires_in": 3600,
+            "scope": "projects",
+            "token_type": "Bearer",
+        }
+
+        tokens = OAuthTokens.from_token_response(data, project_id=None)
+
+        assert tokens.project_id is None
+
+
+class TestOAuthClientInfo:
+    """Tests for the OAuthClientInfo model."""
+
+    def _make_client_info(
+        self,
+        *,
+        client_id: str = "client_abc123",
+        region: str = "us",
+        redirect_uri: str = "http://localhost:19284/callback",
+        scope: str = "projects analysis",
+        created_at: datetime | None = None,
+    ) -> OAuthClientInfo:
+        """Create an OAuthClientInfo instance with sensible defaults.
+
+        Args:
+            client_id: DCR client identifier.
+            region: Mixpanel data residency region.
+            redirect_uri: OAuth redirect URI.
+            scope: OAuth scope string.
+            created_at: Client registration timestamp. Defaults to now.
+
+        Returns:
+            Configured OAuthClientInfo instance.
+        """
+        if created_at is None:
+            created_at = _utcnow()
+        return OAuthClientInfo(
+            client_id=client_id,
+            region=region,
+            redirect_uri=redirect_uri,
+            scope=scope,
+            created_at=created_at,
+        )
+
+    def test_client_info_creation(self) -> None:
+        """Verify that OAuthClientInfo can be created with valid fields."""
+        info = self._make_client_info()
+        assert info.client_id == "client_abc123"
+        assert info.region == "us"
+        assert info.redirect_uri == "http://localhost:19284/callback"
+        assert info.scope == "projects analysis"
+        assert isinstance(info.created_at, datetime)
+
+    def test_client_info_frozen(self) -> None:
+        """Verify that OAuthClientInfo is immutable (frozen)."""
+        info = self._make_client_info()
+        with pytest.raises(ValidationError):
+            info.client_id = "different"  # type: ignore[misc]
+
+    def test_client_info_json_round_trip(self) -> None:
+        """Verify OAuthClientInfo survives JSON serialization round-trip."""
+        original = self._make_client_info(
+            client_id="rt_client",
+            region="eu",
+            redirect_uri="http://localhost:19285/callback",
+            scope="projects events",
+        )
+
+        json_str = original.model_dump_json()
+        restored = OAuthClientInfo.model_validate_json(json_str)
+
+        assert restored.client_id == "rt_client"
+        assert restored.region == "eu"
+        assert restored.redirect_uri == "http://localhost:19285/callback"
+        assert restored.scope == "projects events"
+
+    def test_client_info_different_regions(self) -> None:
+        """Verify OAuthClientInfo supports all valid regions."""
+        for region in ("us", "eu", "in"):
+            info = self._make_client_info(region=region)
+            assert info.region == region
+
+    def test_client_info_created_at_preserved(self) -> None:
+        """Verify that created_at timestamp is preserved."""
+        specific_time = datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        info = self._make_client_info(created_at=specific_time)
+        assert info.created_at == specific_time
+
+
+class TestOAuthTokensSecretRedactionExtended:
+    """Extended tests for secret redaction in various serialization paths."""
+
+    def test_token_not_in_model_dump(self) -> None:
+        """Verify that the raw access_token value does not appear in model_dump output.
+
+        When ``model_dump()`` is called, ``SecretStr`` fields should be
+        redacted (shown as ``**********``), preventing accidental exposure
+        if the dict is logged or serialized.
+        """
+        tokens = _make_tokens(access_token="secret_abc123")
+        dumped = str(tokens.model_dump())
+        assert "secret_abc123" not in dumped
+
+    def test_token_not_in_f_string(self) -> None:
+        """Verify that an f-string interpolation of OAuthTokens does not leak secrets.
+
+        If tokens are accidentally included in a log message via an f-string,
+        the raw access_token and refresh_token values must not appear.
+        """
+        tokens = _make_tokens(
+            access_token="secret_abc123", refresh_token="refresh_secret"
+        )
+        formatted = f"Info: {tokens}"
+        assert "secret_abc123" not in formatted
+        assert "refresh_secret" not in formatted
+
+    def test_token_not_in_exception_to_dict(self) -> None:
+        """Verify that OAuthError.to_dict() does not contain raw token values.
+
+        Confirms that constructing an ``OAuthError`` with descriptive details
+        (not raw tokens) produces a clean serializable dict. This is a positive
+        test that error construction patterns do not leak secrets.
+        """
+        from mixpanel_data.exceptions import OAuthError
+
+        error = OAuthError(
+            message="Token refresh failed",
+            code="OAUTH_REFRESH_ERROR",
+            details={"region": "us", "reason": "expired"},
+        )
+        error_dict = error.to_dict()
+        error_str = str(error_dict)
+        # Verify the error dict contains expected fields, not raw tokens
+        assert "Token refresh failed" in error_str
+        assert "OAUTH_REFRESH_ERROR" in error_str
+        # No token material should be present
+        assert "secret_abc123" not in error_str
+        assert "refresh_secret" not in error_str
+
+
+class TestOAuthTokensExpiryEdgeCases:
+    """Tests for boundary conditions in token expiry via from_token_response().
+
+    Verifies behavior when expires_in is zero, negative, string, float,
+    or extremely large — edge cases that may occur with non-conformant
+    OAuth servers or malformed API responses.
+    """
+
+    def test_from_token_response_zero_expires_in(self) -> None:
+        """Verify that expires_in=0 produces an immediately expired token.
+
+        A zero lifetime means the token was already expired at issuance.
+        ``is_expired()`` must return True because 0 seconds plus the
+        30-second safety buffer puts us past ``expires_at``.
+        """
+        data: dict[str, object] = {
+            "expires_in": 0,
+            "access_token": "tok",
+            "scope": "all",
+            "token_type": "Bearer",
+        }
+        tokens = OAuthTokens.from_token_response(data)
+        assert tokens.is_expired() is True
+
+    def test_from_token_response_negative_expires_in(self) -> None:
+        """Verify that expires_in=-100 produces an expired token.
+
+        A negative lifetime means the token expired before issuance.
+        ``is_expired()`` must return True.
+        """
+        data: dict[str, object] = {
+            "expires_in": -100,
+            "access_token": "tok",
+            "scope": "all",
+            "token_type": "Bearer",
+        }
+        tokens = OAuthTokens.from_token_response(data)
+        assert tokens.is_expired() is True
+
+    def test_from_token_response_string_expires_in(self) -> None:
+        """Verify that expires_in="3600" (string) is accepted and parsed correctly.
+
+        The implementation uses ``int(str(expires_in_raw))`` so numeric
+        strings are coerced to integers. The resulting token should have
+        an ``expires_at`` roughly 3600 seconds in the future.
+        """
+        from datetime import timedelta
+
+        data: dict[str, object] = {
+            "expires_in": "3600",
+            "access_token": "tok",
+            "scope": "all",
+            "token_type": "Bearer",
+        }
+        before = _utcnow()
+        tokens = OAuthTokens.from_token_response(data)
+        after = _utcnow()
+
+        expected_min = before + timedelta(seconds=3600)
+        expected_max = after + timedelta(seconds=3600)
+        assert expected_min <= tokens.expires_at <= expected_max
+        assert tokens.is_expired() is False
+
+    def test_from_token_response_float_expires_in(self) -> None:
+        """Verify that expires_in=3600.5 (float) is accepted and truncated to int.
+
+        The implementation converts via ``int(str(...))``. A float string
+        like ``"3600.5"`` will raise ``ValueError`` from ``int()``, so the
+        float is first converted to string ``"3600.5"`` which cannot be
+        parsed by ``int()``. However, Python's ``str(3600.5)`` produces
+        ``"3600.5"`` which ``int()`` rejects. This test documents that
+        float expires_in raises ValueError.
+        """
+        data: dict[str, object] = {
+            "expires_in": 3600.5,
+            "access_token": "tok",
+            "scope": "all",
+            "token_type": "Bearer",
+        }
+        # int(str(3600.5)) == int("3600.5") raises ValueError
+        with pytest.raises(ValueError, match="invalid literal"):
+            OAuthTokens.from_token_response(data)
+
+    def test_from_token_response_huge_expires_in(self) -> None:
+        """Verify that an extremely large expires_in produces a non-expired token.
+
+        A token with a ~31-year lifetime should not be considered expired.
+        ``is_expired()`` must return False.
+        """
+        data: dict[str, object] = {
+            "expires_in": 999999999,
+            "access_token": "tok",
+            "scope": "all",
+            "token_type": "Bearer",
+        }
+        tokens = OAuthTokens.from_token_response(data)
+        assert tokens.is_expired() is False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -335,12 +335,18 @@ class TestCredentialResolution:
         assert creds.region == "eu"
 
     def test_resolve_falls_back_to_default(
-        self, config_manager: ConfigManager, sample_credentials: dict[str, str]
+        self,
+        config_manager: ConfigManager,
+        sample_credentials: dict[str, str],
+        temp_dir: Path,
     ) -> None:
         """Should fall back to default account from config."""
         config_manager.add_account(**sample_credentials)
 
-        creds = config_manager.resolve_credentials()
+        # Use empty temp dir for OAuth storage to avoid picking up real tokens
+        oauth_dir = temp_dir / "oauth_empty"
+        oauth_dir.mkdir()
+        creds = config_manager.resolve_credentials(_oauth_storage_dir=oauth_dir)
 
         assert creds.username == "sa_test_user"
         assert creds.project_id == "12345"

--- a/tests/unit/test_config_oauth.py
+++ b/tests/unit/test_config_oauth.py
@@ -1,0 +1,278 @@
+"""Unit tests for AuthMethod enum and extended credential resolution (T010).
+
+Tests the AuthMethod enum added to config.py and ensures existing Basic Auth
+credential resolution behavior remains unchanged (regression tests).
+
+Verifies:
+- AuthMethod enum has 'basic' and 'oauth' values
+- Existing Basic Auth resolution is unchanged
+- auth_header() returns correct Authorization header for each method
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from mixpanel_data._internal.config import (
+    AuthMethod,
+    ConfigManager,
+    Credentials,
+)
+from mixpanel_data.exceptions import (
+    ConfigError,
+)
+
+
+class TestAuthMethodEnum:
+    """Tests for the AuthMethod enum values and behavior."""
+
+    def test_basic_value(self) -> None:
+        """Verify AuthMethod.basic has the string value 'basic'.
+
+        This value identifies service account (username/secret) authentication.
+        """
+        assert AuthMethod.basic == "basic"
+        assert AuthMethod.basic.value == "basic"
+
+    def test_oauth_value(self) -> None:
+        """Verify AuthMethod.oauth has the string value 'oauth'.
+
+        This value identifies OAuth 2.0 Bearer token authentication.
+        """
+        assert AuthMethod.oauth == "oauth"
+        assert AuthMethod.oauth.value == "oauth"
+
+    def test_enum_members(self) -> None:
+        """Verify AuthMethod has exactly two members: basic and oauth."""
+        members = list(AuthMethod)
+        assert len(members) == 2
+        assert AuthMethod.basic in members
+        assert AuthMethod.oauth in members
+
+    def test_enum_from_string(self) -> None:
+        """Verify AuthMethod can be constructed from string values.
+
+        Example:
+            ```python
+            method = AuthMethod("basic")
+            assert method == AuthMethod.basic
+            ```
+        """
+        assert AuthMethod("basic") == AuthMethod.basic
+        assert AuthMethod("oauth") == AuthMethod.oauth
+
+    def test_enum_invalid_value_raises(self) -> None:
+        """Verify that invalid string values raise ValueError."""
+        with pytest.raises(ValueError):
+            AuthMethod("invalid")
+
+
+class TestCredentialsAuthHeader:
+    """Tests for the auth_header() method on Credentials."""
+
+    def test_basic_auth_header_format(self) -> None:
+        """Verify auth_header() returns a Basic auth header for basic credentials.
+
+        The header should be 'Basic <base64(username:secret)>' format,
+        matching the standard HTTP Basic Authentication scheme.
+        """
+        import base64
+
+        creds = Credentials(
+            username="sa_test_user",
+            secret=SecretStr("test_secret"),
+            project_id="12345",
+            region="us",
+        )
+
+        header = creds.auth_header()
+
+        # Verify it starts with "Basic "
+        assert header.startswith("Basic ")
+
+        # Decode and verify the payload
+        encoded = header.split(" ", 1)[1]
+        decoded = base64.b64decode(encoded).decode("utf-8")
+        assert decoded == "sa_test_user:test_secret"
+
+    def test_basic_auth_header_is_default(self) -> None:
+        """Verify that the default auth method produces a Basic auth header.
+
+        Existing Credentials without explicit auth_method should default
+        to Basic authentication to preserve backward compatibility.
+        """
+        creds = Credentials(
+            username="user",
+            secret=SecretStr("secret"),
+            project_id="123",
+            region="us",
+        )
+
+        header = creds.auth_header()
+        assert header.startswith("Basic ")
+
+
+class TestCredentialsBasicAuthRegression:
+    """Regression tests ensuring existing Basic Auth behavior is unchanged.
+
+    These tests verify that the introduction of AuthMethod and auth_header()
+    does not alter existing credential creation, validation, or resolution.
+    """
+
+    def test_credentials_still_require_username(self) -> None:
+        """Verify that username is still required and validated."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            Credentials(
+                username="",
+                secret=SecretStr("secret"),
+                project_id="123",
+                region="us",
+            )
+
+    def test_credentials_still_require_project_id(self) -> None:
+        """Verify that project_id is still required and validated."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            Credentials(
+                username="user",
+                secret=SecretStr("secret"),
+                project_id="",
+                region="us",
+            )
+
+    def test_credentials_still_validate_region(self) -> None:
+        """Verify that region validation is unchanged."""
+        with pytest.raises(ValueError, match="Region must be one of"):
+            Credentials(
+                username="user",
+                secret=SecretStr("secret"),
+                project_id="123",
+                region="invalid",
+            )
+
+    def test_credentials_still_frozen(self) -> None:
+        """Verify that Credentials is still immutable."""
+        creds = Credentials(
+            username="user",
+            secret=SecretStr("secret"),
+            project_id="123",
+            region="us",
+        )
+        with pytest.raises(ValidationError):
+            creds.username = "other"  # type: ignore[misc]
+
+    def test_credentials_still_redact_secret(self) -> None:
+        """Verify that secret is still redacted in repr/str."""
+        creds = Credentials(
+            username="user",
+            secret=SecretStr("my_secret_value"),
+            project_id="123",
+            region="us",
+        )
+        assert "my_secret_value" not in repr(creds)
+        assert "my_secret_value" not in str(creds)
+
+    def test_region_normalization_unchanged(self) -> None:
+        """Verify that region is still normalized to lowercase."""
+        creds = Credentials(
+            username="user",
+            secret=SecretStr("secret"),
+            project_id="123",
+            region="EU",
+        )
+        assert creds.region == "eu"
+
+
+class TestCredentialResolutionRegression:
+    """Regression tests for credential resolution with ConfigManager.
+
+    Ensures that the addition of OAuth support doesn't break existing
+    environment variable and config file credential resolution.
+    """
+
+    def test_env_var_resolution_unchanged(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that environment variable credential resolution still works.
+
+        The priority order must remain: env vars > named account > default.
+        """
+        monkeypatch.setenv("MP_USERNAME", "env_user")
+        monkeypatch.setenv("MP_SECRET", "env_secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "env_project")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        creds = config_manager.resolve_credentials()
+
+        assert creds.username == "env_user"
+        assert creds.secret.get_secret_value() == "env_secret"
+        assert creds.project_id == "env_project"
+        assert creds.region == "us"
+
+    def test_config_file_resolution_unchanged(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """Verify that config file credential resolution still works."""
+        config_manager.add_account(
+            name="test",
+            username="file_user",
+            secret="file_secret",
+            project_id="file_123",
+            region="eu",
+        )
+
+        creds = config_manager.resolve_credentials()
+
+        assert creds.username == "file_user"
+        assert creds.project_id == "file_123"
+        assert creds.region == "eu"
+
+    def test_named_account_resolution_unchanged(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """Verify that named account resolution still works."""
+        config_manager.add_account(
+            name="prod",
+            username="prod_user",
+            secret="prod_secret",
+            project_id="prod_123",
+            region="us",
+        )
+        config_manager.add_account(
+            name="staging",
+            username="staging_user",
+            secret="staging_secret",
+            project_id="staging_456",
+            region="eu",
+        )
+
+        creds = config_manager.resolve_credentials(account="staging")
+
+        assert creds.username == "staging_user"
+        assert creds.region == "eu"
+
+    def test_no_credentials_still_raises(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """Verify that missing credentials still raises ConfigError."""
+        with pytest.raises(ConfigError, match="No credentials configured"):
+            config_manager.resolve_credentials()
+
+    def test_invalid_env_region_still_raises(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that invalid MP_REGION still raises ConfigError."""
+        monkeypatch.setenv("MP_USERNAME", "user")
+        monkeypatch.setenv("MP_SECRET", "secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "123")
+        monkeypatch.setenv("MP_REGION", "invalid")
+
+        with pytest.raises(ConfigError, match="Invalid MP_REGION"):
+            config_manager.resolve_credentials()

--- a/tests/unit/test_config_oauth_resolution.py
+++ b/tests/unit/test_config_oauth_resolution.py
@@ -72,7 +72,7 @@ def _make_expired_tokens(
     )
 
 
-class TestEnvVarsStillResolveToBaiscAuth:
+class TestEnvVarsStillResolveToBasicAuth:
     """Regression: env vars always produce Basic Auth credentials."""
 
     def test_env_vars_produce_basic_auth(

--- a/tests/unit/test_config_oauth_resolution.py
+++ b/tests/unit/test_config_oauth_resolution.py
@@ -1,0 +1,348 @@
+"""Unit tests for OAuth credential resolution in ConfigManager (T033).
+
+Tests the extended credential resolution path that integrates OAuth tokens
+from OAuthStorage into ConfigManager.resolve_credentials().
+
+Verifies:
+- Resolution order: env vars > OAuth tokens > named account > default
+- OAuth tokens are correctly loaded and converted to Credentials
+- Auth method selection: env vars produce basic, stored tokens produce oauth
+- Partial env var mode (MP_PROJECT_ID + MP_REGION without username/secret)
+- Backward compatibility: all existing Basic Auth behavior unchanged
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data._internal.config import (
+    AuthMethod,
+    ConfigManager,
+)
+from mixpanel_data.exceptions import ConfigError
+
+
+def _make_valid_tokens(
+    project_id: str = "12345",
+    access_token: str = "test-access-token",
+) -> OAuthTokens:
+    """Create a non-expired OAuthTokens for testing.
+
+    Args:
+        project_id: Project ID to embed in the tokens.
+        access_token: The access token value.
+
+    Returns:
+        A valid, non-expired OAuthTokens instance.
+    """
+    return OAuthTokens(
+        access_token=SecretStr(access_token),
+        refresh_token=SecretStr("test-refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        scope="read:project",
+        token_type="Bearer",
+        project_id=project_id,
+    )
+
+
+def _make_expired_tokens(
+    project_id: str = "12345",
+) -> OAuthTokens:
+    """Create an expired OAuthTokens for testing.
+
+    Args:
+        project_id: Project ID to embed in the tokens.
+
+    Returns:
+        An expired OAuthTokens instance.
+    """
+    return OAuthTokens(
+        access_token=SecretStr("expired-token"),
+        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        scope="read:project",
+        token_type="Bearer",
+        project_id=project_id,
+    )
+
+
+class TestEnvVarsStillResolveToBaiscAuth:
+    """Regression: env vars always produce Basic Auth credentials."""
+
+    def test_env_vars_produce_basic_auth(
+        self,
+        config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """When all env vars are set, resolve_credentials returns Basic Auth.
+
+        Even if OAuth tokens are stored, env vars always win.
+        """
+        monkeypatch.setenv("MP_USERNAME", "env_user")
+        monkeypatch.setenv("MP_SECRET", "env_secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "99999")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        # Store OAuth tokens to verify they are NOT used
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_valid_tokens(project_id="99999"), region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials()
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "env_user"
+        assert creds.secret.get_secret_value() == "env_secret"
+        assert creds.oauth_access_token is None
+
+    def test_env_vars_take_precedence_over_oauth_and_config(
+        self,
+        config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """Env vars > OAuth tokens > config file accounts."""
+        monkeypatch.setenv("MP_USERNAME", "env_user")
+        monkeypatch.setenv("MP_SECRET", "env_secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "99999")
+        monkeypatch.setenv("MP_REGION", "eu")
+
+        # Store OAuth tokens and config account
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_valid_tokens(project_id="99999"), region="eu")
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="fallback",
+            username="file_user",
+            secret="file_secret",
+            project_id="file_123",
+            region="eu",
+        )
+
+        creds = cm.resolve_credentials()
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "env_user"
+
+
+class TestOAuthTokenResolution:
+    """Tests for OAuth token resolution in ConfigManager."""
+
+    def test_oauth_tokens_resolve_when_no_env_vars(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """When no env vars, stored OAuth tokens should resolve to oauth Credentials."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id="12345")
+        storage.save_tokens(tokens, region="us")
+
+        # Config must have an account to get project_id and region
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="default",
+            username="sa_user",
+            secret="sa_secret",
+            project_id="12345",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.oauth_access_token is not None
+        assert creds.oauth_access_token.get_secret_value() == "test-access-token"
+        assert creds.project_id == "12345"
+        assert creds.region == "us"
+
+    def test_oauth_tokens_use_project_id_from_token(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """OAuth tokens with project_id should use that project_id."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id="token-pid")
+        storage.save_tokens(tokens, region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="default",
+            username="sa_user",
+            secret="sa_secret",
+            project_id="config-pid",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "token-pid"
+
+    def test_expired_oauth_tokens_skip_to_config(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """Expired OAuth tokens should be skipped; fall through to config."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_expired_tokens(project_id="12345"), region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="default",
+            username="config_user",
+            secret="config_secret",
+            project_id="12345",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "config_user"
+
+    def test_no_oauth_tokens_falls_through_to_config(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """When no OAuth tokens stored, resolution falls through to config file."""
+        oauth_dir = temp_dir / "oauth_empty"  # empty dir, no tokens
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="default",
+            username="config_user",
+            secret="config_secret",
+            project_id="12345",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "config_user"
+
+    def test_oauth_with_partial_env_vars(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MP_PROJECT_ID and MP_REGION set without username/secret uses those for OAuth lookup."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id="env-pid")
+        storage.save_tokens(tokens, region="eu")
+
+        monkeypatch.setenv("MP_PROJECT_ID", "env-pid")
+        monkeypatch.setenv("MP_REGION", "eu")
+        # MP_USERNAME and MP_SECRET NOT set
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "env-pid"
+        assert creds.region == "eu"
+
+    def test_no_oauth_no_config_still_raises(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """No env vars, no OAuth, no config should still raise ConfigError."""
+        oauth_dir = temp_dir / "oauth_empty"
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError, match="No credentials configured"):
+            cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+
+class TestResolutionOrder:
+    """Tests for the full resolution priority chain."""
+
+    def test_resolution_order_env_over_oauth(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Env vars > OAuth tokens."""
+        monkeypatch.setenv("MP_USERNAME", "env_user")
+        monkeypatch.setenv("MP_SECRET", "env_secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "12345")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_valid_tokens(), region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "env_user"
+
+    def test_resolution_order_oauth_over_config(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """OAuth tokens > named/default account from config."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_valid_tokens(project_id="12345"), region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="default",
+            username="config_user",
+            secret="config_secret",
+            project_id="12345",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.oauth_access_token is not None
+
+    def test_named_account_bypasses_oauth(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """When an explicit named account is requested, OAuth is NOT checked."""
+        oauth_dir = temp_dir / "oauth"
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        storage.save_tokens(_make_valid_tokens(project_id="12345"), region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        cm.add_account(
+            name="prod",
+            username="prod_user",
+            secret="prod_secret",
+            project_id="12345",
+            region="us",
+        )
+
+        creds = cm.resolve_credentials(account="prod", _oauth_storage_dir=oauth_dir)
+
+        # Named account requested explicitly → should get basic auth
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "prod_user"

--- a/tests/unit/test_fetcher_service.py
+++ b/tests/unit/test_fetcher_service.py
@@ -43,7 +43,9 @@ class TestTransformEvent:
 
         assert result["event_name"] == "Sign Up"
         # Unix timestamp 1609459200 = 2021-01-01 00:00:00 UTC
-        assert result["event_time"] == datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert result["event_time"] == datetime(
+            2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
         assert result["distinct_id"] == "user_123"
         assert result["insert_id"] == "abc-123-def"
         assert result["properties"] == {"browser": "Chrome", "country": "US"}
@@ -128,7 +130,9 @@ class TestTransformEvent:
         assert result["event_name"] == "No Properties"
         assert result["distinct_id"] == ""
         # Unix timestamp 0 = 1970-01-01 00:00:00 UTC (epoch)
-        assert result["event_time"] == datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert result["event_time"] == datetime(
+            1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
 
 
 class TestTransformProfile:

--- a/tests/unit/test_oauth_integration.py
+++ b/tests/unit/test_oauth_integration.py
@@ -1,0 +1,378 @@
+# ruff: noqa: ARG001, ARG005
+"""Integration tests for the OAuth flow, credential resolution, and workspace scoping.
+
+Tests cover end-to-end OAuth login with mocked HTTP, credential resolution
+priority (OAuth vs Basic Auth fallthrough), backward-compatibility of
+Basic Auth env vars, and workspace resolution with scoped paths.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.callback_server import CallbackResult
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+from mixpanel_data._internal.config import AuthMethod, ConfigManager, Credentials
+
+
+def _make_token_response(
+    access_token: str = "new-access-token",
+    refresh_token: str = "new-refresh-token",
+    expires_in: int = 3600,
+    scope: str = "projects analysis events",
+    token_type: str = "Bearer",
+) -> dict[str, Any]:
+    """Build a mock OAuth token endpoint response.
+
+    Args:
+        access_token: The access token value.
+        refresh_token: The refresh token value.
+        expires_in: Token lifetime in seconds.
+        scope: Space-separated scopes.
+        token_type: Token type string.
+
+    Returns:
+        Dictionary matching the OAuth token endpoint response schema.
+    """
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_in": expires_in,
+        "scope": scope,
+        "token_type": token_type,
+    }
+
+
+def _make_registration_response(client_id: str = "test-client-id") -> dict[str, Any]:
+    """Build a mock DCR registration response.
+
+    Args:
+        client_id: The client identifier to return.
+
+    Returns:
+        Dictionary matching the OAuth registration endpoint response schema.
+    """
+    return {
+        "client_id": client_id,
+        "redirect_uris": ["http://localhost:19284/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+
+
+class TestFullOAuthFlowEndToEnd:
+    """End-to-end integration test for the OAuth flow with mocked HTTP."""
+
+    @patch("mixpanel_data._internal.auth.flow.webbrowser")
+    @patch("mixpanel_data._internal.auth.flow.start_callback_server")
+    def test_full_oauth_flow_end_to_end(
+        self,
+        mock_start_callback: MagicMock,
+        mock_webbrowser: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Full chain: register, login, save, expire, refresh.
+
+        1. Create OAuthStorage with temp_dir.
+        2. Create httpx.MockTransport for registration and token exchange.
+        3. Create OAuthFlow with mocked HTTP and storage.
+        4. Mock start_callback_server to return a CallbackResult.
+        5. Mock webbrowser.open to do nothing.
+        6. Call flow.login(project_id="12345").
+        7. Verify tokens saved in storage.
+        8. Verify tokens have correct project_id.
+        9. Create expired tokens, save to storage.
+        10. Save client_info to storage.
+        11. Mock a refresh token response.
+        12. Call flow.get_valid_token(region="us").
+        13. Verify auto-refresh happened.
+        """
+        storage = OAuthStorage(storage_dir=tmp_path)
+
+        # Track which URLs are hit
+        request_log: list[str] = []
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            """Handle HTTP requests for registration and token exchange.
+
+            Args:
+                request: The outgoing HTTP request.
+
+            Returns:
+                Mocked response for registration or token endpoints.
+            """
+            request_log.append(str(request.url))
+            url = str(request.url)
+
+            if "mcp/register/" in url:
+                return httpx.Response(
+                    201,
+                    json=_make_registration_response("test-client-abc"),
+                )
+            if "token/" in url:
+                return httpx.Response(
+                    200,
+                    json=_make_token_response(
+                        access_token="fresh-access-token",
+                        refresh_token="fresh-refresh-token",
+                    ),
+                )
+            return httpx.Response(404, text="Not found")
+
+        transport = httpx.MockTransport(mock_handler)
+        http_client = httpx.Client(transport=transport)
+
+        flow = OAuthFlow(region="us", storage=storage, http_client=http_client)
+
+        # Mock callback server to return immediately with an auth code
+        mock_start_callback.return_value = (
+            CallbackResult(code="auth-code-123", state="ignored"),
+            19284,
+        )
+        mock_webbrowser.open.return_value = True
+
+        # Step 6: Call login
+        tokens = flow.login(project_id="12345")
+
+        # Step 7: Verify tokens saved
+        loaded = storage.load_tokens(region="us")
+        assert loaded is not None
+        assert loaded.access_token.get_secret_value() == "fresh-access-token"
+
+        # Step 8: Verify project_id
+        assert loaded.project_id == "12345"
+        assert tokens.project_id == "12345"
+
+        # Step 9: Create expired tokens and save
+        expired_tokens = OAuthTokens(
+            access_token=SecretStr("expired-access-token"),
+            refresh_token=SecretStr("old-refresh-token"),
+            expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            scope="projects analysis events",
+            token_type="Bearer",
+            project_id="12345",
+        )
+        storage.save_tokens(expired_tokens, region="us")
+
+        # Step 10: Save client_info
+        client_info = OAuthClientInfo(
+            client_id="test-client-abc",
+            region="us",
+            redirect_uri="http://localhost:19284/callback",
+            scope="projects analysis events",
+            created_at=datetime.now(timezone.utc),
+        )
+        storage.save_client_info(client_info)
+
+        # Step 11: The mock_handler already handles refresh via token/ endpoint
+        # Clear request_log to track only the refresh call
+        request_log.clear()
+
+        # Step 12: Call get_valid_token — should auto-refresh
+        new_token = flow.get_valid_token(region="us")
+
+        # Step 13: Verify auto-refresh happened
+        assert new_token == "fresh-access-token"
+        token_requests = [u for u in request_log if "token/" in u]
+        assert len(token_requests) >= 1, "Expected a token refresh request"
+
+        # Verify refreshed tokens are persisted
+        refreshed = storage.load_tokens(region="us")
+        assert refreshed is not None
+        assert refreshed.access_token.get_secret_value() == "fresh-access-token"
+
+
+class TestCredentialResolutionOAuthFallthrough:
+    """Tests for OAuth-to-Basic credential fallthrough."""
+
+    def test_credential_resolution_oauth_fallthrough(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OAuth tokens are preferred; when removed, falls through to config.
+
+        1. Create temp config dir and temp oauth storage dir.
+        2. Store valid OAuth tokens with project_id="99999".
+        3. Set MP_PROJECT_ID=99999, MP_REGION=us.
+        4. Create ConfigManager with temp config path.
+        5. Add a basic auth account to config.
+        6. Call resolve_credentials() — assert OAuth.
+        7. Remove token files.
+        8. Call resolve_credentials() again — assert Basic.
+        """
+        config_path = tmp_path / "config" / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir(parents=True, exist_ok=True)
+
+        # Step 2: Store valid OAuth tokens
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = OAuthTokens(
+            access_token=SecretStr("my-oauth-token"),
+            refresh_token=SecretStr("my-refresh-token"),
+            expires_at=datetime(2099, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+            scope="projects analysis events",
+            token_type="Bearer",
+            project_id="99999",
+        )
+        storage.save_tokens(tokens, region="us")
+
+        # Step 3: Set env vars (partial — no MP_USERNAME/MP_SECRET)
+        monkeypatch.setenv("MP_PROJECT_ID", "99999")
+        monkeypatch.setenv("MP_REGION", "us")
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.delenv("MP_CONFIG_PATH", raising=False)
+
+        # Step 4-5: Create ConfigManager and add basic account
+        config = ConfigManager(config_path=config_path)
+        config.add_account(
+            name="default",
+            username="sa-user",
+            secret="sa-secret",
+            project_id="99999",
+            region="us",
+        )
+
+        # Step 6: Resolve credentials — expect OAuth
+        creds = config.resolve_credentials(_oauth_storage_dir=oauth_dir)
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "99999"
+
+        # Step 7: Remove token files
+        for f in oauth_dir.glob("*.json"):
+            f.unlink()
+
+        # Step 8: Resolve credentials again — expect Basic
+        creds2 = config.resolve_credentials(_oauth_storage_dir=oauth_dir)
+        assert creds2.auth_method == AuthMethod.basic
+        assert creds2.project_id == "99999"
+
+
+class TestBackwardCompatBasicAuthUnaffected:
+    """Verifies that Basic Auth env vars take priority over stored OAuth tokens."""
+
+    def test_backward_compat_basic_auth_unaffected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Env-var-based Basic Auth takes priority even when OAuth tokens exist.
+
+        1. Set all 4 env vars: MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION.
+        2. Store OAuth tokens (to verify env vars take priority).
+        3. Call resolve_credentials().
+        4. Assert auth_method == AuthMethod.basic.
+        5. Assert auth_header() starts with "Basic ".
+        """
+        # Step 1: Set all env vars
+        monkeypatch.setenv("MP_USERNAME", "env-user")
+        monkeypatch.setenv("MP_SECRET", "env-secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "77777")
+        monkeypatch.setenv("MP_REGION", "us")
+        monkeypatch.delenv("MP_CONFIG_PATH", raising=False)
+
+        # Step 2: Store OAuth tokens
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir(parents=True, exist_ok=True)
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = OAuthTokens(
+            access_token=SecretStr("should-not-be-used"),
+            expires_at=datetime(2099, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+            scope="projects",
+            token_type="Bearer",
+            project_id="77777",
+        )
+        storage.save_tokens(tokens, region="us")
+
+        # Step 3: Resolve credentials
+        config = ConfigManager(config_path=tmp_path / "config.toml")
+        creds = config.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        # Step 4: Assert Basic Auth
+        assert creds.auth_method == AuthMethod.basic
+
+        # Step 5: Assert auth_header starts with "Basic "
+        assert creds.auth_header().startswith("Basic ")
+
+
+class TestWorkspaceResolvePlusScopedPath:
+    """Tests workspace resolution and scoped path building."""
+
+    def test_workspace_resolve_plus_scoped_path(self) -> None:
+        """Resolve workspace ID and build scoped path.
+
+        1. Create mock credentials (OAuth).
+        2. Create MixpanelAPIClient with MockTransport.
+        3. Mock list_workspaces to return one workspace (id=42, is_default=True).
+        4. Call client.resolve_workspace_id().
+        5. Assert returns 42.
+        6. Call client.maybe_scoped_path("dashboards").
+        7. Assert path contains /workspaces/42/dashboards.
+        """
+        from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+        creds = Credentials(
+            username="",
+            secret=SecretStr(""),
+            project_id="12345",
+            region="us",
+            auth_method=AuthMethod.oauth,
+            oauth_access_token=SecretStr("test-oauth-token"),
+        )
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            """Handle workspace listing requests.
+
+            Args:
+                request: The outgoing HTTP request.
+
+            Returns:
+                Mocked response with a single default workspace.
+            """
+            url = str(request.url)
+            if "workspaces/public" in url:
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": 42,
+                                "name": "Default Workspace",
+                                "project_id": 12345,
+                                "is_default": True,
+                                "description": "",
+                                "is_global": False,
+                                "is_restricted": False,
+                                "is_visible": True,
+                            }
+                        ]
+                    },
+                )
+            return httpx.Response(404, text="Not found")
+
+        transport = httpx.MockTransport(mock_handler)
+
+        client = MixpanelAPIClient(creds, _transport=transport)
+        client.__enter__()
+
+        try:
+            # Step 4-5: Resolve workspace
+            ws_id = client.resolve_workspace_id()
+            assert ws_id == 42
+
+            # Step 6-7: Now set the workspace_id and check scoped path
+            client.set_workspace_id(42)
+            path = client.maybe_scoped_path("dashboards")
+            assert "/workspaces/42/dashboards" in path
+        finally:
+            client.__exit__(None, None, None)

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -1,0 +1,454 @@
+"""Unit tests for cursor-based pagination helper.
+
+Tests for paginate_all() function that iterates through paginated App API responses.
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable
+from unittest.mock import patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.config import AuthMethod, Credentials
+from mixpanel_data._internal.pagination import paginate_all
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    MixpanelDataError,
+    RateLimitError,
+    ServerError,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def oauth_credentials() -> Credentials:
+    """Create OAuth credentials for pagination testing."""
+    return Credentials(
+        username="",
+        secret=SecretStr(""),
+        project_id="12345",
+        region="us",
+        auth_method=AuthMethod.oauth,
+        oauth_access_token=SecretStr("test-oauth-token"),
+    )
+
+
+def create_mock_client(
+    credentials: Credentials,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> MixpanelAPIClient:
+    """Create a client with mock transport.
+
+    Args:
+        credentials: Authentication credentials.
+        handler: Mock HTTP handler function.
+
+    Returns:
+        MixpanelAPIClient configured with mock transport.
+    """
+    transport = httpx.MockTransport(handler)
+    return MixpanelAPIClient(credentials, _transport=transport)
+
+
+# =============================================================================
+# T028: Cursor pagination tests
+# =============================================================================
+
+
+class TestPaginateAll:
+    """Test paginate_all() cursor pagination helper."""
+
+    def test_yields_all_results_across_pages(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """paginate_all() should yield all results from multiple pages."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            cursor = request.url.params.get("cursor")
+
+            if cursor is None:
+                # First page
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 1}, {"id": 2}],
+                        "pagination": {
+                            "page_size": 2,
+                            "next_cursor": "cursor_page2",
+                        },
+                    },
+                )
+            elif cursor == "cursor_page2":
+                # Second page
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 3}],
+                        "pagination": {
+                            "page_size": 2,
+                            "next_cursor": None,
+                        },
+                    },
+                )
+            else:
+                return httpx.Response(404, json={"error": "Unknown cursor"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/dashboards"))
+
+        assert items == [{"id": 1}, {"id": 2}, {"id": 3}]
+        assert call_count == 2
+
+    def test_follows_next_cursor_until_none(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """paginate_all() should stop when next_cursor is None."""
+        cursors_seen: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            cursor = request.url.params.get("cursor")
+            cursors_seen.append(cursor)
+
+            if cursor is None:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 1}],
+                        "pagination": {
+                            "page_size": 1,
+                            "next_cursor": "c2",
+                        },
+                    },
+                )
+            elif cursor == "c2":
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 2}],
+                        "pagination": {
+                            "page_size": 1,
+                            "next_cursor": "c3",
+                        },
+                    },
+                )
+            else:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 3}],
+                        "pagination": {
+                            "page_size": 1,
+                            "next_cursor": None,
+                        },
+                    },
+                )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/items"))
+
+        assert len(items) == 3
+        assert cursors_seen == [None, "c2", "c3"]
+
+    def test_handles_empty_results(self, oauth_credentials: Credentials) -> None:
+        """paginate_all() should handle empty results gracefully."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [],
+                    "pagination": {
+                        "page_size": 100,
+                        "next_cursor": None,
+                    },
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/dashboards"))
+
+        assert items == []
+
+    def test_handles_missing_pagination_field(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """paginate_all() should treat missing pagination as single page."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1}, {"id": 2}],
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/dashboards"))
+
+        assert items == [{"id": 1}, {"id": 2}]
+
+    def test_respects_page_size_parameter(self, oauth_credentials: Credentials) -> None:
+        """paginate_all() should pass page_size as query parameter."""
+        captured_params: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.append(dict(request.url.params))
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1}],
+                    "pagination": {"page_size": 25, "next_cursor": None},
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            list(paginate_all(client, "/projects/12345/dashboards", page_size=25))
+
+        assert captured_params[0]["page_size"] == "25"
+
+    def test_passes_additional_params(self, oauth_credentials: Credentials) -> None:
+        """paginate_all() should merge extra params with pagination params."""
+        captured_params: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.append(dict(request.url.params))
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [],
+                    "pagination": {"page_size": 100, "next_cursor": None},
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            list(
+                paginate_all(
+                    client,
+                    "/projects/12345/dashboards",
+                    params={"include_archived": "true"},
+                )
+            )
+
+        assert captured_params[0]["include_archived"] == "true"
+
+    def test_handles_response_without_results_key(
+        self, oauth_credentials: Credentials
+    ) -> None:
+        """paginate_all() should handle responses where app_request returns a list."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # app_request unwraps results, so if the API returns results as
+            # a list directly, paginate_all gets a list
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1}],
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/items"))
+
+        assert items == [{"id": 1}]
+
+
+class TestPaginateAllRobustness:
+    """Test paginate_all() robustness against infinite loops and bad responses."""
+
+    def test_infinite_loop_same_cursor(self, oauth_credentials: Credentials) -> None:
+        """Verify pagination terminates when the server returns the same cursor forever.
+
+        A server that always returns the same next_cursor would cause an
+        infinite loop without the MAX_PAGES guard.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return the same cursor on every page.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Response with a constant cursor.
+            """
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1}],
+                    "pagination": {
+                        "page_size": 1,
+                        "next_cursor": "same",
+                    },
+                },
+            )
+
+        # Use a small MAX_PAGES for the test to avoid long runtime
+        with patch("mixpanel_data._internal.pagination.MAX_PAGES", 50):
+            client = create_mock_client(oauth_credentials, handler)
+            with client, pytest.raises(MixpanelDataError, match="maximum page limit"):
+                # Consume all items — should raise before 15000
+                list(
+                    itertools.islice(
+                        paginate_all(client, "/projects/12345/items"), 15000
+                    )
+                )
+
+    def test_non_json_response(self, oauth_credentials: Credentials) -> None:
+        """Verify pagination raises a clear error for non-JSON responses.
+
+        If the server returns HTML or other non-JSON content, the function
+        should raise MixpanelDataError rather than a raw JSONDecodeError.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return HTML instead of JSON.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                HTML response.
+            """
+            return httpx.Response(
+                200,
+                content=b"<html><body>Error</body></html>",
+                headers={"content-type": "text/html"},
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(MixpanelDataError, match="Non-JSON response"):
+            list(paginate_all(client, "/projects/12345/items"))
+
+    def test_http_429_mid_pagination(self, oauth_credentials: Credentials) -> None:
+        """Verify that a 429 on the second page raises RateLimitError.
+
+        Rate limits can occur mid-pagination; the error should propagate
+        as a proper RateLimitError.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return OK on first page, 429 on second.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Success or rate-limit response.
+            """
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 1}],
+                        "pagination": {"page_size": 1, "next_cursor": "c2"},
+                    },
+                )
+            return httpx.Response(
+                429,
+                json={"error": "rate_limited"},
+                headers={"Retry-After": "30"},
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(RateLimitError):
+            list(paginate_all(client, "/projects/12345/items"))
+
+    def test_http_500_mid_pagination(self, oauth_credentials: Credentials) -> None:
+        """Verify that a 500 on the second page raises ServerError.
+
+        Server errors during pagination should be mapped to ServerError.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return OK on first page, 500 on second.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Success or server-error response.
+            """
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 1}],
+                        "pagination": {"page_size": 1, "next_cursor": "c2"},
+                    },
+                )
+            return httpx.Response(500, json={"error": "internal_error"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(ServerError):
+            list(paginate_all(client, "/projects/12345/items"))
+
+    def test_http_401_mid_pagination(self, oauth_credentials: Credentials) -> None:
+        """Verify that a 401 on the second page raises AuthenticationError.
+
+        Token expiry during pagination should be mapped to AuthenticationError.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return OK on first page, 401 on second.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Success or auth-error response.
+            """
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": [{"id": 1}],
+                        "pagination": {"page_size": 1, "next_cursor": "c2"},
+                    },
+                )
+            return httpx.Response(401, json={"error": "unauthorized"})
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(AuthenticationError):
+            list(paginate_all(client, "/projects/12345/items"))

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2651,7 +2651,9 @@ class TestInMemoryMode:
                     "properties": {"key": "value"},
                 }
             ]
-            metadata = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
 
             row_count = storage.create_events_table("events", iter(events), metadata)
             assert row_count == 1
@@ -2701,7 +2703,9 @@ class TestInMemoryMode:
                     "properties": {},
                 }
             ]
-            metadata = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
             storage.create_events_table("my_events", iter(events), metadata)
 
             # Introspection should work
@@ -2725,7 +2729,9 @@ class TestInMemoryMode:
                     "last_seen": datetime.now(timezone.utc),
                 }
             ]
-            metadata = TableMetadata(type="profiles", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="profiles", fetched_at=datetime.now(timezone.utc)
+            )
 
             row_count = storage.create_profiles_table(
                 "profiles", iter(profiles), metadata
@@ -2751,7 +2757,9 @@ class TestInMemoryMode:
                 }
                 for i in range(5)
             ]
-            metadata = TableMetadata(type="events", fetched_at=datetime.now(timezone.utc))
+            metadata = TableMetadata(
+                type="events", fetched_at=datetime.now(timezone.utc)
+            )
             storage.create_events_table("events", iter(events), metadata)
 
             # execute_df

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 from hypothesis import given
@@ -2637,3 +2638,183 @@ class TestPropertyCoverageResultProperties:
         df1 = result.df
         df2 = result.df
         assert df1 is df2
+
+
+# =============================================================================
+# OAuth Types PBT (Phase 023)
+# =============================================================================
+
+
+class TestPkceChallengePBT:
+    """Property-based tests for PKCE challenge generation."""
+
+    @given(st.integers(min_value=1, max_value=50))
+    def test_verifier_always_86_chars(self, _n: int) -> None:
+        """Every generated PKCE challenge has a 86-char verifier."""
+        from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+        challenge = PkceChallenge.generate()
+        assert len(challenge.verifier) == 86
+
+    @given(st.integers(min_value=1, max_value=50))
+    def test_challenge_always_43_chars(self, _n: int) -> None:
+        """Every generated PKCE challenge has a 43-char SHA-256 hash."""
+        from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+        challenge = PkceChallenge.generate()
+        assert len(challenge.challenge) == 43
+
+    @given(st.integers(min_value=1, max_value=50))
+    def test_verifier_is_base64url(self, _n: int) -> None:
+        """Verifier only contains base64url characters (no padding)."""
+        import re
+
+        from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+        challenge = PkceChallenge.generate()
+        assert re.match(r"^[A-Za-z0-9_-]+$", challenge.verifier)
+
+    @given(st.integers(min_value=1, max_value=50))
+    def test_challenge_is_sha256_of_verifier(self, _n: int) -> None:
+        """Challenge is always SHA-256(verifier) in base64url no-pad."""
+        import base64
+        import hashlib
+
+        from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+        pair = PkceChallenge.generate()
+        expected = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(pair.verifier.encode("ascii")).digest()
+            )
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        assert pair.challenge == expected
+
+    @given(st.integers(min_value=1, max_value=20))
+    def test_each_generation_unique(self, _n: int) -> None:
+        """Two consecutive generations produce different verifiers."""
+        from mixpanel_data._internal.auth.pkce import PkceChallenge
+
+        a = PkceChallenge.generate()
+        b = PkceChallenge.generate()
+        assert a.verifier != b.verifier
+
+
+class TestOAuthTokensRoundTripPBT:
+    """Property-based tests for OAuthTokens JSON round-trip via storage."""
+
+    @given(
+        scope=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "Zs")),
+            min_size=1,
+            max_size=200,
+        ),
+        project_id=st.one_of(st.none(), st.text(min_size=1, max_size=20)),
+        expires_in=st.integers(min_value=60, max_value=86400),
+    )
+    def test_from_token_response_round_trip(
+        self, scope: str, project_id: str | None, expires_in: int
+    ) -> None:
+        """from_token_response always produces a valid OAuthTokens."""
+        from mixpanel_data._internal.auth.token import OAuthTokens
+
+        data = {
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",
+            "expires_in": expires_in,
+            "scope": scope,
+            "token_type": "Bearer",
+        }
+        tokens = OAuthTokens.from_token_response(data, project_id=project_id)
+
+        assert tokens.access_token.get_secret_value() == "test_access_token"
+        assert tokens.scope == scope
+        assert tokens.project_id == project_id
+        assert tokens.token_type == "Bearer"
+
+    @given(buffer_seconds=st.integers(min_value=31, max_value=100000))
+    def test_not_expired_when_far_future(self, buffer_seconds: int) -> None:
+        """Tokens with expires_at far in the future are never expired."""
+        from mixpanel_data._internal.auth.token import OAuthTokens
+
+        tokens = OAuthTokens.from_token_response(
+            {
+                "access_token": "tok",
+                "expires_in": buffer_seconds,
+                "scope": "all",
+                "token_type": "Bearer",
+            }
+        )
+        assert not tokens.is_expired()
+
+    @given(seconds_past=st.integers(min_value=0, max_value=100000))
+    def test_expired_when_in_past(self, seconds_past: int) -> None:
+        """Tokens with expires_at in the past are always expired."""
+        from datetime import timedelta, timezone
+
+        from pydantic import SecretStr
+
+        from mixpanel_data._internal.auth.token import OAuthTokens
+
+        now = datetime.now(timezone.utc)
+        tokens = OAuthTokens(
+            access_token=SecretStr("tok"),
+            expires_at=now - timedelta(seconds=seconds_past),
+            scope="all",
+            token_type="Bearer",
+        )
+        assert tokens.is_expired()
+
+    @given(
+        access_token=st.text(
+            min_size=1,
+            max_size=500,
+            alphabet=st.characters(whitelist_categories=("L", "N", "P")),
+        ),
+        scope=st.text(min_size=1, max_size=200),
+        project_id=st.one_of(st.none(), st.text(min_size=1, max_size=20)),
+        expires_in=st.integers(min_value=31, max_value=86400),
+    )
+    def test_storage_save_load_round_trip(
+        self,
+        access_token: str,
+        scope: str,
+        project_id: str | None,
+        expires_in: int,
+    ) -> None:
+        """OAuthStorage save/load round-trips preserve all token fields.
+
+        Verifies that saving tokens to disk and loading them back yields
+        identical access_token, scope, and project_id values.
+
+        Args:
+            access_token: Randomly generated access token string.
+            scope: Randomly generated scope string.
+            project_id: Optional randomly generated project ID.
+            expires_in: Token lifetime in seconds (>30 to avoid expiry edge case).
+        """
+        import tempfile
+
+        from mixpanel_data._internal.auth.storage import OAuthStorage
+        from mixpanel_data._internal.auth.token import OAuthTokens
+
+        tokens = OAuthTokens.from_token_response(
+            {
+                "access_token": access_token,
+                "expires_in": expires_in,
+                "scope": scope,
+                "token_type": "Bearer",
+            },
+            project_id=project_id,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = OAuthStorage(storage_dir=Path(tmpdir))
+            storage.save_tokens(tokens, region="us")
+            loaded = storage.load_tokens(region="us")
+
+        assert loaded is not None
+        assert loaded.access_token.get_secret_value() == access_token
+        assert loaded.scope == scope
+        assert loaded.project_id == project_id

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -1535,16 +1535,19 @@ class TestSavedReportResultProperties:
         )
 
         report_type = result.report_type
-        assert report_type in ("insights", "retention", "funnel")
+        assert report_type in ("insights", "retention", "funnel", "flows")
 
         # Verify detection logic
         has_retention = any("$retention" in h.lower() for h in headers)
         has_funnel = any("$funnel" in h.lower() for h in headers)
+        has_flows = any("$flows" in h.lower() for h in headers)
 
         if has_retention:
             assert report_type == "retention"
         elif has_funnel:
             assert report_type == "funnel"
+        elif has_flows:
+            assert report_type == "flows"
         else:
             assert report_type == "insights"
 

--- a/tests/unit/test_workspace_oauth.py
+++ b/tests/unit/test_workspace_oauth.py
@@ -1,0 +1,405 @@
+"""Unit tests for Workspace OAuth integration (T034).
+
+Integration tests for Workspace construction with OAuth tokens and
+workspace management methods (list_workspaces, resolve_workspace_id,
+set_workspace_id, workspace_id property).
+
+Verifies:
+- Workspace construction with OAuth credentials
+- list_workspaces() delegates to api_client
+- resolve_workspace_id() delegates to api_client
+- set_workspace_id() delegates to api_client
+- workspace_id property returns current workspace id
+- Backward compatibility with Basic Auth Workspace usage
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data._internal.config import (
+    AuthMethod,
+    ConfigManager,
+    Credentials,
+)
+from mixpanel_data._internal.storage import StorageEngine
+from mixpanel_data.types import PublicWorkspace
+from mixpanel_data.workspace import Workspace
+
+
+def _make_oauth_credentials(
+    project_id: str = "12345",
+    region: str = "us",
+    access_token: str = "test-oauth-token",
+) -> Credentials:
+    """Create OAuth Credentials for testing.
+
+    Args:
+        project_id: Mixpanel project ID.
+        region: Data residency region.
+        access_token: OAuth access token.
+
+    Returns:
+        A Credentials instance with auth_method=oauth.
+    """
+    return Credentials(
+        username="",
+        secret=SecretStr(""),
+        project_id=project_id,
+        region=region,
+        auth_method=AuthMethod.oauth,
+        oauth_access_token=SecretStr(access_token),
+    )
+
+
+def _make_basic_credentials(
+    project_id: str = "12345",
+    region: str = "us",
+) -> Credentials:
+    """Create Basic Auth Credentials for testing.
+
+    Args:
+        project_id: Mixpanel project ID.
+        region: Data residency region.
+
+    Returns:
+        A Credentials instance with auth_method=basic.
+    """
+    return Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id=project_id,
+        region=region,
+    )
+
+
+def _workspaces_json() -> list[dict[str, Any]]:
+    """Return a sample list of workspace dicts for mock responses.
+
+    Returns:
+        List of workspace dictionaries matching the Mixpanel API format.
+    """
+    return [
+        {
+            "id": 100,
+            "name": "Default Workspace",
+            "project_id": 12345,
+            "is_default": True,
+            "description": "The default workspace",
+            "is_global": False,
+            "is_restricted": False,
+            "is_visible": True,
+            "created_iso": "2024-01-01T00:00:00Z",
+            "creator_name": "Admin",
+        },
+        {
+            "id": 200,
+            "name": "Dev Workspace",
+            "project_id": 12345,
+            "is_default": False,
+            "description": "Development workspace",
+            "is_global": False,
+            "is_restricted": False,
+            "is_visible": True,
+            "created_iso": "2024-02-01T00:00:00Z",
+            "creator_name": "Dev",
+        },
+    ]
+
+
+def _make_workspace_handler() -> Callable[[httpx.Request], httpx.Response]:
+    """Create a mock HTTP handler that returns workspace list responses.
+
+    Returns:
+        A handler function for httpx.MockTransport.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Handle mock HTTP requests for workspace endpoints.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            Mock response with workspace data for workspace paths,
+            404 for unrecognized paths.
+        """
+        url_path = request.url.path
+        if "workspaces/public" in url_path:
+            return httpx.Response(
+                200,
+                json={"results": _workspaces_json(), "status": "ok"},
+            )
+        return httpx.Response(404, json={"error": "not found"})
+
+    return handler
+
+
+def _setup_config_with_account(temp_dir: Path) -> ConfigManager:
+    """Create a ConfigManager with a dummy account for credential resolution.
+
+    Args:
+        temp_dir: Temporary directory for the config file.
+
+    Returns:
+        ConfigManager with a test account configured.
+    """
+    cm = ConfigManager(config_path=temp_dir / "config.toml")
+    cm.add_account(
+        name="test",
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="us",
+    )
+    return cm
+
+
+class TestWorkspaceConstructionWithOAuth:
+    """Tests for Workspace construction with OAuth credentials."""
+
+    def test_workspace_with_oauth_credentials(
+        self,
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Workspace can be constructed with OAuth credentials.
+
+        Uses OAuth tokens stored on disk and partial env vars to resolve
+        OAuth credentials during Workspace construction.
+        """
+        # Set up OAuth tokens on disk
+        oauth_dir = temp_dir / "oauth"
+        oauth_storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = OAuthTokens(
+            access_token=SecretStr("test-oauth-token"),
+            refresh_token=SecretStr("test-refresh"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scope="read:project",
+            token_type="Bearer",
+            project_id="12345",
+        )
+        oauth_storage.save_tokens(tokens, region="us")
+
+        # Use partial env vars (project_id + region but NO username/secret)
+        # and point OAuth storage to our temp dir
+        monkeypatch.setenv("MP_PROJECT_ID", "12345")
+        monkeypatch.setenv("MP_REGION", "us")
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(oauth_dir))
+
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        db_storage = StorageEngine(path=temp_dir / "test.db")
+
+        cm = ConfigManager(config_path=temp_dir / "config.toml")
+        ws = Workspace(
+            _config_manager=cm,
+            _api_client=client,
+            _storage=db_storage,
+        )
+
+        # The workspace should have resolved OAuth credentials
+        assert ws._credentials is not None
+        assert ws._credentials.auth_method == AuthMethod.oauth
+
+    def test_workspace_backward_compat_basic_auth(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """Workspace still works with Basic Auth credentials (regression)."""
+        basic_creds = _make_basic_credentials()
+        transport = httpx.MockTransport(lambda _r: httpx.Response(200, json=[]))
+        client = MixpanelAPIClient(basic_creds, _transport=transport)
+        db_storage = StorageEngine(path=temp_dir / "test.db")
+
+        cm = _setup_config_with_account(temp_dir)
+
+        ws = Workspace(
+            _config_manager=cm,
+            _api_client=client,
+            _storage=db_storage,
+        )
+
+        assert ws._credentials is not None
+        assert ws._credentials.auth_method == AuthMethod.basic
+        assert ws._credentials.username == "test_user"
+
+
+class TestWorkspaceListWorkspaces:
+    """Tests for Workspace.list_workspaces()."""
+
+    def test_list_workspaces_returns_workspace_models(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """list_workspaces() returns a list of PublicWorkspace objects."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        workspaces = ws.list_workspaces()
+
+        assert len(workspaces) == 2
+        assert isinstance(workspaces[0], PublicWorkspace)
+        assert workspaces[0].name == "Default Workspace"
+        assert workspaces[0].id == 100
+        assert workspaces[0].is_default is True
+        assert workspaces[1].id == 200
+
+    def test_list_workspaces_empty(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """list_workspaces() returns empty list when no workspaces exist."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return empty workspace list.
+
+            Args:
+                _request: The HTTP request (unused).
+
+            Returns:
+                Response with empty results.
+            """
+            return httpx.Response(
+                200,
+                json={"results": [], "status": "ok"},
+            )
+
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        workspaces = ws.list_workspaces()
+        assert workspaces == []
+
+
+class TestWorkspaceResolveWorkspaceId:
+    """Tests for Workspace.resolve_workspace_id()."""
+
+    def test_resolve_workspace_id_returns_default(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """resolve_workspace_id() returns the default workspace ID."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        ws_id = ws.resolve_workspace_id()
+        assert ws_id == 100  # The default workspace
+
+
+class TestWorkspaceSetWorkspaceId:
+    """Tests for Workspace.set_workspace_id() and workspace_id property."""
+
+    def test_set_and_get_workspace_id(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """set_workspace_id() sets the workspace_id readable from property."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        ws.set_workspace_id(42)
+        assert ws.workspace_id == 42
+
+    def test_workspace_id_initially_none(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """workspace_id is None before any workspace is set."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        assert ws.workspace_id is None
+
+    def test_clear_workspace_id(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """set_workspace_id(None) clears the workspace_id."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+        )
+
+        ws.set_workspace_id(42)
+        assert ws.workspace_id == 42
+
+        ws.set_workspace_id(None)
+        assert ws.workspace_id is None
+
+    def test_workspace_id_constructor_param(
+        self,
+        temp_dir: Path,
+    ) -> None:
+        """Workspace constructor accepts workspace_id parameter."""
+        oauth_creds = _make_oauth_credentials()
+        transport = httpx.MockTransport(_make_workspace_handler())
+        client = MixpanelAPIClient(oauth_creds, _transport=transport)
+        storage = StorageEngine(path=temp_dir / "test.db")
+
+        ws = Workspace(
+            _config_manager=_setup_config_with_account(temp_dir),
+            _api_client=client,
+            _storage=storage,
+            workspace_id=999,
+        )
+
+        assert ws.workspace_id == 999

--- a/tests/unit/test_workspace_oauth.py
+++ b/tests/unit/test_workspace_oauth.py
@@ -217,8 +217,14 @@ class TestWorkspaceConstructionWithOAuth:
     def test_workspace_backward_compat_basic_auth(
         self,
         temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Workspace still works with Basic Auth credentials (regression)."""
+        # Isolate OAuth storage so real tokens on the machine are not found
+        oauth_dir = temp_dir / "empty_oauth"
+        oauth_dir.mkdir()
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(oauth_dir))
+
         basic_creds = _make_basic_credentials()
         transport = httpx.MockTransport(lambda _r: httpx.Response(200, json=[]))
         client = MixpanelAPIClient(basic_creds, _transport=transport)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1281,6 +1281,7 @@ dev = [
     { name = "click-man" },
     { name = "pre-commit" },
     { name = "psutil" },
+    { name = "ruff" },
     { name = "types-psutil" },
 ]
 
@@ -1317,6 +1318,7 @@ dev = [
     { name = "click-man", specifier = ">=0.5.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "psutil", specifier = ">=7.2.0" },
+    { name = "ruff", specifier = ">=0.1" },
     { name = "types-psutil", specifier = ">=7.2.0.20251228" },
 ]
 


### PR DESCRIPTION
## Summary

- Add OAuth 2.0 PKCE authentication with browser-based login, per-region token storage (`~/.mp/oauth/`), automatic refresh, and dynamic client registration (RFC 7591)
- Add App API client infrastructure with `app_request()`, workspace-scoped endpoint paths, auto-discovery of default workspace, and generic cursor-based pagination
- Add CLI commands (`mp auth login/logout/status/token`), global `--workspace-id` option, new exceptions (`OAuthError`, `WorkspaceScopeError`), and new types (`PublicWorkspace`, `CursorPagination`, `PaginatedResponse`)
- Update all documentation (docs/, CLAUDE.md, README.md) to reflect OAuth auth, workspace scoping, new CLI commands, exceptions, and types

## Test plan

- [x] `just check` passes (lint, typecheck, tests)
- [x] New unit tests cover OAuth PKCE flow, token storage, callback server, client registration, config resolution with OAuth, workspace scoping, pagination, and CLI auth commands
- [x] Property-based tests cover new types (`PublicWorkspace`, `CursorPagination`, `PaginatedResponse`)
- [x] Integration tests updated for new credential/storage interfaces
- [x] Manual: `mp auth login --region us` opens browser, completes OAuth flow, saves tokens
- [x] Manual: `mp auth status` shows per-region auth state
- [x] Manual: `mp auth token` outputs raw access token
- [x] Manual: `mp auth logout` removes stored tokens
- [ ] Docs build correctly with `mkdocs serve`