### PR TITLE
feat(infra): extract shared builders, validators, and segfilter converter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ Task(subagent_type="mixpanel-data:narrator", prompt="...")
 - Mixpanel App API (remote CRUD for entities and data governance)
 - Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames) (029-insights-query-api)
 - N/A — live query only, no local persistence (029-insights-query-api)
+- Python 3.10+ (mypy --strict) + httpx (HTTP), Pydantic v2 (validation), pandas (DataFrames) (031-shared-infra-extraction)
 
 ## Recent Changes
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/context/unified-bookmark-query-design.md
+++ b/context/unified-bookmark-query-design.md
@@ -1,0 +1,1220 @@
+# Unified Bookmark Query System — Design Document
+
+**Date**: 2026-04-05
+**Status**: Design — Decisions Finalized
+**Builds on**: `specs/029-insights-query-api/` (PR #86, #87)
+**Reference**: `analytics/` repo (Mixpanel canonical implementation)
+
+---
+
+## 1. Executive Summary
+
+This document specifies the design for extending `mixpanel_data`'s typed query system — currently limited to insights bookmarks via `Workspace.query()` — to cover the full Mixpanel bookmark query language: **funnels**, **retention**, and **flows**.
+
+The system adds three new public methods — `query_funnel()`, `query_retention()`, and `query_flow()` — that reuse the infrastructure already built for `query()`: the two-layer validation engine, the bookmark params builder, the `Filter`/`GroupBy` types, and the `_resolve_and_build_params` pipeline. Each method generates valid bookmark JSON for its report type, POSTs it to the `/insights` endpoint (funnels, retention) or `/arb_funnels` endpoint (flows), and returns a typed result with lazy DataFrame conversion.
+
+### Why Not One Method?
+
+The research reveals that insights, funnels, retention, and flows have **fundamentally different `behavior` structures** in `sections.show[]`. They also have different required parameters, different valid math types, different chart types, different response formats, and different result semantics. A single `query()` method accepting all four would require:
+
+- A union-typed `events` parameter that changes meaning per report type
+- Conditional validation rules that depend on which behavior type is being built
+- A union return type that loses type specificity
+
+Separate methods with shared infrastructure is both more type-safe and more discoverable. An LLM agent seeing `query_funnel(steps=[...])` immediately knows it's building a funnel. An LLM seeing `query(events=[...], behavior_type="funnel")` has to reason about which parameters apply.
+
+### Design Principles
+
+1. **Shared infrastructure, separate interfaces** — Reuse `Filter`, `GroupBy`, validation engine, time range handling, and API client. Separate what's semantically different.
+2. **Progressive disclosure** — The simplest funnel is `query_funnel(["Signup", "Purchase"])`. Everything else is a keyword argument.
+3. **Fail-fast with actionable errors** — Two-layer validation catches invalid combinations before any API call, with structured `ValidationError` objects including fuzzy-matched suggestions.
+4. **Result types match semantics** — Funnel results have step-level conversion data. Retention results have cohort-level rates. Flows results have node/edge graphs. Each gets a typed result class with an appropriate `.df` shape.
+5. **Debuggable** — Every result includes `.params` (the bookmark JSON sent) for inspection and persistence via `create_bookmark()`.
+
+---
+
+## 2. Architecture
+
+### 2.1 What Already Exists
+
+```
+Workspace
+├── query()              → QueryResult          (insights bookmarks)
+├── build_params()       → dict                  (params without execution)
+├── _resolve_and_build_params()                  (shared validation + build pipeline)
+├── _build_query_params()                        (insights bookmark JSON builder)
+├── _build_filter_entry()                        (Filter → bookmark filter dict)
+│
+├── _internal/
+│   ├── validation.py                            (two-layer validation engine)
+│   │   ├── validate_query_args()                (Layer 1: argument rules V0-V27)
+│   │   └── validate_bookmark()                  (Layer 2: structure rules B1-B19)
+│   ├── bookmark_enums.py                        (canonical enum constants)
+│   ├── api_client.py
+│   │   ├── insights_query()                     (POST /insights with inline params)
+│   │   └── query_flows()                        (GET /arb_funnels with bookmark_id)
+│   └── services/live_query.py
+│       ├── query()                              (insights: build body → POST → transform)
+│       ├── query_flows()                        (flows: GET by bookmark_id → transform)
+│       └── _transform_query_result()            (response → QueryResult)
+│
+├── types.py
+│   ├── Metric, Filter, GroupBy, Formula         (input types)
+│   ├── QueryResult                              (insights result)
+│   └── FlowsResult                              (flows result — existing, bookmark_id-based)
+│
+└── exceptions.py
+    ├── BookmarkValidationError                  (wraps list[ValidationError])
+    └── ValidationError                          (path, message, code, severity, suggestion)
+```
+
+### 2.2 What Will Be Added
+
+```
+Workspace
+├── query_funnel()       → FunnelQueryResult     (NEW)
+├── query_retention()    → RetentionQueryResult  (NEW)
+├── query_flow()         → FlowQueryResult       (NEW)
+├── build_funnel_params()  → dict                (NEW — params without execution)
+├── build_retention_params() → dict              (NEW — params without execution)
+├── build_flow_params()    → dict                (NEW — params without execution)
+│
+├── _build_funnel_params()                       (NEW — funnel bookmark JSON builder)
+├── _build_retention_params()                    (NEW — retention bookmark JSON builder)
+├── _build_flow_params()                         (NEW — flows bookmark JSON builder)
+│
+├── _internal/
+│   ├── validation.py
+│   │   ├── validate_funnel_args()               (NEW — Layer 1 funnel rules)
+│   │   ├── validate_retention_args()            (NEW — Layer 1 retention rules)
+│   │   ├── validate_flow_args()                 (NEW — Layer 1 flow rules)
+│   │   └── validate_bookmark()                  (EXTENDED — funnel/retention structure rules)
+│   ├── bookmark_enums.py                        (EXTENDED — funnel/retention/flows enums)
+│   ├── api_client.py
+│   │   └── arb_funnels_query()                  (NEW — POST /arb_funnels with inline params)
+│   └── services/live_query.py
+│       ├── query_funnel()                       (NEW — insights endpoint with funnel behavior)
+│       ├── query_retention()                    (NEW — insights endpoint with retention behavior)
+│       ├── query_flow()                         (NEW — arb_funnels endpoint with flows params)
+│       ├── _transform_funnel_result()           (NEW)
+│       ├── _transform_retention_result()        (NEW)
+│       └── _transform_flow_result()             (NEW)
+│
+├── types.py
+│   ├── FunnelStep                               (NEW — frozen dataclass)
+│   ├── FunnelQueryResult                        (NEW — frozen dataclass)
+│   ├── RetentionQueryResult                     (NEW — frozen dataclass)
+│   ├── FlowStep                                 (NEW — frozen dataclass)
+│   ├── FlowQueryResult                          (NEW — frozen dataclass)
+│   └── FunnelMathType, RetentionMathType, ...   (NEW — type aliases)
+```
+
+### 2.3 Shared vs. Report-Specific
+
+| Component | Shared | Insights | Funnels | Retention | Flows |
+|-----------|--------|----------|---------|-----------|-------|
+| `Filter` type | Yes | Yes | Yes | Yes | Yes (via `_build_segfilter_entry()`)* |
+| `GroupBy` type | Yes | Yes | Yes | Yes | No** |
+| Time range handling | Yes | Yes | Yes | Yes | Different format*** |
+| `_build_filter_entry()` | Yes | Yes | Yes (per-step) | Yes (per-event) | Via segfilter converter* |
+| Two-layer validation | Yes | Yes | Yes | Yes | Yes |
+| `BookmarkValidationError` | Yes | Yes | Yes | Yes | Yes |
+| `validate_bookmark()` L2 | Partially | Yes | Extended | Extended | Separate |
+| Bookmark JSON structure | `sections.*` | Yes | Yes | Yes | Flat (no sections) |
+| API endpoint | — | `/insights` | `/insights` | `/insights` | `/arb_funnels` |
+| Auth | Yes | Basic/OAuth | Basic/OAuth | Basic/OAuth | Basic/OAuth |
+
+\* Flows use legacy `property_filter_params_list` (segfilter format) per step. A `_build_segfilter_entry()` converter translates `Filter` objects to segfilter format (~100 lines).
+\** Flows use `segments` and `group_by` at the top level, not `sections.group[]`.
+\*** Flows use a flat `date_range` object, not `sections.time[]`.
+
+---
+
+## 3. Funnels: `query_funnel()`
+
+### 3.1 Method Signature
+
+```python
+def query_funnel(
+    self,
+    steps: Sequence[str | FunnelStep],
+    *,
+    # Conversion window
+    conversion_window: int = 14,
+    conversion_window_unit: Literal["second", "minute", "hour", "day", "week", "month", "session"] = "day",
+
+    # Funnel ordering
+    order: Literal["loose", "any"] = "loose",
+
+    # Time range (shared pattern)
+    from_date: str | None = None,
+    to_date: str | None = None,
+    last: int = 30,
+    unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
+
+    # Aggregation
+    math: FunnelMathType = "conversion_rate_unique",
+
+    # Breakdown (shared)
+    group_by: str | GroupBy | list[str | GroupBy] | None = None,
+
+    # Filters (shared — global)
+    where: Filter | list[Filter] | None = None,
+
+    # Exclusions
+    exclusions: list[str | Exclusion] | None = None,
+
+    # Hold property constant
+    holding_constant: str | HoldingConstant | list[str | HoldingConstant] | None = None,
+
+    # Result shape
+    mode: Literal["steps", "trends", "table"] = "steps",
+) -> FunnelQueryResult:
+```
+
+### 3.2 `FunnelStep` Type
+
+```python
+@dataclass(frozen=True)
+class FunnelStep:
+    """A single step in a funnel query.
+
+    Use plain event name strings when no per-step configuration is needed.
+    Use FunnelStep for per-step filters, custom labels, or any-order control.
+
+    Attributes:
+        event: Mixpanel event name.
+        label: Display label for this step (defaults to event name).
+        filters: Per-step filters.
+        filters_combinator: How per-step filters combine ("all"=AND, "any"=OR).
+        order: Per-step ordering override for any-order funnels.
+            Only meaningful when the funnel's top-level order="any".
+
+    Example:
+        ```python
+        FunnelStep("Sign Up")
+        FunnelStep("Purchase", label="First Purchase",
+                   filters=[Filter.greater_than("amount", 50)])
+        ```
+    """
+
+    event: str
+    label: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+    order: Literal["loose", "any"] | None = None
+```
+
+### 3.3 `FunnelMathType`
+
+```python
+FunnelMathType = Literal[
+    # Conversion rates (most common)
+    "conversion_rate_unique",   # Unique users conversion rate (default)
+    "conversion_rate_total",    # Total events conversion rate
+    "conversion_rate_session",  # Session-based conversion rate
+
+    # Raw counts
+    "unique",                   # Unique users at each step
+    "total",                    # Total events at each step
+
+    # Property aggregation (requires holding_constant or group_by on property)
+    "average", "median", "min", "max",
+    "p25", "p75", "p90", "p99",
+]
+```
+
+### 3.4 `FunnelQueryResult`
+
+```python
+@dataclass(frozen=True)
+class FunnelQueryResult(ResultWithDataFrame):
+    """Result of a funnel query.
+
+    Contains step-level conversion data with timing and statistical
+    significance information.
+
+    Attributes:
+        computed_at: When the query was computed (ISO format).
+        from_date: Effective start date.
+        to_date: Effective end date.
+        steps_data: List of step-level results. Each entry is a dict with:
+            count, step_conv_ratio, overall_conv_ratio,
+            avg_time (seconds from previous step),
+            avg_time_from_start (seconds from step 1).
+        series: Raw series data from API (for advanced use).
+        params: Generated bookmark params (for debugging/persistence).
+        meta: Response metadata.
+    """
+
+    computed_at: str
+    from_date: str
+    to_date: str
+    steps_data: list[dict[str, Any]] = field(default_factory=list)
+    series: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def overall_conversion_rate(self) -> float:
+        """End-to-end conversion rate (step 1 to last step)."""
+        if not self.steps_data:
+            return 0.0
+        return self.steps_data[-1].get("overall_conv_ratio", 0.0)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Convert to DataFrame.
+
+        Columns: step, event, count, step_conv_ratio, overall_conv_ratio,
+                 avg_time, avg_time_from_start.
+        One row per funnel step.
+        """
+        ...
+```
+
+### 3.2b `Exclusion` Type
+
+```python
+@dataclass(frozen=True)
+class Exclusion:
+    """An event to exclude between funnel steps.
+
+    Use plain event name strings to exclude between ALL steps.
+    Use Exclusion for step-range targeting.
+
+    Attributes:
+        event: Event name to exclude.
+        from_step: Start of exclusion range (0-indexed). Default: 0.
+        to_step: End of exclusion range (0-indexed).
+            Default: None (= last step).
+
+    Example:
+        ```python
+        # Exclude Logout between all steps
+        exclusions=["Logout"]
+
+        # Exclude Refund only between steps 2 and 3
+        exclusions=[Exclusion("Refund", from_step=2, to_step=3)]
+        ```
+    """
+
+    event: str
+    from_step: int = 0
+    to_step: int | None = None
+```
+
+### 3.2c `HoldingConstant` Type
+
+```python
+@dataclass(frozen=True)
+class HoldingConstant:
+    """A property to hold constant across funnel steps.
+
+    Use plain property name strings for event properties (the common case).
+    Use HoldingConstant for user-property HPC.
+
+    Attributes:
+        property: Property name to hold constant.
+        resource_type: Resource type. Default: "events".
+
+    Example:
+        ```python
+        # Hold platform constant (event property)
+        holding_constant="platform"
+
+        # Hold plan constant (user property)
+        holding_constant=HoldingConstant("plan", resource_type="people")
+        ```
+    """
+
+    property: str
+    resource_type: Literal["events", "people"] = "events"
+```
+
+### 3.5 Bookmark JSON Mapping
+
+```python
+# query_funnel(["Signup", "Purchase"], conversion_window=7, math="conversion_rate_unique")
+# generates:
+{
+    "sections": {
+        "show": [{
+            "behavior": {
+                "type": "funnel",
+                "name": None,
+                "resourceType": "events",
+                "dataGroupId": None,
+                "filters": [],
+                "behaviors": [
+                    {"id": None, "type": "event", "name": "Signup",
+                     "filters": [], "filtersDeterminer": "all", "funnelOrder": "loose"},
+                    {"id": None, "type": "event", "name": "Purchase",
+                     "filters": [], "filtersDeterminer": "all", "funnelOrder": "loose"},
+                ],
+                "conversionWindowDuration": 7,
+                "conversionWindowUnit": "day",
+                "funnelOrder": "loose",
+                "exclusions": [],
+                "aggregateBy": [],
+                "dataset": "$mixpanel",
+                "profileType": None,
+                "search": "",
+            },
+            "measurement": {
+                "math": "conversion_rate_unique",
+                "stepIndex": None,
+                "property": None,
+                "perUserAggregation": None,
+            },
+        }],
+        "filter": [],
+        "group": [],
+        "time": [{"dateRangeType": "in the last", "unit": "day",
+                  "window": {"unit": "day", "value": 30}}],
+        "formula": [],
+    },
+    "displayOptions": {
+        "chartType": "funnel-steps",
+        "analysis": "linear",
+    },
+}
+```
+
+### 3.6 Execution Path
+
+Funnel bookmarks with `sections.show[].behavior.type == "funnel"` are POSTed to the same `/api/query/insights` endpoint as insights bookmarks. The Mixpanel insights API internally detects the funnel behavior type (at `api.py:1248`) and delegates to `funnels_query` (the `arb_funnels` service). The response is then converted back to the insights result format.
+
+This means we can reuse the existing `insights_query()` API client method. The only difference is the bookmark params structure and the response parsing.
+
+### 3.7 Validation Rules (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| F1 | At least 2 steps required | `funnel requires at least 2 steps (got {n})` |
+| F2 | Each step event must be non-empty | `step[{i}] event name must be non-empty` |
+| F3 | conversion_window must be positive | `conversion_window must be positive` |
+| F4 | exclusions must reference valid event names | `exclusion '{name}' is not in the funnel steps` |
+| F5 | Shared time range rules (V7-V11 from insights) | Reuse existing validation |
+| F6 | Shared GroupBy rules (V11-V12 from insights) | Reuse existing validation |
+
+### 3.8 Example Calls
+
+```python
+# Simplest funnel
+result = ws.query_funnel(["Signup", "Purchase"])
+
+# With conversion window and ordering
+result = ws.query_funnel(
+    ["Signup", "Add to Cart", "Checkout", "Purchase"],
+    conversion_window=7,
+    conversion_window_unit="day",
+    order="loose",
+)
+
+# With per-step filters
+result = ws.query_funnel([
+    FunnelStep("Signup"),
+    FunnelStep("Purchase", filters=[Filter.greater_than("amount", 50)]),
+])
+
+# Trends view (conversion over time)
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    mode="trends",
+    unit="week",
+    last=90,
+)
+
+# Segmented funnel
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    group_by="platform",
+    where=[Filter.equals("country", "US")],
+)
+
+# Debug / persist
+print(result.params)
+ws.create_bookmark(CreateBookmarkParams(
+    name="Signup → Purchase Funnel",
+    bookmark_type="funnels",
+    params=result.params,
+))
+```
+
+---
+
+## 4. Retention: `query_retention()`
+
+### 4.1 Method Signature
+
+```python
+def query_retention(
+    self,
+    born_event: str | RetentionEvent,
+    return_event: str | RetentionEvent,
+    *,
+    # Retention configuration
+    retention_unit: Literal["day", "week", "month"] = "week",
+    alignment: Literal["birth", "interval_start"] = "birth",
+    bucket_sizes: list[int] | None = None,
+
+    # Time range (shared pattern)
+    from_date: str | None = None,
+    to_date: str | None = None,
+    last: int = 30,
+    unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
+
+    # Aggregation
+    math: RetentionMathType = "retention_rate",
+
+    # Breakdown (shared)
+    group_by: str | GroupBy | list[str | GroupBy] | None = None,
+
+    # Filters (shared — global)
+    where: Filter | list[Filter] | None = None,
+
+    # Result shape
+    mode: Literal["curve", "trends", "table"] = "curve",
+) -> RetentionQueryResult:
+```
+
+### 4.2 `RetentionEvent` Type
+
+```python
+@dataclass(frozen=True)
+class RetentionEvent:
+    """An event specification for a retention query.
+
+    Use plain event name strings for simple cases.
+    Use RetentionEvent for per-event filters.
+
+    Attributes:
+        event: Mixpanel event name.
+        filters: Per-event filters.
+        filters_combinator: How filters combine ("all"=AND, "any"=OR).
+
+    Example:
+        ```python
+        RetentionEvent("Login")
+        RetentionEvent("Login", filters=[Filter.equals("platform", "iOS")])
+        ```
+    """
+
+    event: str
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+```
+
+### 4.3 `RetentionMathType`
+
+```python
+RetentionMathType = Literal[
+    "retention_rate",   # Percentage retained (default)
+    "unique",           # Unique users per cohort/bucket
+]
+```
+
+### 4.4 `RetentionQueryResult`
+
+```python
+@dataclass(frozen=True)
+class RetentionQueryResult(ResultWithDataFrame):
+    """Result of a retention query.
+
+    Contains cohort-level retention data with rates per bucket.
+
+    Attributes:
+        computed_at: When the query was computed (ISO format).
+        from_date: Effective start date.
+        to_date: Effective end date.
+        cohorts: Dict mapping cohort date → {first, counts, rates}.
+            ``first``: cohort size (users who did born_event).
+            ``counts``: list of user counts per retention bucket.
+            ``rates``: list of retention rates per bucket (count/first).
+        average: The ``$average`` synthetic cohort aggregating all cohorts.
+        params: Generated bookmark params (for debugging/persistence).
+        meta: Response metadata (incomplete_buckets, etc.).
+    """
+
+    computed_at: str
+    from_date: str
+    to_date: str
+    cohorts: dict[str, dict[str, Any]] = field(default_factory=dict)
+    average: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Convert to DataFrame.
+
+        Columns: cohort_date, bucket, count, rate.
+        One row per (cohort, retention bucket) pair.
+        """
+        ...
+```
+
+### 4.5 Bookmark JSON Mapping
+
+```python
+# query_retention("Signup", "Login", retention_unit="week")
+# generates:
+{
+    "sections": {
+        "show": [{
+            "behavior": {
+                "type": "retention",
+                "resourceType": "events",
+                "behaviors": [
+                    {"type": "event", "name": "Signup",
+                     "filters": [], "filtersDeterminer": "all"},
+                    {"type": "event", "name": "Login",
+                     "filters": [], "filtersDeterminer": "all"},
+                ],
+                "retentionUnit": "week",
+                "retentionCustomBucketSizes": [],
+                "retentionAlignmentType": "birth",
+                "retentionUnboundedMode": None,
+                "dataGroupId": None,
+            },
+            "measurement": {
+                "math": "retention_rate",
+                "retentionBucketIndex": 0,
+                "retentionSegmentationEvent": None,
+            },
+        }],
+        "filter": [],
+        "group": [],
+        "time": [{"dateRangeType": "in the last", "unit": "day",
+                  "window": {"unit": "day", "value": 30}}],
+        "formula": [],
+    },
+    "displayOptions": {
+        "chartType": "retention-curve",
+    },
+}
+```
+
+### 4.6 Execution Path
+
+Retention bookmarks with `sections.show[].behavior.type == "retention"` are also POSTed to `/api/query/insights`. The insights API detects the retention behavior type (at `api.py:2946`) and delegates to `retention_query` (the retention service). The response flows back through the insights result formatter.
+
+Same as funnels: reuse `insights_query()` API client, different params structure, different response parsing.
+
+### 4.7 Validation Rules (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| R1 | born_event must be non-empty | `born_event must be a non-empty string` |
+| R2 | return_event must be non-empty | `return_event must be a non-empty string` |
+| R3 | Shared time range rules (V7-V11) | Reuse existing validation |
+| R4 | Shared GroupBy rules (V11-V12) | Reuse existing validation |
+| R5 | bucket_sizes must be positive integers | `bucket_sizes values must be positive integers` |
+| R6 | bucket_sizes must be in ascending order | `bucket_sizes must be in ascending order` |
+
+### 4.8 Example Calls
+
+```python
+# Simplest retention
+result = ws.query_retention("Signup", "Login")
+
+# Weekly retention with 90-day window
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_unit="week",
+    last=90,
+)
+
+# With per-event filters
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    RetentionEvent("Login"),
+    retention_unit="day",
+)
+
+# Segmented retention
+result = ws.query_retention(
+    "Signup", "Purchase",
+    group_by="platform",
+    retention_unit="week",
+)
+
+# Trends view (retention over time)
+result = ws.query_retention(
+    "Signup", "Login",
+    mode="trends",
+    unit="week",
+    last=90,
+)
+
+# Custom non-uniform retention buckets
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_unit="day",
+    bucket_sizes=[1, 3, 7, 14, 30],
+)
+
+# Inspect the cohort data
+print(result.average)         # Average retention across cohorts
+print(result.cohorts.keys())  # Cohort dates
+print(result.df.head())       # Tabular view
+```
+
+---
+
+## 5. Flows: `query_flow()`
+
+### 5.1 The Flows Difference
+
+Flows bookmarks are fundamentally different from insights/funnels/retention:
+
+1. **Flat structure** — No `sections` wrapper. All fields are top-level.
+2. **Different endpoint** — Uses `/arb_funnels` with `query_type=flows_sankey` or `flows_top_paths`, not `/insights`.
+3. **Step semantics** — Steps define an "anchor" event with `forward` (steps after) and `reverse` (steps before) counts, not a sequential funnel.
+4. **Filter format** — Uses legacy `property_filter_params_list` (segfilter format), not the `sections.filter[]` structured format.
+5. **Response structure** — Returns a node/edge graph, not time-series or step-array data.
+
+Because of these differences, `query_flow()` builds a flat params dict (not `sections`-based) and uses a separate API path.
+
+### 5.2 Method Signature
+
+```python
+def query_flow(
+    self,
+    event: str | FlowStep | Sequence[str | FlowStep],
+    *,
+    # Flow configuration
+    forward: int = 3,
+    reverse: int = 0,
+
+    # Time range
+    from_date: str | None = None,
+    to_date: str | None = None,
+    last: int = 30,
+
+    # Conversion window
+    conversion_window: int = 7,
+    conversion_window_unit: Literal["day", "week", "month"] = "day",
+
+    # Counting
+    count_type: Literal["unique", "total", "session"] = "unique",
+
+    # Flow settings
+    cardinality: int = 3,
+    collapse_repeated: bool = False,
+    hidden_events: list[str] | None = None,
+
+    # Result shape
+    mode: Literal["sankey", "paths"] = "sankey",
+) -> FlowQueryResult:
+```
+
+### 5.3 `FlowStep` Type
+
+```python
+@dataclass(frozen=True)
+class FlowStep:
+    """An anchor step for a flow query.
+
+    Use plain event name strings for simple flows (single anchor event
+    with top-level forward/reverse counts). Use FlowStep for per-step
+    forward/reverse control or per-step filters.
+
+    Attributes:
+        event: Mixpanel event name.
+        forward: Number of steps to show after this event (0-5).
+        reverse: Number of steps to show before this event (0-5).
+        label: Display label for this step.
+
+    Example:
+        ```python
+        FlowStep("Purchase", forward=3, reverse=2)
+        FlowStep("Checkout", forward=0, reverse=3, label="Checkout Flow")
+        ```
+    """
+
+    event: str
+    forward: int | None = None
+    reverse: int | None = None
+    label: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["and", "or"] = "and"
+```
+
+### 5.4 `FlowQueryResult`
+
+```python
+@dataclass(frozen=True)
+class FlowQueryResult(ResultWithDataFrame):
+    """Result of an ad-hoc flow query.
+
+    Contains node/edge graph data representing user paths.
+
+    Attributes:
+        computed_at: When the query was computed (ISO format).
+        steps: Flow step data with nodes and edges.
+        breakdowns: Path breakdown data.
+        overall_conversion_rate: End-to-end flow conversion rate.
+        params: Generated flows bookmark params (for debugging/persistence).
+        meta: Response metadata (sampling factor, etc.).
+    """
+
+    computed_at: str
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    breakdowns: list[dict[str, Any]] = field(default_factory=list)
+    overall_conversion_rate: float = 0.0
+    params: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Convert flow steps to DataFrame.
+
+        Flattens the node/edge graph into rows with columns:
+        step_index, event, count, edges (list of next events).
+        """
+        ...
+```
+
+### 5.5 Bookmark JSON Mapping
+
+Flows use a flat structure — no `sections` wrapper:
+
+```python
+# query_flow("Purchase", forward=3, reverse=2)
+# generates:
+{
+    "steps": [
+        {"event": "Purchase", "step_label": "Purchase",
+         "forward": 3, "reverse": 2,
+         "bool_op": "and", "property_filter_params_list": []},
+    ],
+    "date_range": {
+        "type": "in the last",
+        "from_date": {"unit": "day", "value": 30},
+        "to_date": "$now",
+    },
+    "chartType": "sankey",
+    "flows_merge_type": "graph",
+    "count_type": "unique",
+    "cardinality_threshold": 3,
+    "version": 2,
+    "conversion_window": {"unit": "day", "value": 7},
+    "anchor_position": 1,
+    "collapse_repeated": False,
+    "show_custom_events": True,
+    "hidden_events": [],
+    "exclusions": [],
+}
+```
+
+### 5.6 Execution Path
+
+Flows queries use the `/arb_funnels` endpoint with inline bookmark params — confirmed working via source code analysis (`FunnelMetricParams.get_bookmark_from_params()` at `funnel_metric_params.py:674` checks for inline `bookmark` dict before `bookmark_id`).
+
+**Request format**:
+```python
+POST /api/2.0/arb_funnels
+{
+    "bookmark": flows_params_dict,        # flat flows bookmark (no sections wrapper)
+    "project_id": project_id,
+    "query_type": "flows_sankey",         # or "flows_top_paths" for paths mode
+}
+```
+
+A new `arb_funnels_query()` method on `MixpanelAPIClient` handles this POST. The existing `query_flows()` API client method (GET with `bookmark_id`) remains for querying saved flows reports.
+
+### 5.7 Validation Rules (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| FL1 | At least one event/step required | `flow requires at least one event` |
+| FL2 | Each step event must be non-empty | `step[{i}] event name must be non-empty` |
+| FL3 | forward must be 0-5 | `forward must be between 0 and 5` |
+| FL4 | reverse must be 0-5 | `reverse must be between 0 and 5` |
+| FL5 | forward + reverse must be > 0 | `flow step must have at least one forward or reverse step` |
+| FL6 | cardinality must be 1-50 | `cardinality must be between 1 and 50` |
+| FL7 | conversion_window must be positive | `conversion_window must be positive` |
+| FL8 | last must be positive | Reuse existing V7 |
+
+### 5.8 Example Calls
+
+```python
+# Simplest flow — what happens after Purchase?
+result = ws.query_flow("Purchase", forward=3)
+
+# What happens before AND after Purchase?
+result = ws.query_flow("Purchase", forward=3, reverse=2)
+
+# With conversion window and counting
+result = ws.query_flow(
+    "Add to Cart",
+    forward=5,
+    conversion_window=14,
+    count_type="unique",
+)
+
+# Multiple anchor steps
+result = ws.query_flow([
+    FlowStep("Signup", forward=3, reverse=0),
+    FlowStep("Purchase", forward=0, reverse=3),
+])
+
+# Hide noisy events
+result = ws.query_flow(
+    "Checkout",
+    forward=3,
+    hidden_events=["Page View", "Session Start"],
+)
+
+# Paths view (list of top paths instead of sankey graph)
+result = ws.query_flow("Purchase", forward=3, mode="paths")
+```
+
+---
+
+## 6. Infrastructure Reuse Plan
+
+### 6.1 Shared Time Range Handling
+
+All four methods use the same time range parameters: `from_date`, `to_date`, `last`, `unit`. The validation rules (V7-V11, V15, V20) are identical. The bookmark time section generation differs only in format:
+
+- **Insights/Funnels/Retention**: `sections.time[{"dateRangeType": "...", ...}]`
+- **Flows**: `date_range: {"type": "...", "from_date": {...}, "to_date": "$now"}`
+
+Extract a shared `_build_time_section()` for sections-based reports and a separate `_build_date_range()` for flows.
+
+### 6.2 Shared Filter Handling
+
+`Filter` objects and `_build_filter_entry()` are reused for:
+- **Global filters**: `sections.filter[]` (insights, funnels, retention)
+- **Per-event/step filters**: `behavior.behaviors[].filters[]` (funnel steps, retention events)
+- **Flows step filters**: Converted to `property_filter_params_list` via `_build_segfilter_entry()`
+
+A `_build_segfilter_entry(f: Filter) -> dict` converter (~100 lines) translates `Filter` objects to the legacy segfilter format used by flows steps. Key mappings:
+
+| Aspect | Bookmark filter (`_build_filter_entry`) | Segfilter (`_build_segfilter_entry`) |
+|--------|----------------------------------------|--------------------------------------|
+| Operator | Human-readable (`"equals"`) | Symbolic (`"=="`) |
+| Property location | `value: "country"` | `property: {"name": "country", "source": "properties"}` |
+| String equals value | `filterValue: ["US"]` | `filter.operand: ["US"]` |
+| Number value | `filterValue: 50` | `filter.operand: "50"` (stringified) |
+| Boolean | `filterOperator: "true"` | No operator field, `filter.operand: "true"` |
+| Date format | `YYYY-MM-DD` | `MM/DD/YYYY` |
+| Resource type | `resourceType: "events"` | `property.source: "properties"` |
+
+**Reference implementations in `analytics/`:**
+
+| File | What | Lines |
+|------|------|-------|
+| `iron/common/widgets/property-filter-menu/models/segfilter.ts` | Canonical TypeScript bidirectional converter. `toSegfilterFilter()` is the PropertyFilter→segfilter direction. | ~L403+ |
+| `iron/common/widgets/property-filter-menu/models/__test__/segfilter.ts` | Round-trip test cases for every operator type — serves as the specification. | Full file |
+| `iron/common/widgets/property-filter-menu/models/segfilter.ts` | `Segfilter` interface definition (`property`, `type`, `selected_property_type`, `filter`). | L110-115 |
+| `iron/common/widgets/property-filter-menu/models/segfilter.ts` | `SegfilterFilter` interface (`operator`, `operand`, `segments`, `unit`). | L82-89 |
+| `iron/common/widgets/property-filter-menu/models/segfilter.ts` | `Property` interface (`name`, `source`, `type`). | L91-101 |
+| `bookmark_parser/common/segfilter/segfilter_to_property_filter.py` | Python segfilter→PropertyFilter converter (the reverse direction — useful for understanding field mappings). | Full file |
+| `mixpanel_mcp/mcp_server/utils/reports/flows.py` | Existing (buggy) Python PropertyFilter→segfilter attempt: `convert_to_property_filter_params()`. Known bugs: wrong `"is set"` mapping, wrong `"contains"` mapping, no type-aware operand shaping. | L73-143 |
+| `iron/common/report/funnels/models/types.ts` | `BookmarkBaseStep` + `PropertyFilterParams` types defining the step structure that contains `property_filter_params_list`. | L17-55 |
+
+### 6.3 Shared GroupBy Handling
+
+`GroupBy` objects and the group section builder are reused identically for insights, funnels, and retention. All three write to `sections.group[]`. Flows do not use `sections.group[]` — they have a top-level `group_by` array with a different format.
+
+For v1, flows `group_by` is not exposed (it's complex and flows-specific). Users who need segmented flows can use `create_bookmark()` + `query_flows()`.
+
+### 6.4 Shared Validation Infrastructure
+
+The two-layer validation pattern is reused across all report types:
+
+```python
+# Layer 1: Argument validation (report-specific)
+errors = validate_funnel_args(steps=..., math=..., ...)  # NEW
+errors = validate_retention_args(born_event=..., ...)     # NEW
+errors = validate_flow_args(event=..., forward=..., ...)  # NEW
+
+# Layer 2: Bookmark structure validation (shared, extended)
+errors = validate_bookmark(params, bookmark_type="funnels")    # EXTENDED
+errors = validate_bookmark(params, bookmark_type="retention")  # EXTENDED
+# Flows: separate flat-bookmark validator
+errors = validate_flow_bookmark(params)                        # NEW
+```
+
+The `bookmark_type` parameter on `validate_bookmark()` is already present but unused — it was designed for exactly this extension. The validator will use `bookmark_type` to select the correct valid math types (VALID_MATH_FUNNELS, VALID_MATH_RETENTION) and validate behavior-type-specific fields.
+
+### 6.5 Shared `build_*_params()` Pattern
+
+Each report type gets a public `build_*_params()` method that mirrors `build_params()`:
+
+```python
+ws.build_funnel_params(["Signup", "Purchase"])      # → dict
+ws.build_retention_params("Signup", "Login")         # → dict
+ws.build_flow_params("Purchase", forward=3)          # → dict
+```
+
+These enable:
+- **Debugging**: Inspect the generated bookmark JSON
+- **Persistence**: Pass to `create_bookmark()` to save as a report
+- **Testing**: Verify params without credentials or API access
+
+---
+
+## 7. Response Format Differences
+
+### 7.1 How Each Report Type Responds
+
+| Report | Endpoint | Response Shape | Key Fields |
+|--------|----------|---------------|------------|
+| Insights | `/insights` | `{computed_at, date_range, headers, series, meta}` | `series: {metric_name: {date: value}}` |
+| Funnels | `/insights` (delegates to arb) | Same wrapper, but `series` contains step data | Step arrays with `count`, `step_conv_ratio`, `overall_conv_ratio`, `avg_time` |
+| Retention | `/insights` (delegates to retention) | Same wrapper, but `series` contains cohort data | Cohort dicts with `first`, `counts[]`, `rates[]` |
+| Flows | `/arb_funnels` | `{computed_at, steps, breakdowns, overallConversionRate, metadata}` | `steps[].nodes[].edges[]` graph structure |
+
+### 7.2 DataFrame Shapes
+
+| Report | DataFrame Columns | Rows |
+|--------|-------------------|------|
+| Insights (timeseries) | `date, event, count` | One per (date, metric) |
+| Insights (total) | `event, count` | One per metric |
+| Funnels (steps) | `step, event, count, step_conv_ratio, overall_conv_ratio, avg_time` | One per step |
+| Funnels (trends) | `date, event, count` | One per (date, step) — like insights |
+| Retention (curve) | `cohort_date, bucket, count, rate` | One per (cohort, bucket) |
+| Retention (trends) | `date, event, count` | Like insights |
+| Flows | `step_index, event, type, count` | One per node |
+
+---
+
+## 8. Phased Implementation Plan
+
+### Phase 1: Shared Infrastructure Extraction
+
+Extract shared components from the existing `query()` pipeline:
+- `_build_time_section()` — shared time clause builder for sections-based reports
+- `_build_date_range()` — flows-specific flat date range builder
+- `_build_segfilter_entry()` — `Filter` → segfilter converter (~100 lines)
+- `_validate_time_args()` — extracted from `validate_query_args()`
+- `_validate_group_by_args()` — extracted from `validate_query_args()`
+- Extend `bookmark_enums.py` with funnel/retention/flows-specific constants
+
+### Phase 2: Funnels (`query_funnel()`)
+
+- `FunnelStep` and `FunnelQueryResult` types
+- `validate_funnel_args()` — Layer 1 validation
+- `_build_funnel_params()` — bookmark JSON builder
+- `build_funnel_params()` — public params helper
+- `query_funnel()` — public method
+- `_transform_funnel_result()` — response parser
+- Extend `validate_bookmark()` for funnel structure (L2)
+
+### Phase 3: Retention (`query_retention()`)
+
+- `RetentionEvent` and `RetentionQueryResult` types
+- `validate_retention_args()` — Layer 1 validation
+- `_build_retention_params()` — bookmark JSON builder
+- `build_retention_params()` — public params helper
+- `query_retention()` — public method
+- `_transform_retention_result()` — response parser
+- Extend `validate_bookmark()` for retention structure (L2)
+
+### Phase 4: Flows (`query_flow()`)
+
+- `FlowStep` and `FlowQueryResult` types
+- `validate_flow_args()` — Layer 1 validation
+- `_build_flow_params()` — flat bookmark builder (uses `_build_segfilter_entry()` for per-step filters)
+- `validate_flow_bookmark()` — separate L2 for flat structure
+- `build_flow_params()` — public params helper
+- `query_flow()` — public method
+- `arb_funnels_query()` — new API client method (POST with inline `bookmark` + `query_type`)
+- `_transform_flow_result()` — response parser
+
+### Phase 5: Polish
+
+- Property-based tests (Hypothesis) for all new types
+- Mutation testing on new validation rules
+- Documentation: docstrings, quickstart examples
+- Exports in `__init__.py`
+
+---
+
+## 9. Resolved Design Decisions
+
+All design questions were resolved through source code analysis and collaborative discussion.
+
+### 9.1 Flows Inline Params → **Inline POST to `/arb_funnels`**
+
+`/arb_funnels` accepts an inline `bookmark` dict in the POST body. Confirmed via `FunnelMetricParams.get_bookmark_from_params()` at `funnel_metric_params.py:674` — inline `bookmark` is checked before `bookmark_id`. Single API call, no transient state.
+
+Request body: `{"bookmark": flows_params, "project_id": id, "query_type": "flows_sankey"}`.
+
+### 9.2 Flows Per-Step Filters → **Build `Filter` → segfilter converter in v1**
+
+A `_build_segfilter_entry()` converter (~100 lines) translates `Filter` objects to the legacy segfilter format. The conversion is well-specified by the TypeScript reference implementation (`segfilter.ts:toSegfilterFilter`) with round-trip tests. Key structural differences: symbolic operators (`"=="` vs `"equals"`), stringified numbers, MM/DD/YYYY dates, `source: "properties"` vs `resourceType: "events"`.
+
+`FlowStep` accepts `filters: list[Filter] | None` and `filters_combinator: Literal["and", "or"]`.
+
+### 9.3 Funnel Exclusions → **Typed `exclusions: list[str | Exclusion]`**
+
+Plain strings exclude between ALL steps (common case). `Exclusion(event, from_step=0, to_step=None)` enables step-range targeting. Maps to bookmark `behavior.exclusions[]` with `steps: {"from": N, "to": M}`.
+
+### 9.4 Funnel Hold Property Constant → **Typed `holding_constant: str | HoldingConstant | list[...]`**
+
+Plain strings hold event properties constant (common case). `HoldingConstant(property, resource_type="events")` enables user-property HPC. Maps to bookmark `behavior.aggregateBy[]`.
+
+### 9.5 Retention Custom Bucket Sizes → **Include `bucket_sizes: list[int] | None` in v1**
+
+Optional parameter for non-uniform retention periods (e.g., `[1, 3, 7, 14, 30]`). Maps directly to `retentionCustomBucketSizes`. Validation: positive integers in ascending order. `None` (default) = uniform buckets via `retention_unit`.
+
+---
+
+## 10. Summary: API Surface
+
+### New Public Types
+
+| Type | Purpose |
+|------|---------|
+| `FunnelStep` | Funnel step with optional label, per-step filters, and ordering |
+| `Exclusion` | Funnel step exclusion with optional step-range targeting |
+| `HoldingConstant` | Hold-property-constant with resource type control |
+| `FunnelMathType` | Literal for funnel math types |
+| `FunnelQueryResult` | Funnel result with step data and conversion rates |
+| `RetentionEvent` | Retention event with optional per-event filters |
+| `RetentionMathType` | Literal for retention math types |
+| `RetentionQueryResult` | Retention result with cohort data and rates |
+| `FlowStep` | Flow anchor step with forward/reverse counts and per-step filters |
+| `FlowQueryResult` | Flow result with node/edge graph data |
+
+### New Public Methods
+
+| Method | Minimum Call | Returns |
+|--------|-------------|---------|
+| `query_funnel(steps)` | `ws.query_funnel(["Signup", "Purchase"])` | `FunnelQueryResult` |
+| `query_retention(born, return)` | `ws.query_retention("Signup", "Login")` | `RetentionQueryResult` |
+| `query_flow(event)` | `ws.query_flow("Purchase", forward=3)` | `FlowQueryResult` |
+| `build_funnel_params(steps)` | `ws.build_funnel_params(["Signup", "Purchase"])` | `dict` |
+| `build_retention_params(born, return)` | `ws.build_retention_params("Signup", "Login")` | `dict` |
+| `build_flow_params(event)` | `ws.build_flow_params("Purchase", forward=3)` | `dict` |
+
+### Reused Types (from existing `query()`)
+
+`Filter`, `GroupBy`, `Formula`, `BookmarkValidationError`, `ValidationError`, `FilterDateUnit`, `FilterPropertyType`
+
+### New Internal Components
+
+| Component | Purpose |
+|-----------|---------|
+| `_build_segfilter_entry()` | Convert `Filter` → segfilter format for flows steps (~100 lines) |
+| `_build_time_section()` | Shared time clause builder for sections-based reports |
+| `_build_date_range()` | Flows-specific flat date range builder |
+| `validate_funnel_args()` | Layer 1 funnel validation (F1-F6) |
+| `validate_retention_args()` | Layer 1 retention validation (R1-R6) |
+| `validate_flow_args()` | Layer 1 flow validation (FL1-FL8) |
+| `validate_flow_bookmark()` | Layer 2 for flat flows structure |
+| `arb_funnels_query()` | API client: POST to `/arb_funnels` with inline params |
+
+---
+
+## Appendix A: Canonical Bookmark JSON Reference
+
+### A.1 Insights Behavior (`behavior.type: "event"`)
+
+```json
+{
+  "type": "event",
+  "name": "Login",
+  "resourceType": "events",
+  "filtersDeterminer": "all",
+  "filters": []
+}
+```
+
+### A.2 Funnel Behavior (`behavior.type: "funnel"`)
+
+```json
+{
+  "type": "funnel",
+  "name": null,
+  "resourceType": "events",
+  "dataGroupId": null,
+  "filters": [],
+  "behaviors": [
+    {"id": null, "type": "event", "name": "Signup",
+     "filters": [], "filtersDeterminer": "all", "funnelOrder": "loose"},
+    {"id": null, "type": "event", "name": "Purchase",
+     "filters": [], "filtersDeterminer": "all", "funnelOrder": "loose"}
+  ],
+  "conversionWindowDuration": 14,
+  "conversionWindowUnit": "day",
+  "funnelOrder": "loose",
+  "exclusions": [],
+  "aggregateBy": [],
+  "dataset": "$mixpanel",
+  "profileType": null,
+  "search": ""
+}
+```
+
+### A.3 Retention Behavior (`behavior.type: "retention"`)
+
+```json
+{
+  "type": "retention",
+  "resourceType": "events",
+  "dataGroupId": null,
+  "behaviors": [
+    {"type": "event", "name": "Signup",
+     "filters": [], "filtersDeterminer": "all"},
+    {"type": "event", "name": "Login",
+     "filters": [], "filtersDeterminer": "all"}
+  ],
+  "retentionUnit": "week",
+  "retentionCustomBucketSizes": [],
+  "retentionAlignmentType": "birth",
+  "retentionUnboundedMode": null
+}
+```
+
+### A.4 Flows Bookmark (flat — no sections)
+
+```json
+{
+  "steps": [
+    {"event": "Purchase", "step_label": "Purchase",
+     "forward": 3, "reverse": 2,
+     "bool_op": "and", "property_filter_params_list": []}
+  ],
+  "date_range": {
+    "type": "in the last",
+    "from_date": {"unit": "day", "value": 30},
+    "to_date": "$now"
+  },
+  "chartType": "sankey",
+  "flows_merge_type": "graph",
+  "count_type": "unique",
+  "cardinality_threshold": 3,
+  "version": 2,
+  "conversion_window": {"unit": "day", "value": 7},
+  "anchor_position": 1,
+  "collapse_repeated": false,
+  "show_custom_events": true,
+  "hidden_events": [],
+  "exclusions": []
+}
+```
+
+### A.5 Measurement Block Differences
+
+| Report | measurement.math | Extra Fields |
+|--------|-----------------|-------------|
+| Insights | `total`, `unique`, `dau`, `average`, etc. | `property`, `perUserAggregation`, `percentile` |
+| Funnels | `conversion_rate_unique`, `unique`, `total`, etc. | `stepIndex`, `actionMode`, `actionStep` |
+| Retention | `retention_rate`, `unique` | `retentionBucketIndex`, `retentionSegmentationEvent` |
+| Flows | N/A (top-level `count_type`) | N/A |
+
+### A.6 DisplayOptions Differences
+
+| Report | chartType Values | Extra Fields |
+|--------|-----------------|-------------|
+| Insights | `line`, `bar`, `table`, `pie`, `insights-metric` | `analysis`, `rollingWindowSize` |
+| Funnels | `funnel-steps`, `funnel-top-paths`, `line`, `bar`, `table` | `funnelStepsSelectedTableColumns`, `statSigControl` |
+| Retention | `retention-curve`, `line`, `bar`, `table` | `selected_segments`, `expanded_segments` |
+| Flows | N/A (top-level `chartType`) | N/A |

--- a/context/unified-bookmark-query-design.md
+++ b/context/unified-bookmark-query-design.md
@@ -739,7 +739,7 @@ class FlowStep:
     reverse: int | None = None
     label: str | None = None
     filters: list[Filter] | None = None
-    filters_combinator: Literal["and", "or"] = "and"
+    filters_combinator: Literal["all", "any"] = "all"
 ```
 
 ### 5.4 `FlowQueryResult`

--- a/specs/031-shared-infra-extraction/checklists/requirements.md
+++ b/specs/031-shared-infra-extraction/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Phase 1 — Shared Infrastructure Extraction
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references validation rule codes (V7, V11, etc.) and bookmark JSON field names — these are domain terminology from the Mixpanel bookmark query language, not implementation details.
+- User stories are framed from the perspective of "library developer" since this is infrastructure for a developer SDK, not end-user-facing functionality.

--- a/specs/031-shared-infra-extraction/data-model.md
+++ b/specs/031-shared-infra-extraction/data-model.md
@@ -162,7 +162,7 @@ No new validation entities. Extracted validators (`validate_time_args`, `validat
 | `VALID_RETENTION_UNITS` | `frozenset[str]` | `{"day", "week", "month"}` |
 | `VALID_RETENTION_ALIGNMENT` | `frozenset[str]` | `{"birth", "interval_start"}` |
 | `VALID_FLOWS_COUNT_TYPES` | `frozenset[str]` | `{"unique", "total", "session"}` |
-| `VALID_FLOWS_CHART_TYPES` | `frozenset[str]` | `{"sankey", "top-paths"}` |
+| `VALID_FLOWS_CHART_TYPES` | `frozenset[str]` | `{"sankey", "top-paths"}` — user-facing API uses `"paths"` which maps to `"top-paths"` internally |
 
 ## Enum Constants (Extended)
 

--- a/specs/031-shared-infra-extraction/data-model.md
+++ b/specs/031-shared-infra-extraction/data-model.md
@@ -1,0 +1,171 @@
+# Data Model: Phase 1 — Shared Infrastructure Extraction
+
+**Date**: 2026-04-05
+**Status**: Complete
+
+## Overview
+
+Phase 1 introduces no new public types. All new entities are internal dict structures (not frozen dataclasses) produced by extracted builder functions. This document defines the shapes of those dict outputs for contract validation.
+
+## Entities
+
+### Time Section Entry (sections-based reports)
+
+Produced by `build_time_section()`. Used by insights, funnels, and retention.
+
+**Variant 1: Absolute date range**
+```python
+{
+    "dateRangeType": "between",       # Literal["between"]
+    "unit": str,                       # e.g. "day", "week", "month"
+    "value": [str, str],              # [from_date, to_date] in YYYY-MM-DD
+}
+```
+
+**Variant 2: Relative date range**
+```python
+{
+    "dateRangeType": "in the last",   # Literal["in the last"]
+    "unit": str,                       # e.g. "day", "week"
+    "window": {
+        "unit": "day",                # Always "day" for the window unit
+        "value": int,                 # Number of days
+    },
+}
+```
+
+**Invariants**:
+- Exactly one of `"value"` or `"window"` is present, never both.
+- `dateRangeType` is always one of `{"between", "in the last"}`.
+- When `value` is present, both elements are valid `YYYY-MM-DD` strings.
+- When `window` is present, `value` is a positive integer.
+
+### Flows Date Range (flat format)
+
+Produced by `build_date_range()`. Used only by flows.
+
+**Variant 1: Relative**
+```python
+{
+    "type": "in the last",
+    "from_date": {"unit": "day", "value": int},  # e.g. 30
+    "to_date": "$now",
+}
+```
+
+**Variant 2: Absolute**
+```python
+{
+    "type": "between",
+    "from_date": str,     # YYYY-MM-DD
+    "to_date": str,       # YYYY-MM-DD
+}
+```
+
+**Invariants**:
+- `type` is always one of `{"in the last", "between"}`.
+- When `type` is `"in the last"`, `from_date` is a dict with `unit` and `value`; `to_date` is the string `"$now"`.
+- When `type` is `"between"`, both `from_date` and `to_date` are `YYYY-MM-DD` strings.
+
+### Filter Section Entry
+
+Produced by `_build_filter_entry()` (existing) and consumed by `build_filter_section()` (new wrapper).
+
+```python
+{
+    "resourceType": str,      # e.g. "events", "people"
+    "filterType": str,        # e.g. "string", "number", "datetime", "boolean"
+    "defaultType": str,       # Same as filterType
+    "value": str,             # Property name
+    "filterValue": Any,       # Operator-dependent value
+    "filterOperator": str,    # e.g. "equals", "is greater than"
+    "filterDateUnit": str,    # Optional — only for relative date filters
+}
+```
+
+### Group Section Entry
+
+Produced by `build_group_section()`.
+
+```python
+{
+    "value": str,                   # Property name
+    "propertyName": str,            # Property name (duplicate of value)
+    "resourceType": "events",       # Resource type
+    "propertyType": str,            # e.g. "string", "number"
+    "propertyDefaultType": str,     # Same as propertyType
+    "customBucket": {               # Optional — only when bucket_size is set
+        "bucketSize": float,
+        "min": float,               # Optional
+        "max": float,               # Optional
+    },
+}
+```
+
+### Segfilter Entry
+
+Produced by `build_segfilter_entry()`. Used by flows step filters.
+
+```python
+{
+    "property": {
+        "name": str,               # Property name
+        "source": str,             # "properties" | "user" | "cohort" | "other"
+        "type": str,               # "string" | "number" | "datetime" | "boolean"
+    },
+    "type": str,                   # Same as property.type
+    "selected_property_type": str, # Same as property.type
+    "filter": {
+        "operator": str,           # Symbolic: "==", "!=", ">", "<", etc.
+        "operand": Any,            # Type-dependent: str, list[str], int, ""
+        "unit": str,               # Optional — only for relative date filters
+    },
+}
+```
+
+**Invariants**:
+- `property.source` is mapped from `resourceType` via `RESOURCE_TYPE_MAP` (e.g. `"events"` → `"properties"`).
+- `type` and `selected_property_type` always equal `property.type`.
+- `filter.operator` is omitted for boolean filters (operand carries the value).
+- Numeric values in `filter.operand` are always stringified.
+- Date values in `filter.operand` use `MM/DD/YYYY` format (not `YYYY-MM-DD`).
+
+## Relationships
+
+```
+Workspace._build_query_params()
+    ├── calls build_time_section()      → sections.time[]
+    ├── calls build_filter_section()    → sections.filter[]
+    │         └── calls _build_filter_entry() per Filter
+    └── calls build_group_section()     → sections.group[]
+
+(future) Workspace._build_funnel_params()
+    ├── calls build_time_section()      → sections.time[]
+    ├── calls build_filter_section()    → sections.filter[]
+    └── calls build_group_section()     → sections.group[]
+
+(future) Workspace._build_flow_params()
+    ├── calls build_date_range()        → date_range (flat)
+    └── calls build_segfilter_entry()   → steps[].property_filter_params_list[]
+```
+
+## Validation Rules
+
+No new validation entities. Extracted validators (`validate_time_args`, `validate_group_by_args`) return `list[ValidationError]` using the existing `ValidationError` type unchanged.
+
+## Enum Constants (New)
+
+| Constant | Type | Values |
+|---|---|---|
+| `VALID_FUNNEL_ORDER` | `frozenset[str]` | `{"loose", "any"}` |
+| `VALID_CONVERSION_WINDOW_UNITS` | `frozenset[str]` | `{"second", "minute", "hour", "day", "week", "month", "session"}` |
+| `VALID_RETENTION_UNITS` | `frozenset[str]` | `{"day", "week", "month"}` |
+| `VALID_RETENTION_ALIGNMENT` | `frozenset[str]` | `{"birth", "interval_start"}` |
+| `VALID_FLOWS_COUNT_TYPES` | `frozenset[str]` | `{"unique", "total", "session"}` |
+| `VALID_FLOWS_CHART_TYPES` | `frozenset[str]` | `{"sankey", "top-paths"}` |
+
+## Enum Constants (Extended)
+
+| Constant | Added Values |
+|---|---|
+| `VALID_MATH_FUNNELS` | `"average"`, `"median"`, `"min"`, `"max"`, `"p25"`, `"p75"`, `"p90"`, `"p99"` |

--- a/specs/031-shared-infra-extraction/plan.md
+++ b/specs/031-shared-infra-extraction/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Phase 1 — Shared Infrastructure Extraction
+
+**Branch**: `031-shared-infra-extraction` | **Date**: 2026-04-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/031-shared-infra-extraction/spec.md`
+
+## Summary
+
+Extract shared time-range building, filter/group-section building, and validation logic from the existing `query()` / `_build_query_params()` / `validate_query_args()` pipeline into reusable helpers. Add a new `_build_segfilter_entry()` converter for flows. Extend bookmark enum constants for funnel/retention/flows domains. All existing behavior must remain unchanged (zero regressions).
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (mypy --strict)
+**Primary Dependencies**: httpx (HTTP), Pydantic v2 (validation), pandas (DataFrames)
+**Storage**: N/A — live query only
+**Testing**: pytest, Hypothesis (property-based), mutmut (mutation)
+**Target Platform**: Cross-platform Python library + CLI
+**Project Type**: Library + CLI
+**Performance Goals**: N/A — infrastructure extraction, no new API calls
+**Constraints**: Zero behavioral regressions; 90% code coverage; mypy --strict
+**Scale/Scope**: ~5 new internal functions, ~1 new internal module (~100 lines), ~15 new enum constants
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | All new functions are library-internal; no CLI changes |
+| II. Agent-Native | PASS | No interactive elements; pure function extraction |
+| III. Context Window Efficiency | PASS | No new data retrieval; infrastructure only |
+| IV. Two Data Paths | PASS | Affects live query path only (shared builders) |
+| V. Explicit Over Implicit | PASS | No hidden behavior; same explicit parameters |
+| VI. Unix Philosophy | PASS | Composable internal functions |
+| VII. Secure by Default | PASS | No credential handling in extracted functions |
+
+**Quality Gates**:
+- [x] Type hints on all new functions (mypy --strict)
+- [x] Docstrings on all new functions (Google style)
+- [x] ruff check + ruff format
+- [x] Tests for all new functionality (pytest + Hypothesis)
+- [x] No CLI changes needed
+
+All gates pass. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/031-shared-infra-extraction/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: segfilter research + design decisions
+├── data-model.md        # Phase 1: entity definitions
+├── quickstart.md        # Phase 1: usage guide for extracted functions
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (from /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── workspace.py                    # MODIFY: delegate to extracted helpers
+├── _internal/
+│   ├── validation.py               # MODIFY: extract time/group_by validators
+│   ├── bookmark_enums.py           # MODIFY: add funnel/retention/flows constants
+│   ├── bookmark_builders.py        # NEW: shared time/filter/group section builders
+│   └── segfilter.py                # NEW: Filter → segfilter converter
+
+tests/
+├── unit/
+│   ├── test_bookmark_builders.py   # NEW: tests for extracted builders
+│   ├── test_segfilter.py           # NEW: tests for segfilter converter
+│   ├── test_query_validation.py    # EXISTING: must pass unchanged
+│   ├── test_bookmark_enums.py      # NEW: tests for new enum constants
+│   └── test_query_validation_pbt.py # EXISTING: must pass unchanged
+```
+
+**Structure Decision**: Two new internal modules (`bookmark_builders.py`, `segfilter.py`) alongside existing internal modules. This keeps the segfilter converter isolated (flows-specific complexity) and groups the section builders together (shared across insights/funnels/retention). The existing `validation.py` is refactored in-place to delegate to extracted helpers.
+
+## Implementation Phases
+
+### Phase A: Extract Shared Builders (FR-001, FR-002, FR-006, FR-010, FR-011)
+
+Create `_internal/bookmark_builders.py` with:
+
+1. **`build_time_section()`** — Extract lines 1704-1728 from `workspace.py:_build_query_params()`. Accepts `from_date`, `to_date`, `last`, `unit`. Returns `list[dict]` (the `sections.time` array).
+2. **`build_date_range()`** — New function for flows. Accepts `from_date`, `to_date`, `last`. Returns flat `date_range` dict.
+3. **`build_filter_section()`** — Extract lines 1731-1734 from `workspace.py:_build_query_params()`. Accepts `where: Filter | list[Filter] | None`. Returns `list[dict]` (the `sections.filter` array). Delegates to `_build_filter_entry()`.
+4. **`build_group_section()`** — Extract lines 1737-1772 from `workspace.py:_build_query_params()`. Accepts `group_by: str | GroupBy | list[str | GroupBy] | None`. Returns `list[dict]` (the `sections.group` array).
+
+Then refactor `_build_query_params()` to call these helpers. Verify all existing tests pass.
+
+### Phase B: Extract Shared Validators (FR-003, FR-004, FR-005)
+
+In `_internal/validation.py`:
+
+1. **`validate_time_args()`** — Extract rules V7-V10, V15, V20 (lines 414-512). Accepts `from_date`, `to_date`, `last`. Returns `list[ValidationError]`.
+2. **`validate_group_by_args()`** — Extract rules V11-V12, V18, V24 (lines 514-588). Accepts `group_by`. Returns `list[ValidationError]`.
+
+Then refactor `validate_query_args()` to call these helpers. Verify all existing tests pass identically.
+
+### Phase C: Segfilter Converter (FR-007)
+
+Create `_internal/segfilter.py` with:
+
+1. **`build_segfilter_entry()`** — Convert a `Filter` object to segfilter format. Handles all 15+ operator types currently exposed by `Filter`. Reference: `analytics/iron/common/widgets/property-filter-menu/models/segfilter.ts:toSegfilterFilter()`.
+
+Key translations:
+- Operator mapping: `"equals"` → `"=="`, `"does not equal"` → `"!="`, `"contains"` → `"contains"`, `"is greater than"` → `">"`, etc.
+- Value formatting: numbers stringified, dates `YYYY-MM-DD` → `MM/DD/YYYY`
+- Property structure: `{"name": prop, "source": resource_type, "type": property_type}`
+- Existence operators: `"is set"` / `"is not set"` with correct empty operand
+
+### Phase D: Extend Bookmark Enums (FR-008)
+
+In `_internal/bookmark_enums.py`, add:
+
+1. **`VALID_FUNNEL_ORDER`** — `frozenset({"loose", "any"})`
+2. **`VALID_CONVERSION_WINDOW_UNITS`** — `frozenset({"second", "minute", "hour", "day", "week", "month", "session"})`
+3. **`VALID_RETENTION_UNITS`** — `frozenset({"day", "week", "month"})`
+4. **`VALID_RETENTION_ALIGNMENT`** — `frozenset({"birth", "interval_start"})`
+5. **`VALID_FLOWS_COUNT_TYPES`** — `frozenset({"unique", "total", "session"})`
+6. Verify existing `VALID_MATH_FUNNELS`, `VALID_MATH_RETENTION` are complete per design doc
+7. Extend `VALID_MATH_FUNNELS` if needed (add percentile/property-aggregation math types)
+
+### Phase E: Non-Regression Verification (FR-009)
+
+1. Run full test suite — zero failures
+2. Property-based tests comparing pre/post refactoring output
+3. Mutation testing on new code — 80%+ kill rate
+4. Code coverage check — 90%+ on new modules
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/031-shared-infra-extraction/plan.md
+++ b/specs/031-shared-infra-extraction/plan.md
@@ -109,7 +109,7 @@ Create `_internal/segfilter.py` with:
 1. **`build_segfilter_entry()`** — Convert a `Filter` object to segfilter format. Handles all 15+ operator types currently exposed by `Filter`. Reference: `analytics/iron/common/widgets/property-filter-menu/models/segfilter.ts:toSegfilterFilter()`.
 
 Key translations:
-- Operator mapping: `"equals"` → `"=="`, `"does not equal"` → `"!="`, `"contains"` → `"contains"`, `"is greater than"` → `">"`, etc.
+- Operator mapping: `"equals"` → `"=="`, `"does not equal"` → `"!="`, `"contains"` → `"in"`, `"is greater than"` → `">"`, etc.
 - Value formatting: numbers stringified, dates `YYYY-MM-DD` → `MM/DD/YYYY`
 - Property structure: `{"name": prop, "source": resource_type, "type": property_type}`
 - Existence operators: `"is set"` / `"is not set"` with correct empty operand

--- a/specs/031-shared-infra-extraction/quickstart.md
+++ b/specs/031-shared-infra-extraction/quickstart.md
@@ -1,0 +1,180 @@
+# Quickstart: Phase 1 — Shared Infrastructure Extraction
+
+**Date**: 2026-04-05
+**Audience**: Library developers building Phases 2-4 (funnels, retention, flows)
+
+## Using the Extracted Builders
+
+### Time Section (for insights, funnels, retention)
+
+```python
+from mixpanel_data._internal.bookmark_builders import (
+    build_time_section,
+    build_filter_section,
+    build_group_section,
+)
+
+# Relative date range (default)
+time = build_time_section(from_date=None, to_date=None, last=30, unit="day")
+# [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}]
+
+# Absolute date range
+time = build_time_section(from_date="2026-01-01", to_date="2026-01-31", last=30, unit="day")
+# [{"dateRangeType": "between", "unit": "day", "value": ["2026-01-01", "2026-01-31"]}]
+
+# From-date only (through today)
+time = build_time_section(from_date="2026-01-01", to_date=None, last=30, unit="week")
+# [{"dateRangeType": "between", "unit": "week", "value": ["2026-01-01", "2026-04-05"]}]
+```
+
+### Date Range (for flows)
+
+```python
+from mixpanel_data._internal.bookmark_builders import build_date_range
+
+# Relative
+dr = build_date_range(from_date=None, to_date=None, last=30)
+# {"type": "in the last", "from_date": {"unit": "day", "value": 30}, "to_date": "$now"}
+
+# Absolute
+dr = build_date_range(from_date="2026-01-01", to_date="2026-01-31", last=30)
+# {"type": "between", "from_date": "2026-01-01", "to_date": "2026-01-31"}
+```
+
+### Filter Section
+
+```python
+from mixpanel_data.types import Filter
+
+# Build sections.filter[] from Filter objects
+filters = build_filter_section(where=[
+    Filter.equals("country", "US"),
+    Filter.greater_than("amount", 50),
+])
+# [{"resourceType": "events", "filterType": "string", ...}, {...}]
+
+# Single filter
+filters = build_filter_section(where=Filter.equals("platform", "iOS"))
+
+# No filters
+filters = build_filter_section(where=None)
+# []
+```
+
+### Group Section
+
+```python
+from mixpanel_data.types import GroupBy
+
+# Simple string group-by
+groups = build_group_section(group_by="country")
+# [{"value": "country", "propertyName": "country", "resourceType": "events", ...}]
+
+# Typed GroupBy with bucketing
+groups = build_group_section(group_by=GroupBy("amount", property_type="number",
+                                              bucket_size=10, bucket_min=0, bucket_max=100))
+
+# Multiple group-bys
+groups = build_group_section(group_by=["country", "platform"])
+```
+
+## Using the Segfilter Converter (for flows)
+
+```python
+from mixpanel_data._internal.segfilter import build_segfilter_entry
+from mixpanel_data.types import Filter
+
+# String equals
+sf = build_segfilter_entry(Filter.equals("country", "US"))
+# {
+#     "property": {"name": "country", "source": "properties", "type": "string"},
+#     "type": "string",
+#     "selected_property_type": "string",
+#     "filter": {"operator": "==", "operand": ["US"]},
+# }
+
+# Number comparison (note stringified operand)
+sf = build_segfilter_entry(Filter.greater_than("amount", 50))
+# {
+#     "property": {"name": "amount", "source": "properties", "type": "number"},
+#     "type": "number",
+#     "selected_property_type": "number",
+#     "filter": {"operator": ">", "operand": "50"},
+# }
+
+# Boolean
+sf = build_segfilter_entry(Filter.is_true("verified"))
+# {
+#     "property": {"name": "verified", "source": "properties", "type": "boolean"},
+#     "type": "boolean",
+#     "selected_property_type": "boolean",
+#     "filter": {"operand": "true"},
+# }
+```
+
+## Using the Extracted Validators
+
+```python
+from mixpanel_data._internal.validation import (
+    validate_time_args,
+    validate_group_by_args,
+)
+
+# Time validation — returns list[ValidationError]
+errors = validate_time_args(from_date="2026-02-01", to_date="2026-01-01", last=30)
+# [ValidationError(code="V15_DATE_ORDER", ...)]
+
+errors = validate_time_args(from_date=None, to_date=None, last=-1)
+# [ValidationError(code="V7_LAST_POSITIVE", ...)]
+
+# Group-by validation
+errors = validate_group_by_args(group_by=GroupBy("x", property_type="string", bucket_size=10))
+# [ValidationError(code="V12B_BUCKET_REQUIRES_NUMBER", ...)]
+```
+
+## Building a New Report Type (Phase 2-4 Pattern)
+
+```python
+def _build_funnel_params(self, *, steps, from_date, to_date, last, unit, group_by, where, ...):
+    # Reuse shared builders
+    time_section = build_time_section(from_date=from_date, to_date=to_date, last=last, unit=unit)
+    filter_section = build_filter_section(where=where)
+    group_section = build_group_section(group_by=group_by)
+
+    # Build funnel-specific show section
+    show = [self._build_funnel_behavior(steps, ...)]
+
+    return {
+        "sections": {
+            "show": show,
+            "time": time_section,
+            "filter": filter_section,
+            "group": group_section,
+        },
+        "displayOptions": {"chartType": "funnel-steps"},
+    }
+
+def validate_funnel_args(self, *, steps, from_date, to_date, last, group_by, ...):
+    errors = []
+    # Reuse shared validators
+    errors.extend(validate_time_args(from_date=from_date, to_date=to_date, last=last))
+    errors.extend(validate_group_by_args(group_by=group_by))
+    # Add funnel-specific rules (F1-F6)
+    if len(steps) < 2:
+        errors.append(ValidationError(code="F1_MIN_STEPS", ...))
+    return errors
+```
+
+## New Enum Constants
+
+```python
+from mixpanel_data._internal.bookmark_enums import (
+    VALID_FUNNEL_ORDER,            # {"loose", "any"}
+    VALID_CONVERSION_WINDOW_UNITS, # {"second", "minute", "hour", "day", "week", "month", "session"}
+    VALID_RETENTION_UNITS,         # {"day", "week", "month"}
+    VALID_RETENTION_ALIGNMENT,     # {"birth", "interval_start"}
+    VALID_FLOWS_COUNT_TYPES,       # {"unique", "total", "session"}
+    VALID_FLOWS_CHART_TYPES,       # {"sankey", "top-paths"}
+    VALID_MATH_FUNNELS,            # Extended with property aggregation types
+)
+```

--- a/specs/031-shared-infra-extraction/research.md
+++ b/specs/031-shared-infra-extraction/research.md
@@ -153,4 +153,4 @@
 | `Filter.in_the_last()` | `"was in the"` | `"datetime"` |
 | `Filter.not_in_the_last()` | `"was not in the"` | `"datetime"` |
 
-No `does_not_contain`, `is_between`, `is_at_least`, or `is_at_most` methods exist on the `Filter` class. These operators are only used in legacy bookmarks, not in the current typed API. The converter does not need to handle them unless `Filter` is extended in a future phase.
+`Filter.not_contains()` (operator `"does not contain"`) and `Filter.between()` (operator `"is between"`) exist on the `Filter` class and are handled by the converter. `is_at_least` and `is_at_most` methods do not exist on `Filter` — these operators appear only in legacy bookmarks. The converter handles all operators in its mapping dicts (including legacy ones) for completeness, even if some are not currently constructible via `Filter` class methods.

--- a/specs/031-shared-infra-extraction/research.md
+++ b/specs/031-shared-infra-extraction/research.md
@@ -1,0 +1,156 @@
+# Research: Phase 1 — Shared Infrastructure Extraction
+
+**Date**: 2026-04-05
+**Status**: Complete
+
+## R1: Segfilter Format — Operator Mapping
+
+**Decision**: Map bookmark filter operators to segfilter symbolic operators using the canonical TypeScript reference.
+
+**Rationale**: The TypeScript reference at `analytics/iron/common/widgets/property-filter-menu/models/segfilter.ts` defines the authoritative bidirectional mapping with round-trip test coverage. The existing Python attempt at `mixpanel_mcp/mcp_server/utils/reports/flows.py` has known bugs (wrong `"is set"`, wrong `"contains"`, no type-aware operand shaping).
+
+### Complete Operator Mapping (PropertyFilter → Segfilter)
+
+#### String Operators (`STRING_OPERATOR_MAP`)
+
+| Bookmark `filterOperator` | Segfilter `filter.operator` | Segfilter `filter.operand` |
+|---|---|---|
+| `"equals"` | `"=="` | `["value1", "value2"]` (array) |
+| `"does not equal"` | `"!="` | `["value1", "value2"]` (array) |
+| `"contains"` | `"in"` | `"substring"` (string, not array) |
+| `"does not contain"` | `"not in"` | `"substring"` (string, not array) |
+| `"is set"` | `"set"` | `""` (empty string) |
+| `"is not set"` | `"not set"` | `""` (empty string) |
+
+#### Number Operators (`NUMBER_OPERATOR_MAP`)
+
+| Bookmark `filterOperator` | Segfilter `filter.operator` | Segfilter `filter.operand` |
+|---|---|---|
+| `"is equal to"` / `"equals"` | `"=="` | `"50"` (stringified) |
+| `"does not equal"` | `"!="` | `"50"` (stringified) |
+| `"is greater than"` | `">"` | `"50"` (stringified) |
+| `"is less than"` | `"<"` | `"50"` (stringified) |
+| `"is at least"` | `">="` | `"50"` (stringified) |
+| `"is at most"` | `"<="` | `"50"` (stringified) |
+| `"is between"` / `"between"` | `"><"` | `["10", "50"]` (stringified array) |
+| `"not between"` | `"!><"` | `["10", "50"]` (stringified array) |
+| `"is set"` | `"is set"` | `""` (empty string) |
+| `"is not set"` | `"is not set"` | `""` (empty string) |
+
+**Note**: Number `"is set"` / `"is not set"` use the literal words, while string `"is set"` / `"is not set"` use `"set"` / `"not set"` (no "is" prefix). This is the canonical format — not a bug.
+
+#### Boolean Operators
+
+| Bookmark `filterOperator` | Segfilter `filter.operator` | Segfilter `filter.operand` |
+|---|---|---|
+| `"true"` | *(omitted — no operator field)* | `"true"` |
+| `"false"` | *(omitted — no operator field)* | `"false"` |
+
+#### Datetime Operators (`DATETIME_OPERATOR_MAP`)
+
+| Bookmark `filterOperator` | Segfilter `filter.operator` | Segfilter `filter.operand` | Extra |
+|---|---|---|---|
+| `"on"` | `"=="` | `"MM/DD/YYYY"` | — |
+| `"not on"` | `"!="` | `"MM/DD/YYYY"` | — |
+| `"before"` | `">"` | `"MM/DD/YYYY"` | — |
+| `"since"` | `"<"` | `"MM/DD/YYYY"` | — |
+| `"in the last"` | `">"` | window value (int) | `unit: "days"` |
+| `"not in the last"` | `">"` | window value (int) | `unit: "days"` |
+| `"between"` / `"was between"` | `"><"` | `["MM/DD/YYYY", "MM/DD/YYYY"]` | — |
+| `"not between"` / `"was not between"` | `"!><"` | `["MM/DD/YYYY", "MM/DD/YYYY"]` | — |
+
+**Date format conversion**: `YYYY-MM-DD` (bookmark) → `MM/DD/YYYY` (segfilter).
+
+**Time unit conversion**: `"day"` → `"days"`, `"hour"` → `"hours"`, `"week"` → `"weeks"`, `"month"` → `"months"`, `"minute"` → `"minutes"`.
+
+**Alternatives considered**: Using the buggy `mixpanel_mcp` implementation as a starting point. Rejected because its operator mappings are incorrect (uses `"contains"` instead of `"in"` for string contains, missing type-aware operand shaping).
+
+## R2: Segfilter Format — Property Structure
+
+**Decision**: Map bookmark `resourceType` to segfilter `property.source` using the canonical `RESOURCE_TYPE_MAP`.
+
+**Rationale**: Critical finding — the mapping is NOT identity. `"events"` maps to `"properties"`, not `"events"`.
+
+### Resource Type Mapping
+
+| Bookmark `resourceType` | Segfilter `property.source` |
+|---|---|
+| `"events"` | `"properties"` |
+| `"people"` | `"user"` |
+| `"cohorts"` | `"cohort"` |
+| `"other"` | `"other"` |
+
+### Segfilter Structure
+
+```python
+{
+    "property": {
+        "name": "country",        # from Filter._property
+        "source": "properties",   # from RESOURCE_TYPE_MAP[Filter._resource_type]
+        "type": "string",         # from Filter._property_type
+    },
+    "type": "string",             # Filter._property_type
+    "selected_property_type": "string",  # Filter._property_type
+    "filter": {
+        "operator": "==",         # from operator mapping
+        "operand": ["US"],        # type-aware value shaping
+    },
+}
+```
+
+## R3: Time Section Extraction — Approach
+
+**Decision**: Extract inline time-building code from `workspace.py:_build_query_params()` (lines 1704-1728) into a standalone function that returns a single time entry dict.
+
+**Rationale**: The existing code handles three cases (between with both dates, between with from_date only, relative "in the last"). These exact cases are reused by funnels and retention. Flows needs a separate builder because its date_range format is structurally different (flat dict, not `sections.time[]` entry).
+
+**Alternatives considered**: Single unified builder returning both formats. Rejected because the two formats share no structural overlap — unifying would add conditional logic that obscures both shapes.
+
+## R4: Validation Extraction — Approach
+
+**Decision**: Extract time rules (V7-V10, V15, V20) and group-by rules (V11-V12, V18, V24) into separate functions called by `validate_query_args()`.
+
+**Rationale**: These rule blocks are self-contained — they only depend on their respective parameters, not on events/math/formula parameters. The existing function is 520+ lines; extracting ~175 lines improves readability and enables reuse by `validate_funnel_args()`, `validate_retention_args()`, and `validate_flow_args()`.
+
+**Alternatives considered**: Moving all shared validation into a base class. Rejected because the validation functions are stateless — inheritance adds complexity without benefit.
+
+## R5: Bookmark Enums — New Constants Needed
+
+**Decision**: Add the following new frozenset constants to `bookmark_enums.py`.
+
+| Constant | Values | Source |
+|---|---|---|
+| `VALID_FUNNEL_ORDER` | `{"loose", "any"}` | Design doc section 3.1, `analytics/` funnels behavior |
+| `VALID_CONVERSION_WINDOW_UNITS` | `{"second", "minute", "hour", "day", "week", "month", "session"}` | Design doc section 3.1 |
+| `VALID_RETENTION_UNITS` | `{"day", "week", "month"}` | Design doc section 4.1 |
+| `VALID_RETENTION_ALIGNMENT` | `{"birth", "interval_start"}` | Design doc section 4.1 |
+| `VALID_FLOWS_COUNT_TYPES` | `{"unique", "total", "session"}` | Design doc section 5.2 |
+| `VALID_FLOWS_CHART_TYPES` | `{"sankey", "top-paths"}` | Design doc section 5.5 |
+
+**Existing constants verified**:
+- `VALID_MATH_FUNNELS` — exists, contains `{"general", "unique", "session", "total", "conversion_rate", "conversion_rate_unique", "conversion_rate_total", "conversion_rate_session"}`. Design doc section 3.3 adds property aggregation types (`average`, `median`, `min`, `max`, `p25`, `p75`, `p90`, `p99`) — needs extension.
+- `VALID_MATH_RETENTION` — exists, contains `{"unique", "retention_rate", "total", "average"}`. Matches design doc section 4.3. Complete as-is.
+- `VALID_CHART_TYPES` — exists, already contains `"funnel-steps"`, `"funnel-top-paths"`, `"retention-curve"`. Complete as-is.
+
+## R6: Filter Class — Supported Operators Inventory
+
+**Decision**: The segfilter converter must handle the following 14 `Filter` class methods:
+
+| Method | Bookmark Operator | Property Type |
+|---|---|---|
+| `Filter.equals()` | `"equals"` | `"string"` |
+| `Filter.not_equals()` | `"does not equal"` | `"string"` |
+| `Filter.contains()` | `"contains"` | `"string"` |
+| `Filter.greater_than()` | `"is greater than"` | `"number"` |
+| `Filter.less_than()` | `"is less than"` | `"number"` |
+| `Filter.is_set()` | `"is set"` | `"string"` |
+| `Filter.is_not_set()` | `"is not set"` | `"string"` |
+| `Filter.is_true()` | `"true"` | `"boolean"` |
+| `Filter.is_false()` | `"false"` | `"boolean"` |
+| `Filter.on()` | `"was on"` | `"datetime"` |
+| `Filter.not_on()` | `"was not on"` | `"datetime"` |
+| `Filter.before()` | `"was before"` | `"datetime"` |
+| `Filter.in_the_last()` | `"was in the"` | `"datetime"` |
+| `Filter.not_in_the_last()` | `"was not in the"` | `"datetime"` |
+
+No `does_not_contain`, `is_between`, `is_at_least`, or `is_at_most` methods exist on the `Filter` class. These operators are only used in legacy bookmarks, not in the current typed API. The converter does not need to handle them unless `Filter` is extended in a future phase.

--- a/specs/031-shared-infra-extraction/spec.md
+++ b/specs/031-shared-infra-extraction/spec.md
@@ -60,9 +60,9 @@ A library developer building the flows query method needs to convert `Filter` ob
 
 1. **Given** `Filter.equals("country", "US")`, **When** the segfilter converter is called, **Then** it returns a dict with `filter.operator: "=="`, `filter.operand: ["US"]`, and `property.name: "country"`.
 2. **Given** `Filter.greater_than("amount", 50)`, **When** the segfilter converter is called, **Then** it returns `filter.operator: ">"` and `filter.operand: "50"` (stringified number).
-3. **Given** `Filter.is_set("email")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "is set"` with the correct operand structure.
-4. **Given** `Filter.contains("name", "john")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "contains"` with the correct operand structure.
-5. **Given** a `Filter` with `resource_type="people"`, **When** the segfilter converter is called, **Then** `property.source` is `"people"` (not `"properties"`).
+3. **Given** `Filter.is_set("email")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "set"` with `filter.operand: ""` (empty string).
+4. **Given** `Filter.contains("name", "john")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "in"` with `filter.operand: "john"`.
+5. **Given** a `Filter` with `resource_type="people"`, **When** the segfilter converter is called, **Then** `property.source` is `"user"` (mapped from `"people"` via `RESOURCE_TYPE_MAP`).
 
 ---
 

--- a/specs/031-shared-infra-extraction/spec.md
+++ b/specs/031-shared-infra-extraction/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Phase 1 — Shared Infrastructure Extraction
+
+**Feature Branch**: `031-shared-infra-extraction`
+**Created**: 2026-04-05
+**Status**: Draft
+**Input**: User description: "Phase 1: Shared Infrastructure Extraction — Extract shared components from the existing query() pipeline for reuse by funnels, retention, and flows query methods"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Reusable Time Range Building (Priority: P1)
+
+A library developer building the funnel, retention, or flows query method needs to generate the correct time section JSON without duplicating the logic already embedded in `_build_query_params()`. They call a shared time-builder that accepts the same `from_date`, `to_date`, `last`, and `unit` parameters and produces either a `sections.time[]` entry (for insights/funnels/retention) or a flat `date_range` dict (for flows).
+
+**Why this priority**: Every query method requires time range handling. Without this extraction, every new report type would copy-paste ~25 lines of date logic, creating divergence risk across four code paths.
+
+**Independent Test**: Can be fully tested by calling the extracted time builder with various date combinations and asserting the output dict structure matches the expected bookmark JSON. No API credentials or network access needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** `from_date="2026-01-01"` and `to_date="2026-01-31"` and `unit="day"`, **When** the sections-based time builder is called, **Then** it returns `{"dateRangeType": "between", "unit": "day", "value": ["2026-01-01", "2026-01-31"]}`.
+2. **Given** `from_date="2026-01-01"` and `to_date=None` and `unit="day"`, **When** the sections-based time builder is called, **Then** it returns a `"between"` entry spanning from `from_date` through today's date.
+3. **Given** `from_date=None` and `to_date=None` and `last=30` and `unit="day"`, **When** the sections-based time builder is called, **Then** it returns `{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}`.
+4. **Given** `from_date=None` and `last=30`, **When** the flows date-range builder is called, **Then** it returns `{"type": "in the last", "from_date": {"unit": "day", "value": 30}, "to_date": "$now"}`.
+5. **Given** `from_date="2026-01-01"` and `to_date="2026-01-31"`, **When** the flows date-range builder is called, **Then** it returns `{"type": "between", "from_date": "2026-01-01", "to_date": "2026-01-31"}`.
+6. **Given** `where=Filter.equals("country", "US")`, **When** the filter-section builder is called, **Then** it returns a single-element list containing the filter entry dict with `filterOperator: "equals"` and `filterValue: ["US"]`.
+7. **Given** `where=[Filter.equals("country", "US"), Filter.greater_than("amount", 50)]`, **When** the filter-section builder is called, **Then** it returns a two-element list with both filter entries.
+8. **Given** `where=None`, **When** the filter-section builder is called, **Then** it returns an empty list.
+9. **Given** `group_by="country"`, **When** the group-section builder is called, **Then** it returns a single-element list with `value: "country"`, `propertyName: "country"`, `resourceType: "events"`, and `propertyType: "string"`.
+10. **Given** `group_by=GroupBy("amount", property_type="number", bucket_size=10, bucket_min=0, bucket_max=100)`, **When** the group-section builder is called, **Then** it returns a list with `customBucket: {"bucketSize": 10, "min": 0, "max": 100}`.
+
+---
+
+### User Story 2 — Reusable Time and GroupBy Validation (Priority: P1)
+
+A library developer building funnel or retention validation needs to apply the same time-range rules (V7-V10, V15, V20) and group-by rules (V11-V12, V18, V24) without duplicating ~175 lines of validation code. They call extracted validation helpers that return a list of `ValidationError` objects, which they combine with report-specific errors.
+
+**Why this priority**: Tied with Story 1. Every new `validate_*_args()` function needs these shared rules. Extracting them first prevents divergence and ensures consistent error messages and codes across all report types.
+
+**Independent Test**: Can be fully tested by calling each extracted validator with valid and invalid inputs and asserting the expected `ValidationError` objects are returned. Existing tests for `validate_query_args()` confirm the extraction didn't change behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** `last=-1`, **When** time validation is called, **Then** it returns a `ValidationError` with code `V7_LAST_POSITIVE`.
+2. **Given** `to_date="2026-01-01"` and `from_date=None`, **When** time validation is called, **Then** it returns a `ValidationError` with code `V9_TO_REQUIRES_FROM`.
+3. **Given** `from_date="2026-02-01"` and `to_date="2026-01-01"`, **When** time validation is called, **Then** it returns a `ValidationError` with code `V15_DATE_ORDER`.
+4. **Given** a `GroupBy` with `bucket_size=10` but `property_type="string"`, **When** group-by validation is called, **Then** it returns a `ValidationError` with code `V12B_BUCKET_REQUIRES_NUMBER`.
+5. **Given** identical arguments, **When** `validate_query_args()` is called before and after refactoring, **Then** it produces identical error lists (no behavioral regression).
+
+---
+
+### User Story 3 — Filter-to-Segfilter Conversion for Flows (Priority: P2)
+
+A library developer building the flows query method needs to convert `Filter` objects (used throughout the library) to the legacy "segfilter" format required by the flows `/arb_funnels` endpoint. They call a converter that translates operator names, property locations, value formatting, and date formats from the bookmark format to the segfilter format.
+
+**Why this priority**: Only flows uses the segfilter format, so this is not blocking funnels or retention. However, it is the single most complex new piece of infrastructure with numerous operator-specific edge cases, so building and testing it in Phase 1 de-risks Phase 4 (Flows).
+
+**Independent Test**: Can be fully tested by creating `Filter` objects with every supported operator and asserting the segfilter output matches the canonical reference (TypeScript round-trip test cases from `analytics/` repo). No API access needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** `Filter.equals("country", "US")`, **When** the segfilter converter is called, **Then** it returns a dict with `filter.operator: "=="`, `filter.operand: ["US"]`, and `property.name: "country"`.
+2. **Given** `Filter.greater_than("amount", 50)`, **When** the segfilter converter is called, **Then** it returns `filter.operator: ">"` and `filter.operand: "50"` (stringified number).
+3. **Given** `Filter.is_set("email")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "is set"` with the correct operand structure.
+4. **Given** `Filter.contains("name", "john")`, **When** the segfilter converter is called, **Then** it returns `filter.operator: "contains"` with the correct operand structure.
+5. **Given** a `Filter` with `resource_type="people"`, **When** the segfilter converter is called, **Then** `property.source` is `"people"` (not `"properties"`).
+
+---
+
+### User Story 4 — Extended Bookmark Enum Constants (Priority: P2)
+
+A library developer building funnel or retention validation needs canonical enum sets for funnel math types, retention math types, funnel ordering modes, retention units, conversion window units, and related constants. These are used for O(1) membership checks and fuzzy-matched error suggestions in the validation engine.
+
+**Why this priority**: The enum constants file already contains partial funnel/retention entries. This story completes coverage and adds new constants. Required before Phase 2/3 validation can be implemented, but the constants alone don't block any execution path.
+
+**Independent Test**: Can be fully tested by asserting that each new frozenset contains the expected members. Cross-reference with the canonical values from the Mixpanel `analytics/` reference repo.
+
+**Acceptance Scenarios**:
+
+1. **Given** the funnel math types constant, **When** checking membership, **Then** it contains `"conversion_rate_unique"`, `"conversion_rate_total"`, `"conversion_rate_session"`, `"unique"`, `"total"`, and property aggregation types (`"average"`, `"median"`, `"min"`, `"max"`, `"p25"`, `"p75"`, `"p90"`, `"p99"`).
+2. **Given** the retention math types constant, **When** checking membership, **Then** it contains `"retention_rate"` and `"unique"`.
+3. **Given** the chart types constant, **When** checking membership, **Then** it contains `"funnel-steps"`, `"funnel-top-paths"`, and `"retention-curve"`.
+4. **Given** a new funnel ordering constant, **When** checking membership, **Then** it contains `"loose"` and `"any"`.
+5. **Given** a new conversion window units constant, **When** checking membership, **Then** it contains `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, and `"session"`.
+
+---
+
+### User Story 5 — Existing query() Remains Unchanged (Priority: P1)
+
+After all extractions and refactoring, the existing `query()` and `build_params()` methods produce identical bookmark JSON for all inputs. No existing test fails. No public API signature changes.
+
+**Why this priority**: This is a non-regression constraint. The extraction must be invisible to existing callers.
+
+**Independent Test**: Run the full existing test suite. All tests pass with zero modifications. Additionally, property-based tests generate random valid inputs and assert the output before and after refactoring is identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** any valid call to `query()` or `build_params()`, **When** executed against the refactored code, **Then** the returned params dict is identical to the pre-refactoring output.
+2. **Given** any invalid call to `query()` or `build_params()`, **When** executed against the refactored code, **Then** the raised `BookmarkValidationError` contains the same error codes and messages.
+3. **Given** the full existing test suite, **When** run after refactoring, **Then** all tests pass without modification.
+
+---
+
+### Edge Cases
+
+- What happens when `from_date` is provided but `to_date` is `None`? The time builder produces a `"between"` range from `from_date` through today.
+- What happens when `last` exceeds the 3650-day cap? The time validator returns `V20_LAST_TOO_LARGE`.
+- What happens when a `Filter` uses a date operator with a relative date unit? The segfilter converter must translate the `filterDateUnit` field correctly.
+- What happens when `GroupBy.bucket_min` equals `GroupBy.bucket_max`? The group-by validator returns `V18_BUCKET_ORDER`.
+- What happens when `Filter` uses an operator not mappable to segfilter format? The converter raises a clear error identifying the unsupported operator.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a shared time-section builder that accepts `from_date`, `to_date`, `last`, and `unit` parameters and returns a `sections.time[]` entry dict for use by insights, funnels, and retention bookmark builders.
+- **FR-002**: System MUST provide a flows-specific date-range builder that accepts `from_date`, `to_date`, and `last` parameters and returns a flat `date_range` dict matching the flows bookmark format.
+- **FR-003**: System MUST provide extracted time-argument validation (rules V7-V10, V15, V20) as a callable that returns a list of `ValidationError` objects.
+- **FR-004**: System MUST provide extracted group-by-argument validation (rules V11-V12, V18, V24) as a callable that returns a list of `ValidationError` objects.
+- **FR-005**: System MUST refactor `validate_query_args()` to delegate to the extracted time and group-by validators without changing its external behavior or error output.
+- **FR-006**: System MUST refactor `_build_query_params()` to delegate to the extracted time-section and group-section builders without changing its output.
+- **FR-007**: System MUST provide a segfilter converter that translates `Filter` objects to the legacy segfilter format used by flows step filters, handling all supported operator types.
+- **FR-008**: System MUST extend the bookmark enums module with frozenset constants for funnel ordering modes, conversion window units, retention units, retention alignment types, and any missing funnel/retention/flows-specific values.
+- **FR-009**: System MUST maintain full backward compatibility — no changes to public API signatures, return types, or exception behavior for existing `query()`, `build_params()`, or validation functions.
+- **FR-010**: System MUST provide a shared group-section builder that accepts `group_by` parameter(s) and returns a `sections.group[]` list for use by insights, funnels, and retention bookmark builders.
+- **FR-011**: System MUST provide a shared filter-section builder that accepts `where` parameter(s) and returns a `sections.filter[]` list for use by insights, funnels, and retention bookmark builders.
+
+### Key Entities
+
+- **Time Section Entry**: A dict representing one `sections.time[]` element with `dateRangeType`, `unit`, and either `value` (date pair) or `window` (relative range).
+- **Flows Date Range**: A flat dict with `type`, `from_date`, and `to_date` fields matching the flows bookmark format.
+- **Segfilter Entry**: A dict with `property` (name, source, type), `type`, `selected_property_type`, and `filter` (operator, operand) fields matching the legacy Mixpanel segfilter format.
+- **Bookmark Enum Constants**: Immutable frozenset collections of valid string values for O(1) membership checks.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing tests pass without modification after refactoring (zero regressions).
+- **SC-002**: The extracted time builder produces identical output to the inline code it replaces, verified by property-based tests across randomized date inputs.
+- **SC-003**: The extracted validators produce identical error lists to the inline code they replace, verified by property-based tests across randomized invalid inputs.
+- **SC-004**: The segfilter converter correctly handles all operator types supported by `Filter`, verified against the canonical TypeScript reference test cases.
+- **SC-005**: Code coverage for the new extracted functions meets the project's 90% minimum threshold.
+- **SC-006**: The refactored `validate_query_args()` and `_build_query_params()` have no duplicated logic — they delegate entirely to the extracted helpers for time and group-by concerns.
+
+## Assumptions
+
+- The existing `Filter` type supports all operators needed for the segfilter converter; no new `Filter` constructors are required in this phase.
+- The `analytics/` reference repository is available for cross-referencing canonical segfilter format and round-trip test cases.
+- The `VALID_MATH_FUNNELS` and `VALID_MATH_RETENTION` frozensets already exist in `bookmark_enums.py` and need only extension/verification, not creation from scratch.
+- The `VALID_CHART_TYPES` frozenset already includes `"funnel-steps"`, `"funnel-top-paths"`, and `"retention-curve"`.
+- Flows `group_by` support is explicitly out of scope for this phase (per design document section 6.3).
+- No new public types (e.g., `FunnelStep`, `RetentionEvent`) are introduced in this phase — those belong to Phases 2-4.
+- The segfilter converter only needs to support the operators that `Filter` currently exposes, not the full set of legacy segfilter operators.

--- a/specs/031-shared-infra-extraction/tasks.md
+++ b/specs/031-shared-infra-extraction/tasks.md
@@ -1,0 +1,258 @@
+# Tasks: Phase 1 — Shared Infrastructure Extraction
+
+**Input**: Design documents from `/specs/031-shared-infra-extraction/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Required — project enforces strict TDD (CLAUDE.md). Tests MUST be written first and FAIL before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this is an existing codebase. Verify baseline.
+
+- [X] T001 Run `just check` to confirm all existing tests pass before any changes
+
+**Checkpoint**: Baseline confirmed — all existing tests green.
+
+---
+
+## Phase 2: Foundational — Bookmark Enum Constants (US4, Priority: P2)
+
+**Goal**: Add funnel/retention/flows-specific enum constants used by validators and builders in later phases.
+
+**Independent Test**: Assert each new frozenset contains the expected members. Cross-reference with design doc canonical values.
+
+### Tests for US4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T002 [P] [US4] Write tests for new enum constants `VALID_FUNNEL_ORDER`, `VALID_CONVERSION_WINDOW_UNITS`, `VALID_RETENTION_UNITS`, `VALID_RETENTION_ALIGNMENT`, `VALID_FLOWS_COUNT_TYPES`, `VALID_FLOWS_CHART_TYPES` in tests/unit/test_bookmark_enums.py
+- [X] T003 [P] [US4] Write tests for extended `VALID_MATH_FUNNELS` (must include property aggregation types: average, median, min, max, p25, p75, p90, p99) in tests/unit/test_bookmark_enums.py
+
+### Implementation for US4
+
+- [X] T004 [US4] Add `VALID_FUNNEL_ORDER`, `VALID_CONVERSION_WINDOW_UNITS`, `VALID_RETENTION_UNITS`, `VALID_RETENTION_ALIGNMENT`, `VALID_FLOWS_COUNT_TYPES`, `VALID_FLOWS_CHART_TYPES` frozensets to src/mixpanel_data/_internal/bookmark_enums.py
+- [X] T005 [US4] Extend `VALID_MATH_FUNNELS` with property aggregation types (`average`, `median`, `min`, `max`, `p25`, `p75`, `p90`, `p99`) in src/mixpanel_data/_internal/bookmark_enums.py
+- [X] T006 [US4] Run `just check` to confirm all tests pass including new enum tests
+
+**Checkpoint**: All new enum constants defined and tested. Existing tests still green.
+
+---
+
+## Phase 3: User Story 1 — Reusable Time Range Building (Priority: P1) 
+
+**Goal**: Extract time-section and date-range builders from inline code in `_build_query_params()` into shared functions. Extract filter-section and group-section builders similarly.
+
+**Independent Test**: Call each extracted builder with various date/filter/group combinations. Assert output dict structure matches expected bookmark JSON. No API access needed.
+
+### Tests for US1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [P] [US1] Write tests for `build_time_section()` — absolute range, from-only range, relative range — in tests/unit/test_bookmark_builders.py
+- [X] T008 [P] [US1] Write tests for `build_date_range()` — relative (last=30), absolute (from+to) — in tests/unit/test_bookmark_builders.py
+- [X] T009 [P] [US1] Write tests for `build_filter_section()` — single filter, multiple filters, None — in tests/unit/test_bookmark_builders.py
+- [X] T010 [P] [US1] Write tests for `build_group_section()` — string group_by, GroupBy with buckets, multiple groups, None — in tests/unit/test_bookmark_builders.py
+
+### Implementation for US1
+
+- [X] T011 [US1] Implement `build_time_section(from_date, to_date, last, unit)` with complete docstring in src/mixpanel_data/_internal/bookmark_builders.py
+- [X] T012 [US1] Implement `build_date_range(from_date, to_date, last)` with complete docstring in src/mixpanel_data/_internal/bookmark_builders.py
+- [X] T013 [US1] Implement `build_filter_section(where)` with complete docstring in src/mixpanel_data/_internal/bookmark_builders.py — delegates to `_build_filter_entry()`
+- [X] T014 [US1] Implement `build_group_section(group_by)` with complete docstring in src/mixpanel_data/_internal/bookmark_builders.py
+- [X] T015 [US1] Refactor `Workspace._build_query_params()` in src/mixpanel_data/workspace.py to delegate time/filter/group building to the new shared functions
+- [X] T016 [US1] Move `_build_filter_entry()` from `Workspace` static method to `bookmark_builders.py` module-level function; keep a delegating alias on `Workspace` for backward compat
+- [X] T017 [US1] Run `just check` to confirm all tests pass — new builder tests AND existing query tests
+
+**Checkpoint**: All four builders extracted, tested, and wired into `_build_query_params()`. Existing `query()` / `build_params()` output unchanged.
+
+---
+
+## Phase 4: User Story 2 — Reusable Time and GroupBy Validation (Priority: P1)
+
+**Goal**: Extract time-argument validation (V7-V10, V15, V20) and group-by validation (V11-V12, V18, V24) from `validate_query_args()` into reusable functions.
+
+**Independent Test**: Call each extracted validator with valid and invalid inputs. Assert the expected `ValidationError` objects (code, path, message) are returned. Compare output against pre-refactoring behavior.
+
+### Tests for US2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T018 [P] [US2] Write tests for `validate_time_args()` — V7 (last positive), V8 (date format), V9 (to requires from), V10 (date/last exclusive), V15 (date order), V20 (last cap) — in tests/unit/test_query_validation.py
+- [X] T019 [P] [US2] Write tests for `validate_group_by_args()` — V11 (bucket requires size), V12 (bucket size positive), V12B (bucket requires number), V12C (bucket requires bounds), V18 (bucket order), V24 (bucket finite) — in tests/unit/test_query_validation.py
+
+### Implementation for US2
+
+- [X] T020 [US2] Extract `validate_time_args(from_date, to_date, last)` from `validate_query_args()` in src/mixpanel_data/_internal/validation.py — rules V7-V10, V15, V20
+- [X] T021 [US2] Extract `validate_group_by_args(group_by)` from `validate_query_args()` in src/mixpanel_data/_internal/validation.py — rules V11-V12, V18, V24
+- [X] T022 [US2] Refactor `validate_query_args()` to call `validate_time_args()` and `validate_group_by_args()` — no change in external behavior
+- [X] T023 [US2] Update validation module exports — add `validate_time_args` and `validate_group_by_args` to the import in src/mixpanel_data/_internal/validation.py
+- [X] T024 [US2] Run `just check` to confirm all tests pass — new validator tests AND existing validation tests produce identical results
+
+**Checkpoint**: Both validators extracted, tested, and wired into `validate_query_args()`. Existing validation behavior unchanged.
+
+---
+
+## Phase 5: User Story 3 — Filter-to-Segfilter Conversion (Priority: P2)
+
+**Goal**: Build a `build_segfilter_entry()` converter that translates `Filter` objects to the legacy segfilter format used by flows step filters.
+
+**Independent Test**: Create `Filter` objects with every supported operator type. Assert the segfilter output matches the canonical TypeScript reference test cases from `analytics/` repo.
+
+### Tests for US3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T025 [P] [US3] Write tests for string operators — `equals` (`"=="`), `not_equals` (`"!="`), `contains` (`"in"`), `is_set` (`"set"`), `is_not_set` (`"not set"`) — in tests/unit/test_segfilter.py
+- [X] T026 [P] [US3] Write tests for number operators — `greater_than` (`">"`), `less_than` (`"<"`), operand stringification — in tests/unit/test_segfilter.py
+- [X] T027 [P] [US3] Write tests for boolean operators — `is_true` (operand `"true"`, no operator field), `is_false` (operand `"false"`) — in tests/unit/test_segfilter.py
+- [X] T028 [P] [US3] Write tests for datetime operators — `on` (`"=="`), `not_on` (`"!="`), `before` (`">"`), `in_the_last` (`">"` with unit), date format conversion `YYYY-MM-DD` → `MM/DD/YYYY` — in tests/unit/test_segfilter.py
+- [X] T029 [P] [US3] Write tests for resource type mapping — `"events"` → `"properties"`, `"people"` → `"user"` — in tests/unit/test_segfilter.py
+- [X] T030 [P] [US3] Write tests for segfilter structure — `property`, `type`, `selected_property_type`, `filter` top-level keys present and correctly populated — in tests/unit/test_segfilter.py
+
+### Implementation for US3
+
+- [X] T031 [US3] Define `BOOKMARK_TO_SEGFILTER_OPERATOR` mapping dict and `RESOURCE_TYPE_MAP` with complete docstrings in src/mixpanel_data/_internal/segfilter.py
+- [X] T032 [US3] Implement `build_segfilter_entry(f: Filter)` with complete docstring in src/mixpanel_data/_internal/segfilter.py — string, number, boolean, and existence operators
+- [X] T033 [US3] Add datetime operator handling to `build_segfilter_entry()` — date format conversion, relative date with unit — in src/mixpanel_data/_internal/segfilter.py
+- [X] T034 [US3] Run `just check` to confirm all segfilter tests pass and no regressions
+
+**Checkpoint**: Segfilter converter handles all 14 `Filter` operator types. Ready for Phase 4 (Flows) integration.
+
+---
+
+## Phase 6: User Story 5 — Non-Regression Verification (Priority: P1)
+
+**Goal**: Comprehensive verification that all extractions and refactoring produced zero behavioral changes in existing `query()`, `build_params()`, and validation functions.
+
+**Independent Test**: Run full test suite + property-based equivalence tests + mutation testing on new code.
+
+### Tests for US5
+
+- [X] T035 [P] [US5] Write property-based test (Hypothesis) that generates random valid (from_date, to_date, last, unit) inputs, calls both `build_time_section()` directly and `_build_query_params()`, and asserts `params["sections"]["time"]` matches `build_time_section()` output (oracle test) — in tests/unit/test_bookmark_builders_pbt.py
+- [X] T036 [P] [US5] Write property-based test (Hypothesis) comparing `validate_query_args()` error output before and after refactoring across randomized invalid inputs — in tests/unit/test_query_validation_pbt.py (extend existing file)
+
+### Verification for US5
+
+- [X] T037 [US5] Run full test suite: `just check` — all existing tests pass without modification
+- [X] T038 [US5] Run property-based tests: `just test-pbt` — equivalence confirmed across randomized inputs
+- [X] T039 [US5] Run code coverage: `just test-cov` — new modules meet 90% threshold
+- [X] T040 [US5] Run mutation testing on new modules: `just mutate` — verify 80%+ kill rate on bookmark_builders.py and segfilter.py
+
+**Checkpoint**: Zero regressions. All quality gates pass.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cleanup and documentation.
+
+- [X] T041 [P] Verify all functions in src/mixpanel_data/_internal/bookmark_builders.py have complete docstrings (summary, args, returns, raises, example)
+- [X] T042 [P] Verify all functions in src/mixpanel_data/_internal/segfilter.py have complete docstrings (summary, args, returns, raises, example)
+- [X] T043 Verify mypy --strict passes: `just typecheck` — all new code fully typed
+- [X] T044 Run final `just check` — all linting, formatting, type checking, and tests pass
+
+**Checkpoint**: All quality gates pass. Phase 1 complete. Ready for Phase 2 (Funnels).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — confirms baseline
+- **Foundational / US4 (Phase 2)**: Depends on Setup — provides enum constants for later phases
+- **US1 (Phase 3)**: Depends on Setup — independent of US4
+- **US2 (Phase 4)**: Depends on Setup — independent of US1 and US4
+- **US3 (Phase 5)**: Depends on Setup — independent of US1, US2, US4
+- **US5 (Phase 6)**: Depends on US1, US2, US3, US4 all complete
+- **Polish (Phase 7)**: Depends on US5
+
+### User Story Dependencies
+
+- **US4 (Enums)**: No deps on other stories. Can start immediately after Setup.
+- **US1 (Builders)**: No deps on other stories. Can start in parallel with US4.
+- **US2 (Validators)**: No deps on other stories. Can start in parallel with US1 and US4.
+- **US3 (Segfilter)**: No deps on other stories. Can start in parallel with US1, US2, US4.
+- **US5 (Regression)**: Depends on ALL other stories being complete.
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation tasks within a story are sequential (later tasks depend on earlier ones)
+- Checkpoint verification at the end of each story
+
+### Parallel Opportunities
+
+- **Phase 2**: T002 and T003 can run in parallel (different test groups)
+- **Phase 3**: T007, T008, T009, T010 can all run in parallel (different test functions)
+- **Phase 4**: T018 and T019 can run in parallel (different test functions)
+- **Phase 5**: T025-T030 can all run in parallel (different test functions)
+- **Phase 6**: T035 and T036 can run in parallel (different PBT files)
+- **Phase 7**: T041 and T042 can run in parallel (different files)
+- **Cross-phase**: US1 (Phase 3), US2 (Phase 4), US3 (Phase 5), and US4 (Phase 2) can all run in parallel with separate developers since they touch different files
+
+---
+
+## Parallel Example: US1 (Builders)
+
+```
+# Launch all test tasks in parallel (different test functions, same file):
+Task T007: "Write tests for build_time_section()"
+Task T008: "Write tests for build_date_range()"
+Task T009: "Write tests for build_filter_section()"
+Task T010: "Write tests for build_group_section()"
+
+# Then implement sequentially (shared file):
+Task T011: "Implement build_time_section()"
+Task T012: "Implement build_date_range()"
+Task T013: "Implement build_filter_section()"
+Task T014: "Implement build_group_section()"
+Task T015: "Refactor _build_query_params() to use builders"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete US1 (Phase 3): Builders extracted and wired
+3. Complete US2 (Phase 4): Validators extracted and wired
+4. **STOP and VALIDATE**: Run `just check` — all existing + new tests pass
+5. Funnels and retention (Phases 2-3 of the project) can now begin
+
+### Incremental Delivery
+
+1. US4 (enums) → Foundation constants ready
+2. US1 (builders) → Time/filter/group builders reusable → validate independently
+3. US2 (validators) → Time/group_by validators reusable → validate independently
+4. US3 (segfilter) → Flows filter converter ready → validate independently
+5. US5 (regression) → Full verification → confirm zero regressions
+6. Each story adds capability without breaking previous stories
+
+### Parallel Strategy
+
+With parallel execution:
+1. Launch US4, US1, US2, US3 simultaneously (all independent)
+2. When all complete → US5 (verification)
+3. Then Polish
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- This project enforces strict TDD — tests written first in every story
+- Commit after each task or logical group
+- Stop at any checkpoint to validate independently
+- The segfilter converter (US3) is the highest-risk component — if it takes longer, US1/US2/US4 can proceed independently

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -6,7 +6,12 @@ run live analytics, stream data, and manage entities via the App API.
 """
 
 from mixpanel_data._internal.validation import validate_bookmark
-from mixpanel_data._literal_types import CountType, HourDayUnit, TimeUnit
+from mixpanel_data._literal_types import (
+    CountType,
+    HourDayUnit,
+    QueryTimeUnit,
+    TimeUnit,
+)
 from mixpanel_data.exceptions import (
     AccountExistsError,
     AccountNotFoundError,
@@ -202,6 +207,7 @@ __all__ = [
     "validate_bookmark",
     # Type aliases
     "CountType",
+    "QueryTimeUnit",
     "HourDayUnit",
     "TimeUnit",
     # Exceptions

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from mixpanel_data._literal_types import QueryTimeUnit
 from mixpanel_data.types import Filter, GroupBy
 
 
@@ -20,7 +21,7 @@ def build_time_section(
     from_date: str | None,
     to_date: str | None,
     last: int,
-    unit: str,
+    unit: QueryTimeUnit,
 ) -> list[dict[str, Any]]:
     """Build the ``sections.time`` array for bookmark params.
 
@@ -57,18 +58,12 @@ def build_time_section(
         #   "value": ["2025-01-01", "2025-01-31"]}]
         ```
     """
-    if from_date is not None and to_date is not None:
+    if from_date is not None:
+        effective_to = to_date if to_date is not None else date.today().isoformat()
         time_entry: dict[str, Any] = {
             "dateRangeType": "between",
             "unit": unit,
-            "value": [from_date, to_date],
-        }
-    elif from_date is not None:
-        today = date.today().isoformat()
-        time_entry = {
-            "dateRangeType": "between",
-            "unit": unit,
-            "value": [from_date, today],
+            "value": [from_date, effective_to],
         }
     else:
         time_entry = {
@@ -87,7 +82,7 @@ def build_date_range(
 ) -> dict[str, Any]:
     """Build a flat date range dict for flows (non-sections format).
 
-    Flows use a flat ``dateRange`` object rather than the sections-based
+    Flows use a flat ``date_range`` object rather than the sections-based
     ``sections.time`` array used by insights.
 
     Args:

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -1,0 +1,258 @@
+"""Reusable builder functions for bookmark JSON sections.
+
+Extracted from ``Workspace._build_query_params()`` to enable reuse across
+insights, funnels, retention, and flows query builders. Each function
+produces a fragment of the Mixpanel bookmark ``params`` JSON structure.
+
+These are internal helpers — import from ``mixpanel_data._internal.bookmark_builders``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from mixpanel_data.types import Filter, GroupBy
+
+
+def build_time_section(
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    last: int,
+    unit: str,
+) -> list[dict[str, Any]]:
+    """Build the ``sections.time`` array for bookmark params.
+
+    Produces a single-element list containing one time entry dict.
+    Three cases are handled:
+
+    - **Absolute range**: both ``from_date`` and ``to_date`` set.
+    - **From-only range**: only ``from_date`` set; ``to_date`` is filled
+      with today's date.
+    - **Relative range**: neither date set; uses ``last`` days.
+
+    Args:
+        from_date: Start date (YYYY-MM-DD) or ``None``.
+        to_date: End date (YYYY-MM-DD) or ``None``.
+        last: Number of days for relative range (used when no dates given).
+        unit: Time granularity (``"hour"``, ``"day"``, ``"week"``,
+            ``"month"``, ``"quarter"``).
+
+    Returns:
+        Single-element list with one time entry dict. Structure varies
+        by case:
+
+        - Absolute: ``{"dateRangeType": "between", "unit": ..., "value": [from, to]}``
+        - From-only: same as absolute with ``to_date`` = today
+        - Relative: ``{"dateRangeType": "in the last", "unit": ..., "window": {...}}``
+
+    Example:
+        ```python
+        time = build_time_section(
+            from_date="2025-01-01", to_date="2025-01-31",
+            last=30, unit="day",
+        )
+        # [{"dateRangeType": "between", "unit": "day",
+        #   "value": ["2025-01-01", "2025-01-31"]}]
+        ```
+    """
+    if from_date is not None and to_date is not None:
+        time_entry: dict[str, Any] = {
+            "dateRangeType": "between",
+            "unit": unit,
+            "value": [from_date, to_date],
+        }
+    elif from_date is not None:
+        today = date.today().isoformat()
+        time_entry = {
+            "dateRangeType": "between",
+            "unit": unit,
+            "value": [from_date, today],
+        }
+    else:
+        time_entry = {
+            "dateRangeType": "in the last",
+            "unit": unit,
+            "window": {"unit": "day", "value": last},
+        }
+    return [time_entry]
+
+
+def build_date_range(
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    last: int,
+) -> dict[str, Any]:
+    """Build a flat date range dict for flows (non-sections format).
+
+    Flows use a flat ``dateRange`` object rather than the sections-based
+    ``sections.time`` array used by insights.
+
+    Args:
+        from_date: Start date (YYYY-MM-DD) or ``None``.
+        to_date: End date (YYYY-MM-DD) or ``None``.
+        last: Number of days for relative range.
+
+    Returns:
+        Date range dict. Structure varies by case:
+
+        - Absolute: ``{"type": "between", "from_date": ..., "to_date": ...}``
+        - Relative: ``{"type": "in the last", "from_date": {"unit": "day", "value": N}, "to_date": "$now"}``
+
+    Example:
+        ```python
+        dr = build_date_range(from_date=None, to_date=None, last=30)
+        # {"type": "in the last",
+        #  "from_date": {"unit": "day", "value": 30},
+        #  "to_date": "$now"}
+        ```
+    """
+    if from_date is not None and to_date is not None:
+        return {
+            "type": "between",
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+    return {
+        "type": "in the last",
+        "from_date": {"unit": "day", "value": last},
+        "to_date": "$now",
+    }
+
+
+def build_filter_section(
+    where: Filter | list[Filter] | None,
+) -> list[dict[str, Any]]:
+    """Build the ``sections.filter`` array for bookmark params.
+
+    Converts ``None``, a single ``Filter``, or a list of ``Filter`` objects
+    into the list-of-dicts format expected by the Mixpanel bookmark API.
+
+    Args:
+        where: Filter specification. ``None`` means no filters,
+            a single ``Filter`` is wrapped in a list, a list is
+            processed element-by-element.
+
+    Returns:
+        List of filter entry dicts (may be empty).
+
+    Example:
+        ```python
+        filters = build_filter_section(Filter.equals("country", "US"))
+        # [{"resourceType": "events", "filterType": "string", ...}]
+        ```
+    """
+    if where is None:
+        return []
+    filters_list = where if isinstance(where, list) else [where]
+    return [build_filter_entry(f) for f in filters_list]
+
+
+def build_group_section(
+    group_by: str | GroupBy | list[str | GroupBy] | None,
+) -> list[dict[str, Any]]:
+    """Build the ``sections.group`` array for bookmark params.
+
+    Converts group-by specifications into the list-of-dicts format
+    expected by the Mixpanel bookmark API. Supports strings (simple
+    property name), ``GroupBy`` objects (with optional bucketing),
+    and lists mixing both.
+
+    Args:
+        group_by: Group-by specification. ``None`` means no grouping.
+            Strings produce default string-typed entries. ``GroupBy``
+            objects allow custom property types and numeric bucketing.
+
+    Returns:
+        List of group entry dicts (may be empty).
+
+    Raises:
+        TypeError: If any element is not ``str`` or ``GroupBy``.
+
+    Example:
+        ```python
+        groups = build_group_section("country")
+        # [{"value": "country", "propertyName": "country",
+        #   "resourceType": "events", "propertyType": "string",
+        #   "propertyDefaultType": "string"}]
+        ```
+    """
+    if group_by is None:
+        return []
+
+    groups = group_by if isinstance(group_by, list) else [group_by]
+    group_section: list[dict[str, Any]] = []
+
+    for g in groups:
+        if isinstance(g, str):
+            group_section.append(
+                {
+                    "value": g,
+                    "propertyName": g,
+                    "resourceType": "events",
+                    "propertyType": "string",
+                    "propertyDefaultType": "string",
+                }
+            )
+        elif isinstance(g, GroupBy):
+            group_entry: dict[str, Any] = {
+                "value": g.property,
+                "propertyName": g.property,
+                "resourceType": "events",
+                "propertyType": g.property_type,
+                "propertyDefaultType": g.property_type,
+            }
+            if g.bucket_size is not None:
+                group_entry["customBucket"] = {
+                    "bucketSize": g.bucket_size,
+                }
+                if g.bucket_min is not None:
+                    group_entry["customBucket"]["min"] = g.bucket_min
+                if g.bucket_max is not None:
+                    group_entry["customBucket"]["max"] = g.bucket_max
+            group_section.append(group_entry)
+        else:
+            raise TypeError(
+                f"group_by elements must be str or GroupBy, "
+                f"got {type(g).__name__}: {g!r}"
+            )
+
+    return group_section
+
+
+def build_filter_entry(f: Filter) -> dict[str, Any]:
+    """Convert a Filter object to a bookmark filter dict.
+
+    Maps the internal Filter fields to the key names expected by the
+    Mixpanel bookmark API. Includes ``filterDateUnit`` only for
+    relative date filters that have a date unit set.
+
+    Args:
+        f: A ``Filter`` object constructed via its class methods.
+
+    Returns:
+        Bookmark filter dict with keys: ``resourceType``, ``filterType``,
+        ``defaultType``, ``value``, ``filterValue``, ``filterOperator``,
+        and optionally ``filterDateUnit``.
+
+    Example:
+        ```python
+        entry = build_filter_entry(Filter.equals("country", "US"))
+        # {"resourceType": "events", "filterType": "string",
+        #  "defaultType": "string", "value": "country",
+        #  "filterValue": ["US"], "filterOperator": "equals"}
+        ```
+    """
+    entry: dict[str, Any] = {
+        "resourceType": f._resource_type,
+        "filterType": f._property_type,
+        "defaultType": f._property_type,
+        "value": f._property,
+        "filterValue": f._value,
+        "filterOperator": f._operator,
+    }
+    if f._date_unit is not None:
+        entry["filterDateUnit"] = f._date_unit
+    return entry

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -98,9 +98,22 @@ VALID_MATH_FUNNELS: frozenset[str] = frozenset(
         "conversion_rate_unique",
         "conversion_rate_total",
         "conversion_rate_session",
+        # Property aggregation types (funnel measure on property)
+        "average",
+        "median",
+        "min",
+        "max",
+        "p25",
+        "p75",
+        "p90",
+        "p99",
     }
 )
-"""Valid math types for funnel context."""
+"""Valid math types for funnel context.
+
+Includes counting/conversion types and property aggregation types
+(average, median, min, max, percentiles) for funnel measure-on-property.
+"""
 
 VALID_MATH_RETENTION: frozenset[str] = frozenset(
     {
@@ -360,3 +373,51 @@ VALID_DATE_RANGE_TYPES: frozenset[str] = frozenset(
     }
 )
 """Valid date range types for time section clauses."""
+
+# =============================================================================
+# Funnel-Specific Constants
+# =============================================================================
+
+VALID_FUNNEL_ORDER: frozenset[str] = frozenset({"loose", "any"})
+"""Valid funnel step ordering modes.
+
+``"loose"`` requires steps in order but allows other events between.
+``"any"`` allows steps in any order.
+"""
+
+VALID_CONVERSION_WINDOW_UNITS: frozenset[str] = frozenset(
+    {
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "session",
+    }
+)
+"""Valid time units for funnel conversion window."""
+
+# =============================================================================
+# Retention-Specific Constants
+# =============================================================================
+
+VALID_RETENTION_UNITS: frozenset[str] = frozenset({"day", "week", "month"})
+"""Valid time units for retention period grouping."""
+
+VALID_RETENTION_ALIGNMENT: frozenset[str] = frozenset({"birth", "interval_start"})
+"""Valid retention alignment modes.
+
+``"birth"`` aligns each user to their first qualifying event.
+``"interval_start"`` aligns to the start of each calendar period.
+"""
+
+# =============================================================================
+# Flows-Specific Constants
+# =============================================================================
+
+VALID_FLOWS_COUNT_TYPES: frozenset[str] = frozenset({"unique", "total", "session"})
+"""Valid counting methods for flows analysis."""
+
+VALID_FLOWS_CHART_TYPES: frozenset[str] = frozenset({"sankey", "top-paths"})
+"""Valid chart types for flows visualization."""

--- a/src/mixpanel_data/_internal/segfilter.py
+++ b/src/mixpanel_data/_internal/segfilter.py
@@ -1,0 +1,332 @@
+"""Filter-to-segfilter conversion for flows step filters.
+
+Converts ``Filter`` objects from the public types module into the legacy
+segfilter dict format consumed by the Mixpanel flows API. Each segfilter
+entry encodes a property constraint with type-specific operator and operand
+encoding.
+
+The segfilter format differs from the bookmark filter format in operator
+names, value encoding (e.g. stringified numbers, MM/DD/YYYY dates), and
+structural layout (nested ``property``/``filter`` dicts).
+
+Example:
+    ```python
+    from mixpanel_data.types import Filter
+    from mixpanel_data._internal.segfilter import build_segfilter_entry
+
+    f = Filter.equals("country", "US")
+    entry = build_segfilter_entry(f)
+    # {
+    #     "property": {"name": "country", "source": "properties", "type": "string"},
+    #     "type": "string",
+    #     "selected_property_type": "string",
+    #     "filter": {"operator": "==", "operand": ["US"]},
+    # }
+    ```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mixpanel_data.types import Filter
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+RESOURCE_TYPE_MAP: dict[str, str] = {
+    "events": "properties",
+    "people": "user",
+    "cohorts": "cohort",
+    "other": "other",
+}
+"""Maps ``Filter._resource_type`` to segfilter ``property.source``."""
+
+STRING_OPERATOR_MAP: dict[str, str] = {
+    "equals": "==",
+    "does not equal": "!=",
+    "contains": "in",
+    "does not contain": "not in",
+    "is set": "set",
+    "is not set": "not set",
+}
+"""Maps string-typed Filter operators to segfilter operators."""
+
+NUMBER_OPERATOR_MAP: dict[str, str] = {
+    "is greater than": ">",
+    "is less than": "<",
+    "is equal to": "==",
+    "equals": "==",
+    "does not equal": "!=",
+    "is at least": ">=",
+    "is at most": "<=",
+    "is between": "><",
+    "between": "><",
+    "not between": "!><",
+    "is set": "is set",
+    "is not set": "is not set",
+}
+"""Maps number-typed Filter operators to segfilter operators."""
+
+DATETIME_OPERATOR_MAP: dict[str, str] = {
+    "was on": "==",
+    "was not on": "!=",
+    "was before": ">",
+    "was since": "<",
+    "was in the": ">",
+    "was not in the": ">",
+    "was between": "><",
+    "was not between": "!><",
+}
+"""Maps datetime-typed Filter operators to segfilter operators."""
+
+# Operators that take no value (set/unset checks)
+_STRING_SETNESS_OPS: frozenset[str] = frozenset({"is set", "is not set"})
+
+# Number operators that take no value
+_NUMBER_SETNESS_OPS: frozenset[str] = frozenset({"is set", "is not set"})
+
+# Number operators that take a two-element list
+_NUMBER_RANGE_OPS: frozenset[str] = frozenset({"is between", "between", "not between"})
+
+# Datetime operators that use relative time (quantity + unit)
+_DATETIME_RELATIVE_OPS: frozenset[str] = frozenset({"was in the", "was not in the"})
+
+# Datetime operators that take a two-date range
+_DATETIME_RANGE_OPS: frozenset[str] = frozenset({"was between", "was not between"})
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _convert_date_format(date_str: str) -> str:
+    """Convert a date string from YYYY-MM-DD to MM/DD/YYYY format.
+
+    Args:
+        date_str: Date in YYYY-MM-DD format (e.g. ``"2026-01-15"``).
+
+    Returns:
+        Date in MM/DD/YYYY format (e.g. ``"01/15/2026"``).
+
+    Example:
+        ```python
+        _convert_date_format("2026-01-15")
+        # "01/15/2026"
+        ```
+    """
+    year, month, day = date_str.split("-")
+    return f"{month}/{day}/{year}"
+
+
+def _pluralize_unit(unit: str) -> str:
+    """Pluralize a time unit string by appending 's'.
+
+    Args:
+        unit: Singular time unit (e.g. ``"day"``, ``"hour"``,
+            ``"week"``, ``"month"``, ``"minute"``).
+
+    Returns:
+        Pluralized unit (e.g. ``"days"``, ``"hours"``).
+
+    Example:
+        ```python
+        _pluralize_unit("day")
+        # "days"
+        ```
+    """
+    return f"{unit}s"
+
+
+# =============================================================================
+# Type-specific filter builders
+# =============================================================================
+
+
+def _build_string_filter(operator: str, value: Any) -> dict[str, Any]:
+    """Build the ``filter`` dict for a string-typed property.
+
+    Args:
+        operator: The ``Filter._operator`` value (e.g. ``"equals"``).
+        value: The ``Filter._value`` (list, str, or None).
+
+    Returns:
+        Dict with ``operator`` and ``operand`` keys.
+
+    Raises:
+        ValueError: If ``operator`` is not in ``STRING_OPERATOR_MAP``.
+    """
+    if operator not in STRING_OPERATOR_MAP:
+        raise ValueError(
+            f"Unknown string operator '{operator}'. "
+            f"Valid operators: {sorted(STRING_OPERATOR_MAP)}"
+        )
+
+    seg_op = STRING_OPERATOR_MAP[operator]
+
+    if operator in _STRING_SETNESS_OPS:
+        operand: Any = ""
+    else:
+        operand = value
+
+    return {"operator": seg_op, "operand": operand}
+
+
+def _build_number_filter(operator: str, value: Any) -> dict[str, Any]:
+    """Build the ``filter`` dict for a number-typed property.
+
+    Args:
+        operator: The ``Filter._operator`` value (e.g. ``"is greater than"``).
+        value: The ``Filter._value`` (numeric, list, or None).
+
+    Returns:
+        Dict with ``operator`` and ``operand`` keys.
+
+    Raises:
+        ValueError: If ``operator`` is not in ``NUMBER_OPERATOR_MAP``.
+    """
+    if operator not in NUMBER_OPERATOR_MAP:
+        raise ValueError(
+            f"Unknown number operator '{operator}'. "
+            f"Valid operators: {sorted(NUMBER_OPERATOR_MAP)}"
+        )
+
+    seg_op = NUMBER_OPERATOR_MAP[operator]
+
+    if operator in _NUMBER_SETNESS_OPS:
+        operand: Any = ""
+    elif operator in _NUMBER_RANGE_OPS:
+        operand = [str(v) for v in value]
+    else:
+        operand = str(value)
+
+    return {"operator": seg_op, "operand": operand}
+
+
+def _build_boolean_filter(operator: str) -> dict[str, Any]:
+    """Build the ``filter`` dict for a boolean-typed property.
+
+    Boolean segfilters have NO ``operator`` key -- only ``operand``.
+
+    Args:
+        operator: The ``Filter._operator`` value (``"true"`` or ``"false"``).
+
+    Returns:
+        Dict with only an ``operand`` key (no ``operator``).
+    """
+    return {"operand": operator}
+
+
+def _build_datetime_filter(
+    operator: str, value: Any, date_unit: str | None
+) -> dict[str, Any]:
+    """Build the ``filter`` dict for a datetime-typed property.
+
+    Handles three date sub-types:
+    - Absolute single date: operand is MM/DD/YYYY string
+    - Absolute date range: operand is [MM/DD/YYYY, MM/DD/YYYY] list
+    - Relative date: operand is integer quantity, plus ``unit`` key
+
+    Args:
+        operator: The ``Filter._operator`` value (e.g. ``"was on"``).
+        value: The ``Filter._value`` (date string, list of date strings,
+            or integer quantity for relative dates).
+        date_unit: The ``Filter._date_unit`` (e.g. ``"day"``), or ``None``
+            for absolute date filters.
+
+    Returns:
+        Dict with ``operator``, ``operand``, and optionally ``unit`` keys.
+
+    Raises:
+        ValueError: If ``operator`` is not in ``DATETIME_OPERATOR_MAP``.
+    """
+    if operator not in DATETIME_OPERATOR_MAP:
+        raise ValueError(
+            f"Unknown datetime operator '{operator}'. "
+            f"Valid operators: {sorted(DATETIME_OPERATOR_MAP)}"
+        )
+
+    seg_op = DATETIME_OPERATOR_MAP[operator]
+    result: dict[str, Any] = {"operator": seg_op}
+
+    if operator in _DATETIME_RELATIVE_OPS:
+        result["operand"] = value
+        if date_unit is not None:
+            result["unit"] = _pluralize_unit(date_unit)
+    elif operator in _DATETIME_RANGE_OPS:
+        result["operand"] = [_convert_date_format(d) for d in value]
+    else:
+        result["operand"] = _convert_date_format(str(value))
+
+    return result
+
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+
+def build_segfilter_entry(f: Filter) -> dict[str, Any]:
+    """Convert a Filter to segfilter format for flows step filters.
+
+    Transforms a typed ``Filter`` object into the legacy segfilter dict
+    structure expected by the Mixpanel flows API. The output structure
+    includes property metadata, type information, and a filter dict
+    with type-specific operator/operand encoding.
+
+    Args:
+        f: A ``Filter`` instance created via one of its class methods
+            (e.g. ``Filter.equals()``, ``Filter.greater_than()``).
+
+    Returns:
+        A dict with the segfilter structure:
+
+        - ``property``: dict with ``name``, ``source``, ``type``
+        - ``type``: property type string
+        - ``selected_property_type``: property type string (same as ``type``)
+        - ``filter``: dict with ``operator``/``operand`` (and optionally ``unit``)
+
+    Raises:
+        ValueError: If the filter's property type or operator is not
+            recognized.
+
+    Example:
+        ```python
+        from mixpanel_data.types import Filter
+        from mixpanel_data._internal.segfilter import build_segfilter_entry
+
+        f = Filter.equals("country", "US")
+        entry = build_segfilter_entry(f)
+        assert entry["filter"]["operator"] == "=="
+        assert entry["filter"]["operand"] == ["US"]
+        ```
+    """
+    prop_type = f._property_type
+    source = RESOURCE_TYPE_MAP.get(f._resource_type, f._resource_type)
+
+    if prop_type == "string":
+        filter_dict = _build_string_filter(f._operator, f._value)
+    elif prop_type == "number":
+        filter_dict = _build_number_filter(f._operator, f._value)
+    elif prop_type == "boolean":
+        filter_dict = _build_boolean_filter(f._operator)
+    elif prop_type == "datetime":
+        filter_dict = _build_datetime_filter(f._operator, f._value, f._date_unit)
+    else:
+        raise ValueError(
+            f"Unsupported property type '{prop_type}'. "
+            f"Supported types: string, number, boolean, datetime"
+        )
+
+    return {
+        "property": {
+            "name": f._property,
+            "source": source,
+            "type": prop_type,
+        },
+        "type": prop_type,
+        "selected_property_type": prop_type,
+        "filter": filter_dict,
+    }

--- a/src/mixpanel_data/_internal/segfilter.py
+++ b/src/mixpanel_data/_internal/segfilter.py
@@ -72,6 +72,9 @@ NUMBER_OPERATOR_MAP: dict[str, str] = {
 DATETIME_OPERATOR_MAP: dict[str, str] = {
     "was on": "==",
     "was not on": "!=",
+    # Segfilter operators describe the operand's relation to matching values,
+    # not the event's relation to the operand. So "was before <date>" becomes
+    # ">" because the operand date is greater than the matching event dates.
     "was before": ">",
     "was since": "<",
     "was in the": ">",
@@ -81,11 +84,8 @@ DATETIME_OPERATOR_MAP: dict[str, str] = {
 }
 """Maps datetime-typed Filter operators to segfilter operators."""
 
-# Operators that take no value (set/unset checks)
-_STRING_SETNESS_OPS: frozenset[str] = frozenset({"is set", "is not set"})
-
-# Number operators that take no value
-_NUMBER_SETNESS_OPS: frozenset[str] = frozenset({"is set", "is not set"})
+# Operators that take no value (set/unset checks) — shared across string and number types
+_SETNESS_OPS: frozenset[str] = frozenset({"is set", "is not set"})
 
 # Number operators that take a two-element list
 _NUMBER_RANGE_OPS: frozenset[str] = frozenset({"is between", "between", "not between"})
@@ -118,26 +118,7 @@ def _convert_date_format(date_str: str) -> str:
         ```
     """
     year, month, day = date_str.split("-")
-    return f"{month}/{day}/{year}"
-
-
-def _pluralize_unit(unit: str) -> str:
-    """Pluralize a time unit string by appending 's'.
-
-    Args:
-        unit: Singular time unit (e.g. ``"day"``, ``"hour"``,
-            ``"week"``, ``"month"``, ``"minute"``).
-
-    Returns:
-        Pluralized unit (e.g. ``"days"``, ``"hours"``).
-
-    Example:
-        ```python
-        _pluralize_unit("day")
-        # "days"
-        ```
-    """
-    return f"{unit}s"
+    return f"{month.zfill(2)}/{day.zfill(2)}/{year}"
 
 
 # =============================================================================
@@ -166,7 +147,7 @@ def _build_string_filter(operator: str, value: Any) -> dict[str, Any]:
 
     seg_op = STRING_OPERATOR_MAP[operator]
 
-    if operator in _STRING_SETNESS_OPS:
+    if operator in _SETNESS_OPS:
         operand: Any = ""
     else:
         operand = value
@@ -195,7 +176,7 @@ def _build_number_filter(operator: str, value: Any) -> dict[str, Any]:
 
     seg_op = NUMBER_OPERATOR_MAP[operator]
 
-    if operator in _NUMBER_SETNESS_OPS:
+    if operator in _SETNESS_OPS:
         operand: Any = ""
     elif operator in _NUMBER_RANGE_OPS:
         operand = [str(v) for v in value]
@@ -254,7 +235,7 @@ def _build_datetime_filter(
     if operator in _DATETIME_RELATIVE_OPS:
         result["operand"] = value
         if date_unit is not None:
-            result["unit"] = _pluralize_unit(date_unit)
+            result["unit"] = f"{date_unit}s"
     elif operator in _DATETIME_RANGE_OPS:
         result["operand"] = [_convert_date_format(d) for d in value]
     else:

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -151,6 +151,268 @@ def _enum_error(
 
 
 # =============================================================================
+# Reusable sub-validators (time, group-by)
+# =============================================================================
+
+
+def validate_time_args(
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    last: int,
+) -> list[ValidationError]:
+    """Validate time-range arguments (rules V7-V10, V15, V20).
+
+    Extracted from ``validate_query_args()`` so callers building
+    non-Insights bookmark types can reuse the same date/last checks
+    without pulling in the full query-arg validator.
+
+    Args:
+        from_date: Start date in YYYY-MM-DD format, or ``None``.
+        to_date: End date in YYYY-MM-DD format, or ``None``.
+        last: Number of days for a relative date range. The default
+            value used by ``Workspace.query()`` is ``30``.
+
+    Returns:
+        List of validation errors. Empty list means all time
+        arguments are valid.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.validation import validate_time_args
+
+        errors = validate_time_args(
+            from_date="2024-01-01",
+            to_date="2024-01-31",
+            last=30,
+        )
+        assert errors == []
+        ```
+    """
+    errors: list[ValidationError] = []
+
+    # V7: last must be positive
+    if last <= 0:
+        errors.append(
+            ValidationError(
+                path="last",
+                message="last must be a positive integer",
+                code="V7_LAST_POSITIVE",
+            )
+        )
+
+    # V8: Date format and calendar validation
+    if from_date is not None:
+        if not _DATE_RE.match(from_date):
+            errors.append(
+                ValidationError(
+                    path="from_date",
+                    message=f"from_date must be YYYY-MM-DD format (got '{from_date}')",
+                    code="V8_DATE_FORMAT",
+                )
+            )
+        elif not _is_valid_date(from_date):
+            errors.append(
+                ValidationError(
+                    path="from_date",
+                    message=f"from_date '{from_date}' is not a valid calendar date",
+                    code="V8_DATE_INVALID",
+                )
+            )
+    if to_date is not None:
+        if not _DATE_RE.match(to_date):
+            errors.append(
+                ValidationError(
+                    path="to_date",
+                    message=f"to_date must be YYYY-MM-DD format (got '{to_date}')",
+                    code="V8_DATE_FORMAT",
+                )
+            )
+        elif not _is_valid_date(to_date):
+            errors.append(
+                ValidationError(
+                    path="to_date",
+                    message=f"to_date '{to_date}' is not a valid calendar date",
+                    code="V8_DATE_INVALID",
+                )
+            )
+
+    # V9: to_date requires from_date
+    if to_date is not None and from_date is None:
+        errors.append(
+            ValidationError(
+                path="to_date",
+                message="to_date requires from_date",
+                code="V9_TO_REQUIRES_FROM",
+            )
+        )
+
+    # V10: Cannot combine explicit dates with non-default last
+    if from_date is not None and last != 30:
+        errors.append(
+            ValidationError(
+                path="last",
+                message=(
+                    f"Cannot combine last={last} with explicit dates; "
+                    f"use either last or from_date/to_date"
+                ),
+                code="V10_DATE_LAST_EXCLUSIVE",
+            )
+        )
+
+    # V15: Date ordering — from_date must be <= to_date
+    if (
+        from_date is not None
+        and to_date is not None
+        and _DATE_RE.match(from_date)
+        and _DATE_RE.match(to_date)
+        and from_date > to_date
+    ):
+        errors.append(
+            ValidationError(
+                path="from_date",
+                message=(
+                    f"from_date '{from_date}' is after to_date '{to_date}'; "
+                    f"dates must be in chronological order"
+                ),
+                code="V15_DATE_ORDER",
+            )
+        )
+
+    # V20: last must not be absurdly large
+    if last > _MAX_LAST_DAYS:
+        errors.append(
+            ValidationError(
+                path="last",
+                message=(
+                    f"last={last} exceeds maximum of {_MAX_LAST_DAYS} days (~10 years)"
+                ),
+                code="V20_LAST_TOO_LARGE",
+            )
+        )
+
+    return errors
+
+
+def validate_group_by_args(
+    *,
+    group_by: str | GroupBy | list[str | GroupBy] | None,
+) -> list[ValidationError]:
+    """Validate group-by arguments (rules V11-V12, V18, V24).
+
+    Extracted from ``validate_query_args()`` so callers building
+    non-Insights bookmark types can reuse the same bucket checks
+    without pulling in the full query-arg validator.
+
+    Args:
+        group_by: Breakdown specification — a property name string,
+            a ``GroupBy`` object with optional bucket config, a list
+            of either, or ``None`` for no breakdown.
+
+    Returns:
+        List of validation errors. Empty list means all group-by
+        arguments are valid.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.validation import validate_group_by_args
+        from mixpanel_data.types import GroupBy
+
+        errors = validate_group_by_args(
+            group_by=GroupBy(
+                "revenue",
+                property_type="number",
+                bucket_size=50,
+                bucket_min=0,
+                bucket_max=500,
+            ),
+        )
+        assert errors == []
+        ```
+    """
+    errors: list[ValidationError] = []
+
+    if group_by is None:
+        return errors
+
+    groups = group_by if isinstance(group_by, list) else [group_by]
+    for i, g in enumerate(groups):
+        if isinstance(g, GroupBy):
+            gpath = f"group_by[{i}]" if len(groups) > 1 else "group_by"
+
+            # V24: Bucket values must be finite (not NaN or Inf)
+            for fname, fval in [
+                ("bucket_size", g.bucket_size),
+                ("bucket_min", g.bucket_min),
+                ("bucket_max", g.bucket_max),
+            ]:
+                if not _is_finite(fval):
+                    errors.append(
+                        ValidationError(
+                            path=gpath,
+                            message=f"{fname} must be a finite number, got {fval}",
+                            code="V24_BUCKET_NOT_FINITE",
+                        )
+                    )
+
+            if (
+                g.bucket_min is not None or g.bucket_max is not None
+            ) and g.bucket_size is None:
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message="bucket_min/bucket_max require bucket_size",
+                        code="V11_BUCKET_REQUIRES_SIZE",
+                    )
+                )
+            if g.bucket_size is not None and g.bucket_size <= 0:
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message="bucket_size must be positive",
+                        code="V12_BUCKET_SIZE_POSITIVE",
+                    )
+                )
+            if g.bucket_size is not None and g.property_type != "number":
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message="bucket_size requires property_type='number'",
+                        code="V12B_BUCKET_REQUIRES_NUMBER",
+                    )
+                )
+            if g.bucket_size is not None and (
+                g.bucket_min is None or g.bucket_max is None
+            ):
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message="bucket_size requires both bucket_min and bucket_max",
+                        code="V12C_BUCKET_REQUIRES_BOUNDS",
+                    )
+                )
+
+            # V18: bucket_min must be < bucket_max
+            if (
+                g.bucket_min is not None
+                and g.bucket_max is not None
+                and g.bucket_min >= g.bucket_max
+            ):
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message=(
+                            f"bucket_min ({g.bucket_min}) must be less than "
+                            f"bucket_max ({g.bucket_max})"
+                        ),
+                        code="V18_BUCKET_ORDER",
+                    )
+                )
+
+    return errors
+
+
+# =============================================================================
 # Layer 1: Argument Validation (V0-V14)
 # =============================================================================
 
@@ -411,181 +673,11 @@ def validate_query_args(
             )
         )
 
-    # V7: last must be positive
-    if last <= 0:
-        errors.append(
-            ValidationError(
-                path="last",
-                message="last must be a positive integer",
-                code="V7_LAST_POSITIVE",
-            )
-        )
+    # V7-V10, V15, V20: Time argument validation (delegated)
+    errors.extend(validate_time_args(from_date=from_date, to_date=to_date, last=last))
 
-    # V8: Date format and calendar validation
-    if from_date is not None:
-        if not _DATE_RE.match(from_date):
-            errors.append(
-                ValidationError(
-                    path="from_date",
-                    message=f"from_date must be YYYY-MM-DD format (got '{from_date}')",
-                    code="V8_DATE_FORMAT",
-                )
-            )
-        elif not _is_valid_date(from_date):
-            errors.append(
-                ValidationError(
-                    path="from_date",
-                    message=f"from_date '{from_date}' is not a valid calendar date",
-                    code="V8_DATE_INVALID",
-                )
-            )
-    if to_date is not None:
-        if not _DATE_RE.match(to_date):
-            errors.append(
-                ValidationError(
-                    path="to_date",
-                    message=f"to_date must be YYYY-MM-DD format (got '{to_date}')",
-                    code="V8_DATE_FORMAT",
-                )
-            )
-        elif not _is_valid_date(to_date):
-            errors.append(
-                ValidationError(
-                    path="to_date",
-                    message=f"to_date '{to_date}' is not a valid calendar date",
-                    code="V8_DATE_INVALID",
-                )
-            )
-
-    # V9: to_date requires from_date
-    if to_date is not None and from_date is None:
-        errors.append(
-            ValidationError(
-                path="to_date",
-                message="to_date requires from_date",
-                code="V9_TO_REQUIRES_FROM",
-            )
-        )
-
-    # V10: Cannot combine explicit dates with non-default last
-    if from_date is not None and last != 30:
-        errors.append(
-            ValidationError(
-                path="last",
-                message=(
-                    f"Cannot combine last={last} with explicit dates; "
-                    f"use either last or from_date/to_date"
-                ),
-                code="V10_DATE_LAST_EXCLUSIVE",
-            )
-        )
-
-    # V15: Date ordering — from_date must be <= to_date
-    if (
-        from_date is not None
-        and to_date is not None
-        and _DATE_RE.match(from_date)
-        and _DATE_RE.match(to_date)
-        and from_date > to_date
-    ):
-        errors.append(
-            ValidationError(
-                path="from_date",
-                message=(
-                    f"from_date '{from_date}' is after to_date '{to_date}'; "
-                    f"dates must be in chronological order"
-                ),
-                code="V15_DATE_ORDER",
-            )
-        )
-
-    # V20: last must not be absurdly large
-    if last > _MAX_LAST_DAYS:
-        errors.append(
-            ValidationError(
-                path="last",
-                message=(
-                    f"last={last} exceeds maximum of {_MAX_LAST_DAYS} days (~10 years)"
-                ),
-                code="V20_LAST_TOO_LARGE",
-            )
-        )
-
-    # V11-V12: GroupBy validation
-    if group_by is not None:
-        groups = group_by if isinstance(group_by, list) else [group_by]
-        for i, g in enumerate(groups):
-            if isinstance(g, GroupBy):
-                gpath = f"group_by[{i}]" if len(groups) > 1 else "group_by"
-
-                # V24: Bucket values must be finite (not NaN or Inf)
-                for fname, fval in [
-                    ("bucket_size", g.bucket_size),
-                    ("bucket_min", g.bucket_min),
-                    ("bucket_max", g.bucket_max),
-                ]:
-                    if not _is_finite(fval):
-                        errors.append(
-                            ValidationError(
-                                path=gpath,
-                                message=f"{fname} must be a finite number, got {fval}",
-                                code="V24_BUCKET_NOT_FINITE",
-                            )
-                        )
-
-                if (
-                    g.bucket_min is not None or g.bucket_max is not None
-                ) and g.bucket_size is None:
-                    errors.append(
-                        ValidationError(
-                            path=gpath,
-                            message="bucket_min/bucket_max require bucket_size",
-                            code="V11_BUCKET_REQUIRES_SIZE",
-                        )
-                    )
-                if g.bucket_size is not None and g.bucket_size <= 0:
-                    errors.append(
-                        ValidationError(
-                            path=gpath,
-                            message="bucket_size must be positive",
-                            code="V12_BUCKET_SIZE_POSITIVE",
-                        )
-                    )
-                if g.bucket_size is not None and g.property_type != "number":
-                    errors.append(
-                        ValidationError(
-                            path=gpath,
-                            message="bucket_size requires property_type='number'",
-                            code="V12B_BUCKET_REQUIRES_NUMBER",
-                        )
-                    )
-                if g.bucket_size is not None and (
-                    g.bucket_min is None or g.bucket_max is None
-                ):
-                    errors.append(
-                        ValidationError(
-                            path=gpath,
-                            message="bucket_size requires both bucket_min and bucket_max",
-                            code="V12C_BUCKET_REQUIRES_BOUNDS",
-                        )
-                    )
-
-                # V18: bucket_min must be < bucket_max
-                if (
-                    g.bucket_min is not None
-                    and g.bucket_max is not None
-                    and g.bucket_min >= g.bucket_max
-                ):
-                    errors.append(
-                        ValidationError(
-                            path=gpath,
-                            message=(
-                                f"bucket_min ({g.bucket_min}) must be less than "
-                                f"bucket_max ({g.bucket_max})"
-                            ),
-                            code="V18_BUCKET_ORDER",
-                        )
-                    )
+    # V11-V12, V18, V24: GroupBy validation (delegated)
+    errors.extend(validate_group_by_args(group_by=group_by))
 
     # V13-V14: Per-Metric validation
     for idx, item in enumerate(events):

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -435,7 +435,8 @@ def validate_query_args(
 ) -> list[ValidationError]:
     """Validate query arguments before bookmark construction (Layer 1).
 
-    Implements validation rules V0-V20.
+    Implements validation rules V0-V27, delegating time (V7-V10, V15,
+    V20) and group-by (V11-V12, V18, V24) to extracted helpers.
     Returns all errors found, not just the first, so callers can
     fix multiple issues in a single pass.
 

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -22,7 +22,10 @@ TimeUnit = Literal["day", "week", "month"]
 # Time units for numeric aggregations (segmentation_numeric, sum, average)
 HourDayUnit = Literal["hour", "day"]
 
+# Time units for bookmark query API (query, build_params, build_time_section)
+QueryTimeUnit = Literal["hour", "day", "week", "month", "quarter"]
+
 # Count/aggregation methods
 CountType = Literal["general", "unique", "average"]
 
-__all__ = ["TimeUnit", "HourDayUnit", "CountType"]
+__all__ = ["TimeUnit", "HourDayUnit", "QueryTimeUnit", "CountType"]

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -32,6 +32,12 @@ from pathlib import Path
 from typing import Any, Literal
 
 from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.bookmark_builders import (
+    build_filter_entry,
+    build_filter_section,
+    build_group_section,
+    build_time_section,
+)
 from mixpanel_data._internal.config import ConfigManager, Credentials
 from mixpanel_data._internal.services.discovery import DiscoveryService
 from mixpanel_data._internal.services.live_query import LiveQueryService
@@ -1702,74 +1708,18 @@ class Workspace:
             show.append(formula_entry)
 
         # --- Build sections.time (array) ---
-        if from_date is not None and to_date is not None:
-            time_entry: dict[str, Any] = {
-                "dateRangeType": "between",
-                "unit": unit,
-                "value": [from_date, to_date],
-            }
-        elif from_date is not None:
-            # "since" with raw dates isn't supported by the API;
-            # use "between" with from_date through today
-            import datetime as _dt
-
-            today = _dt.date.today().isoformat()
-            time_entry = {
-                "dateRangeType": "between",
-                "unit": unit,
-                "value": [from_date, today],
-            }
-        else:
-            time_entry = {
-                "dateRangeType": "in the last",
-                "unit": unit,
-                "window": {"unit": "day", "value": last},
-            }
-        time_section: list[dict[str, Any]] = [time_entry]
+        time_section = build_time_section(
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+        )
 
         # --- Build sections.filter[] ---
-        filter_section: list[dict[str, Any]] = []
-        if where is not None:
-            filters_list = where if isinstance(where, list) else [where]
-            filter_section = [self._build_filter_entry(f) for f in filters_list]
+        filter_section = build_filter_section(where)
 
         # --- Build sections.group[] ---
-        group_section: list[dict[str, Any]] = []
-        if group_by is not None:
-            groups = group_by if isinstance(group_by, list) else [group_by]
-            for g in groups:
-                if isinstance(g, str):
-                    group_section.append(
-                        {
-                            "value": g,
-                            "propertyName": g,
-                            "resourceType": "events",
-                            "propertyType": "string",
-                            "propertyDefaultType": "string",
-                        }
-                    )
-                elif isinstance(g, GroupBy):
-                    group_entry: dict[str, Any] = {
-                        "value": g.property,
-                        "propertyName": g.property,
-                        "resourceType": "events",
-                        "propertyType": g.property_type,
-                        "propertyDefaultType": g.property_type,
-                    }
-                    if g.bucket_size is not None:
-                        group_entry["customBucket"] = {
-                            "bucketSize": g.bucket_size,
-                        }
-                        if g.bucket_min is not None:
-                            group_entry["customBucket"]["min"] = g.bucket_min
-                        if g.bucket_max is not None:
-                            group_entry["customBucket"]["max"] = g.bucket_max
-                    group_section.append(group_entry)
-                else:
-                    raise TypeError(
-                        f"group_by elements must be str or GroupBy, "
-                        f"got {type(g).__name__}: {g!r}"
-                    )
+        group_section = build_group_section(group_by)
 
         # --- Build displayOptions ---
         chart_type_map = {
@@ -1805,6 +1755,9 @@ class Workspace:
     def _build_filter_entry(f: Filter) -> dict[str, Any]:
         """Convert a Filter object to a bookmark filter dict.
 
+        Delegates to :func:`~mixpanel_data._internal.bookmark_builders.build_filter_entry`.
+        Kept as a static method for backward compatibility.
+
         Args:
             f: A Filter object.
 
@@ -1812,17 +1765,7 @@ class Workspace:
             Bookmark filter dict matching Mixpanel's expected format.
             Includes ``filterDateUnit`` for relative date filters.
         """
-        entry: dict[str, Any] = {
-            "resourceType": f._resource_type,
-            "filterType": f._property_type,
-            "defaultType": f._property_type,
-            "value": f._property,
-            "filterValue": f._value,
-            "filterOperator": f._operator,
-        }
-        if f._date_unit is not None:
-            entry["filterDateUnit"] = f._date_unit
-        return entry
+        return build_filter_entry(f)
 
     def query(
         self,

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -43,6 +43,7 @@ from mixpanel_data._internal.services.discovery import DiscoveryService
 from mixpanel_data._internal.services.live_query import LiveQueryService
 from mixpanel_data._internal.transforms import transform_event, transform_profile
 from mixpanel_data._internal.validation import validate_bookmark, validate_query_args
+from mixpanel_data._literal_types import QueryTimeUnit
 from mixpanel_data.exceptions import (
     BookmarkValidationError,
     ConfigError,
@@ -1604,7 +1605,7 @@ class Workspace:
         from_date: str | None,
         to_date: str | None,
         last: int,
-        unit: str,
+        unit: QueryTimeUnit,
         group_by: str | GroupBy | list[str | GroupBy] | None,
         where: Filter | list[Filter] | None,
         formulas: Sequence[Formula],
@@ -1675,7 +1676,7 @@ class Workspace:
             # Build behavior block with optional per-metric filters
             behavior_filters: list[dict[str, Any]] = []
             if item_filters:
-                behavior_filters = [self._build_filter_entry(f) for f in item_filters]
+                behavior_filters = [build_filter_entry(f) for f in item_filters]
 
             entry: dict[str, Any] = {
                 "type": "metric",
@@ -1751,22 +1752,6 @@ class Workspace:
             "displayOptions": display_options,
         }
 
-    @staticmethod
-    def _build_filter_entry(f: Filter) -> dict[str, Any]:
-        """Convert a Filter object to a bookmark filter dict.
-
-        Delegates to :func:`~mixpanel_data._internal.bookmark_builders.build_filter_entry`.
-        Kept as a static method for backward compatibility.
-
-        Args:
-            f: A Filter object.
-
-        Returns:
-            Bookmark filter dict matching Mixpanel's expected format.
-            Includes ``filterDateUnit`` for relative date filters.
-        """
-        return build_filter_entry(f)
-
     def query(
         self,
         events: str | Metric | Formula | Sequence[str | Metric | Formula],
@@ -1774,7 +1759,7 @@ class Workspace:
         from_date: str | None = None,
         to_date: str | None = None,
         last: int = 30,
-        unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
+        unit: QueryTimeUnit = "day",
         math: MathType = "total",
         math_property: str | None = None,
         per_user: PerUserAggregation | None = None,
@@ -1902,7 +1887,7 @@ class Workspace:
         from_date: str | None = None,
         to_date: str | None = None,
         last: int = 30,
-        unit: Literal["hour", "day", "week", "month", "quarter"] = "day",
+        unit: QueryTimeUnit = "day",
         math: MathType = "total",
         math_property: str | None = None,
         per_user: PerUserAggregation | None = None,
@@ -1994,7 +1979,7 @@ class Workspace:
         from_date: str | None,
         to_date: str | None,
         last: int,
-        unit: str,
+        unit: QueryTimeUnit,
         math: MathType,
         math_property: str | None,
         per_user: PerUserAggregation | None,

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -1,0 +1,323 @@
+"""Tests for bookmark builder functions.
+
+Verifies that the extracted builder functions in bookmark_builders.py
+produce the correct bookmark JSON structures for time sections,
+date ranges, filter sections, group sections, and filter entries.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from mixpanel_data._internal.bookmark_builders import (
+    build_date_range,
+    build_filter_entry,
+    build_filter_section,
+    build_group_section,
+    build_time_section,
+)
+from mixpanel_data.types import Filter, GroupBy
+
+
+class TestBuildTimeSection:
+    """Tests for build_time_section() — sections.time array building."""
+
+    def test_absolute_range_from_and_to(self) -> None:
+        """Both from_date and to_date produce a 'between' entry with value list."""
+        result = build_time_section(
+            from_date="2025-01-01",
+            to_date="2025-01-31",
+            last=30,
+            unit="day",
+        )
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["dateRangeType"] == "between"
+        assert entry["unit"] == "day"
+        assert entry["value"] == ["2025-01-01", "2025-01-31"]
+        assert "window" not in entry
+
+    def test_from_only_fills_today(self) -> None:
+        """Only from_date fills to_date with today's date."""
+        with patch("mixpanel_data._internal.bookmark_builders.date") as mock_date:
+            mock_date.today.return_value = date(2025, 6, 15)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            result = build_time_section(
+                from_date="2025-01-01",
+                to_date=None,
+                last=30,
+                unit="week",
+            )
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["dateRangeType"] == "between"
+        assert entry["unit"] == "week"
+        assert entry["value"] == ["2025-01-01", "2025-06-15"]
+
+    def test_relative_range_last_n(self) -> None:
+        """Neither from_date nor to_date produces 'in the last' entry."""
+        result = build_time_section(
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+        )
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["dateRangeType"] == "in the last"
+        assert entry["unit"] == "day"
+        assert entry["window"] == {"unit": "day", "value": 30}
+        assert "value" not in entry
+
+    def test_relative_range_custom_last(self) -> None:
+        """Relative range with custom last value and unit."""
+        result = build_time_section(
+            from_date=None,
+            to_date=None,
+            last=7,
+            unit="hour",
+        )
+        entry = result[0]
+        assert entry["dateRangeType"] == "in the last"
+        assert entry["unit"] == "hour"
+        assert entry["window"]["value"] == 7
+
+    def test_returns_single_element_list(self) -> None:
+        """Result is always a list with exactly one element."""
+        for kwargs in [
+            {
+                "from_date": "2025-01-01",
+                "to_date": "2025-01-31",
+                "last": 30,
+                "unit": "day",
+            },
+            {"from_date": "2025-01-01", "to_date": None, "last": 30, "unit": "day"},
+            {"from_date": None, "to_date": None, "last": 30, "unit": "day"},
+        ]:
+            result = build_time_section(**kwargs)  # type: ignore[arg-type]
+            assert isinstance(result, list)
+            assert len(result) == 1
+
+
+class TestBuildDateRange:
+    """Tests for build_date_range() — flat date range for flows."""
+
+    def test_relative_last_n(self) -> None:
+        """Neither date produces 'in the last' type with $now."""
+        result = build_date_range(
+            from_date=None,
+            to_date=None,
+            last=30,
+        )
+        assert result["type"] == "in the last"
+        assert result["from_date"] == {"unit": "day", "value": 30}
+        assert result["to_date"] == "$now"
+
+    def test_absolute_range(self) -> None:
+        """Both dates produce 'between' type with raw date strings."""
+        result = build_date_range(
+            from_date="2025-01-01",
+            to_date="2025-03-31",
+            last=30,
+        )
+        assert result["type"] == "between"
+        assert result["from_date"] == "2025-01-01"
+        assert result["to_date"] == "2025-03-31"
+
+    def test_relative_custom_last(self) -> None:
+        """Custom last value in relative range."""
+        result = build_date_range(
+            from_date=None,
+            to_date=None,
+            last=7,
+        )
+        assert result["from_date"]["value"] == 7
+        assert result["from_date"]["unit"] == "day"
+
+
+class TestBuildFilterSection:
+    """Tests for build_filter_section() — sections.filter array building."""
+
+    def test_none_returns_empty(self) -> None:
+        """None where clause returns empty list."""
+        result = build_filter_section(None)
+        assert result == []
+
+    def test_single_filter(self) -> None:
+        """Single Filter produces one-element list."""
+        f = Filter.equals("country", "US")
+        result = build_filter_section(f)
+        assert len(result) == 1
+        assert result[0]["value"] == "country"
+        assert result[0]["filterOperator"] == "equals"
+
+    def test_multiple_filters(self) -> None:
+        """List of Filters produces matching-length list."""
+        filters = [
+            Filter.equals("country", "US"),
+            Filter.greater_than("age", 18),
+        ]
+        result = build_filter_section(filters)
+        assert len(result) == 2
+        assert result[0]["value"] == "country"
+        assert result[0]["filterOperator"] == "equals"
+        assert result[1]["value"] == "age"
+        assert result[1]["filterOperator"] == "is greater than"
+
+    def test_single_filter_entry_structure(self) -> None:
+        """Filter entry has all required keys."""
+        f = Filter.equals("country", "US")
+        result = build_filter_section(f)
+        entry = result[0]
+        assert "resourceType" in entry
+        assert "filterType" in entry
+        assert "defaultType" in entry
+        assert "value" in entry
+        assert "filterValue" in entry
+        assert "filterOperator" in entry
+
+
+class TestBuildGroupSection:
+    """Tests for build_group_section() — sections.group array building."""
+
+    def test_none_returns_empty(self) -> None:
+        """None group_by returns empty list."""
+        result = build_group_section(None)
+        assert result == []
+
+    def test_string_group_by(self) -> None:
+        """String group_by produces standard group entry."""
+        result = build_group_section("country")
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["value"] == "country"
+        assert entry["propertyName"] == "country"
+        assert entry["resourceType"] == "events"
+        assert entry["propertyType"] == "string"
+        assert entry["propertyDefaultType"] == "string"
+
+    def test_groupby_object(self) -> None:
+        """GroupBy object produces entry with correct property type."""
+        g = GroupBy("revenue", property_type="number")
+        result = build_group_section(g)
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["value"] == "revenue"
+        assert entry["propertyName"] == "revenue"
+        assert entry["propertyType"] == "number"
+        assert entry["propertyDefaultType"] == "number"
+
+    def test_groupby_with_buckets(self) -> None:
+        """GroupBy with bucket_size produces customBucket entry."""
+        g = GroupBy(
+            "amount",
+            property_type="number",
+            bucket_size=10,
+            bucket_min=0,
+            bucket_max=100,
+        )
+        result = build_group_section(g)
+        entry = result[0]
+        assert "customBucket" in entry
+        assert entry["customBucket"]["bucketSize"] == 10
+        assert entry["customBucket"]["min"] == 0
+        assert entry["customBucket"]["max"] == 100
+
+    def test_groupby_bucket_size_only(self) -> None:
+        """GroupBy with bucket_size but no min/max omits min/max keys."""
+        g = GroupBy("amount", property_type="number", bucket_size=10)
+        result = build_group_section(g)
+        entry = result[0]
+        assert "customBucket" in entry
+        assert entry["customBucket"]["bucketSize"] == 10
+        assert "min" not in entry["customBucket"]
+        assert "max" not in entry["customBucket"]
+
+    def test_multiple_groups_mixed(self) -> None:
+        """List of mixed strings and GroupBy produces correct entries."""
+        groups: list[str | GroupBy] = [
+            "country",
+            GroupBy("revenue", property_type="number"),
+        ]
+        result = build_group_section(groups)
+        assert len(result) == 2
+        assert result[0]["value"] == "country"
+        assert result[0]["propertyType"] == "string"
+        assert result[1]["value"] == "revenue"
+        assert result[1]["propertyType"] == "number"
+
+    def test_invalid_type_raises_typeerror(self) -> None:
+        """Invalid group_by element type raises TypeError."""
+        with pytest.raises(TypeError, match="group_by elements must be str or GroupBy"):
+            build_group_section(123)  # type: ignore[arg-type]
+
+    def test_invalid_element_in_list_raises_typeerror(self) -> None:
+        """Invalid element inside list raises TypeError."""
+        with pytest.raises(TypeError, match="group_by elements must be str or GroupBy"):
+            build_group_section(["country", 42])  # type: ignore[list-item]
+
+
+class TestBuildFilterEntry:
+    """Tests for build_filter_entry() — individual filter dict conversion."""
+
+    def test_string_filter(self) -> None:
+        """String equals filter produces correct entry."""
+        f = Filter.equals("country", "US")
+        entry = build_filter_entry(f)
+        assert entry["resourceType"] == "events"
+        assert entry["filterType"] == "string"
+        assert entry["defaultType"] == "string"
+        assert entry["value"] == "country"
+        assert entry["filterValue"] == ["US"]
+        assert entry["filterOperator"] == "equals"
+        assert "filterDateUnit" not in entry
+
+    def test_number_filter(self) -> None:
+        """Numeric greater-than filter produces correct entry."""
+        f = Filter.greater_than("age", 18)
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "number"
+        assert entry["defaultType"] == "number"
+        assert entry["value"] == "age"
+        assert entry["filterValue"] == 18
+        assert entry["filterOperator"] == "is greater than"
+        assert "filterDateUnit" not in entry
+
+    def test_boolean_filter(self) -> None:
+        """Boolean true filter produces correct entry."""
+        f = Filter.is_true("verified")
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "boolean"
+        assert entry["defaultType"] == "boolean"
+        assert entry["value"] == "verified"
+        assert entry["filterValue"] is None
+        assert entry["filterOperator"] == "true"
+        assert "filterDateUnit" not in entry
+
+    def test_datetime_filter_with_date_unit(self) -> None:
+        """Relative date filter includes filterDateUnit."""
+        f = Filter.in_the_last("$time", 7, "day")
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "datetime"
+        assert entry["defaultType"] == "datetime"
+        assert entry["value"] == "$time"
+        assert entry["filterValue"] == 7
+        assert entry["filterOperator"] == "was in the"
+        assert entry["filterDateUnit"] == "day"
+
+    def test_datetime_filter_without_date_unit(self) -> None:
+        """Absolute date filter does not include filterDateUnit."""
+        f = Filter.on("created", "2025-01-15")
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "datetime"
+        assert entry["filterOperator"] == "was on"
+        assert "filterDateUnit" not in entry
+
+    def test_people_resource_type(self) -> None:
+        """Filter with resource_type='people' sets resourceType correctly."""
+        f = Filter.equals("plan", "premium", resource_type="people")
+        entry = build_filter_entry(f)
+        assert entry["resourceType"] == "people"

--- a/tests/unit/test_bookmark_builders_pbt.py
+++ b/tests/unit/test_bookmark_builders_pbt.py
@@ -1,0 +1,318 @@
+"""Property-based tests for bookmark builder equivalence.
+
+Uses Hypothesis to verify that the extracted builder functions produce
+identical output to the original inline code in ``_build_query_params()``.
+This is an oracle test: the refactored code must match the pre-refactoring
+behavior across randomized inputs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.bookmark_builders import (
+    build_filter_section,
+    build_group_section,
+    build_time_section,
+)
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.types import Filter, GroupBy
+
+# =============================================================================
+# Strategies
+# =============================================================================
+
+date_strs = st.from_regex(
+    r"20[2-3][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])", fullmatch=True
+)
+time_units = st.sampled_from(["hour", "day", "week", "month", "quarter"])
+positive_ints = st.integers(min_value=1, max_value=365)
+event_names = st.text(
+    min_size=1, max_size=50, alphabet=st.characters(categories=("L", "N", "P"))
+)
+property_names = st.text(
+    min_size=1, max_size=30, alphabet=st.characters(categories=("L", "N"))
+)
+
+
+def _make_workspace() -> Workspace:
+    """Create a Workspace with mocked config for testing.
+
+    Returns:
+        Workspace instance with mock credentials.
+    """
+    creds = Credentials(
+        username="test",
+        secret=SecretStr("secret"),
+        project_id="12345",
+        region="us",
+    )
+    mgr = MagicMock(spec=ConfigManager)
+    mgr.resolve_credentials.return_value = creds
+    return Workspace(_config_manager=mgr)
+
+
+# =============================================================================
+# Oracle Tests: build_time_section matches _build_query_params
+# =============================================================================
+
+
+class TestTimeSectionEquivalence:
+    """Verify build_time_section() matches _build_query_params() time output."""
+
+    @given(unit=time_units, last=positive_ints)
+    @settings(max_examples=50)
+    def test_relative_range_equivalence(self, unit: str, last: int) -> None:
+        """Relative time range: build_time_section matches inline code.
+
+        Args:
+            unit: Time unit.
+            last: Number of days for relative range.
+        """
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=last,
+            unit=unit,
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_time_section(from_date=None, to_date=None, last=last, unit=unit)
+        assert params["sections"]["time"] == direct
+
+    @given(
+        from_date=date_strs,
+        to_date=date_strs,
+        unit=time_units,
+    )
+    @settings(max_examples=50)
+    def test_absolute_range_equivalence(
+        self, from_date: str, to_date: str, unit: str
+    ) -> None:
+        """Absolute time range: build_time_section matches inline code.
+
+        Args:
+            from_date: Start date string.
+            to_date: End date string.
+            unit: Time unit.
+        """
+        # Ensure from_date <= to_date for valid date range
+        if from_date > to_date:
+            from_date, to_date = to_date, from_date
+
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=from_date,
+            to_date=to_date,
+            last=30,
+            unit=unit,
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_time_section(
+            from_date=from_date, to_date=to_date, last=30, unit=unit
+        )
+        assert params["sections"]["time"] == direct
+
+
+# =============================================================================
+# Oracle Tests: build_filter_section matches _build_query_params
+# =============================================================================
+
+
+class TestFilterSectionEquivalence:
+    """Verify build_filter_section() matches _build_query_params() filter output."""
+
+    @given(prop=property_names, value=property_names)
+    @settings(max_examples=50)
+    def test_single_filter_equivalence(self, prop: str, value: str) -> None:
+        """Single filter: build_filter_section matches inline code.
+
+        Args:
+            prop: Property name.
+            value: Filter value.
+        """
+        f = Filter.equals(prop, value)
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=None,
+            where=f,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_filter_section(f)
+        assert params["sections"]["filter"] == direct
+
+    def test_none_filter_equivalence(self) -> None:
+        """None filter: build_filter_section returns empty list.
+
+        Matches _build_query_params behavior with where=None.
+        """
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_filter_section(None)
+        assert params["sections"]["filter"] == direct == []
+
+
+# =============================================================================
+# Oracle Tests: build_group_section matches _build_query_params
+# =============================================================================
+
+
+class TestGroupSectionEquivalence:
+    """Verify build_group_section() matches _build_query_params() group output."""
+
+    @given(prop=property_names)
+    @settings(max_examples=50)
+    def test_string_group_equivalence(self, prop: str) -> None:
+        """String group_by: build_group_section matches inline code.
+
+        Args:
+            prop: Property name.
+        """
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=prop,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_group_section(prop)
+        assert params["sections"]["group"] == direct
+
+    @given(
+        prop=property_names,
+        bucket_size=st.floats(
+            min_value=0.1, max_value=1000.0, allow_nan=False, allow_infinity=False
+        ),
+        bucket_min=st.floats(
+            min_value=-1000.0, max_value=0.0, allow_nan=False, allow_infinity=False
+        ),
+        bucket_max=st.floats(
+            min_value=0.1, max_value=10000.0, allow_nan=False, allow_infinity=False
+        ),
+    )
+    @settings(max_examples=30)
+    def test_groupby_with_buckets_equivalence(
+        self,
+        prop: str,
+        bucket_size: float,
+        bucket_min: float,
+        bucket_max: float,
+    ) -> None:
+        """GroupBy with buckets: build_group_section matches inline code.
+
+        Args:
+            prop: Property name.
+            bucket_size: Bucket width.
+            bucket_min: Minimum bucket value.
+            bucket_max: Maximum bucket value.
+        """
+        g = GroupBy(
+            prop,
+            property_type="number",
+            bucket_size=bucket_size,
+            bucket_min=bucket_min,
+            bucket_max=bucket_max,
+        )
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=g,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_group_section(g)
+        assert params["sections"]["group"] == direct
+
+    def test_none_group_equivalence(self) -> None:
+        """None group_by: build_group_section returns empty list.
+
+        Matches _build_query_params behavior with group_by=None.
+        """
+        ws = _make_workspace()
+        params = ws._build_query_params(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        direct = build_group_section(None)
+        assert params["sections"]["group"] == direct == []

--- a/tests/unit/test_bookmark_builders_pbt.py
+++ b/tests/unit/test_bookmark_builders_pbt.py
@@ -1,9 +1,9 @@
-"""Property-based tests for bookmark builder equivalence.
+"""Property-based tests for bookmark builder delegation wiring.
 
-Uses Hypothesis to verify that the extracted builder functions produce
-identical output to the original inline code in ``_build_query_params()``.
-This is an oracle test: the refactored code must match the pre-refactoring
-behavior across randomized inputs.
+Uses Hypothesis to verify that ``_build_query_params()`` correctly
+delegates to the extracted builder functions. These tests confirm
+that the wiring between the composed method and the standalone
+helpers is correct across randomized inputs.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ def _make_workspace() -> Workspace:
 
 
 # =============================================================================
-# Oracle Tests: build_time_section matches _build_query_params
+# Wiring Tests: build_time_section matches _build_query_params
 # =============================================================================
 
 
@@ -138,7 +138,7 @@ class TestTimeSectionEquivalence:
 
 
 # =============================================================================
-# Oracle Tests: build_filter_section matches _build_query_params
+# Wiring Tests: build_filter_section matches _build_query_params
 # =============================================================================
 
 
@@ -202,7 +202,7 @@ class TestFilterSectionEquivalence:
 
 
 # =============================================================================
-# Oracle Tests: build_group_section matches _build_query_params
+# Wiring Tests: build_group_section matches _build_query_params
 # =============================================================================
 
 

--- a/tests/unit/test_bookmark_builders_pbt.py
+++ b/tests/unit/test_bookmark_builders_pbt.py
@@ -83,7 +83,7 @@ class TestTimeSectionEquivalence:
             from_date=None,
             to_date=None,
             last=last,
-            unit=unit,
+            unit=unit,  # type: ignore[arg-type]
             group_by=None,
             where=None,
             formulas=[],
@@ -91,7 +91,7 @@ class TestTimeSectionEquivalence:
             cumulative=False,
             mode="timeseries",
         )
-        direct = build_time_section(from_date=None, to_date=None, last=last, unit=unit)
+        direct = build_time_section(from_date=None, to_date=None, last=last, unit=unit)  # type: ignore[arg-type]
         assert params["sections"]["time"] == direct
 
     @given(
@@ -123,7 +123,7 @@ class TestTimeSectionEquivalence:
             from_date=from_date,
             to_date=to_date,
             last=30,
-            unit=unit,
+            unit=unit,  # type: ignore[arg-type]
             group_by=None,
             where=None,
             formulas=[],
@@ -132,7 +132,10 @@ class TestTimeSectionEquivalence:
             mode="timeseries",
         )
         direct = build_time_section(
-            from_date=from_date, to_date=to_date, last=30, unit=unit
+            from_date=from_date,
+            to_date=to_date,
+            last=30,
+            unit=unit,  # type: ignore[arg-type]
         )
         assert params["sections"]["time"] == direct
 

--- a/tests/unit/test_bookmark_enums.py
+++ b/tests/unit/test_bookmark_enums.py
@@ -15,8 +15,12 @@ from mixpanel_data._internal.bookmark_enums import (
     MATH_REQUIRING_PROPERTY,
     VALID_ANALYSIS_TYPES,
     VALID_CHART_TYPES,
+    VALID_CONVERSION_WINDOW_UNITS,
     VALID_FILTER_OPERATORS,
     VALID_FILTERS_DETERMINER,
+    VALID_FLOWS_CHART_TYPES,
+    VALID_FLOWS_COUNT_TYPES,
+    VALID_FUNNEL_ORDER,
     VALID_MATH_FUNNELS,
     VALID_MATH_INSIGHTS,
     VALID_MATH_RETENTION,
@@ -26,6 +30,8 @@ from mixpanel_data._internal.bookmark_enums import (
     VALID_PROPERTY_TYPES,
     VALID_QUERY_TIME_UNITS,
     VALID_RESOURCE_TYPES,
+    VALID_RETENTION_ALIGNMENT,
+    VALID_RETENTION_UNITS,
     VALID_TIME_UNITS,
 )
 from mixpanel_data.types import (
@@ -159,3 +165,105 @@ class TestEnumCardinality:
             "rolling",
             "cumulative",
         } == VALID_ANALYSIS_TYPES
+
+
+class TestNewEnumConstants:
+    """Tests for new frozenset constants added in Phase 1 (T002)."""
+
+    def test_valid_funnel_order_values(self) -> None:
+        """VALID_FUNNEL_ORDER contains exactly 'loose' and 'any'."""
+        assert {"loose", "any"} == VALID_FUNNEL_ORDER
+
+    def test_valid_funnel_order_is_frozenset(self) -> None:
+        """VALID_FUNNEL_ORDER is a frozenset for immutability."""
+        assert isinstance(VALID_FUNNEL_ORDER, frozenset)
+
+    def test_valid_conversion_window_units_values(self) -> None:
+        """VALID_CONVERSION_WINDOW_UNITS contains all 7 expected units."""
+        expected = {"second", "minute", "hour", "day", "week", "month", "session"}
+        assert expected == VALID_CONVERSION_WINDOW_UNITS
+
+    def test_valid_conversion_window_units_is_frozenset(self) -> None:
+        """VALID_CONVERSION_WINDOW_UNITS is a frozenset."""
+        assert isinstance(VALID_CONVERSION_WINDOW_UNITS, frozenset)
+
+    def test_valid_retention_units_values(self) -> None:
+        """VALID_RETENTION_UNITS contains exactly 'day', 'week', 'month'."""
+        assert {"day", "week", "month"} == VALID_RETENTION_UNITS
+
+    def test_valid_retention_units_is_frozenset(self) -> None:
+        """VALID_RETENTION_UNITS is a frozenset."""
+        assert isinstance(VALID_RETENTION_UNITS, frozenset)
+
+    def test_valid_retention_alignment_values(self) -> None:
+        """VALID_RETENTION_ALIGNMENT contains 'birth' and 'interval_start'."""
+        assert {"birth", "interval_start"} == VALID_RETENTION_ALIGNMENT
+
+    def test_valid_retention_alignment_is_frozenset(self) -> None:
+        """VALID_RETENTION_ALIGNMENT is a frozenset."""
+        assert isinstance(VALID_RETENTION_ALIGNMENT, frozenset)
+
+    def test_valid_flows_count_types_values(self) -> None:
+        """VALID_FLOWS_COUNT_TYPES contains 'unique', 'total', 'session'."""
+        assert {"unique", "total", "session"} == VALID_FLOWS_COUNT_TYPES
+
+    def test_valid_flows_count_types_is_frozenset(self) -> None:
+        """VALID_FLOWS_COUNT_TYPES is a frozenset."""
+        assert isinstance(VALID_FLOWS_COUNT_TYPES, frozenset)
+
+    def test_valid_flows_chart_types_values(self) -> None:
+        """VALID_FLOWS_CHART_TYPES contains 'sankey' and 'top-paths'."""
+        assert {"sankey", "top-paths"} == VALID_FLOWS_CHART_TYPES
+
+    def test_valid_flows_chart_types_is_frozenset(self) -> None:
+        """VALID_FLOWS_CHART_TYPES is a frozenset."""
+        assert isinstance(VALID_FLOWS_CHART_TYPES, frozenset)
+
+
+class TestExtendedMathFunnels:
+    """Tests for extended VALID_MATH_FUNNELS with property aggregation (T003)."""
+
+    def test_contains_original_values(self) -> None:
+        """VALID_MATH_FUNNELS still contains all original counting/conversion types."""
+        original = {
+            "general",
+            "unique",
+            "session",
+            "total",
+            "conversion_rate",
+            "conversion_rate_unique",
+            "conversion_rate_total",
+            "conversion_rate_session",
+        }
+        assert original <= VALID_MATH_FUNNELS
+
+    def test_contains_property_aggregation_types(self) -> None:
+        """VALID_MATH_FUNNELS includes property aggregation types."""
+        property_agg = {"average", "median", "min", "max", "p25", "p75", "p90", "p99"}
+        assert property_agg <= VALID_MATH_FUNNELS
+
+    def test_all_expected_values(self) -> None:
+        """VALID_MATH_FUNNELS contains exactly 16 expected values."""
+        expected = {
+            "general",
+            "unique",
+            "session",
+            "total",
+            "conversion_rate",
+            "conversion_rate_unique",
+            "conversion_rate_total",
+            "conversion_rate_session",
+            "average",
+            "median",
+            "min",
+            "max",
+            "p25",
+            "p75",
+            "p90",
+            "p99",
+        }
+        assert expected == VALID_MATH_FUNNELS
+
+    def test_funnels_still_subset_of_all(self) -> None:
+        """Extended VALID_MATH_FUNNELS remains a subset of VALID_MATH_TYPES."""
+        assert VALID_MATH_FUNNELS <= VALID_MATH_TYPES

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mixpanel_data import Filter, Formula, GroupBy, Metric, Workspace
+from mixpanel_data._internal.bookmark_builders import build_filter_entry
 
 # =============================================================================
 # Fixtures
@@ -1179,33 +1180,33 @@ class TestBuildParams:
 class TestDateFilterParams:
     """T057: Date filter bookmark params generation."""
 
-    def test_absolute_date_omits_date_unit(self, ws: Workspace) -> None:
+    def test_absolute_date_omits_date_unit(self) -> None:
         """Absolute date filter (on) omits filterDateUnit."""
-        entry = ws._build_filter_entry(Filter.on("created", "2024-06-15"))
+        entry = build_filter_entry(Filter.on("created", "2024-06-15"))
         assert entry["filterType"] == "datetime"
         assert entry["filterOperator"] == "was on"
         assert entry["filterValue"] == "2024-06-15"
         assert "filterDateUnit" not in entry
 
-    def test_relative_date_includes_date_unit(self, ws: Workspace) -> None:
+    def test_relative_date_includes_date_unit(self) -> None:
         """Relative date filter (in_the_last) includes filterDateUnit."""
-        entry = ws._build_filter_entry(Filter.in_the_last("created", 7, "day"))
+        entry = build_filter_entry(Filter.in_the_last("created", 7, "day"))
         assert entry["filterDateUnit"] == "day"
         assert entry["filterValue"] == 7
         assert entry["filterType"] == "datetime"
 
-    def test_date_between_value_is_list(self, ws: Workspace) -> None:
+    def test_date_between_value_is_list(self) -> None:
         """Date between filter value is a two-element list."""
-        entry = ws._build_filter_entry(
+        entry = build_filter_entry(
             Filter.date_between("created", "2024-01-01", "2024-06-30")
         )
         assert entry["filterValue"] == ["2024-01-01", "2024-06-30"]
         assert entry["filterOperator"] == "was between"
         assert "filterDateUnit" not in entry
 
-    def test_existing_filters_unaffected(self, ws: Workspace) -> None:
+    def test_existing_filters_unaffected(self) -> None:
         """Non-date filters still omit filterDateUnit (backward compat)."""
-        entry = ws._build_filter_entry(Filter.equals("country", "US"))
+        entry = build_filter_entry(Filter.equals("country", "US"))
         assert "filterDateUnit" not in entry
 
     def test_date_filter_in_where_clause(self, ws: Workspace) -> None:
@@ -1218,22 +1219,22 @@ class TestDateFilterParams:
         assert filt["filterDateUnit"] == "day"
         assert filt["filterType"] == "datetime"
 
-    def test_before_filter_params(self, ws: Workspace) -> None:
+    def test_before_filter_params(self) -> None:
         """Filter.before() produces correct bookmark entry."""
-        entry = ws._build_filter_entry(Filter.before("created", "2024-01-01"))
+        entry = build_filter_entry(Filter.before("created", "2024-01-01"))
         assert entry["filterOperator"] == "was before"
         assert entry["filterValue"] == "2024-01-01"
         assert entry["filterType"] == "datetime"
 
-    def test_since_filter_params(self, ws: Workspace) -> None:
+    def test_since_filter_params(self) -> None:
         """Filter.since() produces correct bookmark entry."""
-        entry = ws._build_filter_entry(Filter.since("created", "2024-01-01"))
+        entry = build_filter_entry(Filter.since("created", "2024-01-01"))
         assert entry["filterOperator"] == "was since"
         assert entry["filterValue"] == "2024-01-01"
 
-    def test_not_in_the_last_includes_date_unit(self, ws: Workspace) -> None:
+    def test_not_in_the_last_includes_date_unit(self) -> None:
         """Filter.not_in_the_last() includes filterDateUnit."""
-        entry = ws._build_filter_entry(Filter.not_in_the_last("created", 30, "day"))
+        entry = build_filter_entry(Filter.not_in_the_last("created", 30, "day"))
         assert entry["filterDateUnit"] == "day"
         assert entry["filterOperator"] == "was not in the"
 

--- a/tests/unit/test_query_pbt.py
+++ b/tests/unit/test_query_pbt.py
@@ -19,6 +19,7 @@ from hypothesis import strategies as st
 from pydantic import SecretStr
 
 from mixpanel_data import Workspace
+from mixpanel_data._internal.bookmark_builders import build_filter_entry
 from mixpanel_data._internal.bookmark_enums import (
     MATH_REQUIRING_PROPERTY,
     VALID_FILTER_OPERATORS,
@@ -121,7 +122,7 @@ class TestMetricParamsInvariant:
             from_date=None,
             to_date=None,
             last=last,
-            unit=unit,
+            unit=unit,  # type: ignore[arg-type]
             group_by=None,
             where=None,
             formulas=[],
@@ -346,9 +347,8 @@ class TestDateFilterInvariant:
         self, prop: str, quantity: int, unit: str
     ) -> None:
         """Relative date filters always emit filterDateUnit in bookmark."""
-        ws = _make_ws()
         f = Filter.in_the_last(prop, quantity, unit)  # type: ignore[arg-type]
-        entry = ws._build_filter_entry(f)
+        entry = build_filter_entry(f)
         assert entry["filterDateUnit"] == unit
         assert entry["filterValue"] == quantity
 
@@ -567,7 +567,7 @@ class TestFilterSerializationEnumConsistency:
     def test_equals_produces_valid_enums(self, prop: str, value: str) -> None:
         """Filter.equals serializes with valid operator, type, and resourceType."""
         f = Filter.equals(prop, value)
-        entry = Workspace._build_filter_entry(f)
+        entry = build_filter_entry(f)
         assert entry["filterOperator"] in VALID_FILTER_OPERATORS
         assert entry["filterType"] in VALID_PROPERTY_TYPES
         assert entry["resourceType"] in VALID_RESOURCE_TYPES
@@ -577,7 +577,7 @@ class TestFilterSerializationEnumConsistency:
         """Filter.greater_than and less_than serialize with valid enums."""
         for factory in [Filter.greater_than, Filter.less_than]:
             f = factory(prop, value)
-            entry = Workspace._build_filter_entry(f)
+            entry = build_filter_entry(f)
             assert entry["filterOperator"] in VALID_FILTER_OPERATORS
             assert entry["filterType"] in VALID_PROPERTY_TYPES
             assert entry["resourceType"] in VALID_RESOURCE_TYPES
@@ -592,7 +592,7 @@ class TestFilterSerializationEnumConsistency:
     ) -> None:
         """Filter.between serializes with valid operator enum."""
         f = Filter.between(prop, min_val, max_val)
-        entry = Workspace._build_filter_entry(f)
+        entry = build_filter_entry(f)
         assert entry["filterOperator"] in VALID_FILTER_OPERATORS
         assert entry["filterType"] in VALID_PROPERTY_TYPES
 
@@ -601,7 +601,7 @@ class TestFilterSerializationEnumConsistency:
         """Filter.is_set/is_not_set serialize with valid enums."""
         for factory in [Filter.is_set, Filter.is_not_set]:
             f = factory(prop)
-            entry = Workspace._build_filter_entry(f)
+            entry = build_filter_entry(f)
             assert entry["filterOperator"] in VALID_FILTER_OPERATORS
             assert entry["filterType"] in VALID_PROPERTY_TYPES
 
@@ -610,7 +610,7 @@ class TestFilterSerializationEnumConsistency:
         """Filter.is_true/is_false serialize with valid enums."""
         for factory in [Filter.is_true, Filter.is_false]:
             f = factory(prop)
-            entry = Workspace._build_filter_entry(f)
+            entry = build_filter_entry(f)
             assert entry["filterOperator"] in VALID_FILTER_OPERATORS
             assert entry["filterType"] in VALID_PROPERTY_TYPES
 

--- a/tests/unit/test_query_validation.py
+++ b/tests/unit/test_query_validation.py
@@ -4,6 +4,10 @@ Tests validation rules V7-V11 (time range) for US1,
 V1-V3 (aggregation) for US2, V13-V14 (per-Metric) for US2,
 V4 (formula) for US5, V5-V6 (analysis mode) for US6.
 
+Also tests reusable validation functions (US2 shared-infra):
+- ``validate_time_args()`` — V7-V10, V15, V20
+- ``validate_group_by_args()`` — V11-V12, V18, V24
+
 Validation is tested via Workspace.query() which raises
 BookmarkValidationError on invalid arguments.
 """
@@ -15,8 +19,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from mixpanel_data import Workspace
-from mixpanel_data._internal.validation import validate_query_args
+from mixpanel_data._internal.validation import (
+    validate_group_by_args,
+    validate_query_args,
+    validate_time_args,
+)
 from mixpanel_data.exceptions import BookmarkValidationError
+from mixpanel_data.types import GroupBy
 
 # =============================================================================
 # Fixtures
@@ -628,3 +637,186 @@ class TestHistogramValidation:
             per_user="total",
         )
         assert isinstance(result, dict)
+
+
+# =============================================================================
+# Reusable validate_time_args() (US2 shared-infra)
+# =============================================================================
+
+
+class TestValidateTimeArgs:
+    """Tests for the reusable validate_time_args() function.
+
+    Calls validate_time_args() directly (not through Workspace)
+    to verify time-related validation rules V7-V10, V15, V20.
+    """
+
+    def test_v7_last_zero(self) -> None:
+        """V7: last=0 returns error with code V7_LAST_POSITIVE."""
+        errors = validate_time_args(from_date=None, to_date=None, last=0)
+        assert len(errors) == 1
+        assert errors[0].code == "V7_LAST_POSITIVE"
+
+    def test_v7_last_negative(self) -> None:
+        """V7: last=-5 returns error with code V7_LAST_POSITIVE."""
+        errors = validate_time_args(from_date=None, to_date=None, last=-5)
+        assert len(errors) == 1
+        assert errors[0].code == "V7_LAST_POSITIVE"
+
+    def test_v8_from_date_bad_format(self) -> None:
+        """V8: from_date='01/01/2024' returns error with code V8_DATE_FORMAT."""
+        errors = validate_time_args(from_date="01/01/2024", to_date=None, last=30)
+        assert any(e.code == "V8_DATE_FORMAT" for e in errors)
+
+    def test_v8_to_date_bad_format(self) -> None:
+        """V8: to_date='Jan 31 2024' returns error with code V8_DATE_FORMAT."""
+        errors = validate_time_args(
+            from_date="2024-01-01", to_date="Jan 31 2024", last=30
+        )
+        assert any(e.code == "V8_DATE_FORMAT" for e in errors)
+
+    def test_v8_invalid_calendar_date(self) -> None:
+        """V8: from_date='2024-02-30' returns error with code V8_DATE_INVALID."""
+        errors = validate_time_args(from_date="2024-02-30", to_date=None, last=30)
+        assert any(e.code == "V8_DATE_INVALID" for e in errors)
+
+    def test_v9_to_date_without_from_date(self) -> None:
+        """V9: to_date without from_date returns error with code V9_TO_REQUIRES_FROM."""
+        errors = validate_time_args(from_date=None, to_date="2024-01-31", last=30)
+        assert any(e.code == "V9_TO_REQUIRES_FROM" for e in errors)
+
+    def test_v10_from_date_with_non_default_last(self) -> None:
+        """V10: from_date + last=7 (non-default) returns error V10_DATE_LAST_EXCLUSIVE."""
+        errors = validate_time_args(
+            from_date="2024-01-01", to_date="2024-01-31", last=7
+        )
+        assert any(e.code == "V10_DATE_LAST_EXCLUSIVE" for e in errors)
+
+    def test_v10_from_date_with_default_last_ok(self) -> None:
+        """V10: from_date + last=30 (default) produces NO error."""
+        errors = validate_time_args(
+            from_date="2024-01-01", to_date="2024-01-31", last=30
+        )
+        assert not any(e.code == "V10_DATE_LAST_EXCLUSIVE" for e in errors)
+
+    def test_v15_from_date_after_to_date(self) -> None:
+        """V15: from_date > to_date returns error with code V15_DATE_ORDER."""
+        errors = validate_time_args(
+            from_date="2024-02-01", to_date="2024-01-01", last=30
+        )
+        assert any(e.code == "V15_DATE_ORDER" for e in errors)
+
+    def test_v20_last_too_large(self) -> None:
+        """V20: last=5000 returns error with code V20_LAST_TOO_LARGE."""
+        errors = validate_time_args(from_date=None, to_date=None, last=5000)
+        assert any(e.code == "V20_LAST_TOO_LARGE" for e in errors)
+
+    def test_valid_date_range(self) -> None:
+        """Valid from_date+to_date with default last returns empty errors list."""
+        errors = validate_time_args(
+            from_date="2024-01-01", to_date="2024-01-31", last=30
+        )
+        assert errors == []
+
+    def test_valid_last_only(self) -> None:
+        """Valid: no dates, last=30 returns empty errors list."""
+        errors = validate_time_args(from_date=None, to_date=None, last=30)
+        assert errors == []
+
+
+# =============================================================================
+# Reusable validate_group_by_args() (US2 shared-infra)
+# =============================================================================
+
+
+class TestValidateGroupByArgs:
+    """Tests for the reusable validate_group_by_args() function.
+
+    Calls validate_group_by_args() directly (not through Workspace)
+    to verify group-by validation rules V11-V12, V18, V24.
+    """
+
+    def test_v11_bucket_min_without_bucket_size(self) -> None:
+        """V11: bucket_min without bucket_size returns V11_BUCKET_REQUIRES_SIZE."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", bucket_min=0),
+        )
+        assert any(e.code == "V11_BUCKET_REQUIRES_SIZE" for e in errors)
+
+    def test_v12_bucket_size_zero(self) -> None:
+        """V12: bucket_size=0 returns error with code V12_BUCKET_SIZE_POSITIVE."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", bucket_size=0),
+        )
+        assert any(e.code == "V12_BUCKET_SIZE_POSITIVE" for e in errors)
+
+    def test_v12_bucket_size_negative(self) -> None:
+        """V12: bucket_size=-5 returns error with code V12_BUCKET_SIZE_POSITIVE."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", bucket_size=-5),
+        )
+        assert any(e.code == "V12_BUCKET_SIZE_POSITIVE" for e in errors)
+
+    def test_v12b_bucket_size_wrong_property_type(self) -> None:
+        """V12B: bucket_size with property_type='string' returns V12B_BUCKET_REQUIRES_NUMBER."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", property_type="string", bucket_size=10),
+        )
+        assert any(e.code == "V12B_BUCKET_REQUIRES_NUMBER" for e in errors)
+
+    def test_v12c_bucket_size_without_bounds(self) -> None:
+        """V12C: bucket_size without bucket_min/bucket_max returns V12C_BUCKET_REQUIRES_BOUNDS."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", property_type="number", bucket_size=10),
+        )
+        assert any(e.code == "V12C_BUCKET_REQUIRES_BOUNDS" for e in errors)
+
+    def test_v18_bucket_min_gte_bucket_max(self) -> None:
+        """V18: bucket_min >= bucket_max returns error with code V18_BUCKET_ORDER."""
+        errors = validate_group_by_args(
+            group_by=GroupBy(
+                "amount",
+                property_type="number",
+                bucket_size=10,
+                bucket_min=100,
+                bucket_max=50,
+            ),
+        )
+        assert any(e.code == "V18_BUCKET_ORDER" for e in errors)
+
+    def test_v24_bucket_size_nan(self) -> None:
+        """V24: bucket_size=float('nan') returns V24_BUCKET_NOT_FINITE."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", bucket_size=float("nan")),
+        )
+        assert any(e.code == "V24_BUCKET_NOT_FINITE" for e in errors)
+
+    def test_v24_bucket_min_inf(self) -> None:
+        """V24: bucket_min=float('inf') returns V24_BUCKET_NOT_FINITE."""
+        errors = validate_group_by_args(
+            group_by=GroupBy("amount", bucket_min=float("inf")),
+        )
+        assert any(e.code == "V24_BUCKET_NOT_FINITE" for e in errors)
+
+    def test_valid_none_group_by(self) -> None:
+        """Valid: None group_by returns empty errors list."""
+        errors = validate_group_by_args(group_by=None)
+        assert errors == []
+
+    def test_valid_string_group_by(self) -> None:
+        """Valid: string group_by returns empty errors list."""
+        errors = validate_group_by_args(group_by="country")
+        assert errors == []
+
+    def test_valid_group_by_with_buckets(self) -> None:
+        """Valid: GroupBy with valid bucket config returns empty errors list."""
+        errors = validate_group_by_args(
+            group_by=GroupBy(
+                "revenue",
+                property_type="number",
+                bucket_size=50,
+                bucket_min=0,
+                bucket_max=500,
+            ),
+        )
+        assert errors == []

--- a/tests/unit/test_query_validation_pbt.py
+++ b/tests/unit/test_query_validation_pbt.py
@@ -1,10 +1,9 @@
-"""Property-based tests for validation equivalence after refactoring.
+"""Property-based tests for query-validator delegation and aggregation.
 
-Verifies that ``validate_query_args()`` produces identical error output
-after extracting ``validate_time_args()`` and ``validate_group_by_args()``
-into standalone functions. The extracted functions are tested as oracles:
-their combined output must match the corresponding subset of errors from
-the monolithic ``validate_query_args()``.
+Verifies that ``validate_query_args()`` includes the same time- and
+group-by-related validation errors produced by ``validate_time_args()``
+and ``validate_group_by_args()`` for the same inputs. These checks
+validate wiring between the composed validator and the extracted helpers.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_query_validation_pbt.py
+++ b/tests/unit/test_query_validation_pbt.py
@@ -1,0 +1,228 @@
+"""Property-based tests for validation equivalence after refactoring.
+
+Verifies that ``validate_query_args()`` produces identical error output
+after extracting ``validate_time_args()`` and ``validate_group_by_args()``
+into standalone functions. The extracted functions are tested as oracles:
+their combined output must match the corresponding subset of errors from
+the monolithic ``validate_query_args()``.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mixpanel_data._internal.validation import (
+    validate_group_by_args,
+    validate_query_args,
+    validate_time_args,
+)
+from mixpanel_data.types import GroupBy
+
+# =============================================================================
+# Strategies
+# =============================================================================
+
+# Dates: mix of valid, invalid-format, and edge-case strings
+valid_dates = st.from_regex(
+    r"20[2-3][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])", fullmatch=True
+)
+invalid_dates = st.sampled_from(
+    [
+        "01/01/2024",
+        "Jan 15 2025",
+        "2024-13-01",
+        "2024-02-30",
+        "not-a-date",
+        "",
+        "2024/01/01",
+    ]
+)
+maybe_dates = st.one_of(valid_dates, invalid_dates, st.none())
+last_values = st.integers(min_value=-100, max_value=5000)
+
+# GroupBy strategies
+property_names = st.text(
+    min_size=1, max_size=30, alphabet=st.characters(categories=("L", "N"))
+)
+property_types: st.SearchStrategy[str] = st.sampled_from(
+    ["string", "number", "boolean", "datetime"]
+)
+bucket_sizes = st.one_of(
+    st.none(),
+    st.floats(min_value=-10, max_value=100),
+    st.just(float("nan")),
+    st.just(float("inf")),
+)
+bucket_bounds = st.one_of(
+    st.none(),
+    st.floats(min_value=-1000, max_value=1000),
+    st.just(float("nan")),
+    st.just(float("inf")),
+)
+
+# Time-related error codes that validate_time_args handles
+TIME_ERROR_CODES = frozenset(
+    {
+        "V7_LAST_POSITIVE",
+        "V8_DATE_FORMAT",
+        "V8_DATE_INVALID",
+        "V9_TO_REQUIRES_FROM",
+        "V10_DATE_LAST_EXCLUSIVE",
+        "V15_DATE_ORDER",
+        "V20_LAST_TOO_LARGE",
+    }
+)
+
+# GroupBy-related error codes that validate_group_by_args handles
+GROUP_ERROR_CODES = frozenset(
+    {
+        "V11_BUCKET_REQUIRES_SIZE",
+        "V12_BUCKET_SIZE_POSITIVE",
+        "V12B_BUCKET_REQUIRES_NUMBER",
+        "V12C_BUCKET_REQUIRES_BOUNDS",
+        "V18_BUCKET_ORDER",
+        "V24_BUCKET_NOT_FINITE",
+    }
+)
+
+
+# =============================================================================
+# Time Validation Equivalence
+# =============================================================================
+
+
+class TestTimeValidationEquivalence:
+    """Verify validate_time_args() produces same errors as validate_query_args()."""
+
+    @given(
+        from_date=maybe_dates,
+        to_date=maybe_dates,
+        last=last_values,
+    )
+    @settings(max_examples=100)
+    def test_time_errors_match(
+        self,
+        from_date: str | None,
+        to_date: str | None,
+        last: int,
+    ) -> None:
+        """Time error codes from standalone function match monolithic function.
+
+        Args:
+            from_date: Start date (may be invalid).
+            to_date: End date (may be invalid).
+            last: Days for relative range (may be invalid).
+        """
+        # Get errors from standalone function
+        standalone_errors = validate_time_args(
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+        )
+        standalone_codes = {e.code for e in standalone_errors}
+
+        # Get errors from monolithic function (only time-related)
+        monolithic_errors = validate_query_args(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            has_formula=False,
+            rolling=None,
+            cumulative=False,
+            group_by=None,
+        )
+        monolithic_time_codes = {
+            e.code for e in monolithic_errors if e.code in TIME_ERROR_CODES
+        }
+
+        assert standalone_codes == monolithic_time_codes, (
+            f"Mismatch for from_date={from_date!r}, to_date={to_date!r}, "
+            f"last={last}: standalone={standalone_codes}, "
+            f"monolithic={monolithic_time_codes}"
+        )
+
+
+# =============================================================================
+# GroupBy Validation Equivalence
+# =============================================================================
+
+
+class TestGroupByValidationEquivalence:
+    """Verify validate_group_by_args() produces same errors as validate_query_args()."""
+
+    @given(
+        prop=property_names,
+        prop_type=property_types,
+        bucket_size=bucket_sizes,
+        bucket_min=bucket_bounds,
+        bucket_max=bucket_bounds,
+    )
+    @settings(max_examples=100)
+    def test_groupby_errors_match(
+        self,
+        prop: str,
+        prop_type: str,
+        bucket_size: float | None,
+        bucket_min: float | None,
+        bucket_max: float | None,
+    ) -> None:
+        """GroupBy error codes from standalone function match monolithic function.
+
+        Args:
+            prop: Property name.
+            prop_type: Property type.
+            bucket_size: Bucket size (may be invalid).
+            bucket_min: Bucket minimum (may be invalid).
+            bucket_max: Bucket maximum (may be invalid).
+        """
+        g = GroupBy(
+            prop,
+            property_type=prop_type,  # type: ignore[arg-type]
+            bucket_size=bucket_size,
+            bucket_min=bucket_min,
+            bucket_max=bucket_max,
+        )
+
+        # Get errors from standalone function
+        standalone_errors = validate_group_by_args(group_by=g)
+        standalone_codes = {e.code for e in standalone_errors}
+
+        # Get errors from monolithic function (only groupby-related)
+        monolithic_errors = validate_query_args(
+            events=["TestEvent"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            has_formula=False,
+            rolling=None,
+            cumulative=False,
+            group_by=g,
+        )
+        monolithic_group_codes = {
+            e.code for e in monolithic_errors if e.code in GROUP_ERROR_CODES
+        }
+
+        assert standalone_codes == monolithic_group_codes, (
+            f"Mismatch for GroupBy({prop!r}, type={prop_type!r}, "
+            f"size={bucket_size}, min={bucket_min}, max={bucket_max}): "
+            f"standalone={standalone_codes}, "
+            f"monolithic={monolithic_group_codes}"
+        )
+
+    def test_none_groupby_no_errors(self) -> None:
+        """None group_by produces no errors from standalone function."""
+        errors = validate_group_by_args(group_by=None)
+        assert errors == []
+
+    def test_string_groupby_no_errors(self) -> None:
+        """String group_by produces no errors from standalone function."""
+        errors = validate_group_by_args(group_by="country")
+        assert errors == []

--- a/tests/unit/test_segfilter.py
+++ b/tests/unit/test_segfilter.py
@@ -11,7 +11,6 @@ import pytest
 from mixpanel_data._internal.segfilter import (
     RESOURCE_TYPE_MAP,
     _convert_date_format,
-    _pluralize_unit,
     build_segfilter_entry,
 )
 from mixpanel_data.types import Filter
@@ -477,30 +476,6 @@ class TestConvertDateFormat:
     def test_december(self) -> None:
         """December date converts correctly."""
         assert _convert_date_format("2025-12-31") == "12/31/2025"
-
-
-class TestPluralizeUnit:
-    """Tests for _pluralize_unit helper."""
-
-    def test_day(self) -> None:
-        """'day' pluralizes to 'days'."""
-        assert _pluralize_unit("day") == "days"
-
-    def test_hour(self) -> None:
-        """'hour' pluralizes to 'hours'."""
-        assert _pluralize_unit("hour") == "hours"
-
-    def test_week(self) -> None:
-        """'week' pluralizes to 'weeks'."""
-        assert _pluralize_unit("week") == "weeks"
-
-    def test_month(self) -> None:
-        """'month' pluralizes to 'months'."""
-        assert _pluralize_unit("month") == "months"
-
-    def test_minute(self) -> None:
-        """'minute' pluralizes to 'minutes'."""
-        assert _pluralize_unit("minute") == "minutes"
 
 
 # =============================================================================

--- a/tests/unit/test_segfilter.py
+++ b/tests/unit/test_segfilter.py
@@ -1,0 +1,560 @@
+"""Unit tests for Filter-to-segfilter conversion.
+
+Tests the ``build_segfilter_entry`` function which converts ``Filter``
+objects into the legacy segfilter dict format used by flows step filters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mixpanel_data._internal.segfilter import (
+    RESOURCE_TYPE_MAP,
+    _convert_date_format,
+    _pluralize_unit,
+    build_segfilter_entry,
+)
+from mixpanel_data.types import Filter
+
+# =============================================================================
+# String Operators
+# =============================================================================
+
+
+class TestSegfilterStringOperators:
+    """Conversion of string-typed Filter operators to segfilter format."""
+
+    def test_equals(self) -> None:
+        """Filter.equals produces operator '==' with list operand."""
+        f = Filter.equals("country", "US")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "=="
+        assert result["filter"]["operand"] == ["US"]
+
+    def test_equals_multi_value(self) -> None:
+        """Filter.equals with a list produces operator '==' with list operand."""
+        f = Filter.equals("country", ["US", "UK"])
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "=="
+        assert result["filter"]["operand"] == ["US", "UK"]
+
+    def test_not_equals(self) -> None:
+        """Filter.not_equals produces operator '!=' with list operand."""
+        f = Filter.not_equals("country", "US")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "!="
+        assert result["filter"]["operand"] == ["US"]
+
+    def test_contains(self) -> None:
+        """Filter.contains produces operator 'in' with string operand."""
+        f = Filter.contains("name", "john")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "in"
+        assert result["filter"]["operand"] == "john"
+
+    def test_not_contains(self) -> None:
+        """Filter.not_contains produces operator 'not in' with string operand."""
+        f = Filter.not_contains("name", "john")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "not in"
+        assert result["filter"]["operand"] == "john"
+
+    def test_is_set(self) -> None:
+        """Filter.is_set produces operator 'set' with empty string operand."""
+        f = Filter.is_set("email")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "set"
+        assert result["filter"]["operand"] == ""
+
+    def test_is_not_set(self) -> None:
+        """Filter.is_not_set produces operator 'not set' with empty string operand."""
+        f = Filter.is_not_set("email")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "not set"
+        assert result["filter"]["operand"] == ""
+
+
+# =============================================================================
+# Number Operators
+# =============================================================================
+
+
+class TestSegfilterNumberOperators:
+    """Conversion of number-typed Filter operators to segfilter format."""
+
+    def test_greater_than(self) -> None:
+        """Filter.greater_than produces operator '>' with stringified operand."""
+        f = Filter.greater_than("amount", 50)
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == ">"
+        assert result["filter"]["operand"] == "50"
+
+    def test_less_than(self) -> None:
+        """Filter.less_than produces operator '<' with stringified operand."""
+        f = Filter.less_than("amount", 50)
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "<"
+        assert result["filter"]["operand"] == "50"
+
+    def test_operand_stringified_int(self) -> None:
+        """Numeric integer values are stringified in segfilter output."""
+        f = Filter.greater_than("count", 100)
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operand"] == "100"
+        assert isinstance(result["filter"]["operand"], str)
+
+    def test_operand_stringified_float(self) -> None:
+        """Numeric float values are stringified in segfilter output."""
+        f = Filter.greater_than("price", 9.99)
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operand"] == "9.99"
+        assert isinstance(result["filter"]["operand"], str)
+
+    def test_between(self) -> None:
+        """Filter.between produces operator '><' with stringified list operand."""
+        f = Filter.between("amount", 10, 100)
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "><"
+        assert result["filter"]["operand"] == ["10", "100"]
+
+    def test_number_is_set(self) -> None:
+        """Number is_set uses 'is set' operator with empty string operand.
+
+        Note: Filter.is_set always creates a string-typed filter, so this
+        test constructs a number-typed filter directly to verify the number
+        operator mapping handles is_set correctly.
+        """
+        f = Filter(
+            _property="score",
+            _operator="is set",
+            _value=None,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "is set"
+        assert result["filter"]["operand"] == ""
+
+    def test_number_is_not_set(self) -> None:
+        """Number is_not_set uses 'is not set' operator with empty string operand."""
+        f = Filter(
+            _property="score",
+            _operator="is not set",
+            _value=None,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "is not set"
+        assert result["filter"]["operand"] == ""
+
+    def test_equals_number(self) -> None:
+        """Number 'equals' maps to '==' with stringified operand."""
+        f = Filter(
+            _property="count",
+            _operator="equals",
+            _value=42,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "=="
+        assert result["filter"]["operand"] == "42"
+
+    def test_is_equal_to_number(self) -> None:
+        """Number 'is equal to' maps to '==' with stringified operand."""
+        f = Filter(
+            _property="count",
+            _operator="is equal to",
+            _value=42,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "=="
+        assert result["filter"]["operand"] == "42"
+
+    def test_not_equals_number(self) -> None:
+        """Number 'does not equal' maps to '!=' with stringified operand."""
+        f = Filter(
+            _property="count",
+            _operator="does not equal",
+            _value=7,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "!="
+        assert result["filter"]["operand"] == "7"
+
+    def test_is_at_least(self) -> None:
+        """Number 'is at least' maps to '>=' with stringified operand."""
+        f = Filter(
+            _property="count",
+            _operator="is at least",
+            _value=5,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == ">="
+        assert result["filter"]["operand"] == "5"
+
+    def test_is_at_most(self) -> None:
+        """Number 'is at most' maps to '<=' with stringified operand."""
+        f = Filter(
+            _property="count",
+            _operator="is at most",
+            _value=10,
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "<="
+        assert result["filter"]["operand"] == "10"
+
+    def test_not_between(self) -> None:
+        """Number 'not between' maps to '!><' with stringified list operand."""
+        f = Filter(
+            _property="amount",
+            _operator="not between",
+            _value=[10, 100],  # type: ignore[arg-type]  # testing runtime int list
+            _property_type="number",
+            _resource_type="events",
+        )
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "!><"
+        assert result["filter"]["operand"] == ["10", "100"]
+
+
+# =============================================================================
+# Boolean Operators
+# =============================================================================
+
+
+class TestSegfilterBooleanOperators:
+    """Conversion of boolean-typed Filter operators to segfilter format."""
+
+    def test_is_true(self) -> None:
+        """Filter.is_true produces operand 'true' with NO 'operator' key."""
+        f = Filter.is_true("verified")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operand"] == "true"
+        assert "operator" not in result["filter"]
+
+    def test_is_false(self) -> None:
+        """Filter.is_false produces operand 'false' with NO 'operator' key."""
+        f = Filter.is_false("verified")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operand"] == "false"
+        assert "operator" not in result["filter"]
+
+
+# =============================================================================
+# Datetime Operators
+# =============================================================================
+
+
+class TestSegfilterDatetimeOperators:
+    """Conversion of datetime-typed Filter operators to segfilter format."""
+
+    def test_on(self) -> None:
+        """Filter.on produces operator '==' with MM/DD/YYYY operand."""
+        f = Filter.on("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "=="
+        assert result["filter"]["operand"] == "01/15/2026"
+
+    def test_not_on(self) -> None:
+        """Filter.not_on produces operator '!=' with MM/DD/YYYY operand."""
+        f = Filter.not_on("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "!="
+        assert result["filter"]["operand"] == "01/15/2026"
+
+    def test_before(self) -> None:
+        """Filter.before produces operator '>' with MM/DD/YYYY operand."""
+        f = Filter.before("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == ">"
+        assert result["filter"]["operand"] == "01/15/2026"
+
+    def test_since(self) -> None:
+        """Filter.since produces operator '<' with MM/DD/YYYY operand."""
+        f = Filter.since("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "<"
+        assert result["filter"]["operand"] == "01/15/2026"
+
+    def test_in_the_last(self) -> None:
+        """Filter.in_the_last produces operator '>' with quantity and unit."""
+        f = Filter.in_the_last("$time", 7, "day")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == ">"
+        assert result["filter"]["operand"] == 7
+        assert result["filter"]["unit"] == "days"
+
+    def test_not_in_the_last(self) -> None:
+        """Filter.not_in_the_last produces operator '>' with quantity and unit."""
+        f = Filter.not_in_the_last("$time", 3, "week")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == ">"
+        assert result["filter"]["operand"] == 3
+        assert result["filter"]["unit"] == "weeks"
+
+    def test_date_between(self) -> None:
+        """Filter.date_between produces operator '><' with MM/DD/YYYY list."""
+        f = Filter.date_between("$time", "2026-01-01", "2026-01-31")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operator"] == "><"
+        assert result["filter"]["operand"] == ["01/01/2026", "01/31/2026"]
+
+    def test_date_format_conversion(self) -> None:
+        """YYYY-MM-DD dates are converted to MM/DD/YYYY in output."""
+        f = Filter.on("$time", "2026-03-05")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["operand"] == "03/05/2026"
+
+    def test_no_unit_for_absolute_dates(self) -> None:
+        """Absolute date filters do NOT have a 'unit' key in filter dict."""
+        f = Filter.on("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert "unit" not in result["filter"]
+
+    def test_in_the_last_hour_unit(self) -> None:
+        """Relative date with hour unit pluralizes to 'hours'."""
+        f = Filter.in_the_last("$time", 24, "hour")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["unit"] == "hours"
+
+    def test_in_the_last_month_unit(self) -> None:
+        """Relative date with month unit pluralizes to 'months'."""
+        f = Filter.in_the_last("$time", 3, "month")
+        result = build_segfilter_entry(f)
+
+        assert result["filter"]["unit"] == "months"
+
+
+# =============================================================================
+# Resource Type Mapping
+# =============================================================================
+
+
+class TestSegfilterResourceTypeMapping:
+    """Mapping of Filter._resource_type to segfilter property.source."""
+
+    def test_events_maps_to_properties(self) -> None:
+        """resource_type 'events' maps to property.source 'properties'."""
+        f = Filter.equals("country", "US", resource_type="events")
+        result = build_segfilter_entry(f)
+
+        assert result["property"]["source"] == "properties"
+
+    def test_people_maps_to_user(self) -> None:
+        """resource_type 'people' maps to property.source 'user'."""
+        f = Filter.equals("plan", "premium", resource_type="people")
+        result = build_segfilter_entry(f)
+
+        assert result["property"]["source"] == "user"
+
+    def test_resource_type_map_constant(self) -> None:
+        """RESOURCE_TYPE_MAP contains expected entries."""
+        assert RESOURCE_TYPE_MAP["events"] == "properties"
+        assert RESOURCE_TYPE_MAP["people"] == "user"
+
+
+# =============================================================================
+# Output Structure
+# =============================================================================
+
+
+class TestSegfilterStructure:
+    """Structural validation of segfilter output dicts."""
+
+    def test_top_level_keys(self) -> None:
+        """Output dict has 'property', 'type', 'selected_property_type', 'filter'."""
+        f = Filter.equals("country", "US")
+        result = build_segfilter_entry(f)
+
+        assert "property" in result
+        assert "type" in result
+        assert "selected_property_type" in result
+        assert "filter" in result
+
+    def test_property_structure(self) -> None:
+        """property dict contains 'name', 'source', 'type'."""
+        f = Filter.equals("country", "US")
+        result = build_segfilter_entry(f)
+
+        prop = result["property"]
+        assert prop["name"] == "country"
+        assert prop["source"] == "properties"
+        assert prop["type"] == "string"
+
+    def test_type_consistency(self) -> None:
+        """type, selected_property_type, and property.type are all the same."""
+        f = Filter.greater_than("amount", 50)
+        result = build_segfilter_entry(f)
+
+        assert result["type"] == "number"
+        assert result["selected_property_type"] == "number"
+        assert result["property"]["type"] == "number"
+
+    def test_boolean_type_consistency(self) -> None:
+        """Boolean filters have 'boolean' in all type fields."""
+        f = Filter.is_true("verified")
+        result = build_segfilter_entry(f)
+
+        assert result["type"] == "boolean"
+        assert result["selected_property_type"] == "boolean"
+        assert result["property"]["type"] == "boolean"
+
+    def test_datetime_type_consistency(self) -> None:
+        """Datetime filters have 'datetime' in all type fields."""
+        f = Filter.on("$time", "2026-01-15")
+        result = build_segfilter_entry(f)
+
+        assert result["type"] == "datetime"
+        assert result["selected_property_type"] == "datetime"
+        assert result["property"]["type"] == "datetime"
+
+    def test_property_name_preserved(self) -> None:
+        """The property name from the Filter is used as-is."""
+        f = Filter.equals("$browser", "Chrome")
+        result = build_segfilter_entry(f)
+
+        assert result["property"]["name"] == "$browser"
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+class TestConvertDateFormat:
+    """Tests for _convert_date_format helper."""
+
+    def test_standard_conversion(self) -> None:
+        """YYYY-MM-DD converts to MM/DD/YYYY."""
+        assert _convert_date_format("2026-01-15") == "01/15/2026"
+
+    def test_leading_zeros_preserved(self) -> None:
+        """Month and day leading zeros are preserved."""
+        assert _convert_date_format("2026-03-05") == "03/05/2026"
+
+    def test_december(self) -> None:
+        """December date converts correctly."""
+        assert _convert_date_format("2025-12-31") == "12/31/2025"
+
+
+class TestPluralizeUnit:
+    """Tests for _pluralize_unit helper."""
+
+    def test_day(self) -> None:
+        """'day' pluralizes to 'days'."""
+        assert _pluralize_unit("day") == "days"
+
+    def test_hour(self) -> None:
+        """'hour' pluralizes to 'hours'."""
+        assert _pluralize_unit("hour") == "hours"
+
+    def test_week(self) -> None:
+        """'week' pluralizes to 'weeks'."""
+        assert _pluralize_unit("week") == "weeks"
+
+    def test_month(self) -> None:
+        """'month' pluralizes to 'months'."""
+        assert _pluralize_unit("month") == "months"
+
+    def test_minute(self) -> None:
+        """'minute' pluralizes to 'minutes'."""
+        assert _pluralize_unit("minute") == "minutes"
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestSegfilterEdgeCases:
+    """Edge-case coverage for segfilter conversion."""
+
+    def test_unknown_operator_raises(self) -> None:
+        """Unknown operator for a property type raises ValueError."""
+        f = Filter(
+            _property="x",
+            _operator="magical_unicorn",
+            _value="y",
+            _property_type="string",
+            _resource_type="events",
+        )
+        with pytest.raises(ValueError, match="Unknown string operator"):
+            build_segfilter_entry(f)
+
+    def test_unknown_number_operator_raises(self) -> None:
+        """Unknown number operator raises ValueError."""
+        f = Filter(
+            _property="x",
+            _operator="magical_unicorn",
+            _value=1,
+            _property_type="number",
+            _resource_type="events",
+        )
+        with pytest.raises(ValueError, match="Unknown number operator"):
+            build_segfilter_entry(f)
+
+    def test_unknown_datetime_operator_raises(self) -> None:
+        """Unknown datetime operator raises ValueError."""
+        f = Filter(
+            _property="x",
+            _operator="magical_unicorn",
+            _value="2026-01-01",
+            _property_type="datetime",
+            _resource_type="events",
+        )
+        with pytest.raises(ValueError, match="Unknown datetime operator"):
+            build_segfilter_entry(f)
+
+    def test_unknown_property_type_raises(self) -> None:
+        """Unknown property type raises ValueError."""
+        f = Filter(
+            _property="x",
+            _operator="equals",
+            _value="y",
+            _property_type="list",
+            _resource_type="events",
+        )
+        with pytest.raises(ValueError, match="Unsupported property type"):
+            build_segfilter_entry(f)


### PR DESCRIPTION
## Summary

- **Bookmark builders**: Extract `build_time_section()`, `build_date_range()`, `build_filter_section()`, `build_group_section()`, and `build_filter_entry()` from `Workspace._build_query_params()` into reusable `bookmark_builders.py` module
- **Segfilter converter**: New `segfilter.py` module converting `Filter` objects to legacy segfilter format for flows step filters, with complete operator mapping across string, number, boolean, and datetime types
- **Validation extraction**: Extract `validate_time_args()` (V7-V10, V15, V20) and `validate_group_by_args()` (V11-V12, V18, V24) from monolithic `validate_query_args()` for reuse by funnel/retention/flows validators
- **Enum constants**: Add 6 new frozensets (`VALID_FUNNEL_ORDER`, `VALID_CONVERSION_WINDOW_UNITS`, `VALID_RETENTION_UNITS`, `VALID_RETENTION_ALIGNMENT`, `VALID_FLOWS_COUNT_TYPES`, `VALID_FLOWS_CHART_TYPES`) and extend `VALID_MATH_FUNNELS` with property aggregation types

## Test plan

- [x] 130 new tests added (3248 total, up from 3118 baseline)
- [x] PBT oracle tests confirm builder equivalence across randomized inputs
- [x] PBT equivalence tests confirm validator refactoring produces identical error codes
- [x] 99-100% code coverage on new modules (`bookmark_builders.py`, `segfilter.py`)
- [x] `just check` passes (ruff lint, ruff format, mypy --strict, all tests)
- [x] Zero regressions — all 3118 existing tests pass without modification