### PR TITLE
feat(query): build_params(), date filters, percentile, histogram

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -117,11 +117,12 @@ Typed results for all operations:
 The library exports these type aliases:
 
 ```python
-from mixpanel_data import CountType, HourDayUnit, TimeUnit
+from mixpanel_data import CountType, HourDayUnit, TimeUnit, FilterDateUnit
 
 # CountType: Literal["general", "unique", "average", "median", "min", "max"]
 # HourDayUnit: Literal["hour", "day"]
 # TimeUnit: Literal["day", "week", "month", "quarter", "year"]
+# FilterDateUnit: Literal["hour", "day", "week", "month"]
 ```
 
 ## Complete API Reference

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -95,6 +95,8 @@ Aggregate a numeric property across events. Requires `math_property`:
 | `"median"` | Median value |
 | `"min"` / `"max"` | Extremes |
 | `"p25"` / `"p75"` / `"p90"` / `"p99"` | Percentiles |
+| `"percentile"` + `percentile_value` | Custom percentile (e.g. p95) |
+| `"histogram"` | Distribution of property values |
 
 ```python
 # Average purchase amount per day
@@ -108,6 +110,17 @@ result = ws.query(
 
 # P90 response time
 result = ws.query("API Call", math="p90", math_property="duration_ms")
+
+# Custom percentile (p95) — use math="percentile" with percentile_value
+result = ws.query(
+    "API Call",
+    math="percentile",
+    math_property="duration_ms",
+    percentile_value=95,
+)
+
+# Histogram — distribution of purchase amounts
+result = ws.query("Purchase", math="histogram", math_property="amount")
 ```
 
 ### Per-User Aggregation
@@ -141,6 +154,15 @@ result = ws.query([
     Metric("Signup", math="unique"),
     Metric("Purchase", math="total", property="revenue"),
 ])
+```
+
+`Metric` also supports `percentile_value` for custom percentiles:
+
+```python
+# Per-metric custom percentile
+result = ws.query(
+    Metric("API Call", math="percentile", property="duration_ms", percentile_value=95),
+)
 ```
 
 Plain strings inherit the top-level `math`, `math_property`, and `per_user` defaults. `Metric` objects override them per-event:
@@ -250,6 +272,39 @@ result = ws.query(Metric(
     ],
     filters_combinator="any",  # match US OR CA
 ))
+```
+
+### Date Filters
+
+Filter by datetime properties using purpose-built factory methods:
+
+```python
+from mixpanel_data import Filter
+
+# Absolute date filters
+Filter.on("created", "2025-01-15")              # exact date match
+Filter.not_on("created", "2025-01-15")           # not on date
+Filter.before("created", "2025-01-01")           # before a date
+Filter.since("created", "2025-01-01")            # on or after a date
+Filter.date_between("created", "2025-01-01", "2025-06-30")  # date range
+
+# Relative date filters — "in the last N units"
+Filter.in_the_last("created", 30, "day")         # last 30 days
+Filter.in_the_last("last_seen", 2, "week")       # last 2 weeks
+Filter.not_in_the_last("created", 90, "day")     # NOT in last 90 days
+```
+
+The relative date methods accept a `FilterDateUnit`: `"hour"`, `"day"`, `"week"`, or `"month"`.
+
+```python
+from mixpanel_data import FilterDateUnit  # Literal["hour", "day", "week", "month"]
+
+# Example: recent signups with purchases
+result = ws.query(
+    "Purchase",
+    where=Filter.in_the_last("signup_date", 7, "day"),
+    last=30,
+)
 ```
 
 ## Breakdowns
@@ -622,6 +677,31 @@ wau = ws.query(
 )
 ```
 
+## Generating Params Without Querying
+
+Use `build_params()` to generate bookmark params without making an API call — useful for debugging, inspecting the generated JSON, or saving queries as reports:
+
+```python
+# Same arguments as query(), returns dict instead of QueryResult
+params = ws.build_params(
+    "Login",
+    math="dau",
+    group_by="platform",
+    where=Filter.in_the_last("created", 30, "day"),
+    last=90,
+)
+
+import json
+print(json.dumps(params, indent=2))  # inspect the generated bookmark JSON
+
+# Save as a report directly from params
+ws.create_bookmark(CreateBookmarkParams(
+    name="DAU by Platform (90d)",
+    bookmark_type="insights",
+    params=params,
+))
+```
+
 ## What's Next
 
 `query()` is the foundation for a family of typed query methods. Future additions will follow the same pattern — typed Python arguments generating the correct bookmark params:
@@ -629,7 +709,6 @@ wau = ws.query(
 - **`query_funnel()`** — Ad-hoc funnel conversion analysis with typed step definitions
 - **`query_retention()`** — Ad-hoc retention curves with event pairs
 - **Cohort behaviors** — Querying by cohort membership
-- **`build_params()`** — Generate bookmark params without executing
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,8 +178,8 @@ Discovery commands let you survey what exists before writing queries—no guessi
 - Formula-based metrics (conversion rates, ratios)
 - Per-user aggregation (average purchases per user)
 - Rolling and cumulative analysis modes
-- Percentiles (p25, p75, p90, p99)
-- Typed filters (`Filter.equals()`, `Filter.greater_than()`, etc.)
+- Percentiles (p25, p75, p90, p99, custom percentiles, histogram distributions)
+- Typed filters (`Filter.equals()`, `Filter.greater_than()`, date filters like `Filter.in_the_last()`, etc.)
 - Property breakdowns with numeric bucketing
 - Results as DataFrames, persistable as saved reports
 

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -58,10 +58,10 @@ Inspired by CloudFlare's "Code Mode" MCP and Anthropic's "programmatic tool call
 
 | File | Lines | Content |
 |------|-------|---------|
-| `python-api.md` | ~450 | Typed Query API + complete Workspace method signatures |
+| `python-api.md` | ~530 | Typed Query API + complete Workspace method signatures |
 | `pandas-patterns.md` | ~250 | DataFrame workflows, visualization patterns |
 | `analytical-frameworks.md` | ~300 | AARRR, GQM, North Star, diagnosis methodology |
-| `code-patterns.md` | ~300 | 12 ready-to-use Python analysis snippets |
+| `code-patterns.md` | ~340 | 14 ready-to-use Python analysis snippets |
 
 ## How It Works
 

--- a/mixpanel-plugin/agents/query.md
+++ b/mixpanel-plugin/agents/query.md
@@ -93,8 +93,12 @@ ws.query(
 | `"p75"` | 75th percentile | Yes | No |
 | `"p90"` | 90th percentile | Yes | No |
 | `"p99"` | 99th percentile | Yes | No |
+| `"percentile"` | Custom percentile (requires `percentile_value`) | Yes | No |
+| `"histogram"` | Distribution of property values | Yes | No |
 
 There is no `"sum"` math type. To sum a property, use `math="total", math_property="prop"`.
+
+`math="percentile"` requires `percentile_value` on `query()` or `Metric` (e.g. `percentile_value=95` for p95).
 
 ### PerUserAggregation
 
@@ -122,6 +126,15 @@ Filter.is_set(property)                      # property exists
 Filter.is_not_set(property)                  # property is null
 Filter.is_true(property)                     # boolean true
 Filter.is_false(property)                    # boolean false
+
+# Date filters
+Filter.on(property, date)                    # exact date (YYYY-MM-DD)
+Filter.not_on(property, date)                # not on date
+Filter.before(property, date)                # before date
+Filter.since(property, date)                 # on or after date
+Filter.in_the_last(property, qty, unit)      # last N hours/days/weeks/months
+Filter.not_in_the_last(property, qty, unit)  # NOT in last N units
+Filter.date_between(property, from_d, to_d)  # date range
 ```
 
 ### GroupBy
@@ -162,6 +175,8 @@ Formula("(B/A)*100", label="CVR")
 | "total/sum of X" (property) | `math="total", math_property="X"` |
 | "median X" | `math="median", math_property="X"` |
 | "p90/p99 of X" | `math="p90"/"p99", math_property="X"` |
+| "p95 of X" / "custom percentile" | `math="percentile", math_property="X", percentile_value=95` |
+| "distribution of X" / "histogram" | `math="histogram", math_property="X"` |
 | "average X per user" | `math="total", per_user="average", math_property="X"` |
 | "by country" / "broken down by" | `group_by="country"` |
 | "in buckets of 50" / "revenue distribution" | `GroupBy("prop", property_type="number", bucket_size=50)` |
@@ -169,6 +184,11 @@ Formula("(B/A)*100", label="CVR")
 | "greater than 100" | `Filter.greater_than("prop", 100)` |
 | "premium users" / "where plan is" | `where=Filter.equals("plan", "premium")` |
 | "has email" / "email is set" | `Filter.is_set("email")` |
+| "created today" / "on date" | `Filter.on("created", "2025-01-15")` |
+| "created before" | `Filter.before("created", "2025-01-01")` |
+| "in the last 30 days" | `Filter.in_the_last("created", 30, "day")` |
+| "not in the last week" | `Filter.not_in_the_last("created", 1, "week")` |
+| "between two dates" | `Filter.date_between("created", "2025-01-01", "2025-06-30")` |
 | "conversion rate from X to Y" | `[Metric("X", math="unique"), Metric("Y", math="unique")], formula="(B/A)*100"` |
 | "rolling 7-day" / "smoothed" | `rolling=7` |
 | "cumulative" / "running total" | `cumulative=True` |

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -234,6 +234,19 @@ Filter.is_set("email")
 Filter.contains("page_url", "/pricing")
 Filter.is_true("is_premium")
 
+# Date filters
+Filter.on("created", "2025-01-15")             # exact date
+Filter.not_on("created", "2025-01-15")         # not on date
+Filter.before("created", "2025-01-01")         # before date
+Filter.since("created", "2025-01-01")          # on or after date
+Filter.in_the_last("created", 30, "day")       # last 30 days
+Filter.not_in_the_last("created", 90, "day")   # NOT in last 90 days
+Filter.date_between("created", "2025-01-01", "2025-06-30")  # date range
+
+# Custom percentile and histogram
+ws.query("API Call", math="percentile", math_property="duration_ms", percentile_value=95)
+ws.query("Purchase", math="histogram", math_property="amount")
+
 # Legacy string filters (still work with segmentation/retention/funnel)
 where='properties["platform"] == "iOS"'
 on='properties["platform"]'

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -151,6 +151,7 @@ Not all SQL is expressible: no JOINs, no subqueries, no UNION. Formulas are the 
 | `median` | `PERCENTILE_CONT(0.5)` |
 | `min` / `max` | `MIN` / `MAX` |
 | `p25` / `p75` / `p90` / `p99` | Percentiles |
+| `custom_percentile` | Custom percentile (set `measurement.percentile`) |
 | `unique_values` | `COUNT(DISTINCT property)` |
 | `histogram` | Distribution buckets |
 
@@ -190,6 +191,21 @@ With property aggregation:
   }
 }
 ```
+
+With custom percentile (e.g. p95):
+```json
+"measurement": {
+  "math": "custom_percentile",
+  "percentile": 95,
+  "property": {
+    "name": "duration_ms", "dataset": "mixpanel",
+    "defaultType": "number", "type": "number",
+    "resourceType": "events"
+  }
+}
+```
+
+Note: `query()` maps `math="percentile"` to `"custom_percentile"` in bookmark JSON and `percentile_value` to `measurement.percentile`.
 
 ### Show Clause — Formula
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/code-patterns.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/code-patterns.md
@@ -268,7 +268,48 @@ print("=== Purchase: Paid vs Free ===")
 print(comparison.describe())
 ```
 
-## 11. Multi-Metric Dashboard
+## 11. Date-Filtered Analysis
+
+```python
+"""Filter by date properties — signup cohorts, time-bounded queries."""
+import mixpanel_data as mp
+from mixpanel_data import Filter
+
+ws = mp.Workspace()
+
+# Users who signed up in the last 30 days
+recent_signups = ws.query(
+    "Purchase",
+    math="total",
+    math_property="revenue",
+    where=Filter.in_the_last("signup_date", 30, "day"),
+    last=30,
+)
+
+# Activity before a specific date
+early_users = ws.query(
+    "Login",
+    math="unique",
+    where=Filter.before("created", "2024-01-01"),
+    last=90,
+)
+
+# Custom percentile — p95 response time
+p95_latency = ws.query(
+    "API Call",
+    math="percentile",
+    math_property="duration_ms",
+    percentile_value=95,
+    last=30,
+)
+
+print("=== Recent Signup Revenue ===")
+print(recent_signups.df.describe())
+print("=== P95 Latency ===")
+print(p95_latency.df.tail())
+```
+
+## 12. Multi-Metric Dashboard
 
 ```python
 """Generate a text-based executive dashboard."""
@@ -303,7 +344,7 @@ print(f"║  ARPU:        ${results['ARPU']['count'].mean():>11,.2f}      ║")
 print("╚══════════════════════════════════╝")
 ```
 
-## 12. Data Governance Audit
+## 13. Data Governance Audit
 
 ```python
 """Audit event schema and data quality."""
@@ -335,7 +376,7 @@ if anomalies:
         print(f"  - {a}")
 ```
 
-## 13. Create Dashboard with Reports
+## 14. Create Dashboard with Reports
 
 ```python
 """Create a Mixpanel dashboard and populate it with reports programmatically."""

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
@@ -43,7 +43,8 @@ ws.query(
     last: int = 30,                        # relative window in `unit`s; ignored if from_date set
     unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
     math: MathType = "total",              # aggregate function
-    math_property: str | None = None,      # required for average/median/min/max/p25/p75/p90/p99
+    math_property: str | None = None,      # required for average/median/min/max/p25/p75/p90/p99/percentile/histogram
+    percentile_value: int | float | None = None,  # required when math="percentile" (e.g. 95)
     per_user: PerUserAggregation | None = None,  # nest per-user then aggregate
     group_by: str | GroupBy | list[str | GroupBy] | None = None,
     where: Filter | list[Filter] | None = None,
@@ -65,6 +66,7 @@ Metric(
     math: MathType = "total",
     math_property: str | None = None,
     per_user: PerUserAggregation | None = None,
+    percentile_value: int | float | None = None,  # required when math="percentile"
     where: Filter | list[Filter] | None = None,
     label: str | None = None,              # display label
 )
@@ -86,7 +88,18 @@ Filter.is_set(property, *, resource_type="events")
 Filter.is_not_set(property, *, resource_type="events")
 Filter.is_true(property, *, resource_type="events")
 Filter.is_false(property, *, resource_type="events")
+
+# Date/datetime filters
+Filter.on(property, date, *, resource_type="events")                    # exact date (YYYY-MM-DD)
+Filter.not_on(property, date, *, resource_type="events")                # not on date
+Filter.before(property, date, *, resource_type="events")                # before date
+Filter.since(property, date, *, resource_type="events")                 # on or after date
+Filter.in_the_last(property, quantity, date_unit, *, resource_type="events")      # last N units
+Filter.not_in_the_last(property, quantity, date_unit, *, resource_type="events")  # NOT in last N
+Filter.date_between(property, from_date, to_date, *, resource_type="events")     # date range
 ```
+
+`FilterDateUnit = Literal["hour", "day", "week", "month"]` — used by `in_the_last()` and `not_in_the_last()`.
 
 ### GroupBy
 
@@ -144,8 +157,12 @@ result.computed_at # API computation timestamp
 | `p75` | 75th percentile | Yes |
 | `p90` | 90th percentile | Yes |
 | `p99` | 99th percentile | Yes |
+| `percentile` | Custom percentile (requires `percentile_value`) | Yes |
+| `histogram` | Distribution of property values | Yes |
 
 There is **no `"sum"`** math type. To sum a property, use `math="total"` with `math_property="..."`.
+
+`math="percentile"` requires `percentile_value` (e.g. `percentile_value=95` for p95). `math="histogram"` shows property value distribution.
 
 ### PerUserAggregation
 
@@ -158,6 +175,22 @@ There is **no `"sum"`** math type. To sum a property, use `math="total"` with `m
 | `max` | Maximum per user |
 
 Requires `math_property`. Incompatible with `dau`, `wau`, `mau`, `unique`.
+
+---
+
+### build_params()
+
+Same signature as `query()` but returns the bookmark params dict without making an API call:
+
+```python
+ws.build_params(
+    events, *, from_date, to_date, last, unit, math, math_property,
+    percentile_value, per_user, group_by, where, formula, formula_label,
+    rolling, cumulative, mode,
+) -> dict
+```
+
+Useful for debugging, inspecting generated JSON, or passing to `create_bookmark()`.
 
 ---
 

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -109,6 +109,7 @@ from mixpanel_data.types import (
     FeatureFlag,
     FeatureFlagStatus,
     Filter,
+    FilterDateUnit,
     FilterPropertyType,
     FlagContractStatus,
     FlagHistoryParams,
@@ -374,6 +375,7 @@ __all__ = [
     "Filter",
     "Formula",
     "GroupBy",
+    "FilterDateUnit",
     "FilterPropertyType",
     "QueryResult",
     # Schema Registry & Data Governance types (Phase 028)

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -290,7 +290,7 @@ VALID_FILTER_OPERATORS: frozenset[str] = frozenset(
         # Boolean operators
         "true",
         "false",
-        # Date operators
+        # Date operators (legacy segfilter format — DateRangeType)
         "on",
         "not on",
         "in the last",
@@ -299,9 +299,31 @@ VALID_FILTER_OPERATORS: frozenset[str] = frozenset(
         "before",
         "in the next",
         "since",
+        # Date operators (canonical bookmark sections — InsightsDateRangeType)
+        "was on",
+        "was not on",
+        "was in the",
+        "was not in the",
+        "was between",
+        "was not between",
+        "was less than",
+        "was before",
+        "was since",
+        "was in the next",
     }
 )
-"""Valid filter operators from the canonical operator expression schema."""
+"""Valid filter operators from the canonical operator expression schema.
+
+Includes both legacy ``DateRangeType`` operators (``"on"``, ``"in the last"``,
+etc.) and canonical ``InsightsDateRangeType`` operators (``"was on"``,
+``"was in the"``, etc.).  The ``InsightsDateRangeType`` form is what the
+Mixpanel webapp writes into bookmark ``sections.filter[]`` entries; the
+legacy form appears in old v2 bookmarks and segfilter-based params.  Both
+are accepted by the Mixpanel API.
+
+Reference: ``analytics/bookmark_parser/common/segfilter/
+segfilter_to_property_filter.py`` — ``InsightsDateRangeType`` class.
+"""
 
 # =============================================================================
 # Filters Determiner

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -40,6 +40,7 @@ VALID_MATH_TYPES: frozenset[str] = frozenset(
         "p90",
         "p99",
         "custom_percentile",
+        "percentile",
         # Advanced
         "histogram",
         "unique_values",
@@ -78,6 +79,7 @@ VALID_MATH_INSIGHTS: frozenset[str] = frozenset(
         "p90",
         "p99",
         "custom_percentile",
+        "percentile",
         "histogram",
         "unique_values",
         "most_frequent",
@@ -123,6 +125,8 @@ MATH_REQUIRING_PROPERTY: frozenset[str] = frozenset(
         "p90",
         "p99",
         "custom_percentile",
+        "percentile",
+        "histogram",
     }
 )
 """Math types that require a measurement property to be specified."""

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -40,7 +40,6 @@ VALID_MATH_TYPES: frozenset[str] = frozenset(
         "p90",
         "p99",
         "custom_percentile",
-        "percentile",
         # Advanced
         "histogram",
         "unique_values",
@@ -79,7 +78,6 @@ VALID_MATH_INSIGHTS: frozenset[str] = frozenset(
         "p90",
         "p99",
         "custom_percentile",
-        "percentile",
         "histogram",
         "unique_values",
         "most_frequent",

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -161,6 +161,7 @@ def validate_query_args(
     math: MathType,
     math_property: str | None,
     per_user: PerUserAggregation | None,
+    percentile_value: int | float | None = None,
     from_date: str | None,
     to_date: str | None,
     last: int,
@@ -283,6 +284,29 @@ def validate_query_args(
                     f"({', '.join(valid)}), not '{math}'"
                 ),
                 code="V2_MATH_REJECTS_PROPERTY",
+            )
+        )
+
+    # V26: percentile math requires percentile_value
+    if math == "percentile" and percentile_value is None:
+        errors.append(
+            ValidationError(
+                path="percentile_value",
+                message=("math='percentile' requires percentile_value to be set"),
+                code="V26_PERCENTILE_REQUIRES_VALUE",
+            )
+        )
+
+    # V27: histogram math requires per_user
+    if math == "histogram" and per_user is None:
+        errors.append(
+            ValidationError(
+                path="per_user",
+                message=(
+                    "math='histogram' requires per_user to be set "
+                    "(e.g. per_user='total')"
+                ),
+                code="V27_HISTOGRAM_REQUIRES_PER_USER",
             )
         )
 
@@ -598,6 +622,33 @@ def validate_query_args(
                             f"({', '.join(valid)}), not '{m_math}'"
                         ),
                         code="V14_METRIC_REJECTS_PROPERTY",
+                    )
+                )
+
+            # V27: Per-Metric histogram requires per_user
+            if m_math == "histogram" and m_per_user is None:
+                errors.append(
+                    ValidationError(
+                        path=mpath,
+                        message=(
+                            f"Metric('{item.event}'): math='histogram' "
+                            f"requires per_user to be set "
+                            f"(e.g. per_user='total')"
+                        ),
+                        code="V27_HISTOGRAM_REQUIRES_PER_USER",
+                    )
+                )
+
+            # V26: Per-Metric percentile requires percentile_value
+            if m_math == "percentile" and item.percentile_value is None:
+                errors.append(
+                    ValidationError(
+                        path=mpath,
+                        message=(
+                            f"Metric('{item.event}'): math='percentile' "
+                            f"requires percentile_value to be set"
+                        ),
+                        code="V26_PERCENTILE_REQUIRES_VALUE",
                     )
                 )
 

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -17,7 +17,9 @@ without recomputation.
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass, field
+from datetime import date as dt_date
 from datetime import datetime
 from enum import Enum
 from typing import Any, Generic, Literal, TypeVar
@@ -7039,7 +7041,7 @@ class Filter:
     _resource_type: Literal["events", "people"] = "events"
     """Resource type to filter."""
 
-    _date_unit: str | None = None
+    _date_unit: FilterDateUnit | None = None
     """Time unit for relative date filters (hour, day, week, month).
 
     Set by ``in_the_last()`` and ``not_in_the_last()`` factory methods.
@@ -7332,22 +7334,22 @@ class Filter:
     # --- Date/datetime filters ---
 
     @staticmethod
-    def _validate_date(date_str: str) -> None:
-        """Validate a date string is YYYY-MM-DD and a valid calendar date.
+    def _validate_date(date_str: str) -> dt_date:
+        """Validate a date string is YYYY-MM-DD and return parsed date.
 
         Args:
             date_str: Date string to validate.
 
+        Returns:
+            Parsed ``datetime.date`` object.
+
         Raises:
             ValueError: If format is wrong or date is invalid.
         """
-        import re
-        from datetime import date as dt_date
-
         if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
             raise ValueError(f"Date must be YYYY-MM-DD format (got '{date_str}')")
         try:
-            dt_date.fromisoformat(date_str)
+            return dt_date.fromisoformat(date_str)
         except ValueError:
             raise ValueError(f"'{date_str}' is not a valid calendar date") from None
 
@@ -7565,11 +7567,9 @@ class Filter:
             ValueError: If dates are not valid YYYY-MM-DD or
                 from_date is after to_date.
         """
-        from datetime import date as dt_date
-
-        cls._validate_date(from_date)
-        cls._validate_date(to_date)
-        if dt_date.fromisoformat(from_date) > dt_date.fromisoformat(to_date):
+        from_parsed = cls._validate_date(from_date)
+        to_parsed = cls._validate_date(to_date)
+        if from_parsed > to_parsed:
             raise ValueError(
                 f"from_date must be before to_date (got '{from_date}' > '{to_date}')"
             )

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -46,6 +46,8 @@ MathType = Literal[
     "p75",
     "p90",
     "p99",
+    "percentile",
+    "histogram",
 ]
 """Aggregation function for query metrics.
 
@@ -78,11 +80,19 @@ MathType = Literal[
 +-----------+------------------------------------------------------------------+--------------------+
 | p99       | 99th percentile of a numeric property                            | Yes                |
 +-----------+------------------------------------------------------------------+--------------------+
+| percentile| Custom percentile (requires ``percentile_value``)                | Yes                |
++-----------+------------------------------------------------------------------+--------------------+
+| histogram | Distribution of a numeric property's values                      | Yes                |
++-----------+------------------------------------------------------------------+--------------------+
 
 Note: Mixpanel has no ``"sum"`` math type. Use ``math="total"`` with
 a ``property`` to sum a numeric property's values.
 
 ``dau``, ``wau``, ``mau``, and ``unique`` are incompatible with ``per_user``.
+
+``percentile`` maps to ``custom_percentile`` in bookmark JSON and requires
+``percentile_value`` on Metric (or as a top-level param on ``query()``/``build_params()``).
+``histogram`` maps directly to ``histogram`` in bookmark JSON.
 """
 
 PerUserAggregation = Literal["unique_values", "total", "average", "min", "max"]
@@ -111,8 +121,17 @@ Maps to ``perUserAggregation`` in the bookmark measurement block.
 FilterPropertyType = Literal["string", "number", "boolean", "datetime", "list"]
 """Property data type for filter conditions.
 
-Includes ``"datetime"`` and ``"list"`` for API compatibility;
-no Filter factory methods currently produce these types.
+Includes ``"datetime"`` and ``"list"`` for API compatibility.
+Datetime factory methods (``Filter.on``, ``Filter.before``, etc.)
+produce filters with ``filterType="datetime"``.
+"""
+
+FilterDateUnit = Literal["hour", "day", "week", "month"]
+"""Time unit for relative date filters.
+
+Used by ``Filter.in_the_last()`` and ``Filter.not_in_the_last()``
+to specify the granularity of the relative time window.
+Maps to ``filterDateUnit`` in bookmark JSON.
 """
 
 # =============================================================================
@@ -6924,6 +6943,13 @@ class Metric:
     per_user: PerUserAggregation | None = None
     """Per-user pre-aggregation type."""
 
+    percentile_value: int | float | None = None
+    """Custom percentile value (e.g. 95 for p95).
+
+    Required when ``math="percentile"``. Ignored for other math types.
+    Maps to ``percentile`` in bookmark JSON.
+    """
+
     filters: list[Filter] | None = None
     """Per-metric filters (list of Filter objects)."""
 
@@ -7012,6 +7038,14 @@ class Filter:
 
     _resource_type: Literal["events", "people"] = "events"
     """Resource type to filter."""
+
+    _date_unit: str | None = None
+    """Time unit for relative date filters (hour, day, week, month).
+
+    Set by ``in_the_last()`` and ``not_in_the_last()`` factory methods.
+    Maps to ``filterDateUnit`` in bookmark JSON. ``None`` for non-date
+    and absolute date filters.
+    """
 
     @classmethod
     def equals(
@@ -7292,6 +7326,258 @@ class Filter:
             _operator="false",
             _value=None,
             _property_type="boolean",
+            _resource_type=resource_type,
+        )
+
+    # --- Date/datetime filters ---
+
+    @staticmethod
+    def _validate_date(date_str: str) -> None:
+        """Validate a date string is YYYY-MM-DD and a valid calendar date.
+
+        Args:
+            date_str: Date string to validate.
+
+        Raises:
+            ValueError: If format is wrong or date is invalid.
+        """
+        import re
+        from datetime import date as dt_date
+
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+            raise ValueError(f"Date must be YYYY-MM-DD format (got '{date_str}')")
+        try:
+            dt_date.fromisoformat(date_str)
+        except ValueError:
+            raise ValueError(f"'{date_str}' is not a valid calendar date") from None
+
+    @classmethod
+    def on(
+        cls,
+        property: str,
+        date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date equality filter (exact date match).
+
+        Args:
+            property: Property name (e.g. ``"$time"``, ``"created"``).
+            date: Date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for exact date match.
+
+        Raises:
+            ValueError: If date is not valid YYYY-MM-DD.
+        """
+        cls._validate_date(date)
+        return cls(
+            _property=property,
+            _operator="was on",
+            _value=date,
+            _property_type="datetime",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def not_on(
+        cls,
+        property: str,
+        date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date inequality filter (not on date).
+
+        Args:
+            property: Property name.
+            date: Date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for date inequality.
+
+        Raises:
+            ValueError: If date is not valid YYYY-MM-DD.
+        """
+        cls._validate_date(date)
+        return cls(
+            _property=property,
+            _operator="was not on",
+            _value=date,
+            _property_type="datetime",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def before(
+        cls,
+        property: str,
+        date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date before filter.
+
+        Args:
+            property: Property name.
+            date: Date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for dates before the specified date.
+
+        Raises:
+            ValueError: If date is not valid YYYY-MM-DD.
+        """
+        cls._validate_date(date)
+        return cls(
+            _property=property,
+            _operator="was before",
+            _value=date,
+            _property_type="datetime",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def since(
+        cls,
+        property: str,
+        date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date since filter (from date onward).
+
+        Args:
+            property: Property name.
+            date: Date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for dates on or after the specified date.
+
+        Raises:
+            ValueError: If date is not valid YYYY-MM-DD.
+        """
+        cls._validate_date(date)
+        return cls(
+            _property=property,
+            _operator="was since",
+            _value=date,
+            _property_type="datetime",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def in_the_last(
+        cls,
+        property: str,
+        quantity: int,
+        date_unit: FilterDateUnit,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a relative date filter (in the last N units).
+
+        Args:
+            property: Property name.
+            quantity: Number of time units (must be positive).
+            date_unit: Time unit (``"hour"``, ``"day"``, ``"week"``,
+                ``"month"``).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for events within the last N units.
+
+        Raises:
+            ValueError: If quantity is not positive.
+        """
+        if quantity <= 0:
+            raise ValueError(f"quantity must be a positive integer (got {quantity})")
+        return cls(
+            _property=property,
+            _operator="was in the",
+            _value=quantity,
+            _property_type="datetime",
+            _resource_type=resource_type,
+            _date_unit=date_unit,
+        )
+
+    @classmethod
+    def not_in_the_last(
+        cls,
+        property: str,
+        quantity: int,
+        date_unit: FilterDateUnit,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a relative date exclusion filter (not in the last N units).
+
+        Args:
+            property: Property name.
+            quantity: Number of time units (must be positive).
+            date_unit: Time unit (``"hour"``, ``"day"``, ``"week"``,
+                ``"month"``).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for events NOT within the last N units.
+
+        Raises:
+            ValueError: If quantity is not positive.
+        """
+        if quantity <= 0:
+            raise ValueError(f"quantity must be a positive integer (got {quantity})")
+        return cls(
+            _property=property,
+            _operator="was not in the",
+            _value=quantity,
+            _property_type="datetime",
+            _resource_type=resource_type,
+            _date_unit=date_unit,
+        )
+
+    @classmethod
+    def date_between(
+        cls,
+        property: str,
+        from_date: str,
+        to_date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date range filter (between two dates, inclusive).
+
+        Args:
+            property: Property name.
+            from_date: Start date in YYYY-MM-DD format.
+            to_date: End date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for dates within the range.
+
+        Raises:
+            ValueError: If dates are not valid YYYY-MM-DD or
+                from_date is after to_date.
+        """
+        from datetime import date as dt_date
+
+        cls._validate_date(from_date)
+        cls._validate_date(to_date)
+        if dt_date.fromisoformat(from_date) > dt_date.fromisoformat(to_date):
+            raise ValueError(
+                f"from_date must be before to_date (got '{from_date}' > '{to_date}')"
+            )
+        return cls(
+            _property=property,
+            _operator="was between",
+            _value=[from_date, to_date],
+            _property_type="datetime",
             _resource_type=resource_type,
         )
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1865,6 +1865,9 @@ class Workspace:
             math_property: Property name for property-based math
                 (average, sum, percentiles).
             per_user: Per-user pre-aggregation (average, total, min, max).
+            percentile_value: Custom percentile value (e.g. 95 for p95).
+                Required when ``math="percentile"``. Maps to ``percentile``
+                in bookmark measurement. Ignored for other math types.
             group_by: Break down results by property. Accepts a string,
                 GroupBy object, or list of strings/GroupBys.
             where: Filter results by conditions. Accepts a Filter
@@ -1988,6 +1991,8 @@ class Workspace:
                 Default: ``"total"``.
             math_property: Property name for property-based math.
             per_user: Per-user pre-aggregation.
+            percentile_value: Custom percentile value (e.g. 95).
+                Required when ``math="percentile"``.
             group_by: Break down results by property.
             where: Filter results by conditions.
             formula: Formula expression referencing events by position.
@@ -2075,6 +2080,9 @@ class Workspace:
             math: Aggregation function.
             math_property: Property for property-based math.
             per_user: Per-user pre-aggregation.
+            percentile_value: Custom percentile value. Required when
+                ``math="percentile"``. Maps to ``percentile`` in
+                bookmark measurement JSON.
             group_by: Breakdown specification.
             where: Filter conditions.
             formula: Top-level formula expression.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -1594,6 +1594,7 @@ class Workspace:
         math: MathType,
         math_property: str | None,
         per_user: PerUserAggregation | None,
+        percentile_value: int | float | None = None,
         from_date: str | None,
         to_date: str | None,
         last: int,
@@ -1637,6 +1638,7 @@ class Workspace:
                 item_math = item.math
                 item_prop = item.property
                 item_per_user = item.per_user
+                item_percentile = item.percentile_value
                 item_filters = item.filters
                 item_filters_combinator = item.filters_combinator
             else:
@@ -1644,10 +1646,16 @@ class Workspace:
                 item_math = math
                 item_prop = math_property
                 item_per_user = per_user
+                item_percentile = percentile_value
                 item_filters = None
                 item_filters_combinator = "all"
 
-            measurement: dict[str, Any] = {"math": item_math}
+            # Map user-facing "percentile" to bookmark "custom_percentile"
+            bookmark_math = (
+                "custom_percentile" if item_math == "percentile" else item_math
+            )
+
+            measurement: dict[str, Any] = {"math": bookmark_math}
             if item_prop is not None:
                 measurement["property"] = {
                     "name": item_prop,
@@ -1655,6 +1663,8 @@ class Workspace:
                 }
             if item_per_user is not None:
                 measurement["perUserAggregation"] = item_per_user
+            if item_percentile is not None:
+                measurement["percentile"] = item_percentile
 
             # Build behavior block with optional per-metric filters
             behavior_filters: list[dict[str, Any]] = []
@@ -1800,8 +1810,9 @@ class Workspace:
 
         Returns:
             Bookmark filter dict matching Mixpanel's expected format.
+            Includes ``filterDateUnit`` for relative date filters.
         """
-        return {
+        entry: dict[str, Any] = {
             "resourceType": f._resource_type,
             "filterType": f._property_type,
             "defaultType": f._property_type,
@@ -1809,6 +1820,9 @@ class Workspace:
             "filterValue": f._value,
             "filterOperator": f._operator,
         }
+        if f._date_unit is not None:
+            entry["filterDateUnit"] = f._date_unit
+        return entry
 
     def query(
         self,
@@ -1821,6 +1835,7 @@ class Workspace:
         math: MathType = "total",
         math_property: str | None = None,
         per_user: PerUserAggregation | None = None,
+        percentile_value: int | float | None = None,
         group_by: str | GroupBy | list[str | GroupBy] | None = None,
         where: Filter | list[Filter] | None = None,
         formula: str | None = None,
@@ -1901,6 +1916,178 @@ class Workspace:
                  Formula("(B / A) * 100", label="Conversion Rate")],
             )
             ```
+        """
+        params = self._resolve_and_build_params(
+            events=events,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+            math=math,
+            math_property=math_property,
+            per_user=per_user,
+            percentile_value=percentile_value,
+            group_by=group_by,
+            where=where,
+            formula=formula,
+            formula_label=formula_label,
+            rolling=rolling,
+            cumulative=cumulative,
+            mode=mode,
+        )
+
+        # Delegate to service — _live_query_service calls _require_api_client
+        # which ensures _credentials is not None
+        credentials = self._credentials
+        if credentials is None:
+            raise ConfigError(
+                "API access requires credentials. "
+                "Use Workspace() with credentials instead of Workspace.open()."
+            )
+        return self._live_query_service.query(
+            bookmark_params=params,
+            project_id=int(credentials.project_id),
+        )
+
+    def build_params(
+        self,
+        events: str | Metric | Formula | Sequence[str | Metric | Formula],
+        *,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        last: int = 30,
+        unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
+        math: MathType = "total",
+        math_property: str | None = None,
+        per_user: PerUserAggregation | None = None,
+        percentile_value: int | float | None = None,
+        group_by: str | GroupBy | list[str | GroupBy] | None = None,
+        where: Filter | list[Filter] | None = None,
+        formula: str | None = None,
+        formula_label: str | None = None,
+        rolling: int | None = None,
+        cumulative: bool = False,
+        mode: Literal["timeseries", "total", "table"] = "timeseries",
+    ) -> dict[str, Any]:
+        """Build validated bookmark params without executing the API call.
+
+        Has the same signature as :meth:`query` but returns the generated
+        bookmark params dict instead of querying the Mixpanel API. Useful
+        for debugging, inspecting generated JSON, persisting via
+        :meth:`create_bookmark`, or testing.
+
+        Args:
+            events: Event name(s) to query. Accepts a single string,
+                a Metric object, a Formula object, or a sequence mixing
+                strings, Metrics, and Formulas.
+            from_date: Start date (YYYY-MM-DD). If set, overrides ``last``.
+            to_date: End date (YYYY-MM-DD). Requires ``from_date``.
+            last: Relative time range in days. Default: 30.
+            unit: Time aggregation unit. Default: ``"day"``.
+            math: Aggregation function for plain-string events.
+                Default: ``"total"``.
+            math_property: Property name for property-based math.
+            per_user: Per-user pre-aggregation.
+            group_by: Break down results by property.
+            where: Filter results by conditions.
+            formula: Formula expression referencing events by position.
+            formula_label: Display label for formula result.
+            rolling: Rolling window size in periods.
+            cumulative: Enable cumulative analysis mode.
+            mode: Result shape. Default: ``"timeseries"``.
+
+        Returns:
+            Bookmark params dict with ``sections`` and ``displayOptions``
+            keys, ready for use with the insights API or
+            :meth:`create_bookmark`.
+
+        Raises:
+            BookmarkValidationError: If arguments violate validation rules.
+
+        Example:
+            ```python
+            ws = Workspace()
+
+            # Inspect generated bookmark JSON
+            params = ws.build_params("Login", math="unique", last=7)
+            print(json.dumps(params, indent=2))
+
+            # Save as a bookmark
+            ws.create_bookmark(CreateBookmarkParams(
+                name="Daily Unique Logins",
+                bookmark_type="insights",
+                params=params,
+            ))
+            ```
+        """
+        return self._resolve_and_build_params(
+            events=events,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+            math=math,
+            math_property=math_property,
+            per_user=per_user,
+            percentile_value=percentile_value,
+            group_by=group_by,
+            where=where,
+            formula=formula,
+            formula_label=formula_label,
+            rolling=rolling,
+            cumulative=cumulative,
+            mode=mode,
+        )
+
+    def _resolve_and_build_params(
+        self,
+        *,
+        events: str | Metric | Formula | Sequence[str | Metric | Formula],
+        from_date: str | None,
+        to_date: str | None,
+        last: int,
+        unit: str,
+        math: MathType,
+        math_property: str | None,
+        per_user: PerUserAggregation | None,
+        percentile_value: int | float | None = None,
+        group_by: str | GroupBy | list[str | GroupBy] | None = None,
+        where: Filter | list[Filter] | None = None,
+        formula: str | None = None,
+        formula_label: str | None = None,
+        rolling: int | None = None,
+        cumulative: bool = False,
+        mode: str = "timeseries",
+    ) -> dict[str, Any]:
+        """Normalize, validate, and build bookmark params.
+
+        Shared implementation for :meth:`query` and :meth:`build_params`.
+        Handles type guards, event/formula normalization, argument
+        validation (Layer 1), bookmark construction, and bookmark
+        structure validation (Layer 2).
+
+        Args:
+            events: Raw events input (str, Metric, Formula, or sequence).
+            from_date: Start date (YYYY-MM-DD) or None.
+            to_date: End date (YYYY-MM-DD) or None.
+            last: Relative time range in days.
+            unit: Time aggregation unit.
+            math: Aggregation function.
+            math_property: Property for property-based math.
+            per_user: Per-user pre-aggregation.
+            group_by: Breakdown specification.
+            where: Filter conditions.
+            formula: Top-level formula expression.
+            formula_label: Display label for formula.
+            rolling: Rolling window size.
+            cumulative: Cumulative analysis mode.
+            mode: Result shape.
+
+        Returns:
+            Validated bookmark params dict.
+
+        Raises:
+            BookmarkValidationError: If validation fails at any layer.
         """
         # Type guard: events must be str, Metric, Formula, or sequence thereof
         if not isinstance(events, (str, Metric, Formula, list, tuple)):
@@ -1986,6 +2173,7 @@ class Workspace:
             math=math,
             math_property=math_property,
             per_user=per_user,
+            percentile_value=percentile_value,
             from_date=from_date,
             to_date=to_date,
             last=last,
@@ -2004,6 +2192,7 @@ class Workspace:
             math=math,
             math_property=math_property,
             per_user=per_user,
+            percentile_value=percentile_value,
             from_date=from_date,
             to_date=to_date,
             last=last,
@@ -2021,18 +2210,7 @@ class Workspace:
         if any(e.severity == "error" for e in bookmark_errors):
             raise BookmarkValidationError(bookmark_errors)
 
-        # Delegate to service — _live_query_service calls _require_api_client
-        # which ensures _credentials is not None
-        credentials = self._credentials
-        if credentials is None:
-            raise ConfigError(
-                "API access requires credentials. "
-                "Use Workspace() with credentials instead of Workspace.open()."
-            )
-        return self._live_query_service.query(
-            bookmark_params=params,
-            project_id=int(credentials.project_id),
-        )
+        return params
 
     # =========================================================================
     # ESCAPE HATCHES

--- a/tests/unit/test_bookmark_enums.py
+++ b/tests/unit/test_bookmark_enums.py
@@ -38,17 +38,21 @@ from mixpanel_data.types import (
 class TestMathTypeCompleteness:
     """Verify math type enum coverage."""
 
+    # User-facing math aliases that map to different bookmark values.
+    # "percentile" -> "custom_percentile" in bookmark JSON.
+    USER_FACING_ALIASES: frozenset[str] = frozenset({"percentile"})
+
     def test_math_type_literal_subset_of_insights(self) -> None:
-        """Every MathType Literal value is in VALID_MATH_INSIGHTS."""
-        literal_values = set(get_args(MathType))
+        """Every MathType Literal value (excluding aliases) is in VALID_MATH_INSIGHTS."""
+        literal_values = set(get_args(MathType)) - self.USER_FACING_ALIASES
         assert literal_values <= VALID_MATH_INSIGHTS, (
             f"MathType values not in VALID_MATH_INSIGHTS: "
             f"{literal_values - VALID_MATH_INSIGHTS}"
         )
 
     def test_math_type_literal_subset_of_all(self) -> None:
-        """Every MathType Literal value is in VALID_MATH_TYPES."""
-        literal_values = set(get_args(MathType))
+        """Every MathType Literal value (excluding aliases) is in VALID_MATH_TYPES."""
+        literal_values = set(get_args(MathType)) - self.USER_FACING_ALIASES
         assert literal_values <= VALID_MATH_TYPES
 
     def test_insights_subset_of_all(self) -> None:
@@ -64,8 +68,10 @@ class TestMathTypeCompleteness:
         assert VALID_MATH_RETENTION <= VALID_MATH_TYPES
 
     def test_requiring_property_subset_of_insights(self) -> None:
-        """MATH_REQUIRING_PROPERTY is a subset of VALID_MATH_INSIGHTS."""
-        assert MATH_REQUIRING_PROPERTY <= VALID_MATH_INSIGHTS
+        """MATH_REQUIRING_PROPERTY (excluding aliases) is a subset of VALID_MATH_INSIGHTS."""
+        assert (
+            MATH_REQUIRING_PROPERTY - self.USER_FACING_ALIASES
+        ) <= VALID_MATH_INSIGHTS
 
     def test_property_optional_subset_of_insights(self) -> None:
         """MATH_PROPERTY_OPTIONAL is a subset of VALID_MATH_INSIGHTS."""

--- a/tests/unit/test_query_integration.py
+++ b/tests/unit/test_query_integration.py
@@ -405,3 +405,25 @@ class TestFormulaInListIntegration:
         )
         behavior = result.params["sections"]["show"][0]["behavior"]
         assert behavior["filtersDeterminer"] == "any"
+
+
+# =============================================================================
+# T054d: build_params() does not invoke API
+# =============================================================================
+
+
+class TestBuildParamsNoApiCall:
+    """T054d: build_params() does not invoke the API."""
+
+    def test_does_not_call_api(self, ws: Workspace, mock_api_client: MagicMock) -> None:
+        """build_params() returns params without calling API client."""
+        result = ws.build_params("Login")
+        mock_api_client.insights_query.assert_not_called()
+        assert isinstance(result, dict)
+
+    def test_works_without_credentials(self, mock_config_manager: MagicMock) -> None:
+        """build_params() does not require live credentials."""
+        workspace = Workspace(_config_manager=mock_config_manager)
+        # No _api_client set at all
+        result = workspace.build_params("Login")
+        assert "sections" in result

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -3,6 +3,7 @@
 Tests _build_query_params() in Workspace for US1 (basic params),
 US2 (aggregation), US3 (filters/groups), US4 (multi-event),
 US5 (formula), US6 (analysis mode), US7 (result mode).
+Also tests build_params() public helper (T054).
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mixpanel_data import Formula, Workspace
+from mixpanel_data import Filter, Formula, GroupBy, Metric, Workspace
 
 # =============================================================================
 # Fixtures
@@ -1114,3 +1115,262 @@ class TestFormulaObjectParams:
         )
         assert params["sections"]["show"][0]["isHidden"] is True
         assert params["sections"]["show"][1]["isHidden"] is True
+
+
+# =============================================================================
+# T054: build_params() public helper
+# =============================================================================
+
+
+class TestBuildParams:
+    """T054: build_params() returns bookmark params without API call."""
+
+    def test_build_params_returns_dict(self, ws: Workspace) -> None:
+        """T054a: build_params() returns a dict with sections and displayOptions."""
+        result = ws.build_params("Login")
+        assert isinstance(result, dict)
+        assert "sections" in result
+        assert "displayOptions" in result
+
+    def test_build_params_accepts_all_query_kwargs(self, ws: Workspace) -> None:
+        """T054b: build_params() accepts the full query() signature."""
+        result = ws.build_params(
+            [Metric("Login", math="unique"), Metric("Purchase")],
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            unit="week",
+            group_by=GroupBy("country"),
+            where=Filter.equals("region", "US"),
+            formula="A + B",
+            formula_label="Combined",
+            mode="total",
+        )
+        assert result["sections"]["show"][0]["behavior"]["name"] == "Login"
+        assert result["sections"]["show"][0]["measurement"]["math"] == "unique"
+        assert result["displayOptions"]["chartType"] == "bar"
+
+    def test_build_params_output_matches_query_params(self, ws: Workspace) -> None:
+        """T054c: build_params() output matches _build_query_params() for same input."""
+        build_result = ws.build_params("Login", math="unique", last=7, unit="day")
+        internal_result = ws._build_query_params(
+            events=["Login"],
+            math="unique",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=7,
+            unit="day",
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        assert build_result == internal_result
+
+
+# =============================================================================
+# T057: Date filter bookmark params
+# =============================================================================
+
+
+class TestDateFilterParams:
+    """T057: Date filter bookmark params generation."""
+
+    def test_absolute_date_omits_date_unit(self, ws: Workspace) -> None:
+        """Absolute date filter (on) omits filterDateUnit."""
+        entry = ws._build_filter_entry(Filter.on("created", "2024-06-15"))
+        assert entry["filterType"] == "datetime"
+        assert entry["filterOperator"] == "was on"
+        assert entry["filterValue"] == "2024-06-15"
+        assert "filterDateUnit" not in entry
+
+    def test_relative_date_includes_date_unit(self, ws: Workspace) -> None:
+        """Relative date filter (in_the_last) includes filterDateUnit."""
+        entry = ws._build_filter_entry(Filter.in_the_last("created", 7, "day"))
+        assert entry["filterDateUnit"] == "day"
+        assert entry["filterValue"] == 7
+        assert entry["filterType"] == "datetime"
+
+    def test_date_between_value_is_list(self, ws: Workspace) -> None:
+        """Date between filter value is a two-element list."""
+        entry = ws._build_filter_entry(
+            Filter.date_between("created", "2024-01-01", "2024-06-30")
+        )
+        assert entry["filterValue"] == ["2024-01-01", "2024-06-30"]
+        assert entry["filterOperator"] == "was between"
+        assert "filterDateUnit" not in entry
+
+    def test_existing_filters_unaffected(self, ws: Workspace) -> None:
+        """Non-date filters still omit filterDateUnit (backward compat)."""
+        entry = ws._build_filter_entry(Filter.equals("country", "US"))
+        assert "filterDateUnit" not in entry
+
+    def test_date_filter_in_where_clause(self, ws: Workspace) -> None:
+        """Date filter works in sections.filter when passed as where=."""
+        params = ws.build_params(
+            "Login",
+            where=Filter.in_the_last("created", 7, "day"),
+        )
+        filt = params["sections"]["filter"][0]
+        assert filt["filterDateUnit"] == "day"
+        assert filt["filterType"] == "datetime"
+
+    def test_before_filter_params(self, ws: Workspace) -> None:
+        """Filter.before() produces correct bookmark entry."""
+        entry = ws._build_filter_entry(Filter.before("created", "2024-01-01"))
+        assert entry["filterOperator"] == "was before"
+        assert entry["filterValue"] == "2024-01-01"
+        assert entry["filterType"] == "datetime"
+
+    def test_since_filter_params(self, ws: Workspace) -> None:
+        """Filter.since() produces correct bookmark entry."""
+        entry = ws._build_filter_entry(Filter.since("created", "2024-01-01"))
+        assert entry["filterOperator"] == "was since"
+        assert entry["filterValue"] == "2024-01-01"
+
+    def test_not_in_the_last_includes_date_unit(self, ws: Workspace) -> None:
+        """Filter.not_in_the_last() includes filterDateUnit."""
+        entry = ws._build_filter_entry(Filter.not_in_the_last("created", 30, "day"))
+        assert entry["filterDateUnit"] == "day"
+        assert entry["filterOperator"] == "was not in the"
+
+
+# =============================================================================
+# T060: Multiple formulas via events list
+# =============================================================================
+
+
+class TestMultiFormulaParams:
+    """T060: Multiple formulas via events list."""
+
+    def test_two_formulas_produce_two_entries(self, ws: Workspace) -> None:
+        """Two Formula objects in events list produce two formula show entries."""
+        params = ws.build_params(
+            [
+                Metric("Signup", math="unique"),
+                Metric("Purchase", math="unique"),
+                Formula("B / A", label="Conv Rate"),
+                Formula("A + B", label="Total"),
+            ],
+        )
+        formulas = [e for e in params["sections"]["show"] if e.get("type") == "formula"]
+        assert len(formulas) == 2
+        assert formulas[0]["definition"] == "B / A"
+        assert formulas[0]["name"] == "Conv Rate"
+        assert formulas[1]["definition"] == "A + B"
+        assert formulas[1]["name"] == "Total"
+
+    def test_metrics_hidden_with_multiple_formulas(self, ws: Workspace) -> None:
+        """All metrics get isHidden=True when formulas are present."""
+        params = ws.build_params(
+            [
+                Metric("A"),
+                Metric("B"),
+                Formula("A+B"),
+                Formula("A-B"),
+            ],
+        )
+        metrics = [e for e in params["sections"]["show"] if e.get("type") == "metric"]
+        assert all(e["isHidden"] is True for e in metrics)
+
+    def test_three_formulas_with_three_events(self, ws: Workspace) -> None:
+        """Three formulas referencing three events all produce entries."""
+        params = ws.build_params(
+            [
+                Metric("A", math="unique"),
+                Metric("B", math="unique"),
+                Metric("C", math="unique"),
+                Formula("A + B", label="AB"),
+                Formula("B + C", label="BC"),
+                Formula("(A + B + C) / 3", label="Avg"),
+            ],
+        )
+        show = params["sections"]["show"]
+        assert len(show) == 6  # 3 metrics + 3 formulas
+        formulas = [e for e in show if e.get("type") == "formula"]
+        assert len(formulas) == 3
+
+
+# =============================================================================
+# T065: Custom percentile bookmark params
+# =============================================================================
+
+
+class TestPercentileParams:
+    """T065: Custom percentile bookmark params."""
+
+    def test_maps_to_custom_percentile(self, ws: Workspace) -> None:
+        """math='percentile' maps to measurement.math='custom_percentile'."""
+        params = ws.build_params(
+            "Login",
+            math="percentile",
+            math_property="duration",
+            percentile_value=95,
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "custom_percentile"
+        assert m["percentile"] == 95
+        assert m["property"]["name"] == "duration"
+
+    def test_metric_percentile_maps_correctly(self, ws: Workspace) -> None:
+        """Metric(math='percentile') maps to custom_percentile in bookmark."""
+        params = ws.build_params(
+            Metric(
+                "Login",
+                math="percentile",
+                property="duration",
+                percentile_value=95,
+            ),
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "custom_percentile"
+        assert m["percentile"] == 95
+
+    def test_percentile_float_value(self, ws: Workspace) -> None:
+        """Percentile value supports float (e.g. 99.9)."""
+        params = ws.build_params(
+            "Login",
+            math="percentile",
+            math_property="duration",
+            percentile_value=99.9,
+        )
+        assert params["sections"]["show"][0]["measurement"]["percentile"] == 99.9
+
+
+# =============================================================================
+# T069: Histogram bookmark params
+# =============================================================================
+
+
+class TestHistogramParams:
+    """T069: Histogram bookmark params."""
+
+    def test_histogram_math_in_bookmark(self, ws: Workspace) -> None:
+        """math='histogram' maps directly to measurement.math='histogram'."""
+        params = ws.build_params(
+            "Purchase",
+            math="histogram",
+            math_property="amount",
+            per_user="total",
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "histogram"
+        assert m["property"]["name"] == "amount"
+        assert m["perUserAggregation"] == "total"
+
+    def test_histogram_metric_in_bookmark(self, ws: Workspace) -> None:
+        """Metric(math='histogram') maps correctly."""
+        params = ws.build_params(
+            Metric(
+                "Purchase",
+                math="histogram",
+                property="amount",
+                per_user="total",
+            ),
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "histogram"
+        assert m["perUserAggregation"] == "total"

--- a/tests/unit/test_query_pbt.py
+++ b/tests/unit/test_query_pbt.py
@@ -4,6 +4,10 @@ Uses Hypothesis to verify:
 - Valid Metric → valid params (no exception from _build_query_params)
 - Valid Filter → correct filterValue format
 - Validation exhaustiveness (no invalid combination passes through)
+- build_params with comprehensive inputs → passes validate_bookmark
+- Filter factory → _build_filter_entry produces valid enum values
+- Metric-level overrides propagate into bookmark show clauses
+- Formula position validation: in-bounds accepted, out-of-bounds rejected
 """
 
 from __future__ import annotations
@@ -15,11 +19,19 @@ from hypothesis import strategies as st
 from pydantic import SecretStr
 
 from mixpanel_data import Workspace
-from mixpanel_data._internal.bookmark_enums import MATH_REQUIRING_PROPERTY
+from mixpanel_data._internal.bookmark_enums import (
+    MATH_REQUIRING_PROPERTY,
+    VALID_FILTER_OPERATORS,
+    VALID_PROPERTY_TYPES,
+    VALID_RESOURCE_TYPES,
+)
 from mixpanel_data._internal.config import ConfigManager, Credentials
-from mixpanel_data._internal.validation import validate_query_args
+from mixpanel_data._internal.validation import validate_bookmark, validate_query_args
 from mixpanel_data.types import (
     Filter,
+    Formula,
+    GroupBy,
+    Metric,
     QueryResult,
 )
 
@@ -259,3 +271,571 @@ class TestQueryResultDfInvariant:
         df = qr.df
         assert len(df) == n_metrics * n_dates
         assert list(df.columns) == ["date", "event", "count"]
+
+
+# =============================================================================
+# T054e: build_params() invariants
+# =============================================================================
+
+
+class TestBuildParamsInvariant:
+    """T054e: build_params() always produces structurally valid bookmark."""
+
+    @given(
+        event=event_names,
+        math=non_property_math,
+        unit=units,
+        last=positive_ints,
+        mode=modes,
+    )
+    def test_build_params_produces_valid_structure(
+        self,
+        event: str,
+        math: str,
+        unit: str,
+        last: int,
+        mode: str,
+    ) -> None:
+        """build_params() always returns dict with sections and displayOptions."""
+        ws = _make_ws()
+        result = ws.build_params(
+            event,
+            math=math,  # type: ignore[arg-type]
+            unit=unit,  # type: ignore[arg-type]
+            last=last,
+            mode=mode,  # type: ignore[arg-type]
+        )
+        assert isinstance(result, dict)
+        assert "sections" in result
+        assert "displayOptions" in result
+        assert result["sections"]["show"][0]["measurement"]["math"] == math
+
+
+# =============================================================================
+# T059: Date filter invariants
+# =============================================================================
+
+date_units = st.sampled_from(["hour", "day", "week", "month"])
+positive_quantity = st.integers(min_value=1, max_value=365)
+
+
+class TestDateFilterInvariant:
+    """T059: Date filter property-based invariants."""
+
+    @given(prop=event_names, quantity=positive_quantity, unit=date_units)
+    def test_in_the_last_always_has_date_unit(
+        self, prop: str, quantity: int, unit: str
+    ) -> None:
+        """Filter.in_the_last always sets _date_unit."""
+        f = Filter.in_the_last(prop, quantity, unit)  # type: ignore[arg-type]
+        assert f._date_unit == unit
+        assert f._value == quantity
+        assert f._property_type == "datetime"
+
+    @given(prop=event_names, quantity=positive_quantity, unit=date_units)
+    def test_not_in_the_last_always_has_date_unit(
+        self, prop: str, quantity: int, unit: str
+    ) -> None:
+        """Filter.not_in_the_last always sets _date_unit."""
+        f = Filter.not_in_the_last(prop, quantity, unit)  # type: ignore[arg-type]
+        assert f._date_unit == unit
+        assert f._property_type == "datetime"
+
+    @given(prop=event_names, quantity=positive_quantity, unit=date_units)
+    def test_relative_date_filter_serializes_date_unit(
+        self, prop: str, quantity: int, unit: str
+    ) -> None:
+        """Relative date filters always emit filterDateUnit in bookmark."""
+        ws = _make_ws()
+        f = Filter.in_the_last(prop, quantity, unit)  # type: ignore[arg-type]
+        entry = ws._build_filter_entry(f)
+        assert entry["filterDateUnit"] == unit
+        assert entry["filterValue"] == quantity
+
+
+# =============================================================================
+# T066: Percentile invariants
+# =============================================================================
+
+percentile_values = st.one_of(
+    st.integers(min_value=1, max_value=99),
+    st.floats(min_value=0.1, max_value=99.9, allow_nan=False, allow_infinity=False),
+)
+
+
+class TestPercentileInvariant:
+    """T066: Percentile property-based invariants."""
+
+    @given(event=event_names, prop=event_names, pv=percentile_values)
+    def test_percentile_always_maps_to_custom_percentile(
+        self, event: str, prop: str, pv: float
+    ) -> None:
+        """math='percentile' always maps to 'custom_percentile' in bookmark."""
+        ws = _make_ws()
+        params = ws.build_params(
+            event,
+            math="percentile",
+            math_property=prop,
+            percentile_value=pv,
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "custom_percentile"
+        assert m["percentile"] == pv
+
+
+# =============================================================================
+# T070: Histogram invariants
+# =============================================================================
+
+
+class TestHistogramInvariant:
+    """T070: Histogram property-based invariant."""
+
+    @given(event=event_names, prop=event_names)
+    def test_histogram_always_has_property(self, event: str, prop: str) -> None:
+        """Histogram bookmark always has property and perUserAggregation."""
+        ws = _make_ws()
+        params = ws.build_params(
+            event, math="histogram", math_property=prop, per_user="total"
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "histogram"
+        assert m["property"]["name"] == prop
+        assert m["perUserAggregation"] == "total"
+
+
+# =============================================================================
+# Comprehensive build_params → validate_bookmark consistency
+# =============================================================================
+
+# Strategies for comprehensive bookmark generation
+filter_strategies = st.one_of(
+    st.builds(
+        Filter.equals, property=event_names, value=st.text(min_size=1, max_size=10)
+    ),
+    st.builds(
+        Filter.greater_than,
+        property=event_names,
+        value=st.integers(min_value=-1000, max_value=1000),
+    ),
+    st.builds(
+        Filter.between,
+        property=event_names,
+        min_val=st.integers(min_value=-100, max_value=0),
+        max_val=st.integers(min_value=1, max_value=100),
+    ),
+    st.builds(Filter.is_set, property=event_names),
+    st.builds(Filter.is_true, property=event_names),
+)
+
+group_by_strategies = st.one_of(
+    event_names,  # plain string group-by
+    st.builds(GroupBy, property=event_names),
+    st.builds(
+        GroupBy,
+        property=event_names,
+        property_type=st.just("number"),
+        bucket_size=st.floats(
+            min_value=0.1, max_value=100, allow_nan=False, allow_infinity=False
+        ),
+        bucket_min=st.floats(
+            min_value=-1000, max_value=0, allow_nan=False, allow_infinity=False
+        ),
+        bucket_max=st.floats(
+            min_value=0.1, max_value=1000, allow_nan=False, allow_infinity=False
+        ),
+    ),
+)
+
+metric_strategies = st.one_of(
+    # Non-property math Metric
+    st.builds(
+        Metric,
+        event=event_names,
+        math=non_property_math,
+    ),
+    # Property math Metric
+    st.builds(
+        Metric,
+        event=event_names,
+        math=property_math,
+        property=event_names,
+    ),
+    # Metric with per-user aggregation
+    st.builds(
+        Metric,
+        event=event_names,
+        math=st.just("total"),
+        property=event_names,
+        per_user=per_user_agg,
+    ),
+    # Metric with per-metric filters
+    st.builds(
+        Metric,
+        event=event_names,
+        math=non_property_math,
+        filters=st.lists(filter_strategies, min_size=1, max_size=3),
+    ),
+)
+
+
+class TestBuildParamsBookmarkConsistency:
+    """build_params with any valid input always produces a valid bookmark.
+
+    This is the most important invariant: the builder's output must always
+    pass the validator. Tests the contract between _build_query_params
+    (Layer 0) and validate_bookmark (Layer 2) across the full input space.
+    """
+
+    @given(
+        metrics=st.lists(metric_strategies, min_size=1, max_size=4),
+        unit=units,
+        last=positive_ints,
+        mode=modes,
+        where=st.one_of(st.none(), filter_strategies),
+        group_by=st.one_of(st.none(), group_by_strategies),
+        rolling=st.one_of(st.none(), st.integers(min_value=1, max_value=30)),
+    )
+    def test_valid_metrics_always_produce_valid_bookmark(
+        self,
+        metrics: list[Metric],
+        unit: str,
+        last: int,
+        mode: str,
+        where: Filter | None,
+        group_by: str | GroupBy | None,
+        rolling: int | None,
+    ) -> None:
+        """Any list of valid Metrics produces a bookmark passing validate_bookmark."""
+        ws = _make_ws()
+        params = ws.build_params(
+            metrics,
+            unit=unit,  # type: ignore[arg-type]
+            last=last,
+            mode=mode,  # type: ignore[arg-type]
+            where=where,
+            group_by=group_by,
+            rolling=rolling,
+            cumulative=False,
+        )
+        errors = validate_bookmark(params)
+        hard_errors = [e for e in errors if e.severity == "error"]
+        assert hard_errors == [], (
+            f"Valid inputs produced bookmark errors: {hard_errors}"
+        )
+
+    @given(
+        events=st.lists(event_names, min_size=2, max_size=4),
+        formula_expr=st.sampled_from(["A + B", "(B / A) * 100", "A - B"]),
+    )
+    def test_formula_always_produces_valid_bookmark(
+        self,
+        events: list[str],
+        formula_expr: str,
+    ) -> None:
+        """Formula queries always produce valid bookmarks."""
+        ws = _make_ws()
+        params = ws.build_params(
+            events,
+            formula=formula_expr,
+            formula_label="Test Formula",
+        )
+        errors = validate_bookmark(params)
+        hard_errors = [e for e in errors if e.severity == "error"]
+        assert hard_errors == [], f"Formula bookmark produced errors: {hard_errors}"
+
+
+# =============================================================================
+# Filter factory → _build_filter_entry produces valid enum values
+# =============================================================================
+
+
+class TestFilterSerializationEnumConsistency:
+    """Every Filter factory method serializes to bookmark-valid enum values.
+
+    Catches drift between Filter._operator / _property_type / _resource_type
+    and the authoritative enum sets in bookmark_enums.py.
+
+    Date filter operators ("was on", "was in the", etc.) are intentionally
+    different from the bookmark enum values ("on", "in the last") — the
+    validator treats these as warnings, not errors. This test verifies
+    the non-date filters produce exact enum matches and that all filters
+    produce valid filterType and resourceType.
+    """
+
+    @given(prop=event_names, value=st.text(min_size=1, max_size=20))
+    def test_equals_produces_valid_enums(self, prop: str, value: str) -> None:
+        """Filter.equals serializes with valid operator, type, and resourceType."""
+        f = Filter.equals(prop, value)
+        entry = Workspace._build_filter_entry(f)
+        assert entry["filterOperator"] in VALID_FILTER_OPERATORS
+        assert entry["filterType"] in VALID_PROPERTY_TYPES
+        assert entry["resourceType"] in VALID_RESOURCE_TYPES
+
+    @given(prop=event_names, value=st.integers(min_value=-1000, max_value=1000))
+    def test_numeric_filters_produce_valid_enums(self, prop: str, value: int) -> None:
+        """Filter.greater_than and less_than serialize with valid enums."""
+        for factory in [Filter.greater_than, Filter.less_than]:
+            f = factory(prop, value)
+            entry = Workspace._build_filter_entry(f)
+            assert entry["filterOperator"] in VALID_FILTER_OPERATORS
+            assert entry["filterType"] in VALID_PROPERTY_TYPES
+            assert entry["resourceType"] in VALID_RESOURCE_TYPES
+
+    @given(
+        prop=event_names,
+        min_val=st.integers(min_value=-100, max_value=0),
+        max_val=st.integers(min_value=1, max_value=100),
+    )
+    def test_between_produces_valid_enums(
+        self, prop: str, min_val: int, max_val: int
+    ) -> None:
+        """Filter.between serializes with valid operator enum."""
+        f = Filter.between(prop, min_val, max_val)
+        entry = Workspace._build_filter_entry(f)
+        assert entry["filterOperator"] in VALID_FILTER_OPERATORS
+        assert entry["filterType"] in VALID_PROPERTY_TYPES
+
+    @given(prop=event_names)
+    def test_existence_filters_produce_valid_enums(self, prop: str) -> None:
+        """Filter.is_set/is_not_set serialize with valid enums."""
+        for factory in [Filter.is_set, Filter.is_not_set]:
+            f = factory(prop)
+            entry = Workspace._build_filter_entry(f)
+            assert entry["filterOperator"] in VALID_FILTER_OPERATORS
+            assert entry["filterType"] in VALID_PROPERTY_TYPES
+
+    @given(prop=event_names)
+    def test_boolean_filters_produce_valid_enums(self, prop: str) -> None:
+        """Filter.is_true/is_false serialize with valid enums."""
+        for factory in [Filter.is_true, Filter.is_false]:
+            f = factory(prop)
+            entry = Workspace._build_filter_entry(f)
+            assert entry["filterOperator"] in VALID_FILTER_OPERATORS
+            assert entry["filterType"] in VALID_PROPERTY_TYPES
+
+
+# =============================================================================
+# Metric-level overrides propagate into bookmark show clauses
+# =============================================================================
+
+
+class TestMetricOverridePropagation:
+    """Metric-level math/property/per_user override top-level defaults.
+
+    When agents compose Metric objects, each Metric's settings must appear
+    in its corresponding show clause — never silently replaced by top-level
+    defaults. This property is critical for multi-metric queries where
+    different events use different aggregation functions.
+    """
+
+    @given(
+        event=event_names,
+        metric_math=property_math,
+        metric_prop=event_names,
+        top_math=non_property_math,
+    )
+    def test_metric_math_overrides_top_level(
+        self,
+        event: str,
+        metric_math: str,
+        metric_prop: str,
+        top_math: str,
+    ) -> None:
+        """Metric.math appears in bookmark, not the top-level math default."""
+        assume(metric_math != top_math)
+        ws = _make_ws()
+        m = Metric(event=event, math=metric_math, property=metric_prop)  # type: ignore[arg-type]
+        params = ws.build_params(
+            [m],
+            math=top_math,  # type: ignore[arg-type]
+        )
+        bookmark_math = params["sections"]["show"][0]["measurement"]["math"]
+        # "percentile" maps to "custom_percentile" in bookmark
+        expected = "custom_percentile" if metric_math == "percentile" else metric_math
+        assert bookmark_math == expected
+
+    @given(
+        event=event_names,
+        metric_prop=event_names,
+        top_prop=event_names,
+    )
+    def test_metric_property_overrides_top_level(
+        self,
+        event: str,
+        metric_prop: str,
+        top_prop: str,
+    ) -> None:
+        """Metric.property appears in bookmark, not top-level math_property."""
+        assume(metric_prop != top_prop)
+        ws = _make_ws()
+        m = Metric(event=event, math="average", property=metric_prop)
+        params = ws.build_params(
+            [m],
+            math="average",
+            math_property=top_prop,
+        )
+        assert (
+            params["sections"]["show"][0]["measurement"]["property"]["name"]
+            == metric_prop
+        )
+
+    @given(
+        event=event_names,
+        prop=event_names,
+        metric_per_user=per_user_agg,
+    )
+    def test_metric_per_user_overrides_top_level(
+        self,
+        event: str,
+        prop: str,
+        metric_per_user: str,
+    ) -> None:
+        """Metric.per_user appears in bookmark, not top-level per_user."""
+        ws = _make_ws()
+        m = Metric(
+            event=event,
+            math="total",
+            property=prop,
+            per_user=metric_per_user,  # type: ignore[arg-type]
+        )
+        params = ws.build_params([m])
+        assert (
+            params["sections"]["show"][0]["measurement"]["perUserAggregation"]
+            == metric_per_user
+        )
+
+    @given(
+        events=st.lists(metric_strategies, min_size=2, max_size=4),
+    )
+    def test_each_metric_gets_own_show_clause(
+        self,
+        events: list[Metric],
+    ) -> None:
+        """N Metrics produce exactly N show clauses, each with its own math."""
+        ws = _make_ws()
+        params = ws.build_params(events)
+        show = params["sections"]["show"]
+        assert len(show) == len(events)
+        for i, m in enumerate(events):
+            expected = "custom_percentile" if m.math == "percentile" else m.math
+            assert show[i]["measurement"]["math"] == expected
+
+
+# =============================================================================
+# Formula position validation: metamorphic property
+# =============================================================================
+
+
+class TestFormulaPositionValidation:
+    """Formula position letters must match event count.
+
+    For N events, positions A..chr(A+N-1) are valid. Any position
+    beyond that should be caught by validation. This metamorphic
+    property tests the relationship between event count and valid
+    formula positions.
+    """
+
+    @given(n_events=st.integers(min_value=2, max_value=6))
+    def test_max_valid_position_accepted(self, n_events: int) -> None:
+        """Formula referencing the last valid position passes validation."""
+        max_letter = chr(ord("A") + n_events - 1)
+        events = [f"Event_{i}" for i in range(n_events)]
+        # Formula using the last valid position
+        expr = f"A + {max_letter}"
+        errors = validate_query_args(
+            events=events,
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            has_formula=True,
+            rolling=None,
+            cumulative=False,
+            group_by=None,
+            formulas=[Formula(expression=expr)],
+        )
+        formula_errors = [e for e in errors if "V19" in e.code]
+        assert formula_errors == [], (
+            f"Position {max_letter} with {n_events} events should be valid"
+        )
+
+    @given(n_events=st.integers(min_value=2, max_value=6))
+    def test_one_past_max_position_rejected(self, n_events: int) -> None:
+        """Formula referencing one position beyond event count fails validation."""
+        out_of_bounds = chr(ord("A") + n_events)
+        events = [f"Event_{i}" for i in range(n_events)]
+        expr = f"A + {out_of_bounds}"
+        errors = validate_query_args(
+            events=events,
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            has_formula=True,
+            rolling=None,
+            cumulative=False,
+            group_by=None,
+            formulas=[Formula(expression=expr)],
+        )
+        formula_errors = [e for e in errors if "V19" in e.code]
+        assert len(formula_errors) == 1, (
+            f"Position {out_of_bounds} with {n_events} events should be rejected"
+        )
+
+    @given(n_events=st.integers(min_value=2, max_value=6))
+    def test_position_validation_is_monotonic(self, n_events: int) -> None:
+        """Adding an event should never make a previously valid position invalid.
+
+        If position X is valid with N events, it must also be valid with N+1.
+        """
+        max_letter = chr(ord("A") + n_events - 1)
+        expr = f"A + {max_letter}"
+        formula = Formula(expression=expr)
+
+        # Valid with n_events
+        events_n = [f"Event_{i}" for i in range(n_events)]
+        errors_n = validate_query_args(
+            events=events_n,
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            has_formula=True,
+            rolling=None,
+            cumulative=False,
+            group_by=None,
+            formulas=[formula],
+        )
+
+        # Still valid with n_events + 1
+        events_n1 = events_n + [f"Event_{n_events}"]
+        errors_n1 = validate_query_args(
+            events=events_n1,
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            has_formula=True,
+            rolling=None,
+            cumulative=False,
+            group_by=None,
+            formulas=[formula],
+        )
+
+        bounds_errors_n = [e for e in errors_n if "V19" in e.code]
+        bounds_errors_n1 = [e for e in errors_n1 if "V19" in e.code]
+        # If valid with N events, must be valid with N+1
+        if not bounds_errors_n:
+            assert not bounds_errors_n1, (
+                f"Position {max_letter} valid with {n_events} events "
+                f"but invalid with {n_events + 1}"
+            )

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -16,6 +16,7 @@ from mixpanel_data._internal.bookmark_enums import (
     MATH_REQUIRING_PROPERTY,
 )
 from mixpanel_data.types import (
+    Filter,
     Formula,
     Metric,
     QueryResult,
@@ -95,6 +96,8 @@ class TestTypeConstants:
             "p90",
             "p99",
             "custom_percentile",
+            "percentile",
+            "histogram",
         }
         assert expected == MATH_REQUIRING_PROPERTY
 
@@ -565,3 +568,204 @@ class TestFormulaConstruction:
     def test_inequality(self) -> None:
         """Formulas with different expressions are not equal."""
         assert Formula("A + B") != Formula("A - B")
+
+
+# =============================================================================
+# T055: Date filter factory methods
+# =============================================================================
+
+
+class TestDateFilterConstruction:
+    """T055: Date filter factory methods on Filter class."""
+
+    def test_on_creates_datetime_filter(self) -> None:
+        """Filter.on() creates absolute date equality filter."""
+        f = Filter.on("created", "2024-06-15")
+        assert f._property == "created"
+        assert f._operator == "was on"
+        assert f._value == "2024-06-15"
+        assert f._property_type == "datetime"
+        assert f._date_unit is None
+
+    def test_not_on(self) -> None:
+        """Filter.not_on() creates date inequality filter."""
+        f = Filter.not_on("created", "2024-06-15")
+        assert f._operator == "was not on"
+        assert f._value == "2024-06-15"
+        assert f._property_type == "datetime"
+
+    def test_before(self) -> None:
+        """Filter.before() creates date before filter."""
+        f = Filter.before("created", "2024-01-01")
+        assert f._operator == "was before"
+        assert f._value == "2024-01-01"
+        assert f._property_type == "datetime"
+        assert f._date_unit is None
+
+    def test_since(self) -> None:
+        """Filter.since() creates date since filter."""
+        f = Filter.since("created", "2024-01-01")
+        assert f._operator == "was since"
+        assert f._value == "2024-01-01"
+        assert f._property_type == "datetime"
+
+    def test_in_the_last(self) -> None:
+        """Filter.in_the_last() creates relative date filter with date_unit."""
+        f = Filter.in_the_last("created", 7, "day")
+        assert f._operator == "was in the"
+        assert f._value == 7
+        assert f._date_unit == "day"
+        assert f._property_type == "datetime"
+
+    def test_not_in_the_last(self) -> None:
+        """Filter.not_in_the_last() creates relative negation filter."""
+        f = Filter.not_in_the_last("created", 30, "day")
+        assert f._operator == "was not in the"
+        assert f._value == 30
+        assert f._date_unit == "day"
+        assert f._property_type == "datetime"
+
+    def test_date_between(self) -> None:
+        """Filter.date_between() creates date range filter."""
+        f = Filter.date_between("created", "2024-01-01", "2024-06-30")
+        assert f._operator == "was between"
+        assert f._value == ["2024-01-01", "2024-06-30"]
+        assert f._property_type == "datetime"
+        assert f._date_unit is None
+
+    def test_in_the_last_hour_unit(self) -> None:
+        """Filter.in_the_last() supports hour unit."""
+        f = Filter.in_the_last("ts", 24, "hour")
+        assert f._date_unit == "hour"
+
+    def test_in_the_last_month_unit(self) -> None:
+        """Filter.in_the_last() supports month unit."""
+        f = Filter.in_the_last("ts", 3, "month")
+        assert f._date_unit == "month"
+
+    def test_in_the_last_week_unit(self) -> None:
+        """Filter.in_the_last() supports week unit."""
+        f = Filter.in_the_last("ts", 2, "week")
+        assert f._date_unit == "week"
+
+    def test_immutability_date_filter(self) -> None:
+        """Date filter is frozen."""
+        f = Filter.on("created", "2024-01-01")
+        with pytest.raises(AttributeError):
+            f._date_unit = "day"  # type: ignore[misc]
+
+    def test_resource_type_on_date_filter(self) -> None:
+        """Date filters support resource_type parameter."""
+        f = Filter.on("$created", "2024-01-01", resource_type="people")
+        assert f._resource_type == "people"
+
+
+# =============================================================================
+# T056: Date filter input validation
+# =============================================================================
+
+
+class TestDateFilterValidation:
+    """T056: Date filter factory method input validation."""
+
+    def test_on_rejects_invalid_date_format(self) -> None:
+        """Filter.on() rejects non-YYYY-MM-DD date string."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.on("created", "06/15/2024")
+
+    def test_on_rejects_invalid_calendar_date(self) -> None:
+        """Filter.on() rejects impossible calendar date."""
+        with pytest.raises(ValueError, match="valid calendar date"):
+            Filter.on("created", "2024-02-30")
+
+    def test_before_rejects_invalid_date(self) -> None:
+        """Filter.before() rejects invalid date string."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.before("created", "bad-date")
+
+    def test_since_rejects_invalid_date(self) -> None:
+        """Filter.since() rejects invalid date string."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.since("created", "2024/01/01")
+
+    def test_date_between_rejects_invalid_from(self) -> None:
+        """Filter.date_between() rejects invalid from_date."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.date_between("created", "bad", "2024-06-30")
+
+    def test_date_between_rejects_invalid_to(self) -> None:
+        """Filter.date_between() rejects invalid to_date."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.date_between("created", "2024-01-01", "bad")
+
+    def test_date_between_rejects_reversed_dates(self) -> None:
+        """Filter.date_between() rejects from > to."""
+        with pytest.raises(ValueError, match="must be before"):
+            Filter.date_between("created", "2024-12-31", "2024-01-01")
+
+    def test_in_the_last_rejects_zero(self) -> None:
+        """Filter.in_the_last() rejects non-positive quantity."""
+        with pytest.raises(ValueError, match="positive"):
+            Filter.in_the_last("created", 0, "day")
+
+    def test_in_the_last_rejects_negative(self) -> None:
+        """Filter.in_the_last() rejects negative quantity."""
+        with pytest.raises(ValueError, match="positive"):
+            Filter.in_the_last("created", -5, "day")
+
+    def test_not_in_the_last_rejects_zero(self) -> None:
+        """Filter.not_in_the_last() rejects non-positive quantity."""
+        with pytest.raises(ValueError, match="positive"):
+            Filter.not_in_the_last("created", 0, "week")
+
+
+# =============================================================================
+# T063: Custom percentile type support
+# =============================================================================
+
+
+class TestPercentileType:
+    """T063: Custom percentile support."""
+
+    def test_math_type_accepts_percentile(self) -> None:
+        """MathType literal accepts 'percentile'."""
+        m = Metric("Login", math="percentile", property="duration", percentile_value=95)
+        assert m.math == "percentile"
+
+    def test_percentile_value_default_none(self) -> None:
+        """Metric.percentile_value defaults to None."""
+        assert Metric("Login").percentile_value is None
+
+    def test_percentile_value_int(self) -> None:
+        """Metric.percentile_value accepts int."""
+        m = Metric("Login", math="percentile", property="duration", percentile_value=95)
+        assert m.percentile_value == 95
+
+    def test_percentile_value_float(self) -> None:
+        """Metric.percentile_value accepts float."""
+        m = Metric("X", math="percentile", property="d", percentile_value=99.9)
+        assert m.percentile_value == 99.9
+
+    def test_percentile_immutable(self) -> None:
+        """percentile_value is frozen."""
+        m = Metric("Login", math="percentile", property="d", percentile_value=95)
+        with pytest.raises(AttributeError):
+            m.percentile_value = 50  # type: ignore[misc]
+
+
+# =============================================================================
+# T067: Histogram math type
+# =============================================================================
+
+
+class TestHistogramType:
+    """T067: Histogram math type."""
+
+    def test_math_type_accepts_histogram(self) -> None:
+        """MathType literal accepts 'histogram'."""
+        m = Metric("Purchase", math="histogram", property="amount")
+        assert m.math == "histogram"
+
+    def test_histogram_in_requiring_property(self) -> None:
+        """'histogram' is in MATH_REQUIRING_PROPERTY."""
+        assert "histogram" in MATH_REQUIRING_PROPERTY

--- a/tests/unit/test_query_validation.py
+++ b/tests/unit/test_query_validation.py
@@ -528,3 +528,103 @@ class TestFormulaInListValidation:
             BookmarkValidationError, match="formula requires at least 2 events"
         ):
             ws.query(["Login", Formula("A * 100")])
+
+
+# =============================================================================
+# T054c: build_params() validation parity
+# =============================================================================
+
+
+class TestBuildParamsValidation:
+    """T054c: build_params() runs the same validation as query()."""
+
+    def test_rejects_invalid_last(self, ws: Workspace) -> None:
+        """build_params() raises BookmarkValidationError for last=0."""
+        with pytest.raises(
+            BookmarkValidationError, match="last must be a positive integer"
+        ):
+            ws.build_params("Login", last=0)
+
+    def test_rejects_formula_without_events(self, ws: Workspace) -> None:
+        """build_params() validates formula requires 2+ events."""
+        with pytest.raises(
+            BookmarkValidationError, match="formula requires at least 2 events"
+        ):
+            ws.build_params("Login", formula="A + B")
+
+    def test_rejects_invalid_date_format(self, ws: Workspace) -> None:
+        """build_params() validates date format."""
+        with pytest.raises(BookmarkValidationError, match="YYYY-MM-DD"):
+            ws.build_params("Login", from_date="01/01/2024")
+
+
+# =============================================================================
+# T064: Percentile validation (V1 inherited + new V26)
+# =============================================================================
+
+
+class TestPercentileValidation:
+    """T064: Percentile validation rules."""
+
+    def test_v1_percentile_requires_math_property(self, ws: Workspace) -> None:
+        """V1: math='percentile' requires math_property."""
+        with pytest.raises(BookmarkValidationError, match="requires math_property"):
+            ws.build_params("Login", math="percentile", percentile_value=95)
+
+    def test_v26_percentile_requires_percentile_value(self, ws: Workspace) -> None:
+        """V26: math='percentile' requires percentile_value."""
+        with pytest.raises(BookmarkValidationError, match="percentile_value"):
+            ws.build_params("Login", math="percentile", math_property="duration")
+
+    def test_v26_metric_percentile_requires_value(self, ws: Workspace) -> None:
+        """V26: Metric with math='percentile' requires percentile_value."""
+        from mixpanel_data import Metric
+
+        with pytest.raises(BookmarkValidationError, match="percentile_value"):
+            ws.build_params(Metric("Login", math="percentile", property="duration"))
+
+    def test_valid_percentile_passes(self, ws: Workspace) -> None:
+        """Percentile with property and value passes validation."""
+        result = ws.build_params(
+            "Login",
+            math="percentile",
+            math_property="duration",
+            percentile_value=95,
+        )
+        assert isinstance(result, dict)
+
+
+# =============================================================================
+# T068: Histogram validation
+# =============================================================================
+
+
+class TestHistogramValidation:
+    """T068: Histogram validation."""
+
+    def test_v1_histogram_requires_property(self, ws: Workspace) -> None:
+        """V1: math='histogram' requires math_property."""
+        with pytest.raises(BookmarkValidationError, match="requires math_property"):
+            ws.build_params("Login", math="histogram")
+
+    def test_v27_histogram_requires_per_user(self, ws: Workspace) -> None:
+        """V27: math='histogram' requires per_user."""
+        with pytest.raises(BookmarkValidationError, match="requires per_user"):
+            ws.build_params("Purchase", math="histogram", math_property="amount")
+
+    def test_v27_metric_histogram_requires_per_user(self, ws: Workspace) -> None:
+        """V27: Metric(math='histogram') requires per_user."""
+        from mixpanel_data import Metric
+
+        with pytest.raises(BookmarkValidationError, match="requires per_user"):
+            ws.build_params(Metric("Purchase", math="histogram", property="amount"))
+
+    def test_histogram_with_property_and_per_user_passes(self, ws: Workspace) -> None:
+        """Histogram with property and per_user passes validation."""
+        result = ws.build_params(
+            "Purchase",
+            math="histogram",
+            math_property="amount",
+            per_user="total",
+        )
+        assert isinstance(result, dict)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -510,6 +510,36 @@ class TestValidateBookmarkLayer2:
         assert len(op_errors) == 1
         assert op_errors[0].severity == "warning"
 
+    def test_b15_insights_date_operators_valid(self) -> None:
+        """B15: InsightsDateRangeType operators pass validation."""
+        insights_date_ops = [
+            "was on",
+            "was not on",
+            "was in the",
+            "was not in the",
+            "was between",
+            "was not between",
+            "was less than",
+            "was before",
+            "was since",
+            "was in the next",
+        ]
+        for op in insights_date_ops:
+            bm = _minimal_bookmark()
+            bm["sections"]["filter"] = [
+                {
+                    "filterType": "datetime",
+                    "filterOperator": op,
+                    "value": "created",
+                    "filterValue": "2024-01-01",
+                }
+            ]
+            errors = validate_bookmark(bm)
+            op_errors = [e for e in errors if e.code == "B15_INVALID_FILTER_OPERATOR"]
+            assert len(op_errors) == 0, (
+                f"Operator {op!r} should be valid but got B15 warning"
+            )
+
     def test_b18_missing_filter_property(self) -> None:
         """B18: Filter without property identifier produces error."""
         bm = _minimal_bookmark()


### PR DESCRIPTION
## Summary

- **`build_params()` public helper** — same signature as `query()`, returns bookmark params dict without API call. Enables debugging, inspection, and persistence via `create_bookmark()`.
- **7 date filter factory methods** on `Filter`: `on()`, `not_on()`, `before()`, `since()`, `in_the_last()`, `not_in_the_last()`, `date_between()`. New `FilterDateUnit` type exported.
- **`math="percentile"`** with `percentile_value` param — maps to `custom_percentile` in bookmark JSON. New validation rule V26.
- **`math="histogram"`** — requires `property` + `per_user`. New validation rule V27.
- **Multi-formula** via `Formula`-in-events-list validated (existing support, no code changes needed).
- Refactored `query()` internals into shared `_resolve_and_build_params()` for DRY.

## Bugs caught by live QA

Live testing against `ecommerce-demo` project caught 3 bugs that unit tests couldn't:
1. Percentile bookmark field name: `percentileValue` → `percentile` (server schema mismatch)
2. Date filter operators need `"was "` prefix for insights API (`"was on"`, `"was in the"`, etc.)
3. Histogram requires `perUserAggregation` — added V27 validation rule

## Test plan

- [x] 55 new unit tests across 5 test files (params, validation, types, integration, PBT)
- [x] 14 property-based tests with Hypothesis
- [x] `just check` passes (ruff + mypy + 3103 tests)
- [x] 42/42 live QA tests pass against Mixpanel API (ecommerce-demo)