### PR TITLE
feat: add add_report_to_dashboard method and CLI command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,6 @@
     "pyright-lsp@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "mixpanel-data@mixpanel-data": true
+    "mixpanel-data@mixpanel-data-marketplace": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ context/fastmcp/
 
 # MCP client configuration (local dev only)
 .mcp.json
+
+# oh-my-claudecode local state
+.omc/

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -172,6 +172,7 @@ See the [Data Governance guide](../guide/data-governance.md) for complete covera
         - unfavorite_dashboard
         - pin_dashboard
         - unpin_dashboard
+        - add_report_to_dashboard
         - remove_report_from_dashboard
         - list_blueprint_templates
         - create_blueprint

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -111,6 +111,7 @@ Manage Mixpanel dashboards via the App API.
 | `mp dashboards unfavorite` | Unfavorite a dashboard |
 | `mp dashboards pin` | Pin a dashboard |
 | `mp dashboards unpin` | Unpin a dashboard |
+| `mp dashboards add-report` | Add a report to a dashboard |
 | `mp dashboards remove-report` | Remove a report from a dashboard |
 | `mp dashboards blueprints` | List blueprint templates |
 | `mp dashboards blueprint-create` | Create dashboard from blueprint |

--- a/docs/guide/entity-management.md
+++ b/docs/guide/entity-management.md
@@ -120,6 +120,23 @@ Manage Mixpanel dashboards, reports (bookmarks), cohorts, feature flags, experim
     mp dashboards unpin 123
     ```
 
+### Add a Report to a Dashboard
+
+=== "Python"
+
+    ```python
+    updated_dash = ws.add_report_to_dashboard(
+        dashboard_id=123,
+        bookmark_id=456
+    )
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp dashboards add-report 123 456
+    ```
+
 ### Remove a Report from a Dashboard
 
 === "Python"
@@ -134,7 +151,7 @@ Manage Mixpanel dashboards, reports (bookmarks), cohorts, feature flags, experim
 === "CLI"
 
     ```bash
-    mp dashboards remove-report 123 --bookmark-id 456
+    mp dashboards remove-report 123 456
     ```
 
 ### Blueprint Dashboards

--- a/mixpanel-plugin/agents/analyst.md
+++ b/mixpanel-plugin/agents/analyst.md
@@ -124,3 +124,13 @@ If `Workspace()` initialization or any query raises `AuthenticationError` or `Co
 ## Entity Management
 
 You can also manage Mixpanel entities (dashboards, cohorts, feature flags, experiments, alerts, annotations, webhooks) via the App API. Use `help.py` to look up the exact CRUD method signatures.
+
+### Bookmark Validation
+
+When creating or updating bookmarks, **always validate params before calling the API**:
+
+```bash
+echo '<params_json>' | python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/validate_bookmark.py --stdin --type insights
+```
+
+This catches invalid chart types, math types, missing fields, wrong funnel step counts, etc. before they produce cryptic API errors. See `references/bookmark-params.md` for the full params schema.

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -55,6 +55,10 @@ ws = mp.Workspace()
 
 # With workspace ID for App API (entity CRUD)
 ws = mp.Workspace(workspace_id=12345)
+
+# IMPORTANT: project_id must be a STRING, not int
+ws = mp.Workspace(project_id="8")           # correct
+# ws = mp.Workspace(project_id=8)           # WRONG — ValidationError
 ```
 
 ## Quick API Reference
@@ -130,6 +134,89 @@ Full CRUD for dashboards, cohorts, feature flags, experiments, alerts, annotatio
 python3 ${CLAUDE_SKILL_DIR}/scripts/help.py Workspace.list_dashboards
 python3 ${CLAUDE_SKILL_DIR}/scripts/help.py Workspace.create_cohort
 python3 ${CLAUDE_SKILL_DIR}/scripts/help.py Workspace.list_feature_flags
+```
+
+### Adding Reports to a Dashboard
+
+Use `add_report_to_dashboard()` to clone an existing bookmark onto a dashboard:
+
+```python
+import mixpanel_data as mp
+from mixpanel_data.types import CreateDashboardParams, CreateBookmarkParams
+
+ws = mp.Workspace(account="myaccount")
+
+# Step 1: Create dashboard
+dashboard = ws.create_dashboard(CreateDashboardParams(title="My Dashboard"))
+
+# Step 2: Create a bookmark
+bookmark = ws.create_bookmark(CreateBookmarkParams(
+    name="Daily Logins",
+    bookmark_type="insights",
+    params={...},  # see Bookmark Params Structure below
+))
+
+# Step 3: Add bookmark to dashboard
+ws.add_report_to_dashboard(dashboard.id, bookmark.id)
+```
+
+**Note**: `CreateBookmarkParams(dashboard_id=...)` does NOT add the report to the dashboard layout — always use `add_report_to_dashboard()` instead.
+
+### Bookmark Params Structure (Insights)
+
+The `params` dict for insights bookmarks follows this structure:
+
+```python
+def make_insights_params(event_name, chart_type="line", unit="month",
+                         value=180, group_by_prop=None):
+    """Build params for an insights bookmark."""
+    metric = {
+        "behavior": {
+            "type": "simple",
+            "name": event_name,
+            "resourceType": "events",
+            "dataGroupId": None,
+            "filters": [],
+            "behaviors": [{
+                "type": "event",
+                "id": None,
+                "name": event_name,
+                "filters": [],
+            }],
+        },
+        "measurement": {
+            "math": "total",         # total | unique
+            "perUserAggregation": None,
+            "property": None,
+        },
+        "isHidden": False,
+        "type": "metric",
+    }
+    sections = {
+        "show": [metric],            # list of metrics (A, B, C...)
+        "filter": [],
+        "formula": [],
+        "time": [{"unit": unit, "value": value}],
+        "group_by": [],
+        "group": [],
+    }
+    if group_by_prop:
+        sections["group_by"] = [{
+            "value": group_by_prop,
+            "resourceType": "events",
+            "propertyType": "string",
+            "typeCast": None,
+            "bucketing": None,
+        }]
+    return {
+        "sections": sections,
+        "displayOptions": {
+            "chartType": chart_type,  # line | bar
+            "plotStyle": "standard",
+            "analysis": "linear",
+            "value": "absolute",
+        },
+    }
 ```
 
 ### DataFrame Conversion
@@ -301,4 +388,3 @@ Load these references on demand when the quick reference above is insufficient:
 - [pandas-patterns.md](references/pandas-patterns.md) — Read when building visualizations, doing statistical analysis, creating heatmaps, or working with streaming data as DataFrames
 - [analytical-frameworks.md](references/analytical-frameworks.md) — Read when the user asks an open-ended question requiring structured investigation (GQM decomposition, diagnosis methodology, retention benchmarks)
 - [code-patterns.md](references/code-patterns.md) — Read when you need a complete, copy-paste starting point for a common analysis scenario (funnel drop-off, retention curves, revenue analysis, feature adoption, executive dashboards)
-- [bookmark-params.md](references/bookmark-params.md) — Read when creating or updating bookmarks (saved reports) via `create_bookmark()` / `update_bookmark()`. Covers the full `params` JSON schema for insights, funnels, retention, and flows report types

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -301,3 +301,4 @@ Load these references on demand when the quick reference above is insufficient:
 - [pandas-patterns.md](references/pandas-patterns.md) — Read when building visualizations, doing statistical analysis, creating heatmaps, or working with streaming data as DataFrames
 - [analytical-frameworks.md](references/analytical-frameworks.md) — Read when the user asks an open-ended question requiring structured investigation (GQM decomposition, diagnosis methodology, retention benchmarks)
 - [code-patterns.md](references/code-patterns.md) — Read when you need a complete, copy-paste starting point for a common analysis scenario (funnel drop-off, retention curves, revenue analysis, feature adoption, executive dashboards)
+- [bookmark-params.md](references/bookmark-params.md) — Read when creating or updating bookmarks (saved reports) via `create_bookmark()` / `update_bookmark()`. Covers the full `params` JSON schema for insights, funnels, retention, and flows report types

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -41,6 +41,26 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/help.py exceptions          # list all excep
 
 Use this before every unfamiliar method. It pulls live docstrings from the installed package — always accurate.
 
+## Bookmark Validation
+
+Before calling `create_bookmark()` or `update_bookmark()`, **always validate the params dict**:
+
+```bash
+# Validate from a Python variable (pipe JSON to stdin)
+python3 -c "import json; print(json.dumps(params))" | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin
+
+# Validate with explicit type
+echo '{"sections": {...}}' | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin --type insights
+
+# Validate from a file
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py params.json
+
+# Get errors as JSON (for programmatic use)
+echo '...' | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin --json
+```
+
+Exit 0 = valid. Exit 1 = errors (printed to stderr). The validator checks chart types, math types, filter operators, required fields, funnel step counts, retention event counts, and flows structure — catching mistakes before they hit the API.
+
 ## Workspace Construction
 
 ```python
@@ -142,6 +162,8 @@ Use `add_report_to_dashboard()` to clone an existing bookmark onto a dashboard:
 
 ```python
 import mixpanel_data as mp
+import json
+import subprocess
 from mixpanel_data.types import CreateDashboardParams, CreateBookmarkParams
 
 ws = mp.Workspace(account="myaccount")
@@ -149,15 +171,27 @@ ws = mp.Workspace(account="myaccount")
 # Step 1: Create dashboard
 dashboard = ws.create_dashboard(CreateDashboardParams(title="My Dashboard"))
 
-# Step 2: Create a bookmark
-bookmark = ws.create_bookmark(CreateBookmarkParams(
-    name="Daily Logins",
-    bookmark_type="insights",
-    params={...},  # see Bookmark Params Structure below
-))
+# Step 2: Build and VALIDATE params before creating
+params = {... }  # see Bookmark Params Structure below
 
-# Step 3: Add bookmark to dashboard
-ws.add_report_to_dashboard(dashboard.id, bookmark.id)
+# Validate params (catches errors before hitting the API)
+result = subprocess.run(
+    ["python3", "${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py", "--stdin", "--type", "insights"],
+    input=json.dumps(params), capture_output=True, text=True,
+)
+if result.returncode != 0:
+    print(f"Invalid params: {result.stderr}")
+    # Fix params before proceeding
+else:
+    # Step 3: Create bookmark (params are valid)
+    bookmark = ws.create_bookmark(CreateBookmarkParams(
+        name="Daily Logins",
+        bookmark_type="insights",
+        params=params,
+    ))
+
+    # Step 4: Add bookmark to dashboard
+    ws.add_report_to_dashboard(dashboard.id, bookmark.id)
 ```
 
 **Note**: `CreateBookmarkParams(dashboard_id=...)` does NOT add the report to the dashboard layout — always use `add_report_to_dashboard()` instead.

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -101,7 +101,7 @@ Not all SQL is expressible: no JOINs, no subqueries, no UNION. Formulas are the 
 | `pie` | Part-of-whole composition |
 | `column` | Vertical bar |
 | `insights-metric` | Single KPI number |
-| `stacked-bar` / `stacked-line` | Composition; use `plotStyle: "stacked"` with bar/line |
+| `bar-stacked` / `stacked-line` / `stacked-column` | Composition; plotStyle is set to `"stacked"` automatically |
 
 ### Measurement Math
 
@@ -295,7 +295,7 @@ Funnels go beyond simple SQL aggregation — they express sequential event analy
 |---|---|---|
 | `conversionWindowDuration` | 7 | Max time between first and last step |
 | `conversionWindowUnit` | `"day"` | second, minute, hour, day, week, month, session |
-| `funnelOrder` | `"loose"` | `loose` = any order, `any` = strict order |
+| `funnelOrder` | `"loose"` | `loose` = any order, `strict` = steps must be in order |
 
 ### Funnel Math Types
 `unique`, `general`, `session`, `conversion_rate`, `conversion_rate_unique`, `conversion_rate_total`, `conversion_rate_session`, `total`
@@ -502,6 +502,49 @@ df = result.df
 # Flows
 result = ws.query_flows(bookmark_id)
 ```
+
+## Validation
+
+**Always validate params before calling `create_bookmark()` or `update_bookmark()`.**
+
+```bash
+# Validate from stdin (auto-detects type)
+echo '<json>' | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin
+
+# Validate with explicit type
+echo '<json>' | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin --type funnels
+
+# Get structured errors as JSON
+echo '<json>' | python3 ${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py --stdin --json
+```
+
+The validator checks:
+- Required fields (`displayOptions`, `sections`, `sections.show`, `sections.time`)
+- Valid `chartType` values (context-dependent: insights vs flows)
+- Valid `math` types (context-dependent: insights vs funnels vs retention)
+- Filter operators and resource types
+- Funnel step count (minimum 2)
+- Retention event count (exactly 2)
+- Flows structure (`steps[]`, `date_range`)
+
+Exit 0 = valid, exit 1 = errors. Errors print to stderr; use `--json` for structured output.
+
+In Python scripts, validate inline:
+
+```python
+import json, subprocess
+
+result = subprocess.run(
+    ["python3", "${CLAUDE_SKILL_DIR}/scripts/validate_bookmark.py", "--stdin", "--json"],
+    input=json.dumps(params), capture_output=True, text=True,
+)
+if result.returncode != 0:
+    errors = json.loads(result.stdout)
+    for e in errors:
+        print(f"[{e['severity'].upper()}] {e['path']}: {e['message']}")
+```
+
+---
 
 ## Constraints
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -37,21 +37,32 @@ bookmark = ws.create_bookmark(CreateBookmarkParams(
 
 ## SQL Mental Model
 
-Think in SQL, then translate:
+Bookmark params are a declarative query — like SQL in JSON form. For insights, the `sections` object maps directly to SQL clauses:
 
 ```
-SQL                              Bookmark params
-----------------------------------------------
-SELECT COUNT(DISTINCT user)   →  measurement.math: "unique"
-SELECT COUNT(*)               →  measurement.math: "total"
-SELECT AVG(prop)              →  measurement.math: "average" + measurement.property
-FROM events                   →  behavior.name: "<event_name>"
-WHERE prop = 'val'            →  sections.filter[] or behavior.filters[]
-GROUP BY prop                 →  sections.group[]
-GROUP BY time_unit            →  sections.time[].unit + chartType: "line"
-LIMIT N                       →  sorting.*.viewNLimit
-A / B (ratio)                 →  FormulaShowClause with definition: "A / B"
+sections.show[]    →  SELECT        (each show clause = one metric column)
+sections.filter[]  →  WHERE         (global — applies to all metrics)
+sections.group[]   →  GROUP BY      (property breakdowns)
+sections.time[]    →  GROUP BY time (implicit, controls line chart granularity)
+sorting            →  ORDER BY / LIMIT
 ```
+
+Within each show clause:
+
+```
+behavior.name         →  FROM <table>       (which event to query)
+behavior.filters[]    →  AND <per-metric>   (additional WHERE, scoped to this metric only)
+measurement.math      →  aggregate function (COUNT DISTINCT, AVG, SUM, ...)
+measurement.property  →  aggregate column   (for AVG/MIN/MAX/percentiles)
+```
+
+Formulas reference other metrics by letter (A = first, B = second):
+
+```
+definition: "(A / B) * 100"  →  computed column
+```
+
+Not all SQL is expressible: no JOINs, no subqueries, no UNION. Formulas are the closest to derived columns. Funnels, retention, and flows go beyond SQL — see their sections below.
 
 ## Report Type Detection
 
@@ -72,10 +83,10 @@ A / B (ratio)                 →  FormulaShowClause with definition: "A / B"
 {
   "displayOptions": {"chartType": "<type>"},
   "sections": {
-    "show": [/* metrics and/or formulas */],
-    "time": [/* date range */],
-    "filter": [/* global WHERE clauses */],
-    "group": [/* GROUP BY breakdowns */]
+    "show": [/* SELECT — metrics and formulas */],
+    "time": [/* GROUP BY time — date range + granularity */],
+    "filter": [/* WHERE — global filters across all metrics */],
+    "group": [/* GROUP BY — property breakdowns */]
   }
 }
 ```
@@ -114,7 +125,7 @@ A / B (ratio)                 →  FormulaShowClause with definition: "A / B"
 
 #### Per-User Aggregation
 
-Set `measurement.perUserAggregation` to `total`, `average`, `min`, `max`, or `unique_values`. This aggregates per user first, then applies `math` across users.
+Set `measurement.perUserAggregation` to `total`, `average`, `min`, `max`, or `unique_values`. This aggregates per user first, then applies `math` across users — like a nested query: `SELECT AVG(user_total) FROM (SELECT user_id, COUNT(*) as user_total ... GROUP BY user_id)`.
 
 Example — "Average number of purchases per user":
 ```json
@@ -251,7 +262,7 @@ Numeric bucketing:
 
 ## Funnels Params
 
-Uses `sections` wrapper like insights, but with `behavior.type: "funnel"` and steps in `behavior.behaviors[]`.
+Funnels go beyond simple SQL aggregation — they express sequential event analysis with time constraints (like a self-join with window functions). Uses `sections` wrapper like insights, but with `behavior.type: "funnel"` and ordered steps in `behavior.behaviors[]`.
 
 ```json
 {
@@ -310,7 +321,7 @@ Each step in `behaviors[]` can have inline filters:
 
 ## Retention Params
 
-Uses `sections` wrapper with `behavior.type: "retention"` and exactly 2 behaviors: born event (index 0) and return event (index 1).
+Retention goes beyond SQL — it's cohort analysis, tracking whether users who did event A come back to do event B over time intervals. Uses `sections` wrapper with `behavior.type: "retention"` and exactly 2 behaviors: born event (index 0) and return event (index 1).
 
 ```json
 {
@@ -357,7 +368,7 @@ Uses `sections` wrapper with `behavior.type: "retention"` and exactly 2 behavior
 
 ## Flows Params
 
-Flows use a **completely different flat structure** — no `sections` wrapper.
+Flows have no SQL analogy — they're graph traversal, showing the paths users take before and after anchor events. Completely different flat structure — no `sections` wrapper.
 
 ```json
 {

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -1,0 +1,503 @@
+# Bookmark Params Reference — Building Valid Query JSON
+
+How to construct the `params` dict for `Workspace.create_bookmark()` and `Workspace.update_bookmark()`. The `params` field defines what data the report queries — it is the bookmark's query language.
+
+## Quick Start
+
+```python
+import mixpanel_data as mp
+from mixpanel_data.types import CreateBookmarkParams
+
+ws = mp.Workspace(workspace_id=WORKSPACE_ID)
+
+# Create an insights report
+bookmark = ws.create_bookmark(CreateBookmarkParams(
+    name="Daily Signups (30d)",
+    bookmark_type="insights",
+    params={
+        "displayOptions": {"chartType": "line"},
+        "sections": {
+            "show": [{
+                "type": "metric",
+                "behavior": {
+                    "type": "event", "name": "Sign Up",
+                    "resourceType": "events",
+                    "filtersDeterminer": "all", "filters": []
+                },
+                "measurement": {"math": "unique"}
+            }],
+            "time": [{"dateRangeType": "in the last", "unit": "day",
+                       "window": {"unit": "day", "value": 30}}],
+            "filter": [],
+            "group": []
+        }
+    },
+))
+```
+
+## SQL Mental Model
+
+Think in SQL, then translate:
+
+```
+SQL                              Bookmark params
+----------------------------------------------
+SELECT COUNT(DISTINCT user)   →  measurement.math: "unique"
+SELECT COUNT(*)               →  measurement.math: "total"
+SELECT AVG(prop)              →  measurement.math: "average" + measurement.property
+FROM events                   →  behavior.name: "<event_name>"
+WHERE prop = 'val'            →  sections.filter[] or behavior.filters[]
+GROUP BY prop                 →  sections.group[]
+GROUP BY time_unit            →  sections.time[].unit + chartType: "line"
+LIMIT N                       →  sorting.*.viewNLimit
+A / B (ratio)                 →  FormulaShowClause with definition: "A / B"
+```
+
+## Report Type Detection
+
+| `bookmark_type` | Params structure | Key indicator |
+|---|---|---|
+| `"insights"` | `sections` wrapper | `behavior.type: "event"` |
+| `"funnels"` | `sections` wrapper | `behavior.type: "funnel"` with `behaviors[]` (2+ steps) |
+| `"retention"` | `sections` wrapper | `behavior.type: "retention"` with `behaviors[]` (exactly 2) |
+| `"flows"` | **Flat structure** (no `sections`) | Top-level `steps[]` and `date_range` |
+
+---
+
+## Insights Params
+
+### Skeleton
+
+```json
+{
+  "displayOptions": {"chartType": "<type>"},
+  "sections": {
+    "show": [/* metrics and/or formulas */],
+    "time": [/* date range */],
+    "filter": [/* global WHERE clauses */],
+    "group": [/* GROUP BY breakdowns */]
+  }
+}
+```
+
+### Chart Types
+
+| chartType | Use case |
+|---|---|
+| `bar` | Aggregate totals (single number per segment, deduplicated across date range) |
+| `line` | Time series (per-period values; NOT additive for unique counts) |
+| `table` | Tabular detail |
+| `pie` | Part-of-whole composition |
+| `column` | Vertical bar |
+| `insights-metric` | Single KPI number |
+| `stacked-bar` / `stacked-line` | Composition; use `plotStyle: "stacked"` with bar/line |
+
+### Measurement Math
+
+#### Counting
+| math | SQL equivalent |
+|---|---|
+| `unique` | `COUNT(DISTINCT user_id)` |
+| `total` | `COUNT(*)` |
+| `sessions` | `COUNT(DISTINCT session_id)` |
+| `dau` / `wau` / `mau` | Daily/weekly/monthly active users |
+
+#### Property Aggregation (requires `measurement.property`)
+| math | SQL equivalent |
+|---|---|
+| `average` | `AVG(property)` |
+| `median` | `PERCENTILE_CONT(0.5)` |
+| `min` / `max` | `MIN` / `MAX` |
+| `p25` / `p75` / `p90` / `p99` | Percentiles |
+| `unique_values` | `COUNT(DISTINCT property)` |
+| `histogram` | Distribution buckets |
+
+#### Per-User Aggregation
+
+Set `measurement.perUserAggregation` to `total`, `average`, `min`, `max`, or `unique_values`. This aggregates per user first, then applies `math` across users.
+
+Example — "Average number of purchases per user":
+```json
+"measurement": {"math": "average", "perUserAggregation": "total"}
+```
+
+### Show Clause — Metric
+
+```json
+{
+  "type": "metric",
+  "behavior": {
+    "type": "event",
+    "name": "Sign Up",
+    "resourceType": "events",
+    "filtersDeterminer": "all",
+    "filters": []
+  },
+  "measurement": {"math": "unique"}
+}
+```
+
+With property aggregation:
+```json
+"measurement": {
+  "math": "average",
+  "property": {
+    "name": "Amount", "dataset": "mixpanel",
+    "defaultType": "number", "type": "number",
+    "resourceType": "events"
+  }
+}
+```
+
+### Show Clause — Formula
+
+```json
+{
+  "type": "formula",
+  "name": "Conversion Rate",
+  "definition": "(A / B) * 100",
+  "measurement": {},
+  "referencedMetrics": []
+}
+```
+
+Letters A-Z reference metrics by position in the `show` array (A = first, B = second).
+
+When formulas are present, set `isHidden: true` on the raw metric show clauses to hide them from visualization.
+
+### Time Clause
+
+Relative (last N days):
+```json
+{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}
+```
+
+Absolute (specific dates):
+```json
+{"dateRangeType": "between", "unit": "day", "value": ["2024-01-01", "2024-03-31"]}
+```
+
+Presets:
+```json
+{"dateRangeType": "since", "value": "$start_of_current_day", "unit": "hour"}
+```
+
+The `unit` field controls time granularity for line charts: `hour`, `day`, `week`, `month`.
+
+### Filter Clause
+
+```json
+{
+  "resourceType": "events",
+  "filterType": "string",
+  "defaultType": "string",
+  "value": "$browser",
+  "filterValue": ["Chrome"],
+  "filterOperator": "equals"
+}
+```
+
+#### Filter Operators
+
+| Property Type | Operators |
+|---|---|
+| string | `equals`, `does not equal`, `contains`, `does not contain`, `is set`, `is not set` |
+| number | `is equal to`, `is not equal to`, `is greater than`, `is less than`, `is at least`, `is at most`, `is between` |
+| boolean | `true`, `false` |
+| datetime | `was on`, `was before`, `was since` |
+
+#### filterValue Format
+- String `equals` / `does not equal`: array `["Chrome"]`
+- String `contains` / `does not contain`: plain string `"Chrome"`
+- Number operators: numeric `42`
+- `is between`: array `[10, 100]`
+- `is set` / `is not set`: `null`
+- Boolean: `true` / `false`
+
+#### Resource Types
+- `"events"` — event properties (`$browser`, `$city`, custom event props)
+- `"people"` — user profile properties (`$name`, `$email`, custom user props)
+
+### Group (Breakdown) Clause
+
+Event property breakdown:
+```json
+{
+  "resourceType": "events",
+  "propertyType": "string", "propertyDefaultType": "string",
+  "propertyName": "$browser", "value": "$browser"
+}
+```
+
+User property breakdown:
+```json
+{
+  "resourceType": "people",
+  "propertyType": "string", "propertyDefaultType": "string",
+  "propertyName": "Plan", "value": "Plan"
+}
+```
+
+Numeric bucketing:
+```json
+{
+  "propertyName": "Amount", "propertyType": "number", "propertyDefaultType": "number",
+  "resourceType": "events", "value": "Amount",
+  "customBucket": {"bucketSize": 10, "min": 0, "max": 100}
+}
+```
+
+---
+
+## Funnels Params
+
+Uses `sections` wrapper like insights, but with `behavior.type: "funnel"` and steps in `behavior.behaviors[]`.
+
+```json
+{
+  "displayOptions": {"chartType": "funnel-steps"},
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "funnel", "name": "funnel",
+        "resourceType": "events",
+        "filtersDeterminer": "all", "filters": [],
+        "conversionWindowDuration": 7, "conversionWindowUnit": "day",
+        "funnelOrder": "loose",
+        "behaviors": [
+          {"type": "event", "name": "Sign Up", "filters": [], "filtersDeterminer": "all"},
+          {"type": "event", "name": "Purchase", "filters": [], "filtersDeterminer": "all"}
+        ]
+      },
+      "measurement": {"math": "unique"}
+    }],
+    "time": [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}],
+    "filter": [], "group": []
+  }
+}
+```
+
+### Funnel-Specific Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `conversionWindowDuration` | 7 | Max time between first and last step |
+| `conversionWindowUnit` | `"day"` | second, minute, hour, day, week, month, session |
+| `funnelOrder` | `"loose"` | `loose` = any order, `any` = strict order |
+
+### Funnel Math Types
+`unique`, `general`, `session`, `conversion_rate`, `conversion_rate_unique`, `conversion_rate_total`, `conversion_rate_session`, `total`
+
+### Chart Types
+`funnel-steps` (default bar), `funnel-top-paths` (common paths), `line` (conversion trend over time)
+
+### Per-Step Filters
+
+Each step in `behaviors[]` can have inline filters:
+```json
+{
+  "type": "event", "name": "Page View",
+  "filtersDeterminer": "all",
+  "filters": [{
+    "resourceType": "events", "filterType": "string", "defaultType": "string",
+    "value": "page_url", "filterValue": ["/pricing"], "filterOperator": "equals"
+  }]
+}
+```
+
+---
+
+## Retention Params
+
+Uses `sections` wrapper with `behavior.type: "retention"` and exactly 2 behaviors: born event (index 0) and return event (index 1).
+
+```json
+{
+  "displayOptions": {"chartType": "retention-curve"},
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "retention", "name": "retention",
+        "resourceType": "events",
+        "filtersDeterminer": "all", "filters": [],
+        "retentionType": "birth", "retentionAlignmentType": "birth",
+        "retentionUnit": "day",
+        "retentionUnbounded": false, "retentionUnboundedMode": "none",
+        "behaviors": [
+          {"type": "event", "name": "Sign Up", "filters": [], "filtersDeterminer": "all"},
+          {"type": "event", "name": "Login", "filters": [], "filtersDeterminer": "all"}
+        ]
+      },
+      "measurement": {"math": "retention_rate", "retentionBucketIndex": 0, "retentionCumulative": false}
+    }],
+    "time": [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}],
+    "filter": [], "group": []
+  }
+}
+```
+
+### Retention-Specific Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `retentionType` | `"birth"` | `birth` = first-time users, `addiction` = any occurrence |
+| `retentionAlignmentType` | `"birth"` | `birth` = align to first event |
+| `retentionUnit` | `"day"` | Cohort interval: day, week, month |
+| `retentionUnbounded` | `false` | Allow unbounded windows |
+
+### Retention Math Types
+`unique`, `retention_rate`, `total`, `average`
+
+### Chart Types
+`retention-curve` (default), `line` (trend over time)
+
+---
+
+## Flows Params
+
+Flows use a **completely different flat structure** — no `sections` wrapper.
+
+```json
+{
+  "steps": [{
+    "event": "Product Viewed",
+    "forward": 3, "reverse": 0,
+    "bool_op": "and",
+    "property_filter_params_list": []
+  }],
+  "date_range": {
+    "type": "in the last",
+    "from_date": {"unit": "day", "value": 30},
+    "to_date": "$now", "exclusion_offset": null
+  },
+  "chartType": "sankey",
+  "flows_merge_type": "graph",
+  "count_type": "unique",
+  "cardinality_threshold": 10,
+  "version": 2,
+  "conversion_window": {"unit": "day", "value": 7},
+  "anchor_position": 1,
+  "alignment": [1, 0],
+  "collapse_repeated": false,
+  "show_custom_events": true,
+  "hidden_events": []
+}
+```
+
+### Step Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `event` | required | Event name |
+| `forward` | 0 | Hops to show AFTER this event (0-3) |
+| `reverse` | 0 | Hops to show BEFORE this event (0-3) |
+
+### Flows Date Range
+
+Relative:
+```json
+{"type": "in the last", "from_date": {"unit": "day", "value": 30}, "to_date": "$now", "exclusion_offset": null}
+```
+
+Absolute:
+```json
+{"type": "between", "from_date": "2024-01-01", "to_date": "2024-03-31", "exclusion_offset": null}
+```
+
+### Flows Inline Filters
+
+Different format from insights filters:
+```json
+{
+  "property_filter": {
+    "filter_type": "string", "filter_operator": "equals",
+    "filter_value": ["Chrome"], "property": "$browser",
+    "selected_property_type": "string"
+  }
+}
+```
+
+### Chart Types
+`sankey` (default Sankey diagram), `paths` (path list table)
+
+### Common Patterns
+- **What happens after Sign Up?** — `forward: 3, reverse: 0`
+- **What leads to Purchase?** — `forward: 0, reverse: 3`
+- **Bidirectional from key event** — `forward: 3, reverse: 2`
+
+---
+
+## Common System Properties
+
+| Property | Type | Resource | Description |
+|---|---|---|---|
+| `$browser` | string | events | Browser name |
+| `$city` | string | events | City |
+| `$country_code` | string | events | Country |
+| `$os` | string | events | Operating system |
+| `$device` | string | events | Device type |
+| `$referring_domain` | string | events | Referrer domain |
+| `$current_url` | string | events | Page URL |
+| `$name` | string | people | User display name |
+| `$email` | string | people | User email |
+| `$created` | datetime | people | User creation date |
+| `$last_seen` | datetime | people | Last activity |
+
+---
+
+## Python Integration
+
+### Create a Bookmark
+
+```python
+from mixpanel_data.types import CreateBookmarkParams
+
+bookmark = ws.create_bookmark(CreateBookmarkParams(
+    name="Weekly Signups by Platform",
+    bookmark_type="insights",
+    params={...},  # params dict as described above
+    description="Tracks signup volume segmented by platform",
+))
+print(f"Created bookmark {bookmark.id}: {bookmark.name}")
+```
+
+### Update Bookmark Params
+
+```python
+from mixpanel_data.types import UpdateBookmarkParams
+
+ws.update_bookmark(bookmark_id, UpdateBookmarkParams(
+    params={...},  # new params dict
+))
+```
+
+### Read Params from Existing Bookmark
+
+```python
+bookmark = ws.get_bookmark(bookmark_id)
+print(bookmark.params)       # the params dict
+print(bookmark.bookmark_type) # insights, funnels, retention, flows
+```
+
+### Query a Bookmark
+
+```python
+# Insights, funnels, retention
+result = ws.query_saved_report(bookmark_id)
+df = result.df
+
+# Flows
+result = ws.query_flows(bookmark_id)
+```
+
+## Constraints
+
+- **Funnels require 2+ steps** in `behavior.behaviors[]`
+- **Retention requires exactly 2 events** — born (index 0) and return (index 1)
+- **Flows do NOT use `sections`** — completely flat structure
+- **String filter values for `equals`/`does not equal` must be arrays**: `["Chrome"]` not `"Chrome"`
+- **`bar` gives aggregate totals; `line` gives time-series** — unique counts in `line` are NOT additive across periods
+- **When formulas exist**, set `isHidden: true` on raw metric show clauses
+- **Math types are context-dependent** — insights math != funnels math != retention math

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/code-patterns.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/code-patterns.md
@@ -17,7 +17,7 @@ top = ws.top_events(limit=20)
 print(f"Total events: {len(events)}")
 print("\nTop events by volume:")
 for t in top:
-    print(f"  {t.event:40s}")
+    print(f"  {t.event:40s} {t.count:>10,} ({t.percent_change:+.1f}%)")
 
 # Drill into an event
 event_name = top[0].event
@@ -359,11 +359,96 @@ if anomalies:
         print(f"  - {a}")
 ```
 
+## 13. Create Dashboard with Reports
+
+```python
+"""Create a Mixpanel dashboard and populate it with reports programmatically."""
+import mixpanel_data as mp
+from mixpanel_data.types import CreateDashboardParams, CreateBookmarkParams
+
+ws = mp.Workspace(account="myaccount")
+client = ws.api
+
+# Step 1: Create dashboard
+dashboard = ws.create_dashboard(CreateDashboardParams(
+    title="Monthly KPI Dashboard",
+    description="Key product metrics tracked monthly",
+))
+dash_id = dashboard.id
+
+# Step 2: Helper to build insights bookmark params
+def make_metric(event_name, math="total", filters=None):
+    return {
+        "behavior": {
+            "type": "simple",
+            "name": event_name,
+            "resourceType": "events",
+            "dataGroupId": None,
+            "filters": filters or [],
+            "behaviors": [{"type": "event", "id": None, "name": event_name, "filters": filters or []}],
+        },
+        "measurement": {"math": math, "perUserAggregation": None, "property": None},
+        "isHidden": False,
+        "type": "metric",
+    }
+
+def make_insights_params(metrics, chart_type="line", unit="month", value=180, group_by=None):
+    return {
+        "sections": {
+            "show": metrics,
+            "filter": [],
+            "formula": [],
+            "time": [{"unit": unit, "value": value}],
+            "group_by": group_by or [],
+            "group": [],
+        },
+        "displayOptions": {
+            "chartType": chart_type,
+            "plotStyle": "standard",
+            "analysis": "linear",
+            "value": "absolute",
+        },
+    }
+
+def make_group_by(prop_name):
+    return {"value": prop_name, "resourceType": "events", "propertyType": "string", "typeCast": None, "bucketing": None}
+
+# Step 3: Create bookmarks
+reports = [
+    ws.create_bookmark(CreateBookmarkParams(
+        name="Signups Trend",
+        bookmark_type="insights",
+        params=make_insights_params([make_metric("Sign Up", math="total")]),
+    )),
+    ws.create_bookmark(CreateBookmarkParams(
+        name="Signups by Platform",
+        bookmark_type="insights",
+        params=make_insights_params(
+            [make_metric("Sign Up")],
+            chart_type="bar",
+            group_by=[make_group_by("platform")],
+        ),
+    )),
+]
+
+# Step 4: Add each report to the dashboard
+# NOTE: CreateBookmarkParams(dashboard_id=...) does NOT populate the dashboard layout
+for report in reports:
+    ws.add_report_to_dashboard(dash_id, report.id)
+    print(f"Added: {report.name}")
+
+print(f"\nDashboard '{dashboard.title}' created with {len(reports)} reports (ID={dash_id})")
+```
+
 ## Tips
 
 - Always wrap `from_date`/`to_date` as strings: `"2025-01-01"` not `datetime`
+- `project_id` must be a **string**: `Workspace(project_id="8")` not `project_id=8`
 - Use `type="unique"` for user counts, `type="general"` for event counts
+- `TopEvent` has fields: `event` (str), `count` (int), `percent_change` (float) — no `rank`
+- `BookmarkInfo.type` is a plain string (e.g., `"insights"`), not an enum — use directly, not `.value`
 - JQL is best for user-level calculations that cross events
 - Use `help.py` to look up exact method signatures before writing
 - Start simple, add complexity only when initial results suggest it's needed
 - Print intermediate results to verify before building on them
+- When adding reports to dashboards, `source_bookmark_id` creates a clone ("Duplicate of ...") — edit the clone's name in Mixpanel UI if needed

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
@@ -10,8 +10,10 @@ import mixpanel_data as mp
 ws = mp.Workspace()                              # default account
 ws = mp.Workspace(account="prod")                # named account
 ws = mp.Workspace(workspace_id=12345)            # with workspace for App API
-ws = mp.Workspace(project_id=67890, region="eu") # explicit project
+ws = mp.Workspace(project_id="67890", region="eu") # explicit project — project_id is a STRING
 ```
+
+**Gotcha**: `project_id` must be a **string**, not an int. `Workspace(project_id=8)` raises `ValidationError`.
 
 ## Discovery
 
@@ -156,7 +158,36 @@ ws.unfavorite_dashboard(dashboard_id: int) -> None
 ws.pin_dashboard(dashboard_id: int) -> None
 ws.unpin_dashboard(dashboard_id: int) -> None
 ws.remove_report_from_dashboard(dashboard_id: int, report_id: int) -> None
+ws.add_report_to_dashboard(dashboard_id: int, bookmark_id: int) -> Dashboard
 ```
+
+**Gotchas**:
+- `CreateBookmarkParams(dashboard_id=X)` does **NOT** add the report to the dashboard layout — use `add_report_to_dashboard()` instead
+- `add_report_to_dashboard()` clones the bookmark, creating a "Duplicate of ..." copy on the dashboard
+- `finalize_blueprint()` only works on blueprint-created dashboards, not regular ones
+- Dashboard `layout` cannot be set via `update_dashboard()` PATCH (API rejects `order` and `version` keys)
+
+### Dashboard Layout Structure
+
+The `Dashboard.layout` field follows this format (read-only via API):
+
+```python
+{
+    "rows": {
+        "rowId1": {
+            "cells": [
+                {"id": "cellId", "width": 6, "content_id": 12345, "content_type": "report"},
+                {"id": "cellId", "width": 6, "content_id": 67890, "content_type": "report"},
+            ],
+            "height": 0,
+        },
+    },
+    "order": ["rowId1", ...],  # row display order
+    "version": "2.0.0",
+}
+```
+
+Width is a 12-column grid (6+6 = side by side, 12 = full width).
 
 ## Bookmark / Report CRUD
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
@@ -266,7 +266,7 @@ def show_fields(obj: type, indent: str = "") -> None:
             alias_info = ""
             resolved_alias = finfo.alias
             if resolved_alias is None and alias_gen and callable(alias_gen):
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(TypeError, ValueError, AttributeError):
                     resolved_alias = alias_gen(fname)
             if resolved_alias and resolved_alias != fname:
                 alias_info = f' (json: "{resolved_alias}")'

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
@@ -5,15 +5,23 @@ Usage:
     python help.py Workspace                    # List all Workspace methods
     python help.py Workspace.segmentation       # Method signature + docstring
     python help.py SegmentationResult           # Type/class documentation
+    python help.py FeatureFlagStatus            # Enum members + values
     python help.py types                        # List all public types
     python help.py exceptions                   # List all exceptions
 """
 
+import contextlib
 import dataclasses
+import enum
 import importlib
 import inspect
 import sys
 from typing import Any
+
+try:
+    from pydantic_core import PydanticUndefined
+except ImportError:
+    PydanticUndefined = None  # type: ignore[assignment,misc]
 
 
 def get_obj(path: str) -> Any:
@@ -26,6 +34,51 @@ def get_obj(path: str) -> Any:
     return obj
 
 
+def format_type(annotation: Any) -> str:
+    """Format a type annotation for clean display.
+
+    Args:
+        annotation: A type annotation (class, generic, union, etc.).
+
+    Returns:
+        Human-readable type string with noise removed.
+    """
+    if annotation is None or annotation is type(None):
+        return "None"
+    if hasattr(annotation, "__name__") and not hasattr(annotation, "__args__"):
+        return annotation.__name__
+    s = str(annotation)
+    s = s.replace("typing.", "").replace("typing_extensions.", "")
+    s = s.replace("<class '", "").replace("'>", "")
+    s = s.replace("NoneType", "None")
+    return s
+
+
+def _enum_values_inline(annotation: Any) -> str:
+    """Return inline enum member names if annotation contains an Enum type.
+
+    Args:
+        annotation: A type annotation to inspect.
+
+    Returns:
+        String like ' [ENABLED | DISABLED | ARCHIVED]' or empty string.
+    """
+    candidates: list[type] = []
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        candidates.append(annotation)
+    args = getattr(annotation, "__args__", None)
+    if args:
+        for arg in args:
+            if isinstance(arg, type) and issubclass(arg, enum.Enum):
+                candidates.append(arg)
+    if not candidates:
+        return ""
+    all_names: list[str] = []
+    for cls in candidates:
+        all_names.extend(m.name for m in cls)
+    return f" [{' | '.join(all_names)}]"
+
+
 def format_signature(obj: Any, name: str) -> str:
     """Format a callable's full signature with type annotations."""
     try:
@@ -36,10 +89,7 @@ def format_signature(obj: Any, name: str) -> str:
                 continue
             annotation = ""
             if param.annotation != inspect.Parameter.empty:
-                ann = param.annotation
-                annotation = (
-                    f": {ann.__name__}" if hasattr(ann, "__name__") else f": {ann}"
-                )
+                annotation = f": {format_type(param.annotation)}"
             default = ""
             if param.default != inspect.Parameter.empty:
                 default = f" = {param.default!r}"
@@ -47,8 +97,7 @@ def format_signature(obj: Any, name: str) -> str:
 
         ret = ""
         if sig.return_annotation != inspect.Signature.empty:
-            ra = sig.return_annotation
-            ret = f" -> {ra.__name__}" if hasattr(ra, "__name__") else f" -> {ra}"
+            ret = f" -> {format_type(sig.return_annotation)}"
 
         param_str = ",\n".join(params)
         if params:
@@ -58,8 +107,29 @@ def format_signature(obj: Any, name: str) -> str:
         return f"{name}(...)"
 
 
+def show_enum(obj: type, name: str) -> None:
+    """Display enum members with their values.
+
+    Args:
+        obj: An Enum subclass.
+        name: Display name for the enum.
+    """
+    members = list(obj)  # type: ignore[arg-type]
+    print(f"# {name} \u2014 {len(members)} members\n")
+    max_name_len = max((len(m.name) for m in members), default=0)
+    for member in members:
+        print(f"  {member.name:<{max_name_len}}  = {member.value!r}")
+    doc = inspect.getdoc(obj)
+    if doc:
+        print(f"\n{doc}")
+
+
 def list_members(obj: Any, name: str) -> None:
     """List public methods and properties of an object."""
+    if isinstance(obj, type) and issubclass(obj, enum.Enum):
+        show_enum(obj, name)
+        return
+
     members: list[tuple[str, str]] = []
     for attr_name in sorted(dir(obj)):
         if attr_name.startswith("_"):
@@ -80,7 +150,7 @@ def list_members(obj: Any, name: str) -> None:
         elif callable(attr):
             members.append((attr_name, first_line))
 
-    print(f"# {name} — {len(members)} public members\n")
+    print(f"# {name} \u2014 {len(members)} public members\n")
     for mname, desc in members:
         print(f"  {mname:42s} {desc}")
 
@@ -102,7 +172,7 @@ def list_types() -> None:
             first_line = doc.split("\n")[0] if doc else ""
             types_list.append((name, first_line))
 
-    print(f"# mixpanel_data — {len(types_list)} public types\n")
+    print(f"# mixpanel_data \u2014 {len(types_list)} public types\n")
     for name, desc in types_list:
         print(f"  {name:45s} {desc}")
 
@@ -118,17 +188,22 @@ def list_exceptions() -> None:
             first_line = doc.split("\n")[0] if doc else ""
             excs.append((name, first_line))
 
-    print(f"# mixpanel_data — {len(excs)} exception types\n")
+    print(f"# mixpanel_data \u2014 {len(excs)} exception types\n")
     for name, desc in excs:
         print(f"  {name:35s} {desc}")
 
 
 def show_fields(obj: type, indent: str = "") -> None:
-    """Show fields for dataclasses or Pydantic models."""
+    """Show fields for dataclasses or Pydantic models.
+
+    Args:
+        obj: A dataclass or Pydantic BaseModel class.
+        indent: Prefix for indentation.
+    """
     if hasattr(obj, "__dataclass_fields__"):
         print(f"\n{indent}Fields:")
         for fname, field in obj.__dataclass_fields__.items():
-            ftype = field.type if hasattr(field, "type") else "?"
+            ftype = format_type(field.type) if hasattr(field, "type") else "?"
             default = ""
             try:
                 if field.default is not dataclasses.MISSING:
@@ -142,23 +217,153 @@ def show_fields(obj: type, indent: str = "") -> None:
                 pass
             print(f"{indent}  {fname}: {ftype}{default}")
     elif hasattr(obj, "model_fields"):
+        # Resolve alias generator from model config
+        config = getattr(obj, "model_config", {})
+        alias_gen = config.get("alias_generator")
+
         print(f"\n{indent}Fields:")
         for fname, finfo in obj.model_fields.items():
-            required = " (required)" if finfo.is_required() else ""
-            default = ""
-            if not finfo.is_required() and finfo.default is not None:
+            type_str = format_type(finfo.annotation)
+            enum_inline = _enum_values_inline(finfo.annotation)
+
+            # Default value handling (fix PydanticUndefined leak)
+            if finfo.is_required():
+                default = " (required)"
+            elif PydanticUndefined is not None and finfo.default is PydanticUndefined:
+                if finfo.default_factory is not None:
+                    factory_name = getattr(finfo.default_factory, "__name__", "factory")
+                    default = f" = <factory {factory_name}>"
+                else:
+                    default = " (required)"
+            elif finfo.default is None:
+                default = ""
+            else:
                 default = f" = {finfo.default!r}"
-            print(f"{indent}  {fname}: {finfo.annotation}{required}{default}")
+
+            # Field constraints from metadata
+            constraints = ""
+            if finfo.metadata:
+                constraint_parts: list[str] = []
+                for meta in finfo.metadata:
+                    for attr in (
+                        "max_length",
+                        "min_length",
+                        "ge",
+                        "le",
+                        "gt",
+                        "lt",
+                        "multiple_of",
+                        "pattern",
+                    ):
+                        val = getattr(meta, attr, None)
+                        if val is not None:
+                            constraint_parts.append(f"{attr}={val}")
+                if constraint_parts:
+                    constraints = f" ({', '.join(constraint_parts)})"
+
+            # Alias resolution
+            alias_info = ""
+            resolved_alias = finfo.alias
+            if resolved_alias is None and alias_gen and callable(alias_gen):
+                with contextlib.suppress(Exception):
+                    resolved_alias = alias_gen(fname)
+            if resolved_alias and resolved_alias != fname:
+                alias_info = f' (json: "{resolved_alias}")'
+
+            print(
+                f"{indent}  {fname}: "
+                f"{type_str}{enum_inline}{default}{constraints}{alias_info}"
+            )
+
+
+def show_model_config(obj: type) -> None:
+    """Show non-default Pydantic model config values.
+
+    Args:
+        obj: A Pydantic BaseModel subclass.
+    """
+    config = getattr(obj, "model_config", None)
+    if not config:
+        return
+    defaults = {
+        "frozen": False,
+        "extra": "ignore",
+        "populate_by_name": False,
+    }
+    parts: list[str] = []
+    for key, default_val in defaults.items():
+        val = config.get(key)
+        if val is not None and val != default_val:
+            parts.append(f"{key}={val!r}")
+    ag = config.get("alias_generator")
+    if ag is not None:
+        gen_name = getattr(ag, "__name__", str(ag))
+        parts.append(f"alias_generator={gen_name}")
+    if parts:
+        print(f"  Config: {', '.join(parts)}")
+
+
+def show_related(type_name: str) -> None:
+    """Show Workspace methods that reference the given type.
+
+    Args:
+        type_name: Simple class name to search for in method signatures.
+    """
+    mod = importlib.import_module("mixpanel_data")
+    ws_cls = getattr(mod, "Workspace", None)
+    if ws_cls is None:
+        return
+
+    matches: list[str] = []
+    for attr_name in sorted(dir(ws_cls)):
+        if attr_name.startswith("_"):
+            continue
+        attr = getattr(ws_cls, attr_name, None)
+        if not callable(attr) or isinstance(attr, property):
+            continue
+        try:
+            sig = inspect.signature(attr)
+        except (ValueError, TypeError):
+            continue
+
+        if type_name not in str(sig):
+            continue
+
+        ret = ""
+        if sig.return_annotation != inspect.Signature.empty:
+            ret = f" -> {format_type(sig.return_annotation)}"
+        param_parts: list[str] = []
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            if param.annotation != inspect.Parameter.empty:
+                param_parts.append(f"{pname}: {format_type(param.annotation)}")
+            else:
+                param_parts.append(pname)
+        params_str = ", ".join(param_parts)
+        matches.append(f"  {attr_name}({params_str}){ret}")
+
+    if matches:
+        print(f"\nUsed by Workspace ({len(matches)} methods):")
+        for m in matches:
+            print(m)
 
 
 def show_detail(obj: Any, path: str) -> None:
     """Show detailed documentation for a specific object."""
+    if isinstance(obj, type) and issubclass(obj, enum.Enum):
+        show_enum(obj, path)
+        show_related(path.split(".")[-1])
+        return
+
     if isinstance(obj, type):
         print(f"class {path}")
-        # Show base classes
         bases = [b.__name__ for b in obj.__mro__[1:] if b.__name__ != "object"]
         if bases:
-            print(f"  Inherits: {' → '.join(bases)}")
+            arrow = " \u2192 "
+            print(f"  Inherits: {arrow.join(bases)}")
+        if hasattr(obj, "model_config"):
+            show_model_config(obj)
         show_fields(obj)
     elif callable(obj):
         print(format_signature(obj, path))
@@ -171,8 +376,12 @@ def show_detail(obj: Any, path: str) -> None:
     else:
         print("\n(no docstring)")
 
+    if isinstance(obj, type) and path.split(".")[-1] != "Workspace":
+        show_related(path.split(".")[-1])
+
 
 def main() -> None:
+    """Entry point for the help script."""
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(0)
@@ -193,8 +402,10 @@ def main() -> None:
     elif "." not in query:
         try:
             obj = get_obj(query)
-            if isinstance(obj, type):
-                # For types with fields, show detail; for Workspace, list methods
+            if isinstance(obj, type) and issubclass(obj, enum.Enum):
+                show_enum(obj, query)
+                show_related(query)
+            elif isinstance(obj, type):
                 if hasattr(obj, "model_fields") or hasattr(obj, "__dataclass_fields__"):
                     show_detail(obj, query)
                 else:
@@ -204,7 +415,8 @@ def main() -> None:
         except AttributeError:
             print(f"Error: '{query}' not found in mixpanel_data")
             print(
-                "Try: Workspace, types, exceptions, or a dotted path like Workspace.segmentation"
+                "Try: Workspace, types, exceptions, or a dotted path"
+                " like Workspace.segmentation"
             )
             sys.exit(1)
     else:

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
@@ -16,6 +16,7 @@ import enum
 import importlib
 import inspect
 import sys
+from pathlib import Path
 from typing import Any
 
 try:
@@ -349,6 +350,37 @@ def show_related(type_name: str) -> None:
             print(m)
 
 
+_BOOKMARK_RELATED = frozenset(
+    {
+        "query_saved_report",
+        "query_flows",
+        "SavedReportResult",
+        "SavedReportType",
+        "FlowsResult",
+    }
+)
+
+
+def _maybe_show_bookmark_hint(query: str) -> None:
+    """Print a reference hint if the query relates to bookmarks.
+
+    Args:
+        query: The user's help query string.
+    """
+    parts = query.replace(".", " ").split()
+    if "bookmark" not in query.lower() and not (set(parts) & _BOOKMARK_RELATED):
+        return
+    ref = Path(__file__).resolve().parent.parent / "references" / "bookmark-params.md"
+    if not ref.is_file():
+        return
+    print(
+        "\n---\n"
+        "Tip: For bookmark params JSON schema, "
+        "read references/bookmark-params.md "
+        "(SQL-to-JSON query translation guide)"
+    )
+
+
 def show_detail(obj: Any, path: str) -> None:
     """Show detailed documentation for a specific object."""
     if isinstance(obj, type) and issubclass(obj, enum.Enum):
@@ -434,6 +466,9 @@ def main() -> None:
                 except AttributeError:
                     pass
             sys.exit(1)
+
+    if query not in ("types", "exceptions"):
+        _maybe_show_bookmark_hint(query)
 
 
 if __name__ == "__main__":

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/schemas/README.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/schemas/README.md
@@ -1,0 +1,2 @@
+Vendored copy of the canonical Mixpanel bookmark params JSON Schema.
+To update: re-vendor from the internal source.

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/schemas/bookmark.json
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/schemas/bookmark.json
@@ -1,0 +1,4778 @@
+{
+    "additionalProperties": false,
+    "properties": {
+        "columnWidths": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ColumnWidths"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "displayOptions": {
+            "$ref": "#/definitions/DisplayOptions"
+        },
+        "forecastComparison": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ForecastComparison"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "legend": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/InsightsLegend"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "liftComparison": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/LiftComparison"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "name": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "sections": {
+            "$ref": "#/definitions/Sections"
+        },
+        "sorting": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/InsightsBookmarkSortConfig"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "timeComparison": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/JsonValue"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "versions": {
+            "anyOf": [
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        },
+        "executedMigrations": {
+            "anyOf": [
+                {
+                    "items": {
+                        "$ref": "#/definitions/ExecutedMigration"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": ""
+        }
+    },
+    "required": [
+        "displayOptions",
+        "sections"
+    ],
+    "title": "InsightsBookmarkParams",
+    "type": "object",
+    "definitions": {
+        "AnalysisType": {
+            "enum": [
+                "linear",
+                "logarithmic",
+                "rolling",
+                "cumulative"
+            ],
+            "title": "AnalysisType",
+            "tsEnumNames": [
+                "Linear",
+                "Logarithmic",
+                "Rolling",
+                "Cumulative"
+            ],
+            "type": "string"
+        },
+        "AnnotationOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "tagFilterIds": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "integer"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "showUntagged": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "sortOrder": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortOrderType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "hideAnnotations": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "creatorFilterIds": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "integer"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "AnnotationOptions",
+            "type": "object"
+        },
+        "AxisAssignment": {
+            "enum": [
+                "primary",
+                "secondary"
+            ],
+            "title": "AxisAssignment",
+            "tsEnumNames": [
+                "Primary",
+                "Secondary"
+            ],
+            "type": "string"
+        },
+        "BaseTimeUnit": {
+            "enum": [
+                "hour",
+                "day",
+                "week",
+                "month"
+            ],
+            "title": "BaseTimeUnit",
+            "tsEnumNames": [
+                "Hour",
+                "Day",
+                "Week",
+                "Month"
+            ],
+            "type": "string"
+        },
+        "Behavior": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "renamed": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dataGroupId": {
+                    "$ref": "#/definitions/DataGroupId",
+                    "default": null,
+                    "title": ""
+                },
+                "filters": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filtersDeterminer": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FiltersDeterminer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "resourceType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/InsightsResourceType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "behaviors": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/SubBehavior"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": ""
+                },
+                "raw_cohort": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customBucket": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Bucket"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "conversionWindowDuration": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "conversionWindowUnit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ConversionWindowUnit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "funnelReentryMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FunnelReentryModeType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "funnelOrder": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FunnelOrder"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "exclusions": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/ExclusionFunnelStep"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "aggregateBy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RetentionType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionAlignmentType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RetentionAlignmentType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionUnit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TimeUnit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionUnbounded": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionUnboundedMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RetentionUnboundedModeType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionCustomBucketSizes": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "integer"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "segmentationEvent": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "unsavedId": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "search": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "profileType": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dataset": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "datasetId": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "projectId": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "display": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricDisplay"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "disableCohortize": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customEventSet": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "hasUnsavedChanges": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": false,
+                    "title": ""
+                }
+            },
+            "title": "Behavior",
+            "type": "object"
+        },
+        "BehaviorMeasurement": {
+            "additionalProperties": false,
+            "properties": {
+                "dataGroupId": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataGroupId"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "math": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MATH_TYPE"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "property": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "cumulative": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "perUserAggregation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PER_USER_AGGREGATIONS"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "rolling": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RollingMeasurement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "segmentMethod": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/COUNT_USERS_ONCE_TYPE"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "multiAttribution": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PredefinedMultiAttribution"
+                        },
+                        {
+                            "$ref": "#/definitions/CustomMultiAttribution"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "stepIndex": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "actionMode": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "actionStep": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionBucketIndex": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionCumulative": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retentionSegmentationEvent": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "percentile": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "BehaviorMeasurement",
+            "type": "object"
+        },
+        "BehaviorShowClause": {
+            "additionalProperties": false,
+            "properties": {
+                "_idx": {
+                    "default": null,
+                    "title": "",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "metric",
+                    "default": null,
+                    "title": "",
+                    "tsType": "TopLevelMetricType.Metric",
+                    "type": "string"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "userNamed": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "behavior": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Behavior"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "measurement": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BehaviorMeasurement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "statsig": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Statsig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "srm": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SRM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "comparisons": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": ""
+                },
+                "display": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricDisplay"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isHidden": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isExpanded": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "labelPrefix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "formulaLabel": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "showClauseIndex": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "hasUnsavedChanges": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": false,
+                    "title": ""
+                },
+                "goals": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/Goal"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "overrides": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "BehaviorShowClause",
+            "type": "object"
+        },
+        "Bucket": {
+            "additionalProperties": false,
+            "properties": {
+                "bucketSize": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "disabled": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "groups": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "number"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "max": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "min": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "offset": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "unit": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "Bucket",
+            "type": "object"
+        },
+        "COUNT_USERS_ONCE_TYPE": {
+            "enum": [
+                "all",
+                "first",
+                "last"
+            ],
+            "title": "COUNT_USERS_ONCE_TYPE",
+            "tsEnumNames": [
+                "MULTIPLE",
+                "FIRST",
+                "LAST"
+            ],
+            "type": "string"
+        },
+        "ChartPlotStyle": {
+            "enum": [
+                "standard",
+                "stacked"
+            ],
+            "title": "ChartPlotStyle",
+            "tsEnumNames": [
+                "Standard",
+                "Stacked"
+            ],
+            "type": "string"
+        },
+        "ChartType": {
+            "enum": [
+                "bar",
+                "line",
+                "pie",
+                "bar-stacked",
+                "stacked-line",
+                "table",
+                "insights-metric",
+                "column",
+                "stacked-column",
+                "metric",
+                "sankey",
+                "flows",
+                "paths",
+                "funnel-top-paths",
+                "funnel-steps",
+                "funnel-steps-metric",
+                "funnel-trend",
+                "funnel-frequency-line",
+                "funnel-frequency-bar",
+                "funnel-ttc-line",
+                "funnel-ttc-bar",
+                "funnel-median-ttc",
+                "line-retention",
+                "retention-trend",
+                "retention-trend-metric",
+                "retention-table",
+                "retention-curve",
+                "frequency",
+                "impact-adoption",
+                "impact-trends",
+                "impact-propensity"
+            ],
+            "title": "ChartType",
+            "tsEnumNames": [
+                "Bar",
+                "Line",
+                "Pie",
+                "StackedBar",
+                "StackedLine",
+                "Table",
+                "Metric",
+                "Column",
+                "StackedColumn",
+                "LegacyMetric",
+                "Sankey",
+                "Flows",
+                "FlowsTopPaths",
+                "FunnelTopPaths",
+                "FunnelSteps",
+                "FunnelStepsMetric",
+                "FunnelTrend",
+                "FunnelFrequencyLine",
+                "FunnelFrequencyBar",
+                "FunnelTTCLine",
+                "FunnelTTCBar",
+                "FunnelMedianTTC",
+                "RetentionLine",
+                "RetentionTrend",
+                "RetentionTrendMetric",
+                "RetentionTable",
+                "RetentionCurve",
+                "Frequency",
+                "ImpactAdoption",
+                "ImpactTrends",
+                "ImpactPropensity"
+            ],
+            "type": "string"
+        },
+        "ColumnWidths": {
+            "additionalProperties": true,
+            "properties": {
+                "bar": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dataTable": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataTableColumnWidthOverrides"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "ColumnWidths",
+            "type": "object"
+        },
+        "CommentOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "commentsDisabled": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "CommentOptions",
+            "type": "object"
+        },
+        "ConversionWindowUnit": {
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "session"
+            ],
+            "title": "ConversionWindowUnit",
+            "tsEnumNames": [
+                "Second",
+                "Minute",
+                "Hour",
+                "Day",
+                "Week",
+                "Month",
+                "Session"
+            ],
+            "type": "string"
+        },
+        "CustomMultiAttribution": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/MultiAttributionType",
+                    "tsType": "MultiAttributionType.Custom"
+                },
+                "name": {
+                    "title": "",
+                    "type": "string"
+                },
+                "weights": {
+                    "$ref": "#/definitions/MultiAttributionWeights"
+                }
+            },
+            "required": [
+                "type",
+                "name",
+                "weights"
+            ],
+            "title": "CustomMultiAttribution",
+            "type": "object"
+        },
+        "DataGroupId": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "DataTableColumnWidthOverrides": {
+            "additionalProperties": false,
+            "properties": {
+                "report": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dashboard": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "DataTableColumnWidthOverrides",
+            "type": "object"
+        },
+        "DisplayOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "chartType": {
+                    "$ref": "#/definitions/ChartType",
+                    "title": "InsightsChartType",
+                    "tsType": "ChartType.Bar | ChartType.Line | ChartType.Column | ChartType.Pie | ChartType.Table | ChartType.Metric | ChartType.FunnelSteps | ChartType.FunnelTopPaths | ChartType.RetentionCurve"
+                },
+                "plotStyle": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ChartPlotStyle"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "analysis": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AnalysisType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueRepresentationType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "rollingWindowSize": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "timeUnit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TimeUnit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "primaryYAxisOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "secondaryYAxisOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "theme": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "xAxisOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "annotationOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AnnotationOptions"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "commentOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CommentOptions"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "queryTimeSampling": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "statSigControl": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/SegmentId"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "funnelStepsSelectedTableColumns": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FunnelStepsSelectedTableColumns"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "chartType"
+            ],
+            "title": "DisplayOptions",
+            "type": "object"
+        },
+        "ExclusionFunnelStep": {
+            "additionalProperties": false,
+            "properties": {
+                "bool_op": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FiltersOperator"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "property_filter_params_list": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "event": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "event_id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "custom_event": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "custom_event_name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "step_label": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "session_event": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/START_END_TYPE"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "forward": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "reverse": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "steps": {
+                    "$ref": "#/definitions/StepRange"
+                }
+            },
+            "required": [
+                "steps"
+            ],
+            "title": "ExclusionFunnelStep",
+            "type": "object"
+        },
+        "ExecutedMigration": {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "title": "",
+                    "type": "string"
+                },
+                "succeeded": {
+                    "title": "",
+                    "type": "boolean"
+                },
+                "version": {
+                    "title": "",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "succeeded",
+                "version"
+            ],
+            "title": "ExecutedMigration",
+            "type": "object"
+        },
+        "ExtendedTimeUnit": {
+            "enum": [
+                "second",
+                "minute",
+                "quarter",
+                "year"
+            ],
+            "title": "ExtendedTimeUnit",
+            "tsEnumNames": [
+                "Second",
+                "Minute",
+                "Quarter",
+                "Year"
+            ],
+            "type": "string"
+        },
+        "FUNNELS_MATH_TYPES": {
+            "enum": [
+                "general",
+                "unique",
+                "session",
+                "conversion_rate",
+                "conversion_rate_unique",
+                "conversion_rate_total",
+                "conversion_rate_session",
+                "total"
+            ],
+            "title": "FUNNELS_MATH_TYPES",
+            "tsEnumNames": [
+                "GENERAL",
+                "UNIQUE",
+                "SESSION",
+                "CONVERSION_RATE",
+                "CONVERSION_RATE_UNIQUE",
+                "CONVERSION_RATE_TOTAL",
+                "CONVERSION_RATE_SESSION",
+                "PROPERTY_SUM"
+            ],
+            "type": "string"
+        },
+        "FilteredBreakdownSegments": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/SavedLegend"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/SavedLegend"
+                    },
+                    "type": "array"
+                }
+            ]
+        },
+        "FiltersDeterminer": {
+            "enum": [
+                "all",
+                "any"
+            ],
+            "title": "FiltersDeterminer",
+            "type": "string"
+        },
+        "FiltersOperator": {
+            "enum": [
+                "and",
+                "or",
+                "or_all",
+                "and_any",
+                "then"
+            ],
+            "title": "FiltersOperator",
+            "tsEnumNames": [
+                "And",
+                "Or",
+                "OrAll",
+                "AndAny",
+                "Then"
+            ],
+            "type": "string"
+        },
+        "FlatLabelSortConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "sortBy": {
+                    "const": "label",
+                    "title": "",
+                    "tsType": "SortBy.Label",
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "$ref": "#/definitions/SortOrder"
+                },
+                "valueField": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "viewNLimit": {
+                    "$ref": "#/definitions/ViewNLimit",
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "sortBy",
+                "sortOrder"
+            ],
+            "title": "FlatLabelSortConfig",
+            "type": "object"
+        },
+        "FlatOrColumnSortConfig": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/FlatSortConfig"
+                },
+                {
+                    "$ref": "#/definitions/SortConfig"
+                }
+            ]
+        },
+        "FlatSortConfig": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/FlatLabelSortConfig"
+                },
+                {
+                    "$ref": "#/definitions/FlatValueSortConfig"
+                }
+            ]
+        },
+        "FlatValueSortConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "sortBy": {
+                    "enum": [
+                        "value",
+                        "liftComparisonValue"
+                    ],
+                    "title": "",
+                    "tsType": "SortBy.Value",
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "$ref": "#/definitions/SortOrder"
+                },
+                "valueField": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "valueField required when sorting by value (sortBy.Value) and there is > 1 valueField. Used for data tables.",
+                    "title": ""
+                },
+                "viewNLimit": {
+                    "$ref": "#/definitions/ViewNLimit",
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "sortBy",
+                "sortOrder"
+            ],
+            "title": "FlatValueSortConfig",
+            "type": "object"
+        },
+        "ForecastComparison": {
+            "additionalProperties": false,
+            "properties": {
+                "confidence": {
+                    "title": "",
+                    "type": "number"
+                },
+                "trainingMode": {
+                    "title": "",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "confidence",
+                "trainingMode"
+            ],
+            "title": "ForecastComparison",
+            "type": "object"
+        },
+        "FormulaClause": {
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "title": "",
+                    "type": "string"
+                },
+                "label": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "title": "FormulaClause",
+            "type": "object"
+        },
+        "FormulaMeasurement": {
+            "additionalProperties": false,
+            "properties": {
+                "cumulative": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "rolling": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RollingMeasurement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "multiAttribution": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PredefinedMultiAttribution"
+                        },
+                        {
+                            "$ref": "#/definitions/CustomMultiAttribution"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "FormulaMeasurement",
+            "type": "object"
+        },
+        "FormulaShowClause": {
+            "additionalProperties": false,
+            "properties": {
+                "_idx": {
+                    "default": null,
+                    "title": "",
+                    "type": "string"
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "const": "formula",
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "",
+                    "tsType": "TopLevelMetricType.Formula"
+                },
+                "formula": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "measurement": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FormulaMeasurement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "statsig": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Statsig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "display": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricDisplay"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isHidden": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isExpanded": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "userNamed": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "comparisons": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": ""
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "definition": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "referencedMetrics": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/BehaviorShowClause"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "hasUnsavedChanges": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": false,
+                    "title": ""
+                },
+                "overrides": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "goals": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/Goal"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "FormulaShowClause",
+            "type": "object"
+        },
+        "FunnelOrder": {
+            "enum": [
+                "loose",
+                "any"
+            ],
+            "title": "FunnelOrder",
+            "tsEnumNames": [
+                "Loose",
+                "Any"
+            ],
+            "type": "string"
+        },
+        "FunnelReentryModeType": {
+            "enum": [
+                "default",
+                "basic",
+                "aggressive",
+                "optimized"
+            ],
+            "title": "FunnelReentryModeType",
+            "tsEnumNames": [
+                "Default",
+                "Basic",
+                "Aggressive",
+                "Optimized"
+            ],
+            "type": "string"
+        },
+        "FunnelStepsSelectedTableColumns": {
+            "additionalProperties": false,
+            "properties": {
+                "conv-first-step": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                },
+                "conv-prev-step": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                },
+                "count": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                },
+                "stat-sig": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                },
+                "time-first-step": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                },
+                "time-prev-step": {
+                    "default": false,
+                    "title": "",
+                    "type": "boolean"
+                }
+            },
+            "title": "FunnelStepsSelectedTableColumns",
+            "type": "object"
+        },
+        "Goal": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "title": "",
+                    "type": "string"
+                },
+                "label": {
+                    "title": "",
+                    "type": "string"
+                },
+                "checkpoints": {
+                    "items": {
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ],
+                        "type": "array"
+                    },
+                    "title": "",
+                    "type": "array"
+                },
+                "target_type": {
+                    "default": "absolute",
+                    "enum": [
+                        "absolute",
+                        "relative"
+                    ],
+                    "title": "",
+                    "type": "string"
+                },
+                "target_input": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "unit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "direction": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "id",
+                "label",
+                "checkpoints"
+            ],
+            "title": "Goal",
+            "type": "object"
+        },
+        "GroupByCohort": {
+            "additionalProperties": false,
+            "properties": {
+                "count": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "created_by": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dataset": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "data_group_id": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataGroupId"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "description": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "groups": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "is_locked": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "is_visible": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isInherited": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "last_edited": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "negated": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "raw_cohort": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "resourceType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/InsightsResourceType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "GroupByCohort",
+            "type": "object"
+        },
+        "GroupClause": {
+            "additionalProperties": false,
+            "properties": {
+                "behavior": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "cohorts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/GroupByCohort"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customBucket": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Bucket"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customGroups": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customProperty": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customPropertyId": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "dataGroupId": {
+                    "$ref": "#/definitions/DataGroupId",
+                    "default": null,
+                    "title": ""
+                },
+                "dataset": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "datasetId": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "defaultType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "editing": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "endStepNumber": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "experiments": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filterDateUnit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TimeUnit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filterJoinType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filterOperator": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filterType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filterValue": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/JsonValue"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isHidden": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "isInherited": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "joinPropertyType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "listItemGroup": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "listQuantifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ListQuantifier"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "profileHistoryOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "profileType": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "projectId": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "propertyDefaultType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "propertyFilter": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "propertyName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "propertyObjectKey": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "propertyType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "resourceType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/InsightsResourceType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "scdEvent": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "scdOptions": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "search": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "startStepNumber": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "tempDataGroupId": {
+                    "$ref": "#/definitions/DataGroupId",
+                    "default": null,
+                    "title": ""
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/InsightsResourceType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "typeCast": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PropertyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "unit": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "GroupClause",
+            "type": "object"
+        },
+        "InsightsBookmarkSortConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "bar": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/OldTableSortByValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "line": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FlatOrColumnSortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "In the bookmark, line chart can either have the old FlatSortConfig or the new SortConfig format",
+                    "title": ""
+                },
+                "insights-metric": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "pie": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "retention-curve": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Retention specific",
+                    "title": ""
+                },
+                "funnel-steps": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "InsightsBookmarkSortConfig",
+            "type": "object"
+        },
+        "InsightsLegend": {
+            "additionalProperties": false,
+            "properties": {
+                "individualSelectedSegments": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SavedLegend"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "used for flat data, entire selected segments",
+                    "title": ""
+                },
+                "filteredBreakdownSegments": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FilteredBreakdownSegments"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "used for nested (bar chart) data, filtered segments at each level",
+                    "title": ""
+                },
+                "overrides": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/LegendOverride"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "used for specifying label or color overrides on specific segments",
+                    "title": "LegendOverrides"
+                }
+            },
+            "title": "InsightsLegend",
+            "type": "object"
+        },
+        "InsightsResourceType": {
+            "enum": [
+                "all",
+                "cohort",
+                "cohorts",
+                "event",
+                "events",
+                "formulas",
+                "other",
+                "people",
+                "user"
+            ],
+            "title": "InsightsResourceType",
+            "tsEnumNames": [
+                "All",
+                "Cohort",
+                "Cohorts",
+                "Event",
+                "Events",
+                "Formulas",
+                "Other",
+                "People",
+                "User"
+            ],
+            "type": "string"
+        },
+        "JsonValue": {},
+        "LegendOverride": {
+            "additionalProperties": false,
+            "properties": {
+                "color": {
+                    "title": "",
+                    "type": "string"
+                },
+                "label": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "color"
+            ],
+            "title": "LegendOverride",
+            "type": "object"
+        },
+        "LiftComparison": {
+            "additionalProperties": false,
+            "properties": {
+                "cohort": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "comparisonProperty": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "groupValue": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "type": {
+                    "$ref": "#/definitions/LiftType"
+                },
+                "controlVariant": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "title": "LiftComparison",
+            "type": "object"
+        },
+        "LiftType": {
+            "enum": [
+                "percentOverall",
+                "segment",
+                "timeComparison",
+                "experiment"
+            ],
+            "title": "LiftType",
+            "tsEnumNames": [
+                "Overall",
+                "Segment",
+                "Time",
+                "Experiment"
+            ],
+            "type": "string"
+        },
+        "ListQuantifier": {
+            "enum": [
+                "any",
+                "all",
+                "flatten"
+            ],
+            "title": "ListQuantifier",
+            "tsEnumNames": [
+                "Any",
+                "All",
+                "Flatten"
+            ],
+            "type": "string"
+        },
+        "MATH_TYPE": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/PRIMITIVE_MATH_TYPES"
+                },
+                {
+                    "$ref": "#/definitions/NUMERIC_MATH_TYPES"
+                },
+                {
+                    "$ref": "#/definitions/XAU_MATH_TYPES"
+                },
+                {
+                    "$ref": "#/definitions/PER_USER_AGGREGATIONS"
+                },
+                {
+                    "$ref": "#/definitions/FUNNELS_MATH_TYPES"
+                },
+                {
+                    "$ref": "#/definitions/RETENTION_MATH_TYPES"
+                }
+            ]
+        },
+        "MetricDisplay": {
+            "additionalProperties": false,
+            "properties": {
+                "abbrev": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "axis": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AxisAssignment"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "direction": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "up",
+                                "down"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "hideTrendline": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "precision": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8
+                            ],
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "prefix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "suffix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "trendline": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "MetricDisplay",
+            "type": "object"
+        },
+        "MetricType": {
+            "enum": [
+                "cohort",
+                "custom-event",
+                "event",
+                "formula",
+                "funnel",
+                "people",
+                "retention",
+                "retention-frequency",
+                "saved-metric",
+                "simple",
+                "verified"
+            ],
+            "title": "MetricType",
+            "tsEnumNames": [
+                "Cohort",
+                "CustomEvent",
+                "Event",
+                "Formula",
+                "Funnel",
+                "People",
+                "Retention",
+                "RetentionFrequency",
+                "SavedMetric",
+                "Simple",
+                "Verified"
+            ],
+            "type": "string"
+        },
+        "MultiAttributionType": {
+            "enum": [
+                "first_touch",
+                "last_touch",
+                "linear",
+                "participation",
+                "time_decay",
+                "u_shaped",
+                "j_shaped",
+                "inverse_j_shaped",
+                "custom",
+                "session_replay_last"
+            ],
+            "title": "MultiAttributionType",
+            "tsEnumNames": [
+                "FirstTouch",
+                "LastTouch",
+                "Linear",
+                "Participation",
+                "TimeDecay",
+                "UShaped",
+                "JShaped",
+                "InverseJShaped",
+                "Custom",
+                "SessionReplayLast"
+            ],
+            "type": "string"
+        },
+        "MultiAttributionWeights": {
+            "additionalProperties": false,
+            "properties": {
+                "first": {
+                    "title": "",
+                    "type": "integer"
+                },
+                "middle": {
+                    "title": "",
+                    "type": "integer"
+                },
+                "last": {
+                    "title": "",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "first",
+                "middle",
+                "last"
+            ],
+            "title": "MultiAttributionWeights",
+            "type": "object"
+        },
+        "NUMERIC_MATH_TYPES": {
+            "enum": [
+                "p25",
+                "p75",
+                "p90",
+                "p99"
+            ],
+            "title": "NUMERIC_MATH_TYPES",
+            "tsEnumNames": [
+                "P25",
+                "P75",
+                "P90",
+                "P99"
+            ],
+            "type": "string"
+        },
+        "NonStandardTimeUnit": {
+            "enum": [
+                "session"
+            ],
+            "title": "NonStandardTimeUnit",
+            "tsEnumNames": [
+                "Session"
+            ],
+            "type": "string"
+        },
+        "OldTableSortByValue": {
+            "additionalProperties": false,
+            "description": "Same as SortByValueConfig except:\n1) sortColumn instead of valueField\n2) colSortAttrs can only be FlatLabelSortConfig, not FlatValueSortConfig\n\nMust convert this for use with data-table",
+            "properties": {
+                "sortBy": {
+                    "const": "value",
+                    "title": "",
+                    "tsType": "SortBy.Value",
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "$ref": "#/definitions/SortOrder"
+                },
+                "sortColumn": {
+                    "$ref": "#/definitions/SortColumn"
+                },
+                "colSortAttrs": {
+                    "items": {
+                        "$ref": "#/definitions/FlatSortConfig"
+                    },
+                    "title": "",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "sortBy",
+                "sortOrder",
+                "sortColumn",
+                "colSortAttrs"
+            ],
+            "title": "OldTableSortByValue",
+            "type": "object"
+        },
+        "PER_USER_AGGREGATIONS": {
+            "description": "only a subset of operations are valid for per user aggregations, keep this enum separate",
+            "enum": [
+                "total",
+                "average",
+                "min",
+                "max",
+                "unique_values",
+                "session_replay_id_value"
+            ],
+            "title": "PER_USER_AGGREGATIONS",
+            "tsEnumNames": [
+                "TOTAL",
+                "AVERAGE",
+                "MIN",
+                "MAX",
+                "UNIQUE_VALUES",
+                "SESSION_REPLAY_ID_VALUE"
+            ],
+            "type": "string"
+        },
+        "PRIMITIVE_MATH_TYPES": {
+            "enum": [
+                "total",
+                "unique",
+                "sessions",
+                "average",
+                "median",
+                "p25",
+                "p75",
+                "p90",
+                "p99",
+                "custom_percentile",
+                "min",
+                "max",
+                "cumulative_unique",
+                "histogram",
+                "unique_values",
+                "most_frequent",
+                "first_value",
+                "multi_attribution",
+                "numeric_summary"
+            ],
+            "title": "PRIMITIVE_MATH_TYPES",
+            "tsEnumNames": [
+                "TOTAL",
+                "UNIQUE",
+                "SESSIONS",
+                "AVERAGE",
+                "MEDIAN",
+                "P25",
+                "P75",
+                "P90",
+                "P99",
+                "CUSTOM_PERCENTILE",
+                "MIN",
+                "MAX",
+                "CUMULATIVE_UNIQUE",
+                "HISTOGRAM",
+                "UNIQUE_VALUES",
+                "MOST_FREQUENT",
+                "FIRST_VALUE",
+                "MULTI_ATTRIBUTION",
+                "NUMERIC_SUMMARY"
+            ],
+            "type": "string"
+        },
+        "PredefinedMultiAttribution": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/MultiAttributionType"
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "weights": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MultiAttributionWeights"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "step_index": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "title": "PredefinedMultiAttribution",
+            "type": "object"
+        },
+        "PropertyType": {
+            "enum": [
+                "boolean",
+                "datetime",
+                "list",
+                "number",
+                "string",
+                "dimension",
+                "object",
+                "other",
+                "unknown"
+            ],
+            "title": "PropertyType",
+            "tsEnumNames": [
+                "Boolean",
+                "Datetime",
+                "List",
+                "Number",
+                "String",
+                "Dimension",
+                "Object",
+                "NonProperty",
+                "Unknown"
+            ],
+            "type": "string"
+        },
+        "RETENTION_MATH_TYPES": {
+            "enum": [
+                "unique",
+                "retention_rate",
+                "total",
+                "average"
+            ],
+            "title": "RETENTION_MATH_TYPES",
+            "tsEnumNames": [
+                "UNIQUE",
+                "RETENTION_RATE",
+                "PROPERTY_SUM",
+                "PROPERTY_AVERAGE"
+            ],
+            "type": "string"
+        },
+        "RetentionAlignmentType": {
+            "enum": [
+                "birth",
+                "interval_start"
+            ],
+            "title": "RetentionAlignmentType",
+            "tsEnumNames": [
+                "Birth",
+                "IntervalStart"
+            ],
+            "type": "string"
+        },
+        "RetentionType": {
+            "enum": [
+                "compounded",
+                "birth",
+                "addiction"
+            ],
+            "title": "RetentionType",
+            "type": "string"
+        },
+        "RetentionUnboundedModeType": {
+            "enum": [
+                "none",
+                "carry_back",
+                "carry_forward",
+                "consecutive_forward"
+            ],
+            "title": "RetentionUnboundedModeType",
+            "type": "string"
+        },
+        "RollingMeasurement": {
+            "additionalProperties": false,
+            "properties": {
+                "rollingWindowSize": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "RollingMeasurement",
+            "type": "object"
+        },
+        "SRM": {
+            "additionalProperties": false,
+            "properties": {
+                "expectedRatios": {
+                    "additionalProperties": {
+                        "type": "number"
+                    },
+                    "title": "",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "expectedRatios"
+            ],
+            "title": "SRM",
+            "type": "object"
+        },
+        "START_END_TYPE": {
+            "enum": [
+                "start",
+                "end"
+            ],
+            "title": "START_END_TYPE",
+            "tsEnumNames": [
+                "start",
+                "end"
+            ],
+            "type": "string"
+        },
+        "SavedLegend": {
+            "additionalProperties": false,
+            "properties": {
+                "selected": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/SavedLegendItem"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "expanded": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/SavedLegendItem"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "SavedLegend",
+            "type": "object"
+        },
+        "SavedLegendItem": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "color": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "might still exist on old bookmarks, but it's not used anymore",
+                    "title": ""
+                },
+                "partial": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "SavedLegendItem",
+            "type": "object"
+        },
+        "Sections": {
+            "additionalProperties": false,
+            "properties": {
+                "cohorts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/GroupByCohort"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filter": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "formula": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/FormulaClause"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "globalDataGroupId": {
+                    "$ref": "#/definitions/DataGroupId",
+                    "default": null,
+                    "title": ""
+                },
+                "group": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/GroupClause"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "group_by": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/GroupClause"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "metricLevelDataGroups": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "show": {
+                    "items": {
+                        "$ref": "#/definitions/ShowClause"
+                    },
+                    "title": "",
+                    "type": "array"
+                },
+                "time": {
+                    "items": {
+                        "$ref": "#/definitions/JsonValue"
+                    },
+                    "title": "",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "show",
+                "time"
+            ],
+            "title": "Sections",
+            "type": "object"
+        },
+        "SegmentId": {
+            "additionalProperties": false,
+            "properties": {
+                "prop": {
+                    "description": "raw string value of the segment",
+                    "title": "",
+                    "type": "string"
+                },
+                "propName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "user-friendly renaming of prop, suitable for printing",
+                    "title": ""
+                },
+                "cohortDesc": {
+                    "$ref": "#/definitions/JsonValue",
+                    "default": null,
+                    "description": "Query parameters not encapsulated by the prop which are necessary to recreate\nthis segment.\n\nex: bucketSize and index for a bucketed numeric segment",
+                    "title": ""
+                }
+            },
+            "required": [
+                "prop"
+            ],
+            "title": "SegmentId",
+            "type": "object"
+        },
+        "ShowClause": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/FormulaShowClause"
+                },
+                {
+                    "$ref": "#/definitions/BehaviorShowClause"
+                }
+            ]
+        },
+        "SortByColumnsConfig": {
+            "additionalProperties": false,
+            "description": "sort by segment columns (segment-grouped sort)",
+            "properties": {
+                "sortBy": {
+                    "const": "column",
+                    "title": "",
+                    "tsType": "SortBy.Column",
+                    "type": "string"
+                },
+                "valueField": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "value field to specify which value to sort secondarily on",
+                    "title": ""
+                },
+                "colSortAttrs": {
+                    "items": {
+                        "$ref": "#/definitions/FlatSortConfig"
+                    },
+                    "title": "",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "sortBy",
+                "colSortAttrs"
+            ],
+            "title": "SortByColumnsConfig",
+            "type": "object"
+        },
+        "SortByValueConfig": {
+            "additionalProperties": false,
+            "description": "sort by a single value column (flat sort). Still persists colSortAttrs so that if we switch back to sorting by\ncolumns, we preserve the prior sorts on the columns",
+            "properties": {
+                "sortBy": {
+                    "enum": [
+                        "value",
+                        "liftComparisonValue"
+                    ],
+                    "title": "",
+                    "tsType": "SortBy.Value",
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortOrder"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "valueField": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "valueField required when sorting by value (sortBy.Value) and there is > 1 valueField. Used for data tables.",
+                    "title": ""
+                },
+                "colSortAttrs": {
+                    "items": {
+                        "$ref": "#/definitions/FlatSortConfig"
+                    },
+                    "title": "",
+                    "type": "array"
+                },
+                "viewNLimit": {
+                    "$ref": "#/definitions/ViewNLimit",
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "sortBy",
+                "colSortAttrs"
+            ],
+            "title": "SortByValueConfig",
+            "type": "object"
+        },
+        "SortColumn": {
+            "enum": [
+                "Linear",
+                "sum",
+                "value"
+            ],
+            "title": "SortColumn",
+            "tsEnumNames": [
+                "Linear",
+                "Sum",
+                "Value"
+            ],
+            "type": "string"
+        },
+        "SortConfig": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/SortByColumnsConfig"
+                },
+                {
+                    "$ref": "#/definitions/SortByValueConfig"
+                }
+            ]
+        },
+        "SortOrder": {
+            "enum": [
+                "asc",
+                "desc"
+            ],
+            "title": "SortOrder",
+            "tsEnumNames": [
+                "Ascending",
+                "Descending"
+            ],
+            "type": "string"
+        },
+        "SortOrderType": {
+            "enum": [
+                "asc",
+                "desc"
+            ],
+            "title": "SortOrderType",
+            "tsEnumNames": [
+                "Ascending",
+                "Descending"
+            ],
+            "type": "string"
+        },
+        "SpecialTimeUnit": {
+            "enum": [
+                "hour_of_day",
+                "day_of_week"
+            ],
+            "title": "SpecialTimeUnit",
+            "tsEnumNames": [
+                "HourOfDay",
+                "DayOfWeek"
+            ],
+            "type": "string"
+        },
+        "Statsig": {
+            "additionalProperties": false,
+            "properties": {
+                "confidence": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "control_key": {
+                    "title": "",
+                    "type": "string"
+                },
+                "sequential_testing_adjustment": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/JsonValue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "pre_exposure_date_range": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "winsorization": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Winsorization"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "math": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "exposures": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "additionalProperties": {
+                                            "type": "integer"
+                                        },
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "version": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "required": [
+                "control_key"
+            ],
+            "title": "Statsig",
+            "type": "object"
+        },
+        "StepRange": {
+            "additionalProperties": false,
+            "properties": {
+                "from": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "to": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "StepRange",
+            "type": "object"
+        },
+        "SubBehavior": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "event",
+                                "custom-event",
+                                "funnel"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "",
+                    "tsType": "MetricType.Event | MetricType.CustomEvent | MetricType.Funnel"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "renamed": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "filters": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/JsonValue"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": ""
+                },
+                "filtersDeterminer": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FiltersDeterminer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "all",
+                    "title": ""
+                },
+                "funnelOrder": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FunnelOrder"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "behaviors": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/SubBehavior"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": ""
+                },
+                "display": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricDisplay"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "customEventSet": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "SubBehavior",
+            "type": "object"
+        },
+        "TimeUnit": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/BaseTimeUnit"
+                },
+                {
+                    "$ref": "#/definitions/ExtendedTimeUnit"
+                },
+                {
+                    "$ref": "#/definitions/NonStandardTimeUnit"
+                },
+                {
+                    "$ref": "#/definitions/SpecialTimeUnit"
+                }
+            ]
+        },
+        "ValueRepresentationType": {
+            "enum": [
+                "absolute",
+                "relative"
+            ],
+            "title": "ValueRepresentationType",
+            "tsEnumNames": [
+                "Absolute",
+                "Relative"
+            ],
+            "type": "string"
+        },
+        "ViewNLimit": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "Winsorization": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "lower_percentile": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                },
+                "upper_percentile": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": ""
+                }
+            },
+            "title": "Winsorization",
+            "type": "object"
+        },
+        "XAU_MATH_TYPES": {
+            "enum": [
+                "dau",
+                "wau",
+                "mau"
+            ],
+            "title": "XAU_MATH_TYPES",
+            "tsEnumNames": [
+                "DAU",
+                "WAU",
+                "MAU"
+            ],
+            "type": "string"
+        },
+        "TopLevelMetricType": {
+            "title": "TopLevelMetricType",
+            "description": "This exists at the top of a metric / show clause.",
+            "enum": [
+                "metric",
+                "formula",
+                "metric-entry",
+                "new-metric-entry",
+                "new-formula-entry"
+            ],
+            "type": "string",
+            "tsEnumNames": [
+                "Metric",
+                "Formula",
+                "MetricEntry",
+                "NewMetricEntry",
+                "NewFormulaEntry"
+            ]
+        },
+        "SortBy": {
+            "title": "SortBy",
+            "enum": [
+                "value",
+                "label",
+                "column",
+                "liftComparisonValue"
+            ],
+            "type": "string",
+            "tsEnumNames": [
+                "Value",
+                "Label",
+                "Column",
+                "LiftComparisonValue"
+            ]
+        }
+    }
+}

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/validate_bookmark.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/validate_bookmark.py
@@ -1,0 +1,957 @@
+#!/usr/bin/env python3
+"""
+Validate Mixpanel bookmark JSON against the canonical schema.
+
+Enum values are extracted from the vendored bookmark JSON Schema
+(schemas/bookmark.json) at load time.  If the schema file is missing,
+hardcoded fallback values are used — behavior is identical either way.
+
+Usage:
+  python validate_bookmark.py <json_file_or_string> [--type TYPE]
+  python validate_bookmark.py --stdin [--type TYPE]
+
+Exit codes:
+  0 = valid (or warnings only)
+  1 = invalid (has errors)
+  2 = usage error
+"""
+
+import argparse
+import json
+import sys
+from difflib import get_close_matches
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Schema loading — extract enum values from vendored bookmark.json
+# ---------------------------------------------------------------------------
+
+
+def _load_schema_enums(schema_path: Path | None = None) -> dict[str, set[str]]:
+    """Extract enum values from the canonical bookmark JSON Schema.
+
+    Returns a dict mapping logical name -> set of valid string values.
+    Returns empty dict if schema file is missing or malformed.
+    """
+    if schema_path is None:
+        schema_path = Path(__file__).resolve().parent / "schemas" / "bookmark.json"
+    if not schema_path.is_file():
+        return {}
+    try:
+        schema = json.loads(schema_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    defs = schema.get("definitions", {})
+
+    def enum_values(name: str) -> set[str]:
+        return set(defs.get(name, {}).get("enum", []))
+
+    return {
+        "chart_types": enum_values("ChartType"),
+        "math_primitive": enum_values("PRIMITIVE_MATH_TYPES"),
+        "math_xau": enum_values("XAU_MATH_TYPES"),
+        "math_funnels": enum_values("FUNNELS_MATH_TYPES"),
+        "math_retention": enum_values("RETENTION_MATH_TYPES"),
+        "per_user_aggregations": enum_values("PER_USER_AGGREGATIONS"),
+        "metric_types": enum_values("MetricType"),
+        "resource_types": enum_values("InsightsResourceType"),
+        "property_types": enum_values("PropertyType"),
+        "time_units": (
+            enum_values("BaseTimeUnit")
+            | enum_values("ExtendedTimeUnit")
+            | enum_values("NonStandardTimeUnit")
+            | enum_values("SpecialTimeUnit")
+        ),
+        "funnel_order": enum_values("FunnelOrder"),
+        "conversion_window_unit": enum_values("ConversionWindowUnit"),
+        "retention_type": enum_values("RetentionType"),
+        "retention_alignment_type": enum_values("RetentionAlignmentType"),
+        "retention_unbounded_mode": enum_values("RetentionUnboundedModeType"),
+        "filters_determiner": enum_values("FiltersDeterminer"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Constants — schema-derived with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+_SCHEMA = _load_schema_enums()
+
+# Chart types: schema has 31+, fallback has the most common 13
+VALID_CHART_TYPES_INSIGHTS = _SCHEMA.get(
+    "chart_types",
+    {
+        "bar",
+        "line",
+        "column",
+        "pie",
+        "table",
+        "insights-metric",
+        "bar-stacked",
+        "stacked-line",
+        "stacked-column",
+        "metric",
+        "funnel-steps",
+        "funnel-top-paths",
+        "retention-curve",
+    },
+)
+VALID_CHART_TYPES_FLOWS = {"sankey", "paths", "flows"}  # no flows schema
+
+# Math types: context-dependent (insights vs funnels vs retention)
+VALID_MATH_INSIGHTS = _SCHEMA.get(
+    "math_primitive",
+    {
+        "total",
+        "unique",
+        "sessions",
+        "average",
+        "median",
+        "p25",
+        "p75",
+        "p90",
+        "p99",
+        "custom_percentile",
+        "min",
+        "max",
+        "cumulative_unique",
+        "histogram",
+        "unique_values",
+        "most_frequent",
+        "first_value",
+        "multi_attribution",
+        "numeric_summary",
+    },
+) | _SCHEMA.get("math_xau", {"dau", "wau", "mau"})
+
+VALID_MATH_FUNNELS = _SCHEMA.get(
+    "math_funnels",
+    {
+        "general",
+        "unique",
+        "session",
+        "conversion_rate",
+        "conversion_rate_unique",
+        "conversion_rate_total",
+        "conversion_rate_session",
+        "total",
+    },
+)
+
+VALID_MATH_RETENTION = _SCHEMA.get(
+    "math_retention",
+    {
+        "unique",
+        "retention_rate",
+        "total",
+        "average",
+    },
+)
+
+# Semantic constraint: these math types require measurement.property
+# (not in schema — hand-written)
+MATH_REQUIRING_PROPERTY = {
+    "average",
+    "median",
+    "min",
+    "max",
+    "p25",
+    "p75",
+    "p90",
+    "p99",
+    "custom_percentile",
+}
+
+# Behavior / metric types
+VALID_METRIC_TYPES = _SCHEMA.get(
+    "metric_types",
+    {
+        "cohort",
+        "custom-event",
+        "event",
+        "formula",
+        "funnel",
+        "people",
+        "retention",
+        "retention-frequency",
+        "saved-metric",
+        "simple",
+        "verified",
+    },
+)
+
+VALID_RESOURCE_TYPES = _SCHEMA.get(
+    "resource_types",
+    {
+        "all",
+        "cohort",
+        "cohorts",
+        "event",
+        "events",
+        "formulas",
+        "other",
+        "people",
+        "user",
+    },
+)
+
+VALID_PROPERTY_TYPES = _SCHEMA.get(
+    "property_types",
+    {
+        "boolean",
+        "datetime",
+        "list",
+        "number",
+        "string",
+        "dimension",
+        "object",
+        "other",
+        "unknown",
+    },
+)
+
+VALID_TIME_UNITS = _SCHEMA.get(
+    "time_units",
+    {
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "quarter",
+        "year",
+        "session",
+        "hour_of_day",
+        "day_of_week",
+    },
+)
+
+# Hand-written: schema types these as bare strings, not enums
+VALID_DATE_RANGE_TYPES = {
+    "in the last",
+    "between",
+    "since",
+    "on",
+    "relative_after",
+}
+
+VALID_FILTER_OPERATORS = {
+    "equals",
+    "does not equal",
+    "contains",
+    "does not contain",
+    "is set",
+    "is not set",
+    "is defined",
+    "is not defined",
+    "is at least",
+    "is equal to",
+    "is not equal to",
+    "is greater than",
+    "is less than",
+    "is at most",
+    "is between",
+    "was on",
+    "was before",
+    "was since",
+    "was after",
+    "true",
+    "false",
+}
+
+# Schema-derived: new validation sets (empty fallback = no-op if schema missing)
+VALID_FUNNEL_ORDER = _SCHEMA.get("funnel_order", set())
+VALID_CONVERSION_WINDOW_UNIT = _SCHEMA.get("conversion_window_unit", set())
+VALID_RETENTION_TYPE = _SCHEMA.get("retention_type", set())
+VALID_RETENTION_ALIGNMENT_TYPE = _SCHEMA.get("retention_alignment_type", set())
+VALID_RETENTION_UNBOUNDED_MODE = _SCHEMA.get("retention_unbounded_mode", set())
+VALID_FILTERS_DETERMINER = _SCHEMA.get("filters_determiner", set())
+VALID_PER_USER_AGGREGATIONS = _SCHEMA.get("per_user_aggregations", set())
+
+# Bookmark type mapping (from Mixpanel's internal OpenAPI spec)
+VALID_BOOKMARK_TYPES = {
+    "addiction",
+    "dashboard",
+    "flows",
+    "formulas",
+    "funnel-query",
+    "funnels",
+    "insights",
+    "jql-console",
+    "launch-analysis",
+    "retention",
+    "revenue",
+    "segmentation",
+    "segmentation3",
+    "users",
+}
+
+# Maps outer bookmark_type → structural params type for validation
+BOOKMARK_TYPE_TO_PARAMS_TYPE = {
+    "insights": "insights",
+    "segmentation": "insights",
+    "segmentation3": "insights",
+    "revenue": "insights",
+    "formulas": "insights",
+    "launch-analysis": "insights",
+    "funnels": "funnels",
+    "funnel-query": "funnels",
+    "retention": "retention",
+    "addiction": "retention",
+    "flows": "flows",
+    # dashboard, jql-console, users — non-query types, no params validation
+}
+
+
+# ---------------------------------------------------------------------------
+# Agent-optimized helpers
+# ---------------------------------------------------------------------------
+
+
+def _suggest(value: str, valid: set[str], n: int = 3, cutoff: float = 0.5) -> list[str]:
+    """Return closest matches for a mistyped enum value."""
+    return get_close_matches(value, sorted(valid), n=n, cutoff=cutoff)
+
+
+def _enum_error(
+    path: str, field: str, value: str, valid: set[str], severity: str = "error"
+) -> "ValidationError":
+    """Build an agent-friendly error for an invalid enum value."""
+    matches = _suggest(value, valid)
+    if matches:
+        msg = f"Invalid {field} '{value}'"
+        suggestion = matches
+    else:
+        sample = sorted(valid)[:5]
+        msg = f"Invalid {field} '{value}'. Valid ({len(valid)} total): {sample}"
+        suggestion = None
+    return ValidationError(path, msg, severity=severity, suggestion=suggestion)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class ValidationError:
+    def __init__(
+        self,
+        path: str,
+        message: str,
+        severity: str = "error",
+        suggestion: list[str] | str | None = None,
+        fix: dict | None = None,
+    ):
+        self.path = path
+        self.message = message
+        self.severity = severity  # "error" or "warning"
+        self.suggestion = suggestion  # closest valid value(s)
+        self.fix = fix  # JSON template to insert
+
+    def __str__(self):
+        prefix = "WARNING" if self.severity == "warning" else "ERROR"
+        s = f"[{prefix}] {self.path}: {self.message}"
+        if self.suggestion:
+            if isinstance(self.suggestion, list) and self.suggestion:
+                s += f" Did you mean '{self.suggestion[0]}'?"
+            elif isinstance(self.suggestion, str):
+                s += f" Did you mean '{self.suggestion}'?"
+        if self.fix:
+            s += f"\n  Fix: add {json.dumps(self.fix)}"
+        return s
+
+
+def validate_insights_bookmark(params: dict) -> list[ValidationError]:
+    """Validate InsightsBookmarkParams structure."""
+    errors = []
+
+    # Required top-level fields
+    if "displayOptions" not in params:
+        errors.append(
+            ValidationError("params", "Missing required field 'displayOptions'")
+        )
+    if "sections" not in params:
+        errors.append(ValidationError("params", "Missing required field 'sections'"))
+        return errors  # Can't validate further without sections
+
+    # Validate displayOptions
+    display = params.get("displayOptions", {})
+    if not isinstance(display, dict):
+        errors.append(ValidationError("displayOptions", "Must be a dict"))
+    else:
+        chart_type = display.get("chartType")
+        if chart_type is None:
+            errors.append(
+                ValidationError("displayOptions", "Missing required 'chartType'")
+            )
+        elif chart_type not in VALID_CHART_TYPES_INSIGHTS:
+            errors.append(
+                _enum_error(
+                    "displayOptions.chartType",
+                    "chartType",
+                    chart_type,
+                    VALID_CHART_TYPES_INSIGHTS,
+                )
+            )
+
+    # Validate sections
+    sections = params.get("sections", {})
+    if not isinstance(sections, dict):
+        errors.append(ValidationError("sections", "Must be a dict"))
+        return errors
+
+    # Required sections fields
+    show = sections.get("show")
+    if show is None:
+        errors.append(ValidationError("sections", "Missing required field 'show'"))
+    elif not isinstance(show, list) or len(show) == 0:
+        errors.append(ValidationError("sections.show", "Must be a non-empty list"))
+    else:
+        for i, clause in enumerate(show):
+            errors.extend(validate_show_clause(clause, f"sections.show[{i}]"))
+
+    time = sections.get("time")
+    if time is None:
+        errors.append(ValidationError("sections", "Missing required field 'time'"))
+    elif not isinstance(time, list) or len(time) == 0:
+        errors.append(ValidationError("sections.time", "Must be a non-empty list"))
+    else:
+        for i, t in enumerate(time):
+            errors.extend(validate_time_clause(t, f"sections.time[{i}]"))
+
+    # Optional sections
+    filters = sections.get("filter", [])
+    if filters and isinstance(filters, list):
+        for i, f in enumerate(filters):
+            errors.extend(validate_filter_clause(f, f"sections.filter[{i}]"))
+
+    groups = sections.get("group", [])
+    if groups and isinstance(groups, list):
+        for i, g in enumerate(groups):
+            errors.extend(validate_group_clause(g, f"sections.group[{i}]"))
+
+    return errors
+
+
+def validate_show_clause(clause: dict, path: str) -> list[ValidationError]:
+    """Validate a single show clause (BehaviorShowClause or FormulaShowClause)."""
+    errors = []
+    if not isinstance(clause, dict):
+        errors.append(ValidationError(path, "Must be a dict"))
+        return errors
+
+    clause_type = clause.get("type")
+
+    # FormulaShowClause
+    if clause_type == "formula" or "formula" in clause:
+        if "formula" not in clause and "definition" not in clause:
+            errors.append(
+                ValidationError(path, "Formula clause needs 'formula' or 'definition'")
+            )
+        return errors
+
+    # BehaviorShowClause
+    behavior = clause.get("behavior")
+    if behavior is None:
+        errors.append(ValidationError(path, "Missing 'behavior' in metric show clause"))
+        return errors
+
+    if not isinstance(behavior, dict):
+        errors.append(ValidationError(f"{path}.behavior", "Must be a dict"))
+        return errors
+
+    btype = behavior.get("type")
+    if btype and btype not in VALID_METRIC_TYPES:
+        errors.append(
+            _enum_error(
+                f"{path}.behavior.type",
+                "behavior type",
+                btype,
+                VALID_METRIC_TYPES,
+            )
+        )
+
+    # Check behavior.name for event types
+    if btype in ("event", "simple", "custom-event") and not behavior.get("name"):
+        errors.append(
+            ValidationError(
+                f"{path}.behavior.name",
+                "Event-type behavior requires 'name'",
+                fix={"name": "<EVENT_NAME>"},
+            )
+        )
+
+    # Validate filtersDeterminer
+    fd = behavior.get("filtersDeterminer")
+    if fd and VALID_FILTERS_DETERMINER and fd not in VALID_FILTERS_DETERMINER:
+        errors.append(
+            _enum_error(
+                f"{path}.behavior.filtersDeterminer",
+                "filtersDeterminer",
+                fd,
+                VALID_FILTERS_DETERMINER,
+                severity="warning",
+            )
+        )
+
+    # Validate measurement
+    measurement = clause.get("measurement")
+    if measurement and isinstance(measurement, dict):
+        math = measurement.get("math")
+        if math:
+            # Context-dependent math validation
+            if btype == "funnel":
+                valid = VALID_MATH_FUNNELS
+            elif btype in ("retention", "retention-frequency"):
+                valid = VALID_MATH_RETENTION
+            else:
+                valid = VALID_MATH_INSIGHTS
+            if math not in valid:
+                errors.append(
+                    _enum_error(
+                        f"{path}.measurement.math",
+                        f"math (for behavior type '{btype}')",
+                        math,
+                        valid,
+                    )
+                )
+
+            # Property-aggregation math types require measurement.property
+            if math in MATH_REQUIRING_PROPERTY and not measurement.get("property"):
+                errors.append(
+                    ValidationError(
+                        f"{path}.measurement.property",
+                        f"Math type '{math}' requires 'measurement.property'",
+                        severity="warning",
+                        fix={
+                            "name": "<PROPERTY_NAME>",
+                            "defaultType": "number",
+                            "type": "number",
+                            "resourceType": "events",
+                        },
+                    )
+                )
+
+        # Validate perUserAggregation
+        pua = measurement.get("perUserAggregation")
+        if (
+            pua
+            and VALID_PER_USER_AGGREGATIONS
+            and pua not in VALID_PER_USER_AGGREGATIONS
+        ):
+            errors.append(
+                _enum_error(
+                    f"{path}.measurement.perUserAggregation",
+                    "perUserAggregation",
+                    pua,
+                    VALID_PER_USER_AGGREGATIONS,
+                    severity="warning",
+                )
+            )
+
+    # Validate per-metric behavior.filters[]
+    bfilters = behavior.get("filters", [])
+    if bfilters and isinstance(bfilters, list):
+        for i, f in enumerate(bfilters):
+            errors.extend(validate_filter_clause(f, f"{path}.behavior.filters[{i}]"))
+
+    # Validate funnel-specific fields
+    if btype == "funnel":
+        behaviors = behavior.get("behaviors", [])
+        if not behaviors or len(behaviors) < 2:
+            errors.append(
+                ValidationError(
+                    f"{path}.behavior.behaviors",
+                    "Funnel needs at least 2 sub-behaviors (steps)",
+                )
+            )
+
+        fo = behavior.get("funnelOrder")
+        if fo and VALID_FUNNEL_ORDER and fo not in VALID_FUNNEL_ORDER:
+            errors.append(
+                _enum_error(
+                    f"{path}.behavior.funnelOrder",
+                    "funnelOrder",
+                    fo,
+                    VALID_FUNNEL_ORDER,
+                    severity="warning",
+                )
+            )
+
+        cwu = behavior.get("conversionWindowUnit")
+        if (
+            cwu
+            and VALID_CONVERSION_WINDOW_UNIT
+            and cwu not in VALID_CONVERSION_WINDOW_UNIT
+        ):
+            errors.append(
+                _enum_error(
+                    f"{path}.behavior.conversionWindowUnit",
+                    "conversionWindowUnit",
+                    cwu,
+                    VALID_CONVERSION_WINDOW_UNIT,
+                    severity="warning",
+                )
+            )
+
+    # Validate retention-specific fields
+    if btype in ("retention", "retention-frequency"):
+        behaviors = behavior.get("behaviors", [])
+        if behaviors is not None and len(behaviors) != 2:
+            errors.append(
+                ValidationError(
+                    f"{path}.behavior.behaviors",
+                    "Retention needs exactly 2 sub-behaviors (born + return)",
+                )
+            )
+
+        rt = behavior.get("retentionType")
+        if rt and VALID_RETENTION_TYPE and rt not in VALID_RETENTION_TYPE:
+            errors.append(
+                _enum_error(
+                    f"{path}.behavior.retentionType",
+                    "retentionType",
+                    rt,
+                    VALID_RETENTION_TYPE,
+                    severity="warning",
+                )
+            )
+
+        rat = behavior.get("retentionAlignmentType")
+        if (
+            rat
+            and VALID_RETENTION_ALIGNMENT_TYPE
+            and rat not in VALID_RETENTION_ALIGNMENT_TYPE
+        ):
+            errors.append(
+                _enum_error(
+                    f"{path}.behavior.retentionAlignmentType",
+                    "retentionAlignmentType",
+                    rat,
+                    VALID_RETENTION_ALIGNMENT_TYPE,
+                    severity="warning",
+                )
+            )
+
+        rum = behavior.get("retentionUnboundedMode")
+        if (
+            rum
+            and VALID_RETENTION_UNBOUNDED_MODE
+            and rum not in VALID_RETENTION_UNBOUNDED_MODE
+        ):
+            errors.append(
+                _enum_error(
+                    f"{path}.behavior.retentionUnboundedMode",
+                    "retentionUnboundedMode",
+                    rum,
+                    VALID_RETENTION_UNBOUNDED_MODE,
+                    severity="warning",
+                )
+            )
+
+    return errors
+
+
+def validate_time_clause(clause: dict, path: str) -> list[ValidationError]:
+    """Validate a time clause."""
+    errors = []
+    if not isinstance(clause, dict):
+        errors.append(ValidationError(path, "Must be a dict"))
+        return errors
+
+    # Must have unit
+    unit = clause.get("unit")
+    if unit and unit not in VALID_TIME_UNITS:
+        errors.append(_enum_error(f"{path}.unit", "unit", unit, VALID_TIME_UNITS))
+
+    # Must have dateRangeType or value
+    drt = clause.get("dateRangeType")
+    if drt and drt not in VALID_DATE_RANGE_TYPES:
+        errors.append(
+            _enum_error(
+                f"{path}.dateRangeType",
+                "dateRangeType",
+                drt,
+                VALID_DATE_RANGE_TYPES,
+            )
+        )
+
+    # Validate window if present
+    window = clause.get("window")
+    if window and isinstance(window, dict):
+        wunit = window.get("unit")
+        if wunit and wunit not in VALID_TIME_UNITS:
+            errors.append(
+                _enum_error(
+                    f"{path}.window.unit",
+                    "window unit",
+                    wunit,
+                    VALID_TIME_UNITS,
+                )
+            )
+        if "value" not in window:
+            errors.append(ValidationError(f"{path}.window", "Missing 'value'"))
+
+    return errors
+
+
+def validate_filter_clause(clause: dict, path: str) -> list[ValidationError]:
+    """Validate a filter clause."""
+    errors = []
+    if not isinstance(clause, dict):
+        errors.append(ValidationError(path, "Must be a dict"))
+        return errors
+
+    # Must have property identification
+    if not clause.get("value") and not clause.get("propertyName"):
+        errors.append(
+            ValidationError(
+                path, "Missing property identifier ('value' or 'propertyName')"
+            )
+        )
+
+    # Validate resourceType
+    rt = clause.get("resourceType")
+    if rt and rt not in VALID_RESOURCE_TYPES:
+        errors.append(
+            _enum_error(
+                f"{path}.resourceType",
+                "resourceType",
+                rt,
+                VALID_RESOURCE_TYPES,
+            )
+        )
+
+    # Validate filterType
+    ft = clause.get("filterType")
+    if ft and ft not in VALID_PROPERTY_TYPES:
+        errors.append(
+            _enum_error(
+                f"{path}.filterType",
+                "filterType",
+                ft,
+                VALID_PROPERTY_TYPES,
+            )
+        )
+
+    # Validate filterOperator
+    fo = clause.get("filterOperator")
+    if fo and fo not in VALID_FILTER_OPERATORS:
+        errors.append(
+            _enum_error(
+                f"{path}.filterOperator",
+                "filterOperator",
+                fo,
+                VALID_FILTER_OPERATORS,
+                severity="warning",
+            )
+        )
+
+    return errors
+
+
+def validate_group_clause(clause: dict, path: str) -> list[ValidationError]:
+    """Validate a group/breakdown clause."""
+    errors = []
+    if not isinstance(clause, dict):
+        errors.append(ValidationError(path, "Must be a dict"))
+        return errors
+
+    # Should have propertyName for standard breakdowns
+    if (
+        not clause.get("propertyName")
+        and not clause.get("behavior")
+        and not clause.get("cohorts")
+    ):
+        errors.append(
+            ValidationError(
+                path,
+                "Group clause needs 'propertyName', 'behavior', or 'cohorts'",
+                severity="warning",
+            )
+        )
+
+    pt = clause.get("propertyType")
+    if pt and pt not in VALID_PROPERTY_TYPES:
+        errors.append(
+            _enum_error(
+                f"{path}.propertyType",
+                "propertyType",
+                pt,
+                VALID_PROPERTY_TYPES,
+            )
+        )
+
+    return errors
+
+
+def validate_flows_bookmark(params: dict) -> list[ValidationError]:
+    """Validate FlowsBookmarkParams structure."""
+    errors = []
+
+    if "steps" not in params:
+        errors.append(ValidationError("params", "Missing required 'steps' for flows"))
+    elif not isinstance(params["steps"], list) or len(params["steps"]) == 0:
+        errors.append(ValidationError("params.steps", "Must be a non-empty list"))
+    else:
+        for i, step in enumerate(params["steps"]):
+            if not isinstance(step, dict):
+                errors.append(ValidationError(f"params.steps[{i}]", "Must be a dict"))
+                continue
+            if not step.get("event") and not step.get("custom_event"):
+                errors.append(
+                    ValidationError(
+                        f"params.steps[{i}]",
+                        "Step needs 'event' or 'custom_event'",
+                    )
+                )
+
+    if "date_range" not in params:
+        errors.append(
+            ValidationError("params", "Missing required 'date_range' for flows")
+        )
+
+    return errors
+
+
+def detect_bookmark_type(params: dict) -> str:
+    """Detect bookmark type from params structure."""
+    if "steps" in params and "date_range" in params:
+        return "flows"
+    sections = params.get("sections", {})
+    show = sections.get("show", [])
+    if show and isinstance(show, list) and len(show) > 0:
+        first = show[0]
+        if isinstance(first, dict):
+            behavior = first.get("behavior", {})
+            if isinstance(behavior, dict):
+                btype = behavior.get("type", "")
+                if btype == "funnel":
+                    return "funnels"
+                elif btype in ("retention", "retention-frequency"):
+                    return "retention"
+    return "insights"
+
+
+def validate_bookmark(
+    params: dict, bookmark_type: str | None = None
+) -> list[ValidationError]:
+    """
+    Validate bookmark params.
+
+    Args:
+        params: The bookmark params dict
+        bookmark_type: Bookmark type — accepts both structural types
+            (insights, funnels, retention, flows) and outer types
+            (segmentation, funnel-query, addiction, etc.).
+            Auto-detected from params structure if None.
+
+    Returns:
+        List of ValidationError objects (empty = valid)
+    """
+    errors = []
+
+    # Resolve structural type from bookmark_type
+    if bookmark_type and bookmark_type in BOOKMARK_TYPE_TO_PARAMS_TYPE:
+        structural_type = BOOKMARK_TYPE_TO_PARAMS_TYPE[bookmark_type]
+    elif bookmark_type and bookmark_type in {
+        "insights",
+        "funnels",
+        "retention",
+        "flows",
+    }:
+        structural_type = bookmark_type
+    elif bookmark_type and bookmark_type not in VALID_BOOKMARK_TYPES:
+        errors.append(
+            ValidationError(
+                "bookmark_type",
+                f"Unknown bookmark type '{bookmark_type}'",
+                severity="warning",
+                suggestion=_suggest(bookmark_type, VALID_BOOKMARK_TYPES),
+            )
+        )
+        structural_type = detect_bookmark_type(params)
+    else:
+        structural_type = detect_bookmark_type(params)
+
+    if structural_type == "flows":
+        errors.extend(validate_flows_bookmark(params))
+    else:
+        errors.extend(validate_insights_bookmark(params))
+
+    return errors
+
+
+def main():
+    all_types = sorted(
+        VALID_BOOKMARK_TYPES | {"insights", "funnels", "retention", "flows"}
+    )
+
+    parser = argparse.ArgumentParser(description="Validate Mixpanel bookmark JSON")
+    parser.add_argument("input", nargs="?", help="JSON file path or inline JSON string")
+    parser.add_argument("--stdin", action="store_true", help="Read JSON from stdin")
+    parser.add_argument(
+        "--type", choices=all_types, help="Bookmark type (auto-detected if omitted)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output errors as JSON")
+    args = parser.parse_args()
+
+    if args.stdin:
+        raw = sys.stdin.read()
+    elif args.input:
+        # Try as file path first (only if short enough to be a path)
+        if len(args.input) < 260 and not args.input.startswith("{"):
+            path = Path(args.input)
+            raw = path.read_text() if path.is_file() else args.input
+        else:
+            raw = args.input
+    else:
+        parser.print_help()
+        sys.exit(2)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Handle both {"params": {...}} wrapper and raw params
+    if "params" in data and isinstance(data["params"], dict):
+        params = data["params"]
+    else:
+        params = data
+
+    errors = validate_bookmark(params, args.type)
+
+    if errors:
+        if args.json:
+            out = []
+            for e in errors:
+                entry: dict = {
+                    "path": e.path,
+                    "message": e.message,
+                    "severity": e.severity,
+                }
+                if e.suggestion:
+                    entry["suggestion"] = e.suggestion
+                if e.fix:
+                    entry["fix"] = e.fix
+                out.append(entry)
+            print(json.dumps(out, indent=2))
+        else:
+            for e in errors:
+                print(str(e), file=sys.stderr)
+        real_errors = [e for e in errors if e.severity == "error"]
+        sys.exit(1 if real_errors else 0)
+    else:
+        if args.json:
+            print('{"valid": true}')
+        else:
+            print("Valid bookmark.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/validate_bookmark.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/validate_bookmark.py
@@ -261,14 +261,31 @@ VALID_FILTER_OPERATORS = {
     "false",
 }
 
-# Schema-derived: new validation sets (empty fallback = no-op if schema missing)
-VALID_FUNNEL_ORDER = _SCHEMA.get("funnel_order", set())
-VALID_CONVERSION_WINDOW_UNIT = _SCHEMA.get("conversion_window_unit", set())
-VALID_RETENTION_TYPE = _SCHEMA.get("retention_type", set())
-VALID_RETENTION_ALIGNMENT_TYPE = _SCHEMA.get("retention_alignment_type", set())
-VALID_RETENTION_UNBOUNDED_MODE = _SCHEMA.get("retention_unbounded_mode", set())
-VALID_FILTERS_DETERMINER = _SCHEMA.get("filters_determiner", set())
-VALID_PER_USER_AGGREGATIONS = _SCHEMA.get("per_user_aggregations", set())
+# Schema-derived with hardcoded fallbacks (mirrors pattern above)
+VALID_FUNNEL_ORDER = _SCHEMA.get("funnel_order", {"ordered", "unordered", "strict"})
+VALID_CONVERSION_WINDOW_UNIT = _SCHEMA.get(
+    "conversion_window_unit", {"second", "minute", "hour", "day", "week", "month"}
+)
+VALID_RETENTION_TYPE = _SCHEMA.get("retention_type", {"birth", "compounding"})
+VALID_RETENTION_ALIGNMENT_TYPE = _SCHEMA.get(
+    "retention_alignment_type", {"standard", "calendar"}
+)
+VALID_RETENTION_UNBOUNDED_MODE = _SCHEMA.get(
+    "retention_unbounded_mode", {"none", "unbounded", "cumulative"}
+)
+VALID_FILTERS_DETERMINER = _SCHEMA.get("filters_determiner", {"all", "any"})
+VALID_PER_USER_AGGREGATIONS = _SCHEMA.get(
+    "per_user_aggregations",
+    {
+        "average",
+        "distribution",
+        "max",
+        "median",
+        "min",
+        "sum",
+        "unique_values",
+    },
+)
 
 # Bookmark type mapping (from Mixpanel's internal OpenAPI spec)
 VALID_BOOKMARK_TYPES = {
@@ -328,6 +345,19 @@ def _enum_error(
         msg = f"Invalid {field} '{value}'. Valid ({len(valid)} total): {sample}"
         suggestion = None
     return ValidationError(path, msg, severity=severity, suggestion=suggestion)
+
+
+def _check_enum(
+    errors: list["ValidationError"],
+    path: str,
+    field: str,
+    value: str | None,
+    valid: set[str],
+    severity: str = "warning",
+) -> None:
+    """Append an enum validation error if *value* is set but not in *valid*."""
+    if value and valid and value not in valid:
+        errors.append(_enum_error(path, field, value, valid, severity=severity))
 
 
 # ---------------------------------------------------------------------------
@@ -484,17 +514,13 @@ def validate_show_clause(clause: dict, path: str) -> list[ValidationError]:
         )
 
     # Validate filtersDeterminer
-    fd = behavior.get("filtersDeterminer")
-    if fd and VALID_FILTERS_DETERMINER and fd not in VALID_FILTERS_DETERMINER:
-        errors.append(
-            _enum_error(
-                f"{path}.behavior.filtersDeterminer",
-                "filtersDeterminer",
-                fd,
-                VALID_FILTERS_DETERMINER,
-                severity="warning",
-            )
-        )
+    _check_enum(
+        errors,
+        f"{path}.behavior.filtersDeterminer",
+        "filtersDeterminer",
+        behavior.get("filtersDeterminer"),
+        VALID_FILTERS_DETERMINER,
+    )
 
     # Validate measurement
     measurement = clause.get("measurement")
@@ -535,21 +561,13 @@ def validate_show_clause(clause: dict, path: str) -> list[ValidationError]:
                 )
 
         # Validate perUserAggregation
-        pua = measurement.get("perUserAggregation")
-        if (
-            pua
-            and VALID_PER_USER_AGGREGATIONS
-            and pua not in VALID_PER_USER_AGGREGATIONS
-        ):
-            errors.append(
-                _enum_error(
-                    f"{path}.measurement.perUserAggregation",
-                    "perUserAggregation",
-                    pua,
-                    VALID_PER_USER_AGGREGATIONS,
-                    severity="warning",
-                )
-            )
+        _check_enum(
+            errors,
+            f"{path}.measurement.perUserAggregation",
+            "perUserAggregation",
+            measurement.get("perUserAggregation"),
+            VALID_PER_USER_AGGREGATIONS,
+        )
 
     # Validate per-metric behavior.filters[]
     bfilters = behavior.get("filters", [])
@@ -568,33 +586,20 @@ def validate_show_clause(clause: dict, path: str) -> list[ValidationError]:
                 )
             )
 
-        fo = behavior.get("funnelOrder")
-        if fo and VALID_FUNNEL_ORDER and fo not in VALID_FUNNEL_ORDER:
-            errors.append(
-                _enum_error(
-                    f"{path}.behavior.funnelOrder",
-                    "funnelOrder",
-                    fo,
-                    VALID_FUNNEL_ORDER,
-                    severity="warning",
-                )
-            )
-
-        cwu = behavior.get("conversionWindowUnit")
-        if (
-            cwu
-            and VALID_CONVERSION_WINDOW_UNIT
-            and cwu not in VALID_CONVERSION_WINDOW_UNIT
-        ):
-            errors.append(
-                _enum_error(
-                    f"{path}.behavior.conversionWindowUnit",
-                    "conversionWindowUnit",
-                    cwu,
-                    VALID_CONVERSION_WINDOW_UNIT,
-                    severity="warning",
-                )
-            )
+        _check_enum(
+            errors,
+            f"{path}.behavior.funnelOrder",
+            "funnelOrder",
+            behavior.get("funnelOrder"),
+            VALID_FUNNEL_ORDER,
+        )
+        _check_enum(
+            errors,
+            f"{path}.behavior.conversionWindowUnit",
+            "conversionWindowUnit",
+            behavior.get("conversionWindowUnit"),
+            VALID_CONVERSION_WINDOW_UNIT,
+        )
 
     # Validate retention-specific fields
     if btype in ("retention", "retention-frequency"):
@@ -607,49 +612,27 @@ def validate_show_clause(clause: dict, path: str) -> list[ValidationError]:
                 )
             )
 
-        rt = behavior.get("retentionType")
-        if rt and VALID_RETENTION_TYPE and rt not in VALID_RETENTION_TYPE:
-            errors.append(
-                _enum_error(
-                    f"{path}.behavior.retentionType",
-                    "retentionType",
-                    rt,
-                    VALID_RETENTION_TYPE,
-                    severity="warning",
-                )
-            )
-
-        rat = behavior.get("retentionAlignmentType")
-        if (
-            rat
-            and VALID_RETENTION_ALIGNMENT_TYPE
-            and rat not in VALID_RETENTION_ALIGNMENT_TYPE
-        ):
-            errors.append(
-                _enum_error(
-                    f"{path}.behavior.retentionAlignmentType",
-                    "retentionAlignmentType",
-                    rat,
-                    VALID_RETENTION_ALIGNMENT_TYPE,
-                    severity="warning",
-                )
-            )
-
-        rum = behavior.get("retentionUnboundedMode")
-        if (
-            rum
-            and VALID_RETENTION_UNBOUNDED_MODE
-            and rum not in VALID_RETENTION_UNBOUNDED_MODE
-        ):
-            errors.append(
-                _enum_error(
-                    f"{path}.behavior.retentionUnboundedMode",
-                    "retentionUnboundedMode",
-                    rum,
-                    VALID_RETENTION_UNBOUNDED_MODE,
-                    severity="warning",
-                )
-            )
+        _check_enum(
+            errors,
+            f"{path}.behavior.retentionType",
+            "retentionType",
+            behavior.get("retentionType"),
+            VALID_RETENTION_TYPE,
+        )
+        _check_enum(
+            errors,
+            f"{path}.behavior.retentionAlignmentType",
+            "retentionAlignmentType",
+            behavior.get("retentionAlignmentType"),
+            VALID_RETENTION_ALIGNMENT_TYPE,
+        )
+        _check_enum(
+            errors,
+            f"{path}.behavior.retentionUnboundedMode",
+            "retentionUnboundedMode",
+            behavior.get("retentionUnboundedMode"),
+            VALID_RETENTION_UNBOUNDED_MODE,
+        )
 
     return errors
 
@@ -856,13 +839,6 @@ def validate_bookmark(
     # Resolve structural type from bookmark_type
     if bookmark_type and bookmark_type in BOOKMARK_TYPE_TO_PARAMS_TYPE:
         structural_type = BOOKMARK_TYPE_TO_PARAMS_TYPE[bookmark_type]
-    elif bookmark_type and bookmark_type in {
-        "insights",
-        "funnels",
-        "retention",
-        "flows",
-    }:
-        structural_type = bookmark_type
     elif bookmark_type and bookmark_type not in VALID_BOOKMARK_TYPES:
         errors.append(
             ValidationError(
@@ -904,7 +880,14 @@ def main():
         # Try as file path first (only if short enough to be a path)
         if len(args.input) < 260 and not args.input.startswith("{"):
             path = Path(args.input)
-            raw = path.read_text() if path.is_file() else args.input
+            if path.is_file():
+                try:
+                    raw = path.read_text()
+                except OSError as e:
+                    print(f"Error reading file '{path}': {e}", file=sys.stderr)
+                    sys.exit(2)
+            else:
+                raw = args.input
         else:
             raw = args.input
     else:

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -2834,8 +2834,8 @@ class MixpanelAPIClient:
     ) -> dict[str, Any] | None:
         """Remove a report (bookmark) from a dashboard.
 
-        Calls ``DELETE /api/app/projects/{pid}/dashboards/{dashboard_id}/reports/{bookmark_id}``
-        (or workspace-scoped).
+        Calls ``PATCH /api/app/projects/{pid}/dashboards/{dashboard_id}``
+        (or workspace-scoped) with a ``delete`` content action.
 
         Args:
             dashboard_id: The numeric dashboard identifier.
@@ -2875,7 +2875,7 @@ class MixpanelAPIClient:
 
     def add_report_to_dashboard(
         self, dashboard_id: int, bookmark_id: int
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, Any]:
         """Add a report (bookmark) to a dashboard.
 
         Clones the specified bookmark onto the dashboard by calling
@@ -2887,8 +2887,7 @@ class MixpanelAPIClient:
             bookmark_id: The numeric bookmark/report identifier to add.
 
         Returns:
-            Dictionary representing the updated dashboard after report addition,
-            or None if the API returned 204 No Content.
+            Dictionary representing the updated dashboard after report addition.
 
         Raises:
             AuthenticationError: Invalid credentials (401).

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -2873,6 +2873,51 @@ class MixpanelAPIClient:
             )
         return result
 
+    def add_report_to_dashboard(
+        self, dashboard_id: int, bookmark_id: int
+    ) -> dict[str, Any] | None:
+        """Add a report (bookmark) to a dashboard.
+
+        Clones the specified bookmark onto the dashboard by calling
+        ``PATCH /api/app/projects/{pid}/dashboards/{dashboard_id}``
+        (or workspace-scoped) with a ``create`` content action.
+
+        Args:
+            dashboard_id: The numeric dashboard identifier.
+            bookmark_id: The numeric bookmark/report identifier to add.
+
+        Returns:
+            Dictionary representing the updated dashboard after report addition,
+            or None if the API returned 204 No Content.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Dashboard or bookmark not found (404).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(credentials) as client:
+                client.add_report_to_dashboard(12345, 67890)
+            ```
+        """
+        path = self.maybe_scoped_path(f"dashboards/{dashboard_id}")
+        body: dict[str, Any] = {
+            "content": {
+                "action": "create",
+                "content_type": "report",
+                "content_params": {"source_bookmark_id": bookmark_id},
+            }
+        }
+        result = self.app_request("PATCH", path, json_body=body)
+        if not isinstance(result, dict):
+            raise MixpanelDataError(
+                f"Unexpected response from add_report_to_dashboard: "
+                f"expected dict, got {type(result).__name__}",
+            )
+        return result
+
     def list_blueprint_templates(
         self, *, include_reports: bool = False
     ) -> list[dict[str, Any]]:

--- a/src/mixpanel_data/cli/commands/dashboards.py
+++ b/src/mixpanel_data/cli/commands/dashboards.py
@@ -410,6 +410,39 @@ def dashboards_remove_report(
     output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)
 
 
+@dashboards_app.command("add-report")
+@handle_errors
+def dashboards_add_report(
+    ctx: typer.Context,
+    dashboard_id: Annotated[
+        int,
+        typer.Argument(help="Dashboard ID."),
+    ],
+    bookmark_id: Annotated[
+        int,
+        typer.Argument(help="Bookmark/report ID to add."),
+    ],
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Add a report to a dashboard.
+
+    Clones the specified bookmark/report onto the dashboard and
+    returns the updated dashboard.
+
+    Args:
+        ctx: Typer context with global options.
+        dashboard_id: Dashboard identifier.
+        bookmark_id: Bookmark/report identifier to add.
+        format: Output format.
+        jq_filter: Optional jq filter expression.
+    """
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, "Adding report to dashboard..."):
+        result = workspace.add_report_to_dashboard(dashboard_id, bookmark_id)
+    output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)
+
+
 # =============================================================================
 # Blueprints
 # =============================================================================

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1918,6 +1918,7 @@ class Workspace:
             AuthenticationError: Invalid credentials (401).
             QueryError: Dashboard or bookmark not found (404).
             ServerError: Server-side errors (5xx).
+            MixpanelDataError: If the API response is not a valid dashboard dict.
 
         Example:
             ```python
@@ -1927,6 +1928,11 @@ class Workspace:
         """
         client = self._require_api_client()
         raw = client.add_report_to_dashboard(dashboard_id, bookmark_id)
+        if not isinstance(raw, dict) or "id" not in raw:
+            raise MixpanelDataError(
+                "Unexpected response from add_report_to_dashboard: "
+                f"expected dashboard dict with 'id', got {raw!r}",
+            )
         return Dashboard.model_validate(raw)
 
     def list_blueprint_templates(

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1900,6 +1900,35 @@ class Workspace:
         raw = client.remove_report_from_dashboard(dashboard_id, bookmark_id)
         return Dashboard.model_validate(raw)
 
+    def add_report_to_dashboard(self, dashboard_id: int, bookmark_id: int) -> Dashboard:
+        """Add a report to a dashboard.
+
+        Clones the specified bookmark onto the dashboard. The cloned report
+        appears as a new card in the dashboard layout.
+
+        Args:
+            dashboard_id: Dashboard identifier.
+            bookmark_id: Bookmark/report identifier to add.
+
+        Returns:
+            The updated ``Dashboard``.
+
+        Raises:
+            ConfigError: If credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Dashboard or bookmark not found (404).
+            ServerError: Server-side errors (5xx).
+
+        Example:
+            ```python
+            ws = Workspace()
+            updated = ws.add_report_to_dashboard(12345, 42)
+            ```
+        """
+        client = self._require_api_client()
+        raw = client.add_report_to_dashboard(dashboard_id, bookmark_id)
+        return Dashboard.model_validate(raw)
+
     def list_blueprint_templates(
         self, *, include_reports: bool = False
     ) -> list[BlueprintTemplate]:

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -82,6 +82,7 @@ def mock_workspace() -> MagicMock:
     workspace.pin_dashboard.return_value = None
     workspace.unpin_dashboard.return_value = None
     workspace.remove_report_from_dashboard.return_value = mock_dash
+    workspace.add_report_to_dashboard.return_value = mock_dash
     workspace.list_blueprint_templates.return_value = [
         BlueprintTemplate(title_key="onboarding", description_key="Get started")
     ]

--- a/tests/integration/cli/test_dashboard_commands.py
+++ b/tests/integration/cli/test_dashboard_commands.py
@@ -300,6 +300,17 @@ class TestDashboardsOrganization:
         data = json.loads(result.stdout)
         assert isinstance(data, dict)
 
+    def test_add_report(self, cli_runner: CliRunner, mock_workspace: MagicMock) -> None:
+        """Test adding a report to a dashboard."""
+        with patch(
+            "mixpanel_data.cli.commands.dashboards.get_workspace",
+            return_value=mock_workspace,
+        ):
+            result = cli_runner.invoke(app, ["dashboards", "add-report", "1", "42"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+
 
 class TestDashboardsBlueprints:
     """Tests for mp dashboards blueprints and blueprint-create commands."""

--- a/tests/unit/test_api_client_crud.py
+++ b/tests/unit/test_api_client_crud.py
@@ -348,6 +348,36 @@ class TestDashboardOrganization:
         assert result is not None
         assert result["id"] == 1
 
+    def test_add_report_to_dashboard(self, oauth_credentials: Credentials) -> None:
+        """add_report_to_dashboard() sends PATCH with create action and source_bookmark_id."""
+        captured: list[tuple[str, str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture method, URL, and body."""
+            captured.append(
+                (request.method, str(request.url), json.loads(request.content))
+            )
+            return httpx.Response(
+                200,
+                json={"status": "ok", "results": {"id": 1, "title": "Dash"}},
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            result = client.add_report_to_dashboard(1, 42)
+
+        assert captured[0][0] == "PATCH"
+        assert "/dashboards/1" in captured[0][1]
+        assert captured[0][2] == {
+            "content": {
+                "action": "create",
+                "content_type": "report",
+                "content_params": {"source_bookmark_id": 42},
+            }
+        }
+        assert result is not None
+        assert result["id"] == 1
+
 
 class TestBlueprintOperations:
     """Tests for blueprint API methods."""

--- a/tests/unit/test_workspace_crud.py
+++ b/tests/unit/test_workspace_crud.py
@@ -1515,3 +1515,30 @@ class TestRemoveReportFromDashboard:
         assert isinstance(result, Dashboard)
         assert result.title == "Updated Dashboard"
         assert call_count == 1  # Single PATCH request
+
+
+class TestAddReportToDashboard:
+    """Tests for add_report_to_dashboard using PATCH with content action."""
+
+    def test_add_report_returns_dashboard(self, temp_dir: Path) -> None:
+        """add_report_to_dashboard() sends PATCH and returns updated dashboard."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return updated dashboard for PATCH request."""
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": {"id": 1, "title": "Updated Dashboard"},
+                },
+            )
+
+        ws = _make_workspace(temp_dir, handler)
+        result = ws.add_report_to_dashboard(1, 42)
+
+        assert isinstance(result, Dashboard)
+        assert result.title == "Updated Dashboard"
+        assert call_count == 1  # Single PATCH request

--- a/tests/unit/test_workspace_crud.py
+++ b/tests/unit/test_workspace_crud.py
@@ -18,10 +18,12 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import pytest
 from pydantic import SecretStr
 
 from mixpanel_data._internal.api_client import MixpanelAPIClient
 from mixpanel_data._internal.config import AuthMethod, ConfigManager, Credentials
+from mixpanel_data.exceptions import MixpanelDataError
 from mixpanel_data.types import (
     Bookmark,
     BookmarkHistoryResponse,
@@ -1542,3 +1544,28 @@ class TestAddReportToDashboard:
         assert isinstance(result, Dashboard)
         assert result.title == "Updated Dashboard"
         assert call_count == 1  # Single PATCH request
+
+    def test_add_report_raises_on_unexpected_response(self, temp_dir: Path) -> None:
+        """add_report_to_dashboard() raises MixpanelDataError for non-dashboard response."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return 204-style response without dashboard payload."""
+            return httpx.Response(204)
+
+        ws = _make_workspace(temp_dir, handler)
+        with pytest.raises(MixpanelDataError, match="Unexpected response"):
+            ws.add_report_to_dashboard(1, 42)
+
+    def test_add_report_raises_on_dict_without_id(self, temp_dir: Path) -> None:
+        """add_report_to_dashboard() raises MixpanelDataError when response dict lacks 'id'."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a dict response that is missing the 'id' key."""
+            return httpx.Response(
+                200,
+                json={"status": "ok", "results": {"title": "No ID Dashboard"}},
+            )
+
+        ws = _make_workspace(temp_dir, handler)
+        with pytest.raises(MixpanelDataError, match="Unexpected response"):
+            ws.add_report_to_dashboard(1, 42)


### PR DESCRIPTION
## Summary

- Add first-class `add_report_to_dashboard(dashboard_id, bookmark_id)` method at all three layers (API client, Workspace, CLI), symmetric with the existing `remove_report_from_dashboard`
- Uses PATCH with `content.action="create"` and `source_bookmark_id` to clone bookmarks onto dashboards
- Improve `help.py` with enum display, better type formatting, model config display, and related method discovery
- Update mixpanel-analyst skill docs to reference the new method instead of raw API calls
- Add bookmark-params.md reference for insights report param structure

## Test plan

- [x] Unit test: API client sends correct PATCH body (`test_add_report_to_dashboard`)
- [x] Unit test: Workspace returns typed Dashboard (`test_add_report_returns_dashboard`)
- [x] Integration test: CLI `dashboards add-report` returns exit code 0 (`test_add_report`)
- [x] Full quality gate passes: `just check` (2791 passed, 0 failed)
- [ ] Verify CLI registration: `mp dashboards --help` shows `add-report`
- [ ] End-to-end smoke test against live Mixpanel project