### PR TITLE
feat(query): add typed retention query API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ Task(subagent_type="mixpanel-data:narrator", prompt="...")
 - Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames) (029-insights-query-api)
 - N/A — live query only, no local persistence (029-insights-query-api)
 - Python 3.10+ (mypy --strict) + httpx (HTTP), Pydantic v2 (validation), pandas (DataFrames) (031-shared-infra-extraction)
+- Python 3.10+ (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames) (033-retention-query)
 
 ## Recent Changes
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A complete programmable interface to Mixpanel analytics—Python library and CLI
 
 Mixpanel's web UI is powerful for interactive exploration, but programmatic access requires navigating multiple REST endpoints with different conventions. **mixpanel_data** provides a unified interface: discover your schema, run analytics queries, stream data, and manage entities—all through consistent Python methods or CLI commands.
 
-Core analytics—typed Insights engine queries (DAU/WAU/MAU, formulas, filters, breakdowns), typed funnel queries (ad-hoc steps, exclusions, conversion windows), segmentation, retention, saved reports—plus entity management (dashboards, reports, cohorts, feature flags, experiments), raw JQL execution, and streaming data extraction.
+Core analytics—typed Insights engine queries (DAU/WAU/MAU, formulas, filters, breakdowns), typed funnel queries (ad-hoc steps, exclusions, conversion windows), typed retention queries (event pairs, custom buckets, alignment modes), segmentation, saved reports—plus entity management (dashboards, reports, cohorts, feature flags, experiments), raw JQL execution, and streaming data extraction.
 
 ## Installation
 
@@ -99,7 +99,7 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 ```python
 import mixpanel_data as mp
-from mixpanel_data import Metric, Filter, Formula, GroupBy
+from mixpanel_data import Metric, Filter, Formula, GroupBy, RetentionEvent
 
 ws = mp.Workspace()
 
@@ -133,6 +133,15 @@ funnel = ws.query_funnel(
     last=90,
 )
 print(funnel.overall_conversion_rate)  # e.g. 0.12
+
+# Typed retention query — cohort retention with event pairs
+retention = ws.query_retention(
+    "Signup",
+    "Login",
+    retention_unit="week",
+    last=90,
+)
+print(retention.df.head())  # cohort_date | bucket | count | rate
 
 # Legacy live analytics queries
 result = ws.segmentation(
@@ -252,6 +261,7 @@ Full documentation: [jaredmcfarland.github.io/mixpanel_data](https://jaredmcfarl
 - [Quick Start](https://jaredmcfarland.github.io/mixpanel_data/getting-started/quickstart/)
 - [Insights Queries](https://jaredmcfarland.github.io/mixpanel_data/guide/query/) — Typed analytics with DAU, formulas, filters, breakdowns
 - [Funnel Queries](https://jaredmcfarland.github.io/mixpanel_data/guide/query-funnels/) — Typed funnel conversion analysis with steps, exclusions, conversion windows
+- [Retention Queries](https://jaredmcfarland.github.io/mixpanel_data/guide/query-retention/) — Typed retention analysis with event pairs, custom buckets, alignment modes
 - [CLI Reference](https://jaredmcfarland.github.io/mixpanel_data/cli/)
 - [Python API](https://jaredmcfarland.github.io/mixpanel_data/api/)
 - [Streaming Guide](https://jaredmcfarland.github.io/mixpanel_data/guide/streaming/)
@@ -265,7 +275,7 @@ The entire surface area is self-documenting. Every CLI command supports `--help`
 
 Key design features:
 
-- **Typed Insights Queries**: `query()` generates Mixpanel Insights bookmark params from typed Python arguments — DAU/WAU/MAU, formulas, filters, breakdowns, rolling windows, percentiles, and more
+- **Typed Insights Queries**: `query()`, `query_funnel()`, and `query_retention()` generate Mixpanel Insights bookmark params from typed Python arguments — DAU/WAU/MAU, formulas, funnel steps, retention event pairs, filters, breakdowns, and more
 - **Entity CRUD & Data Governance**: Full lifecycle management of dashboards, reports, cohorts, feature flags, experiments, alerts, annotations, webhooks, plus Lexicon definitions, drop filters, custom properties, custom events, and lookup tables via Mixpanel App API
 - **Discoverable schema**: `events()`, `properties()`, `funnels()`, `cohorts()`, `bookmarks()` reveal what's in your project before you query
 - **Consistent interfaces**: Same operations available as Python methods and CLI commands

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -108,7 +108,7 @@ Typed results for all operations:
 - **QueryResult** — Insights query results (from `query()`)
 - **Metric**, **Filter**, **Formula**, **GroupBy** — Query building blocks
 - **FunnelQueryResult**, **FunnelStep**, **Exclusion** — Typed funnel results
-- **RetentionQueryResult**, **RetentionEvent** — Typed retention results
+- **RetentionQueryResult**, **RetentionEvent**, **RetentionAlignment**, **RetentionMode**, **RetentionMathType** — Typed retention results
 - **SegmentationResult** — Time-series data (legacy)
 - **FunnelResult** — Funnel conversion data (legacy)
 - **RetentionResult** — Retention cohort data (legacy)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,6 +25,9 @@ from mixpanel_data import (
     MathType, PerUserAggregation, FilterPropertyType,
 )
 
+# Retention Query types
+from mixpanel_data import RetentionEvent, RetentionQueryResult
+
 # Auth utilities
 from mixpanel_data.auth import ConfigManager, Credentials, AuthMethod
 
@@ -65,6 +68,8 @@ The main entry point for all operations:
 
 - **Discovery** — Explore events, properties, funnels, cohorts
 - **Insights Queries** — Typed analytics queries using the Insights engine (`query()`)
+- **Funnel Queries** — Typed funnel conversion analysis (`query_funnel()`)
+- **Retention Queries** — Typed retention analysis with event pairs (`query_retention()`)
 - **Live Queries** — Legacy analytics endpoints (segmentation, funnels, retention, JQL)
 - **Streaming** — Stream events and profiles directly from Mixpanel (ETL, pipelines)
 - **Entity CRUD & Data Governance** — Create, read, update, delete dashboards, reports, cohorts, feature flags, experiments, plus Lexicon definitions, drop filters, custom properties, custom events, lookup tables, schema registry, schema enforcement, data auditing, volume anomalies, and event deletion requests
@@ -102,9 +107,11 @@ Typed results for all operations:
 
 - **QueryResult** — Insights query results (from `query()`)
 - **Metric**, **Filter**, **Formula**, **GroupBy** — Query building blocks
+- **FunnelQueryResult**, **FunnelStep**, **Exclusion** — Typed funnel results
+- **RetentionQueryResult**, **RetentionEvent** — Typed retention results
 - **SegmentationResult** — Time-series data (legacy)
-- **FunnelResult** — Funnel conversion data
-- **RetentionResult** — Retention cohort data
+- **FunnelResult** — Funnel conversion data (legacy)
+- **RetentionResult** — Retention cohort data (legacy)
 - **Dashboard**, **Bookmark**, **Cohort** — Entity models for CRUD operations
 - **EventDefinition**, **DropFilter**, **CustomProperty**, **LookupTable** — Data governance models
 - **SchemaEntry**, **SchemaEnforcementConfig**, **AuditResponse**, **DataVolumeAnomaly**, **EventDeletionRequest** — Schema governance models

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -92,6 +92,21 @@ Types for `Workspace.query_retention()` — typed retention analysis with event 
       show_root_heading: true
       show_root_toc_entry: true
 
+::: mixpanel_data.RetentionAlignment
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.RetentionMode
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.RetentionMathType
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ::: mixpanel_data.RetentionQueryResult
     options:
       show_root_heading: true

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -83,6 +83,20 @@ Types for `Workspace.query_funnel()` — typed funnel conversion analysis with s
       show_root_heading: true
       show_root_toc_entry: true
 
+## Retention Query Types
+
+Types for `Workspace.query_retention()` — typed retention analysis with event pairs, custom buckets, alignment modes, and segmentation.
+
+::: mixpanel_data.RetentionEvent
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.RetentionQueryResult
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Legacy Query Results
 
 ::: mixpanel_data.SegmentationResult

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -145,6 +145,8 @@ See the [Data Governance guide](../guide/data-governance.md) for complete covera
         - query
         - query_funnel
         - build_funnel_params
+        - query_retention
+        - build_retention_params
         - segmentation
         - funnel
         - retention

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -242,6 +242,31 @@ print(result.df)
 
 See the [Funnel Queries guide](../guide/query-funnels.md) for full coverage.
 
+### Retention Queries
+
+Measure cohort retention with typed event pairs — no saved report required:
+
+```python
+from mixpanel_data import RetentionEvent, Filter
+
+# Simple retention: do signups come back?
+result = ws.query_retention("Signup", "Login", retention_unit="week", last=90)
+print(result.df.head())
+#   cohort_date  bucket  count      rate
+# 0  2025-01-01       0   1000  1.000000
+# 1  2025-01-01       1    800  0.800000
+
+# With per-event filters and custom buckets
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    "Login",
+    retention_unit="day",
+    bucket_sizes=[1, 3, 7, 14, 30],
+)
+```
+
+See the [Retention Queries guide](../guide/query-retention.md) for full coverage.
+
 ### Legacy Query Methods
 
 For segmentation, funnels, and retention via the older Query API:
@@ -347,6 +372,7 @@ For ETL pipelines or data processing, stream data directly:
 - [Configuration](configuration.md) — Multiple accounts and advanced settings
 - [Insights Queries](../guide/query.md) — Typed analytics with DAU, formulas, filters, and breakdowns
 - [Funnel Queries](../guide/query-funnels.md) — Typed funnel conversion analysis
+- [Retention Queries](../guide/query-retention.md) — Typed retention analysis with event pairs and custom buckets
 - [Live Analytics](../guide/live-analytics.md) — Segmentation, funnels, retention
 - [Entity Management](../guide/entity-management.md) — Manage dashboards, reports, cohorts, feature flags, and experiments
 - [Data Governance](../guide/data-governance.md) — Manage Lexicon definitions, drop filters, custom properties, and lookup tables

--- a/docs/guide/live-analytics.md
+++ b/docs/guide/live-analytics.md
@@ -161,6 +161,9 @@ step.avg_time          # timedelta or None
 
 ## Retention
 
+!!! tip "Looking for Typed Retention Queries?"
+    For per-event filters, custom retention buckets, alignment modes, display modes, typed breakdowns, and persistable results — without expression-string filters — see **[Retention Queries](query-retention.md)**.
+
 Cohort-based retention analysis:
 
 === "Python"

--- a/docs/guide/query-funnels.md
+++ b/docs/guide/query-funnels.md
@@ -648,6 +648,7 @@ ws.create_bookmark(CreateBookmarkParams(
 ## Next Steps
 
 - [Insights Queries](query.md) — Typed analytics with DAU, formulas, filters, and breakdowns
+- [Retention Queries](query-retention.md) — Typed retention analysis with event pairs and custom buckets
 - [Live Analytics — Funnels](live-analytics.md#funnels) — Legacy funnel method (saved funnels by ID)
 - [API Reference — Workspace](../api/workspace.md) — Full method signatures
 - [API Reference — Types](../api/types.md) — FunnelStep, Exclusion, HoldingConstant, FunnelQueryResult details

--- a/docs/guide/query-retention.md
+++ b/docs/guide/query-retention.md
@@ -546,4 +546,4 @@ ws.create_bookmark(CreateBookmarkParams(
 - [Funnel Queries](query-funnels.md) — Typed funnel conversion analysis with steps, exclusions, and conversion windows
 - [Live Analytics — Retention](live-analytics.md#retention) — Legacy retention method
 - [API Reference — Workspace](../api/workspace.md) — Full method signatures
-- [API Reference — Types](../api/types.md) — RetentionEvent, RetentionQueryResult details
+- [API Reference — Types](../api/types.md) — RetentionEvent, RetentionQueryResult, RetentionAlignment, RetentionMode, RetentionMathType details

--- a/docs/guide/query-retention.md
+++ b/docs/guide/query-retention.md
@@ -1,0 +1,549 @@
+# Retention Queries
+
+Build typed retention analysis against Mixpanel's Insights engine — define born/return event pairs, retention periods, custom buckets, and segmentation inline without creating saved reports first.
+
+!!! tip "New in v0.4"
+    `Workspace.query_retention()` is the typed way to run retention analysis programmatically. It supports capabilities not available through the legacy `retention()` method, including per-event filters, custom retention buckets, alignment modes, display modes, and typed breakdowns.
+
+## When to Use `query_retention()`
+
+`query_retention()` builds retention bookmark params and posts them to the Insights engine. The legacy `retention()` method queries the older Retention API endpoint. Use `query_retention()` when you need any of the capabilities in the right column:
+
+| Capability | Legacy `retention()` | `query_retention()` |
+|---|---|---|
+| Basic cohort retention | `retention(born_event=..., return_event=...)` | `query_retention("Signup", "Login")` |
+| Per-event filters | Expression strings only | `RetentionEvent("Signup", filters=[...])` |
+| Custom retention buckets | Not available | `bucket_sizes=[1, 3, 7, 14, 30]` |
+| Alignment modes | Not available | `alignment="birth"` or `"interval_start"` |
+| Display modes | Not available | `mode="curve"`, `"trends"`, or `"table"` |
+| Typed filters | Expression strings | `where=Filter.equals("country", "US")` |
+| Property breakdowns | `on="country"` | `group_by="country"` |
+| Math types | Not available | `math="retention_rate"` or `"unique"` |
+| Save query as a report | N/A | `result.params` → `create_bookmark()` |
+
+Use the legacy `retention()` when:
+
+- You need the older Query API response format → `retention(born_event=..., return_event=...)`
+- You need `born_where` / `return_where` expression-string filters → `retention(born_where='...')`
+
+## Getting Started
+
+The simplest possible retention query — weekly retention over the last 30 days:
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+
+result = ws.query_retention("Signup", "Login")
+print(result.average)  # synthetic average across all cohorts
+print(result.df.head())
+#   cohort_date  bucket  count      rate
+# 0  2025-01-01       0   1000  1.000000
+# 1  2025-01-01       1    800  0.800000
+# 2  2025-01-01       2    650  0.650000
+```
+
+Add a time range and retention unit:
+
+```python
+# Daily retention over the last 14 days
+result = ws.query_retention("Signup", "Login", retention_unit="day", last=14)
+
+# Monthly retention over the last 180 days
+result = ws.query_retention("Signup", "Login", retention_unit="month", last=180)
+
+# Specific date range
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    from_date="2025-01-01",
+    to_date="2025-03-31",
+    retention_unit="week",
+)
+```
+
+## Events
+
+### Plain Strings
+
+The simplest way to define born and return events — pass event names as strings:
+
+```python
+result = ws.query_retention("Signup", "Login")
+```
+
+The first argument is the **born event** (defines cohort membership) and the second is the **return event** (defines what counts as returning).
+
+### The `RetentionEvent` Class
+
+For per-event configuration with filters, use `RetentionEvent` objects:
+
+```python
+from mixpanel_data import RetentionEvent, Filter
+
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    RetentionEvent("Login"),
+)
+```
+
+`RetentionEvent` fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `event` | `str` | (required) | Mixpanel event name |
+| `filters` | `list[Filter] \| None` | `None` | Per-event filter conditions |
+| `filters_combinator` | `"all" \| "any"` | `"all"` | How per-event filters combine (AND/OR) |
+
+Plain strings and `RetentionEvent` objects can be mixed freely:
+
+```python
+result = ws.query_retention(
+    "Signup",  # plain string — no filters needed
+    RetentionEvent("Purchase", filters=[Filter.greater_than("amount", 0)]),
+)
+```
+
+### Per-Event Filters
+
+Apply filters to individual events using `RetentionEvent.filters`. These restrict which events count for that specific role (born or return):
+
+```python
+from mixpanel_data import RetentionEvent, Filter
+
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    RetentionEvent("Purchase", filters=[
+        Filter.equals("country", "US"),
+        Filter.greater_than("amount", 25),
+    ]),
+)
+```
+
+By default, multiple per-event filters combine with AND logic. Use `filters_combinator="any"` for OR logic:
+
+```python
+result = ws.query_retention(
+    "Signup",
+    RetentionEvent(
+        "Purchase",
+        filters=[
+            Filter.equals("country", "US"),
+            Filter.equals("country", "CA"),
+        ],
+        filters_combinator="any",  # match US OR CA
+    ),
+)
+```
+
+See [Insights Queries — Filters](query.md#filters) for the full list of `Filter` factory methods.
+
+## Retention Unit
+
+Control the retention period granularity:
+
+| Unit | Description |
+|---|---|
+| `"day"` | Daily retention buckets |
+| `"week"` (default) | Weekly retention buckets |
+| `"month"` | Monthly retention buckets |
+
+```python
+# Daily retention
+result = ws.query_retention("Signup", "Login", retention_unit="day", last=14)
+
+# Weekly retention (default)
+result = ws.query_retention("Signup", "Login", retention_unit="week", last=90)
+
+# Monthly retention
+result = ws.query_retention("Signup", "Login", retention_unit="month", last=180)
+```
+
+## Alignment
+
+The `alignment` parameter controls how retention periods are anchored:
+
+| Alignment | Behavior |
+|---|---|
+| `"birth"` (default) | Each user's retention clock starts from their born event |
+| `"interval_start"` | Retention periods align to calendar boundaries (start of day/week/month) |
+
+```python
+# Birth-aligned (default) — each user's clock starts individually
+result = ws.query_retention("Signup", "Login", alignment="birth")
+
+# Interval-aligned — retention periods snap to calendar boundaries
+result = ws.query_retention("Signup", "Login", alignment="interval_start")
+```
+
+## Custom Buckets
+
+By default, retention uses uniform bucket sizes (bucket 0, 1, 2, ...). Use `bucket_sizes` for non-uniform retention periods:
+
+```python
+# Custom day-based buckets: day 1, 3, 7, 14, 30
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    retention_unit="day",
+    bucket_sizes=[1, 3, 7, 14, 30],
+)
+```
+
+Bucket sizes must be:
+
+- Positive integers
+- In strictly ascending order
+- Maximum 730 values
+
+## Aggregation
+
+The `math` parameter controls what metric is computed:
+
+| Math type | What it measures |
+|---|---|
+| `"retention_rate"` (default) | Percentage of cohort retained per bucket (0.0–1.0) |
+| `"unique"` | Raw unique user count per bucket |
+
+```python
+# Retention rate (default)
+result = ws.query_retention("Signup", "Login", math="retention_rate")
+
+# Raw unique user counts
+result = ws.query_retention("Signup", "Login", math="unique")
+```
+
+## Filters
+
+### Global Filters
+
+Apply filters across the entire query with `where=`:
+
+```python
+from mixpanel_data import Filter
+
+# Single filter
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    where=Filter.equals("country", "US"),
+)
+
+# Multiple filters (AND logic)
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    where=[
+        Filter.equals("platform", "web"),
+        Filter.is_true("is_premium"),
+    ],
+)
+```
+
+Global filters apply to the overall query. For event-specific filtering, use `RetentionEvent.filters` (see [Events — Per-Event Filters](#per-event-filters)).
+
+See [Insights Queries — Available Filter Methods](query.md#available-filter-methods) for the complete filter reference.
+
+## Breakdowns
+
+Break down retention results by property values with `group_by`:
+
+```python
+from mixpanel_data import GroupBy
+
+# Simple string breakdown
+result = ws.query_retention("Signup", "Login", group_by="platform")
+
+# Multiple breakdowns
+result = ws.query_retention("Signup", "Login", group_by=["country", "platform"])
+
+# Numeric bucketing
+result = ws.query_retention(
+    "Signup",
+    "Purchase",
+    group_by=GroupBy("amount", property_type="number", bucket_size=50),
+)
+```
+
+See [Insights Queries — Breakdowns](query.md#breakdowns) for the full `GroupBy` reference.
+
+## Time Ranges
+
+### Relative (Default)
+
+By default, `query_retention()` returns the last 30 days. Customize with `last` (always in days) and `unit` (aggregation granularity):
+
+```python
+# Last 7 days
+result = ws.query_retention("Signup", "Login", last=7)
+
+# Last 90 days, weekly granularity
+result = ws.query_retention("Signup", "Login", last=90, unit="week")
+
+# Last 180 days, monthly granularity
+result = ws.query_retention("Signup", "Login", last=180, unit="month")
+```
+
+### Absolute
+
+Specify explicit start and end dates:
+
+```python
+# Q1 2025
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    from_date="2025-01-01",
+    to_date="2025-03-31",
+)
+```
+
+Dates must be in `YYYY-MM-DD` format.
+
+## Display Modes
+
+The `mode` parameter controls result presentation:
+
+| Mode | Chart type | Use case |
+|---|---|---|
+| `"curve"` (default) | Retention curve | Standard retention analysis |
+| `"trends"` | Line chart | Track retention performance over time |
+| `"table"` | Table | Detailed cohort-level comparison |
+
+```python
+# Retention curve (default)
+result = ws.query_retention("Signup", "Login", mode="curve")
+
+# Trends over time
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    mode="trends",
+    last=90,
+    unit="week",
+)
+
+# Tabular format
+result = ws.query_retention("Signup", "Login", mode="table")
+```
+
+## Working with Results
+
+### `RetentionQueryResult`
+
+`query_retention()` returns a `RetentionQueryResult` with:
+
+```python
+result = ws.query_retention("Signup", "Login", retention_unit="week", last=90)
+
+# Cohort data — keyed by cohort date
+for date, data in result.cohorts.items():
+    print(f"{date}: {data['first']} users born")
+    print(f"  Retention: {data['rates']}")  # [1.0, 0.8, 0.65, ...]
+
+# Synthetic average across all cohorts
+result.average          # {"first": 500, "counts": [...], "rates": [...]}
+
+# DataFrame (lazy, cached)
+result.df
+#   cohort_date  bucket  count      rate
+# 0  2025-01-01       0   1000  1.000000
+# 1  2025-01-01       1    800  0.800000
+# 2  2025-01-01       2    650  0.650000
+# 3  2025-01-08       0    950  1.000000
+# 4  2025-01-08       1    760  0.800000
+
+# Time range
+result.from_date        # "2025-01-01"
+result.to_date          # "2025-03-31"
+
+# Metadata
+result.computed_at      # "2025-03-31T12:00:00.000000+00:00"
+result.meta             # {"sampling_factor": 1.0, ...}
+
+# Generated bookmark params (for debugging or persistence)
+result.params           # dict — the full bookmark JSON sent to API
+```
+
+### DataFrame Structure
+
+The DataFrame has one row per (cohort_date, bucket) pair:
+
+| Column | Description |
+|---|---|
+| `cohort_date` | Date string identifying the cohort (users born on this date) |
+| `bucket` | Retention bucket index (0 = born period, 1 = first return period, ...) |
+| `count` | Number of users retained in this bucket |
+| `rate` | Retention rate for this bucket (count / cohort size, 0.0–1.0) |
+
+### Cohort Data Structure
+
+Each entry in `result.cohorts` is a dict with:
+
+| Key | Type | Description |
+|---|---|---|
+| `first` | `int` | Cohort size — users who did the born event on this date |
+| `counts` | `list[int]` | User counts retained per bucket |
+| `rates` | `list[float]` | Retention rates per bucket (0.0–1.0) |
+
+### Persisting as a Saved Report
+
+The generated bookmark params can be saved as a Mixpanel report:
+
+```python
+from mixpanel_data import CreateBookmarkParams
+
+result = ws.query_retention("Signup", "Login", retention_unit="week", last=90)
+
+ws.create_bookmark(CreateBookmarkParams(
+    name="Signup → Login Retention (Weekly)",
+    bookmark_type="retention",
+    params=result.params,
+))
+```
+
+### Debugging
+
+Inspect `result.params` to see the exact bookmark JSON sent to the API:
+
+```python
+import json
+
+result = ws.query_retention("Signup", "Login")
+print(json.dumps(result.params, indent=2))
+```
+
+## Validation
+
+`query_retention()` validates all parameter combinations **before** making an API call and raises `BookmarkValidationError` with descriptive messages:
+
+| Rule | Error code | Error message |
+|---|---|---|
+| Empty born event name | `R1_EMPTY_BORN_EVENT` | Born event name must be a non-empty string |
+| Control chars in born event | `R1_CONTROL_CHAR_BORN_EVENT` | Born event name contains control characters |
+| Empty return event name | `R2_EMPTY_RETURN_EVENT` | Return event name must be a non-empty string |
+| Control chars in return event | `R2_CONTROL_CHAR_RETURN_EVENT` | Return event name contains control characters |
+| Non-positive bucket sizes | `R5_BUCKET_SIZES_POSITIVE` | Each bucket size must be a positive integer |
+| Float bucket sizes | `R5_BUCKET_SIZES_INTEGER` | Bucket sizes must be integers, not floats |
+| Buckets not ascending | `R6_BUCKET_SIZES_ASCENDING` | Bucket sizes must be in strictly ascending order |
+| Invalid retention unit | `R7_INVALID_RETENTION_UNIT` | Must be one of: day, week, month |
+| Invalid alignment | `R8_INVALID_ALIGNMENT` | Must be one of: birth, interval_start |
+| Invalid math | `R9_INVALID_MATH` | Must be one of: retention_rate, unique |
+| Invalid mode | `R10_INVALID_MODE` | Must be one of: curve, trends, table |
+| Invalid unit | `R11_INVALID_UNIT` | Must be one of: day, week, month |
+
+Errors are collected — all validation issues are reported at once, not just the first:
+
+```python
+from mixpanel_data import BookmarkValidationError
+
+try:
+    ws.query_retention("", "Login", bucket_sizes=[5, 3, 1])
+except BookmarkValidationError as e:
+    for error in e.errors:
+        print(f"[{error.code}] {error.path}: {error.message}")
+    # [R1_EMPTY_BORN_EVENT] born_event: Born event name must be a non-empty string
+    # [R6_BUCKET_SIZES_ASCENDING] bucket_sizes: Bucket sizes must be in strictly ascending order
+```
+
+## Complete Examples
+
+### User Onboarding Retention
+
+```python
+import mixpanel_data as mp
+from mixpanel_data import RetentionEvent, Filter
+
+ws = mp.Workspace()
+
+# Weekly retention: do new signups come back?
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    "Login",
+    retention_unit="week",
+    last=90,
+    group_by="platform",
+)
+
+# Inspect average retention curve
+avg = result.average
+print(f"Cohort size: {avg['first']}")
+for i, rate in enumerate(avg['rates']):
+    print(f"  Week {i}: {rate:.1%}")
+
+# Export to DataFrame for further analysis
+print(result.df)
+```
+
+### Product Engagement
+
+```python
+# Do users who complete onboarding keep making purchases?
+result = ws.query_retention(
+    "Complete Onboarding",
+    "Purchase",
+    retention_unit="month",
+    last=180,
+    where=Filter.is_true("is_premium"),
+)
+
+# Custom bucket sizes for key retention milestones
+milestone_retention = ws.query_retention(
+    "Signup",
+    "Login",
+    retention_unit="day",
+    bucket_sizes=[1, 3, 7, 14, 30, 60, 90],
+    last=90,
+)
+```
+
+### Retention Trends
+
+```python
+# Track how retention is changing over time
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    mode="trends",
+    unit="week",
+    retention_unit="week",
+    last=180,
+)
+print(result.df)
+```
+
+## Generating Params Without Querying
+
+Use `build_retention_params()` to generate bookmark params without making an API call — useful for debugging, inspecting the generated JSON, or saving queries as reports:
+
+```python
+# Same arguments as query_retention(), returns dict instead of RetentionQueryResult
+params = ws.build_retention_params(
+    "Signup",
+    "Login",
+    retention_unit="week",
+    bucket_sizes=[1, 3, 7, 14, 30],
+    last=90,
+)
+
+import json
+print(json.dumps(params, indent=2))  # inspect the generated bookmark JSON
+
+# Save as a report directly from params
+from mixpanel_data import CreateBookmarkParams
+
+ws.create_bookmark(CreateBookmarkParams(
+    name="Signup → Login Retention (Custom Buckets)",
+    bookmark_type="retention",
+    params=params,
+))
+```
+
+## Next Steps
+
+- [Insights Queries](query.md) — Typed analytics with DAU, formulas, filters, and breakdowns
+- [Funnel Queries](query-funnels.md) — Typed funnel conversion analysis with steps, exclusions, and conversion windows
+- [Live Analytics — Retention](live-analytics.md#retention) — Legacy retention method
+- [API Reference — Workspace](../api/workspace.md) — Full method signatures
+- [API Reference — Types](../api/types.md) — RetentionEvent, RetentionQueryResult details

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -26,7 +26,7 @@ Build typed analytics queries against Mixpanel's Insights engine — the same en
 Use the legacy methods when:
 
 - You need to query a saved funnel by ID → `funnel()`
-- You need cohort retention curves → `retention()`
+- You need cohort retention curves → `query_retention()` ([Retention Queries](query-retention.md))
 - You need raw JQL execution → `jql()`
 - You need Flows analysis → `query_flows()`
 
@@ -709,12 +709,13 @@ ws.create_bookmark(CreateBookmarkParams(
 `query()` is the foundation for a family of typed query methods. Each follows the same pattern — typed Python arguments generating the correct bookmark params:
 
 - **[`query_funnel()`](query-funnels.md)** — Ad-hoc funnel conversion analysis with typed step definitions, exclusions, and conversion windows
-- **`query_retention()`** — Ad-hoc retention curves with event pairs (coming soon)
+- **[`query_retention()`](query-retention.md)** — Ad-hoc retention curves with event pairs, custom buckets, and alignment modes
 - **Cohort behaviors** — Querying by cohort membership (coming soon)
 
 ## Next Steps
 
 - [Funnel Queries](query-funnels.md) — Typed funnel conversion analysis
+- [Retention Queries](query-retention.md) — Typed retention analysis with event pairs and custom buckets
 - [Live Analytics](live-analytics.md) — Legacy query methods (segmentation, funnels, retention)
 - [Data Discovery](discovery.md) — Explore events and properties before querying
 - [API Reference — Workspace](../api/workspace.md) — Full method signature

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ A complete programmable interface to Mixpanel analytics—available as both a Py
 
 Mixpanel's web UI is built for interactive exploration. But many workflows need something different: scripts that run unattended, notebooks that combine Mixpanel data with other sources, agents that query analytics programmatically, or pipelines that move data between systems.
 
-`mixpanel_data` provides direct programmatic access to Mixpanel's analytics platform. Core analytics—typed insights queries, typed funnel queries, segmentation, retention, saved reports—plus capabilities like raw JQL execution and streaming data extraction are available as Python methods or shell commands.
+`mixpanel_data` provides direct programmatic access to Mixpanel's analytics platform. Core analytics—typed insights queries, typed funnel queries, typed retention queries, segmentation, saved reports—plus capabilities like raw JQL execution and streaming data extraction are available as Python methods or shell commands.
 
 ## Two Interfaces, One Capability Set
 
@@ -91,6 +91,16 @@ funnel_result = ws.query_funnel(
     last=90,
 )
 print(funnel_result.overall_conversion_rate)
+
+# Typed retention query — cohort retention with event pairs
+from mixpanel_data import RetentionEvent
+retention_result = ws.query_retention(
+    "Signup",
+    "Login",
+    retention_unit="week",
+    last=90,
+)
+print(retention_result.df.head())  # cohort_date | bucket | count | rate
 
 # Legacy live queries
 segmentation = ws.segmentation(
@@ -195,8 +205,9 @@ Discovery commands let you survey what exists before writing queries—no guessi
 
 - Segmentation with filtering, grouping, and time bucketing
 - Typed funnel queries with ad-hoc step definitions, exclusions, and conversion windows
+- Typed retention queries with event pairs, custom buckets, alignment modes, and segmentation
 - Funnel conversion analysis (legacy saved funnels)
-- Retention analysis
+- Retention analysis (legacy)
 - Saved reports (Insights, Funnels, Flows, Retention)
 - User activity feeds
 - Frequency and engagement analysis
@@ -258,6 +269,7 @@ For interactive exploration of the codebase itself, see [DeepWiki](https://deepw
 - [Quick Start](getting-started/quickstart.md) — Your first queries in 5 minutes
 - [Insights Queries](guide/query.md) — Typed analytics queries with DAU, formulas, filters, and breakdowns
 - [Funnel Queries](guide/query-funnels.md) — Typed funnel conversion analysis with steps, exclusions, and conversion windows
+- [Retention Queries](guide/query-retention.md) — Typed retention analysis with event pairs, custom buckets, and alignment modes
 - [API Reference](api/index.md) — Complete Python API documentation
 - [Entity Management](guide/entity-management.md) — Manage dashboards, reports, cohorts, feature flags, experiments, alerts, annotations, and webhooks
 - [Data Governance](guide/data-governance.md) — Manage Lexicon definitions, drop filters, custom properties, custom events, and lookup tables

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ plugins:
           - guide/discovery.md
           - guide/query.md
           - guide/query-funnels.md
+          - guide/query-retention.md
           - guide/live-analytics.md
           - guide/streaming.md
           - guide/entity-management.md
@@ -132,6 +133,7 @@ plugins:
           - guide/discovery.md: "Explore schema, events, properties, cohorts"
           - guide/query.md: "Typed insights queries — DAU, formulas, filters, breakdowns"
           - guide/query-funnels.md: "Typed funnel queries — steps, exclusions, conversion windows"
+          - guide/query-retention.md: "Typed retention queries — event pairs, custom buckets, alignment modes"
           - guide/live-analytics.md: "Segmentation, funnels, retention, JQL"
           - guide/streaming.md: "Stream events and profiles for ETL"
           - guide/entity-management.md: "Create, update, delete dashboards, reports, and cohorts"
@@ -173,6 +175,7 @@ nav:
       - Data Discovery: guide/discovery.md
       - Insights Queries: guide/query.md
       - Funnel Queries: guide/query-funnels.md
+      - Retention Queries: guide/query-retention.md
       - Live Analytics: guide/live-analytics.md
       - Streaming Data: guide/streaming.md
       - Entity Management: guide/entity-management.md

--- a/specs/033-retention-query/checklists/requirements.md
+++ b/specs/033-retention-query/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Retention Query (`query_retention()`)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- No [NEEDS CLARIFICATION] markers — all design decisions were resolved in the prior design document phase (unified-bookmark-query-design.md Section 9).
+- FR-001 through FR-032 are testable via acceptance scenarios in User Stories 1-6.
+- SC-007 and SC-008 reference project quality standards (test coverage, type checking) which are project-level constraints, not implementation details.

--- a/specs/033-retention-query/contracts/public-api.md
+++ b/specs/033-retention-query/contracts/public-api.md
@@ -1,0 +1,127 @@
+# Public API Contract: Retention Query
+
+**Date**: 2026-04-06
+
+## New Public Types
+
+### RetentionEvent
+
+```
+RetentionEvent(
+    event: str,                              # Required — Mixpanel event name
+    filters: list[Filter] | None = None,     # Optional per-event filters
+    filters_combinator: "all" | "any" = "all" # How filters combine (AND/OR)
+)
+```
+
+- Immutable (frozen dataclass)
+- Plain event name strings are accepted anywhere `RetentionEvent` is expected — auto-converted internally
+
+### RetentionMathType
+
+```
+RetentionMathType = "retention_rate" | "unique"
+```
+
+- Type alias (Literal), not a runtime class
+
+### RetentionQueryResult
+
+```
+RetentionQueryResult(
+    computed_at: str,                        # ISO datetime — when query was computed
+    from_date: str,                          # YYYY-MM-DD — effective start date
+    to_date: str,                            # YYYY-MM-DD — effective end date
+    cohorts: dict[str, dict],                # cohort_date → {first, counts, rates}
+    average: dict,                           # Synthetic $average cohort
+    params: dict,                            # Generated bookmark params (for debugging/persistence)
+    meta: dict,                              # Response metadata
+)
+```
+
+- Immutable (frozen dataclass), extends `ResultWithDataFrame`
+- `.df` → DataFrame with columns: `cohort_date`, `bucket`, `count`, `rate`
+- `.df` is lazily computed and cached
+
+## New Public Methods on Workspace
+
+### query_retention()
+
+```
+Workspace.query_retention(
+    born_event: str | RetentionEvent,
+    return_event: str | RetentionEvent,
+    *,
+    retention_unit: "day" | "week" | "month" = "week",
+    alignment: "birth" | "interval_start" = "birth",
+    bucket_sizes: list[int] | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    last: int = 30,
+    unit: "hour" | "day" | "week" | "month" | "quarter" = "day",
+    math: RetentionMathType = "retention_rate",
+    group_by: str | GroupBy | list[str | GroupBy] | None = None,
+    where: Filter | list[Filter] | None = None,
+    mode: "curve" | "trends" | "table" = "curve",
+) -> RetentionQueryResult
+```
+
+**Behavior**:
+1. Normalizes string events to `RetentionEvent` objects
+2. Validates all arguments (Layer 1: R1-R9)
+3. Builds retention bookmark params
+4. Validates bookmark structure (Layer 2: B1-B19)
+5. POSTs to `/insights` via `insights_query()`
+6. Transforms response to `RetentionQueryResult`
+
+**Errors**:
+- `BookmarkValidationError` — invalid arguments (before API call)
+- `ConfigError` — missing credentials
+- `QueryError` — API error response
+- `RateLimitError` — rate limit exceeded
+- `AuthenticationError` — invalid credentials
+
+### build_retention_params()
+
+```
+Workspace.build_retention_params(
+    born_event: str | RetentionEvent,
+    return_event: str | RetentionEvent,
+    *,
+    # Same keyword arguments as query_retention()
+) -> dict
+```
+
+**Behavior**: Same as `query_retention()` steps 1-4, but returns the raw params dict instead of querying the API. No API call is made.
+
+## New Exports from `mixpanel_data`
+
+```
+from mixpanel_data import RetentionEvent, RetentionMathType, RetentionQueryResult
+```
+
+## Reused Types (no changes)
+
+- `Filter` — filter conditions (per-event and global)
+- `GroupBy` — property breakdown
+- `BookmarkValidationError` — wraps list of `ValidationError`
+- `ValidationError` — structured error with path, message, code, severity, suggestion
+
+## Validation Error Codes
+
+| Code | Field | Condition |
+|------|-------|-----------|
+| R1_EMPTY_BORN_EVENT | born_event | Empty or whitespace-only |
+| R1_CONTROL_CHAR_BORN_EVENT | born_event | Contains control characters |
+| R1_INVISIBLE_BORN_EVENT | born_event | Only invisible characters |
+| R2_EMPTY_RETURN_EVENT | return_event | Empty or whitespace-only |
+| R2_CONTROL_CHAR_RETURN_EVENT | return_event | Contains control characters |
+| R2_INVISIBLE_RETURN_EVENT | return_event | Only invisible characters |
+| R5_BUCKET_SIZES_POSITIVE | bucket_sizes | Contains non-positive values |
+| R5_BUCKET_SIZES_INTEGER | bucket_sizes[i] | Contains float values |
+| R6_BUCKET_SIZES_ASCENDING | bucket_sizes | Not in strictly ascending order |
+| R7_INVALID_RETENTION_UNIT | retention_unit | Not in {day, week, month} |
+| R8_INVALID_ALIGNMENT | alignment | Not in {birth, interval_start} |
+| R9_INVALID_MATH | math | Not in {retention_rate, unique} |
+
+Plus shared codes from `validate_time_args()` (V7-V10, V15, V20) and `validate_group_by_args()` (V11-V12, V18, V24).

--- a/specs/033-retention-query/data-model.md
+++ b/specs/033-retention-query/data-model.md
@@ -1,0 +1,124 @@
+# Data Model: Retention Query (`query_retention()`)
+
+**Date**: 2026-04-06
+
+## Entities
+
+### RetentionEvent
+
+An event specification for retention queries. Wraps an event name with optional per-event filters.
+
+| Field | Type | Default | Constraints | Description |
+|-------|------|---------|-------------|-------------|
+| `event` | string | required | Non-empty, no control chars | Mixpanel event name |
+| `filters` | list of Filter or null | null | Each filter must be a valid Filter object | Per-event filter conditions |
+| `filters_combinator` | "all" or "any" | "all" | Must be one of the two values | How filters combine (AND/OR) |
+
+**Invariants**:
+- Immutable (frozen dataclass)
+- `event` must be non-empty after stripping whitespace
+- `event` must not contain control characters or be invisible-only
+- When `filters` is null, no per-event filtering is applied
+- Used for both born_event and return_event positions
+
+**Relationships**:
+- Contains zero or more `Filter` objects (existing type, reused)
+- Consumed by `_build_retention_params()` to generate behavior entries
+- Validated by `validate_retention_args()` rules R1 and R2
+
+---
+
+### RetentionQueryResult
+
+The result of a retention query. Contains cohort-level retention data.
+
+| Field | Type | Default | Constraints | Description |
+|-------|------|---------|-------------|-------------|
+| `computed_at` | string | required | ISO datetime format | When query was computed |
+| `from_date` | string | required | YYYY-MM-DD format | Effective start date |
+| `to_date` | string | required | YYYY-MM-DD format | Effective end date |
+| `cohorts` | dict (string to dict) | empty dict | Keys are cohort date strings | Cohort-level retention data |
+| `average` | dict | empty dict | Synthetic `$average` cohort | Average retention across all cohorts |
+| `params` | dict | empty dict | Valid bookmark JSON structure | Generated bookmark params sent to API |
+| `meta` | dict | empty dict | Free-form | Response metadata (sampling_factor, etc.) |
+
+**Cohort dict structure** (each value in `cohorts`):
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `first` | int | Cohort size — users who did born_event on this date |
+| `counts` | list of int | User counts retained per bucket |
+| `rates` | list of float | Retention rates per bucket (count / first) |
+
+**Invariants**:
+- Immutable (frozen dataclass)
+- Extends `ResultWithDataFrame` — provides `.df` property
+- `.df` is lazily computed and cached after first access
+- `.df` shape: one row per (cohort_date, bucket) pair
+- `.df` columns: `cohort_date`, `bucket`, `count`, `rate`
+- Empty `cohorts` produces an empty DataFrame with correct column schema
+- `params` always contains the bookmark JSON that was sent to the API
+
+**Relationships**:
+- Extends `ResultWithDataFrame` (existing base class)
+- Created by `_transform_retention_result()` from raw API response
+- Returned by `query_retention()` on the Workspace
+
+---
+
+### RetentionMathType
+
+A constrained type alias for valid retention aggregation functions.
+
+| Value | Description |
+|-------|-------------|
+| `"retention_rate"` | Percentage of cohort retained (default) |
+| `"unique"` | Raw unique user count per bucket |
+
+**Invariants**:
+- Type alias (Literal), not a runtime object
+- Default value in method signatures is `"retention_rate"`
+- Maps directly to the `measurement.math` field in bookmark JSON
+
+## Entity Relationships
+
+```
+RetentionEvent (input)
+    ├── contains → Filter[] (existing, reused)
+    └── consumed by → _build_retention_params()
+                          └── produces → bookmark params dict
+                                            ├── validated by → validate_retention_args() (L1)
+                                            ├── validated by → validate_bookmark() (L2)
+                                            └── sent to → insights_query() API
+                                                            └── response parsed by → _transform_retention_result()
+                                                                                        └── produces → RetentionQueryResult (output)
+```
+
+## Validation Rules
+
+### Layer 1: Argument Validation (`validate_retention_args`)
+
+| Code | Field | Rule | Error Message Template |
+|------|-------|------|----------------------|
+| R1 | born_event | Must be non-empty string (after strip) | `born_event must be a non-empty string` |
+| R1b | born_event | No control characters | `born_event contains control characters` |
+| R1c | born_event | Not invisible-only | `born_event contains only invisible characters` |
+| R2 | return_event | Must be non-empty string (after strip) | `return_event must be a non-empty string` |
+| R2b | return_event | No control characters | `return_event contains control characters` |
+| R2c | return_event | Not invisible-only | `return_event contains only invisible characters` |
+| R3 | time args | Delegated to `validate_time_args()` | (shared V7-V10, V15, V20) |
+| R4 | group_by | Delegated to `validate_group_by_args()` | (shared V11-V12, V18, V24) |
+| R5 | bucket_sizes | Each value must be positive integer | `bucket_sizes values must be positive integers` |
+| R5b | bucket_sizes | Values must be integers, not floats | `bucket_sizes[{i}] must be an integer, got float` |
+| R6 | bucket_sizes | Must be in strictly ascending order | `bucket_sizes must be in strictly ascending order` |
+| R7 | retention_unit | Must be valid retention unit | `invalid retention_unit '{val}'; valid values: day, week, month` |
+| R8 | alignment | Must be valid alignment type | `invalid alignment '{val}'; valid values: birth, interval_start` |
+| R9 | math | Must be valid retention math type | `invalid math '{val}'; valid values: retention_rate, unique` |
+
+### Layer 2: Bookmark Structure Validation (extension to `validate_bookmark`)
+
+| Change | Detail |
+|--------|--------|
+| B9 extension | When `bookmark_type="retention"`, use `VALID_MATH_RETENTION` for math validation instead of `VALID_MATH_INSIGHTS` |
+
+All other B-rules (B1-B8, B10-B19) apply unchanged.

--- a/specs/033-retention-query/plan.md
+++ b/specs/033-retention-query/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Retention Query (`query_retention()`)
+
+**Branch**: `033-retention-query` | **Date**: 2026-04-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/033-retention-query/spec.md`
+
+## Summary
+
+Add typed retention querying to `mixpanel_data` via `query_retention()` and `build_retention_params()`, following the same two-layer validation and bookmark-params architecture established by `query()` (insights) and `query_funnel()` (funnels). New types (`RetentionEvent`, `RetentionMathType`, `RetentionQueryResult`), validation rules (R1-R6), a retention bookmark JSON builder, and a response transformer complete the system. All shared infrastructure (time/filter/group builders, `insights_query()` API client, `validate_bookmark()` L2) is reused without modification.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (mypy --strict)
+**Primary Dependencies**: httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)
+**Storage**: N/A — live query only, no local persistence
+**Testing**: pytest, Hypothesis (property-based), mutmut (mutation)
+**Target Platform**: Cross-platform Python library + CLI
+**Project Type**: Library (with CLI wrapper)
+**Performance Goals**: N/A — thin client over Mixpanel API; latency dominated by API response time
+**Constraints**: Must pass mypy --strict, ruff check, 90%+ test coverage, 80%+ mutation score
+**Scale/Scope**: ~800-1200 new lines of production code, ~1500-2000 lines of tests, across 5 files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Library-First | PASS | `query_retention()` and `build_retention_params()` are library methods on Workspace; CLI wrapping is out of scope for this phase |
+| II. Agent-Native | PASS | Method returns typed `RetentionQueryResult` with `.df` and `.params`; no interactive prompts; structured errors with codes |
+| III. Context Window Efficiency | PASS | Result includes `.df` for compact DataFrame view; `.params` for debugging; introspectable types |
+| IV. Two Data Paths | PASS | This is a live query path; local storage is separate concern |
+| V. Explicit Over Implicit | PASS | All parameters are keyword-only with explicit defaults; validation is fail-fast before API call; credentials resolved at construction |
+| VI. Unix Philosophy | PASS | Method does one thing (retention query); results are composable (DataFrame, dict serialization) |
+| VII. Secure by Default | PASS | Reuses existing credential handling; no new credential paths |
+
+**Gate Result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/033-retention-query/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── public-api.md    # Public method signatures and types
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── __init__.py                          # MODIFY — add RetentionEvent, RetentionMathType, RetentionQueryResult exports
+├── workspace.py                         # MODIFY — add query_retention(), build_retention_params(), _resolve_and_build_retention_params(), _build_retention_params()
+├── types.py                             # MODIFY — add RetentionEvent, RetentionMathType, RetentionQueryResult
+├── _internal/
+│   ├── validation.py                    # MODIFY — add validate_retention_args(), extend validate_bookmark() for bookmark_type="retention"
+│   ├── bookmark_enums.py                # NO CHANGE — VALID_MATH_RETENTION, VALID_RETENTION_UNITS, VALID_RETENTION_ALIGNMENT already exist
+│   ├── bookmark_builders.py             # NO CHANGE — build_time_section, build_filter_section, build_group_section, build_filter_entry reused as-is
+│   ├── api_client.py                    # NO CHANGE — insights_query() reused as-is
+│   └── services/
+│       └── live_query.py                # MODIFY — add query_retention(), _transform_retention_result()
+
+tests/
+├── test_types_retention.py              # NEW — RetentionEvent, RetentionQueryResult unit tests
+├── test_types_retention_pbt.py          # NEW — Hypothesis property-based tests
+├── test_validation_retention.py         # NEW — R1-R6 validation rule tests
+├── test_build_retention_params.py       # NEW — bookmark JSON builder tests
+├── test_transform_retention.py          # NEW — response transformer tests
+└── test_workspace_retention.py          # NEW — integration tests (validation + execution + build_params consistency)
+```
+
+**Structure Decision**: Single-project library structure, extending existing modules. No new files in `src/` — all production code is added to existing modules. Six new test files follow the established per-concern test organization pattern from the funnel implementation.

--- a/specs/033-retention-query/quickstart.md
+++ b/specs/033-retention-query/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Retention Query
+
+## Simple Retention Query
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+
+# Weekly retention: Signup → Login
+result = ws.query_retention("Signup", "Login")
+
+# Inspect results
+print(result.average)              # Average retention across all cohorts
+print(result.cohorts.keys())       # Cohort dates
+print(result.df.head())            # Tabular view
+```
+
+## Weekly Retention Over 90 Days
+
+```python
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_unit="week",
+    last=90,
+)
+
+# DataFrame: cohort_date | bucket | count | rate
+print(result.df)
+```
+
+## Per-Event Filters
+
+```python
+from mixpanel_data import RetentionEvent, Filter
+
+# Only organic signups, any login
+result = ws.query_retention(
+    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
+    RetentionEvent("Login"),
+    retention_unit="day",
+)
+```
+
+## Segmented Retention
+
+```python
+# Compare retention by platform
+result = ws.query_retention(
+    "Signup", "Purchase",
+    group_by="platform",
+    retention_unit="week",
+)
+```
+
+## Custom Retention Buckets
+
+```python
+# Day 1, 3, 7, 14, 30 retention
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_unit="day",
+    bucket_sizes=[1, 3, 7, 14, 30],
+)
+```
+
+## Trends View
+
+```python
+# Retention rate over time (line chart)
+result = ws.query_retention(
+    "Signup", "Login",
+    mode="trends",
+    unit="week",
+    last=90,
+)
+```
+
+## Debug / Persist
+
+```python
+# Inspect generated bookmark params
+params = ws.build_retention_params("Signup", "Login")
+print(params)
+
+# Save as a Mixpanel report
+from mixpanel_data import CreateBookmarkParams
+
+ws.create_bookmark(CreateBookmarkParams(
+    name="Signup → Login Retention",
+    bookmark_type="retention",
+    params=result.params,
+))
+```
+
+## Error Handling
+
+```python
+from mixpanel_data import BookmarkValidationError
+
+try:
+    ws.query_retention("", "Login")
+except BookmarkValidationError as e:
+    for error in e.errors:
+        print(f"[{error.code}] {error.path}: {error.message}")
+    # [R1_EMPTY_BORN_EVENT] born_event: born_event must be a non-empty string
+```

--- a/specs/033-retention-query/research.md
+++ b/specs/033-retention-query/research.md
@@ -1,0 +1,101 @@
+# Research: Retention Query (`query_retention()`)
+
+**Date**: 2026-04-06
+**Status**: Complete — all decisions resolved
+
+## Overview
+
+All design decisions for the retention query system were resolved during the unified bookmark query design phase (see `context/unified-bookmark-query-design.md` §4, §9). This research document consolidates the findings and confirms implementation-level details through codebase analysis.
+
+## Decision 1: API Endpoint
+
+**Decision**: Reuse the existing `/insights` endpoint via `insights_query()` API client method.
+
+**Rationale**: The Mixpanel insights API internally detects `behavior.type == "retention"` in the bookmark params and routes to the retention query engine. This is confirmed by the design document (§4.6) and consistent with how `query_funnel()` already works — both funnel and retention bookmarks use `/insights`, not separate endpoints.
+
+**Alternatives considered**:
+- Direct `/retention` endpoint: Not available — Mixpanel's retention service is accessed only through the insights dispatcher.
+- New API client method: Unnecessary — `insights_query()` accepts any bookmark params dict; the behavior type determines routing.
+
+## Decision 2: Bookmark JSON Structure
+
+**Decision**: Use `sections`-based structure with `behavior.type = "retention"` containing exactly 2 behaviors (born event, return event) and retention-specific fields.
+
+**Rationale**: Confirmed by design document §4.5 (Appendix A.3). The retention behavior block differs from funnel in:
+- Exactly 2 behaviors (born + return) vs N steps
+- `retentionUnit` instead of `conversionWindowDuration`/`conversionWindowUnit`
+- `retentionCustomBucketSizes` instead of exclusions
+- `retentionAlignmentType` instead of `funnelOrder`
+- No `aggregateBy` (holding constant is funnel-only)
+
+**Alternatives considered**: None — the bookmark format is dictated by the Mixpanel API.
+
+## Decision 3: Shared Infrastructure
+
+**Decision**: Reuse all shared builders and validators without modification.
+
+**Rationale**: Verified through codebase analysis:
+- `build_time_section()` (bookmark_builders.py:19-74): Works for all `sections.time[]` formats — retention uses same structure.
+- `build_filter_section()` / `build_filter_entry()` (bookmark_builders.py:120-253): Works for `sections.filter[]` — retention uses same structure.
+- `build_group_section()` (bookmark_builders.py:148-217): Works for `sections.group[]` — retention uses same structure.
+- `validate_time_args()` (validation.py:169-305): Validates V7-V10, V15, V20 — all apply to retention.
+- `validate_group_by_args()` (validation.py:308-423): Validates V11-V12, V18, V24 — all apply to retention.
+- `validate_bookmark()` (validation.py:1143-1257): Already accepts `bookmark_type` parameter. Currently branches on `"funnels"` to select `VALID_MATH_FUNNELS`; adding `"retention"` → `VALID_MATH_RETENTION` is a single conditional.
+
+**Alternatives considered**: None — reuse is the entire design principle of the shared infrastructure.
+
+## Decision 4: Retention-Specific Enums
+
+**Decision**: Use existing enum constants in `bookmark_enums.py`.
+
+**Rationale**: All required constants already exist:
+- `VALID_MATH_RETENTION` (L118-126): `{"unique", "retention_rate", "total", "average"}`
+- `VALID_RETENTION_UNITS` (L426): `{"day", "week", "month"}`
+- `VALID_RETENTION_ALIGNMENT` (L429-430): `{"birth", "interval_start"}`
+- `VALID_CHART_TYPES` (L262-275): Already includes `"retention-curve"` and `"frequency-curve"`
+- `VALID_METRIC_TYPES` (L242-255): Already includes `"retention"`
+
+No new enum constants are needed.
+
+## Decision 5: RetentionMathType Scope
+
+**Decision**: Expose `Literal["retention_rate", "unique"]` as `RetentionMathType` — a 2-value type alias.
+
+**Rationale**: The design document (§4.3) specifies these two values. While `VALID_MATH_RETENTION` in bookmark_enums also includes `"total"` and `"average"`, those are internal bookmark-level math types used by the L2 validator. The public-facing `RetentionMathType` should expose only the user-meaningful values:
+- `"retention_rate"` — percentage of cohort retained (default)
+- `"unique"` — raw unique user count per bucket
+
+**Alternatives considered**:
+- Include `"total"` and `"average"`: These are less useful for retention queries and could confuse users. The L2 validator still accepts them in the bookmark params if users construct params manually.
+
+## Decision 6: Response Format
+
+**Decision**: Parse cohort data from the `series` field of the insights API response, handling multiple format variations.
+
+**Rationale**: Based on the funnel precedent (`_extract_funnel_steps_from_series` handles 5+ format variations), the retention response parser should handle:
+1. Direct cohort dict: `series = {cohort_date: {first, counts, rates}}`
+2. Nested with `$overall`: `series = {"$overall": {cohort_data}}`
+3. Segmented format: `series = {segment_value: {cohort_data}}`
+4. Insights API wrapper: `series = {metric_name: {nested_data}}`
+
+The transformer will extract the `$average` synthetic cohort separately.
+
+## Decision 7: DataFrame Shape
+
+**Decision**: `cohort_date, bucket, count, rate` — one row per (cohort, bucket) pair.
+
+**Rationale**: This is the most flexible shape for downstream analysis. Users can pivot, filter, or aggregate as needed. Consistent with the funnel DataFrame pattern (one row per step) and the insights DataFrame pattern (one row per date/metric).
+
+**Alternatives considered**:
+- Wide format (one column per bucket): Harder to filter and less composable with pandas operations.
+- Separate DataFrames for counts and rates: Unnecessarily splits related data.
+
+## Decision 8: Custom Bucket Sizes Validation
+
+**Decision**: Validate that `bucket_sizes` is a list of positive integers in strictly ascending order.
+
+**Rationale**: Design document §9.5 specifies this. Duplicate values would create overlapping buckets. Non-positive values are meaningless for retention periods. Non-ascending order contradicts the natural progression of retention periods.
+
+**Validation rules**:
+- R5: Each value must be a positive integer (`> 0`)
+- R6: Values must be in strictly ascending order (no duplicates)

--- a/specs/033-retention-query/spec.md
+++ b/specs/033-retention-query/spec.md
@@ -154,7 +154,7 @@ An analyst wants to view retention data in different formats — the default ret
 - **FR-023**: System MUST generate valid retention bookmark JSON with `behavior.type = "retention"`, two behaviors (born event and return event), and retention-specific fields (`retentionUnit`, `retentionCustomBucketSizes`, `retentionAlignmentType`).
 - **FR-024**: System MUST reuse shared bookmark builders for time section, filter section, and group section construction.
 - **FR-025**: Per-event filters from `RetentionEvent` objects MUST be converted to the bookmark filter format using the existing `build_filter_entry()` function.
-- **FR-026**: The measurement block MUST include retention-specific fields (`retentionBucketIndex`, `retentionSegmentationEvent`).
+- **FR-026**: The measurement block MUST include the `math` field. Retention-specific fields (`retentionBucketIndex`, `retentionSegmentationEvent`) are optional and only needed for advanced segmented retention views; they MAY be omitted for standard retention queries.
 
 #### Public Methods
 

--- a/specs/033-retention-query/spec.md
+++ b/specs/033-retention-query/spec.md
@@ -1,0 +1,206 @@
+# Feature Specification: Retention Query (`query_retention()`)
+
+**Feature Branch**: `033-retention-query`  
+**Created**: 2026-04-06  
+**Status**: Draft  
+**Input**: Phase 3 of the Unified Bookmark Query System — add typed retention querying to `mixpanel_data`, following the same architecture as the existing `query()` (insights) and `query_funnel()` (funnels) methods.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Simple Retention Query (Priority: P1)
+
+A data analyst wants to measure how many users who performed a "birth" event (e.g., Signup) come back to perform a "return" event (e.g., Login) over subsequent time periods. They call a single method with two event names and get back structured retention data with cohort-level rates and a DataFrame for analysis.
+
+**Why this priority**: This is the core value proposition — running a retention query with minimal configuration. Without this, nothing else works.
+
+**Independent Test**: Can be fully tested by calling `query_retention("Signup", "Login")` with default parameters and verifying the result contains cohort data, retention rates, and a well-shaped DataFrame.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace with valid credentials, **When** the user calls `query_retention("Signup", "Login")`, **Then** the system returns a `RetentionQueryResult` containing cohort-level retention data with rates per bucket, an average retention row, and a DataFrame with columns `cohort_date, bucket, count, rate`.
+2. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", retention_unit="week", last=90)`, **Then** the system returns weekly retention cohorts over a 90-day window.
+3. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login")`, **Then** the returned result includes a `.params` attribute containing the bookmark JSON that was sent, enabling debugging and persistence via `create_bookmark()`.
+
+---
+
+### User Story 2 - Retention with Filters and Segmentation (Priority: P2)
+
+A product manager wants to compare retention across user segments — for example, iOS vs Android users, or organic vs paid signups. They add global filters and group-by breakdowns to their retention query.
+
+**Why this priority**: Segmented retention is critical for understanding which user cohorts retain best, but depends on the core query working first.
+
+**Independent Test**: Can be tested by calling `query_retention()` with `group_by="platform"` and `where=[Filter.equals("country", "US")]` and verifying the result reflects the segmentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", group_by="platform")`, **Then** the result contains retention data segmented by platform values.
+2. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", where=[Filter.equals("source", "organic")])`, **Then** the result contains only users matching the filter condition.
+3. **Given** a configured Workspace, **When** the user calls `query_retention()` with per-event filters via `RetentionEvent` objects, **Then** each event's filters are applied independently — the birth event filter restricts who enters the cohort, and the return event filter restricts what counts as a return.
+
+---
+
+### User Story 3 - Retention with Custom Bucket Sizes (Priority: P2)
+
+A growth analyst wants non-uniform retention periods — for example, checking retention at day 1, day 3, day 7, day 14, and day 30 instead of every single day. They pass custom bucket sizes to see retention at specific intervals.
+
+**Why this priority**: Custom buckets are commonly needed for "day 1 / day 7 / day 30" style retention reports, but the feature works fine with uniform buckets by default.
+
+**Independent Test**: Can be tested by calling `query_retention("Signup", "Login", retention_unit="day", bucket_sizes=[1, 3, 7, 14, 30])` and verifying the result has exactly 5 retention buckets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", retention_unit="day", bucket_sizes=[1, 3, 7, 14, 30])`, **Then** the result contains exactly 5 retention buckets corresponding to the specified intervals.
+2. **Given** a configured Workspace, **When** the user calls `query_retention()` without `bucket_sizes`, **Then** the system uses uniform buckets based on `retention_unit` (the default behavior).
+
+---
+
+### User Story 4 - Build Params Without Executing (Priority: P3)
+
+A developer wants to inspect or persist the generated retention bookmark JSON without actually querying the API. They use `build_retention_params()` to get the raw params dict.
+
+**Why this priority**: Useful for debugging, testing, and saving reports via `create_bookmark()`, but not essential for querying.
+
+**Independent Test**: Can be tested by calling `build_retention_params("Signup", "Login")` and verifying it returns a dict with the correct structure, without making any API calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace, **When** the user calls `build_retention_params("Signup", "Login")`, **Then** the system returns a dict (not a result object) containing the bookmark JSON structure, and no API call is made.
+2. **Given** a configured Workspace, **When** the user calls `build_retention_params()` and then `query_retention()` with the same arguments, **Then** the bookmark params inside the query result match the params returned by `build_retention_params()`.
+
+---
+
+### User Story 5 - Fail-Fast Validation with Actionable Errors (Priority: P3)
+
+A user provides invalid inputs — fewer than two events, invalid bucket sizes, or invalid retention unit. The system catches the errors before any API call and returns structured, actionable error messages with suggestions.
+
+**Why this priority**: Good error messages dramatically improve developer experience, but they're polish on top of working functionality.
+
+**Independent Test**: Can be tested by calling `query_retention()` with invalid inputs and verifying that `BookmarkValidationError` is raised with the correct error codes, messages, and suggestions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace, **When** the user calls `query_retention("", "Login")`, **Then** the system raises a `BookmarkValidationError` with error code `R1` indicating the born event must be non-empty, and no API call is made.
+2. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", bucket_sizes=[7, 3, 1])`, **Then** the system raises a `BookmarkValidationError` with error code `R6` indicating bucket sizes must be in ascending order.
+3. **Given** a configured Workspace, **When** the user provides multiple invalid inputs simultaneously, **Then** all validation errors are collected and returned together (not just the first one), so the user can fix everything in one pass.
+
+---
+
+### User Story 6 - Result Display Modes (Priority: P3)
+
+An analyst wants to view retention data in different formats — the default retention curve, a trends-over-time view, or a tabular format.
+
+**Why this priority**: Alternative display modes add flexibility but the default curve mode covers the primary use case.
+
+**Independent Test**: Can be tested by calling `query_retention()` with `mode="trends"` and `mode="table"` and verifying different chart types are generated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", mode="curve")`, **Then** the bookmark params specify a retention curve chart type.
+2. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", mode="trends")`, **Then** the bookmark params specify a line chart type for time-series trends.
+3. **Given** a configured Workspace, **When** the user calls `query_retention("Signup", "Login", mode="table")`, **Then** the bookmark params specify a table chart type.
+
+---
+
+### Edge Cases
+
+- What happens when the born event and return event are the same? The system should accept this — it measures "users who did X and came back to do X again."
+- What happens when the API returns an empty cohorts structure (no data in date range)? The result should contain empty cohorts and an empty DataFrame with the correct column schema.
+- What happens when the API returns an error response (e.g., invalid event name, rate limit)? The system should raise the appropriate exception (`QueryError`, `RateLimitError`) with context.
+- What happens when `bucket_sizes` contains duplicate values (e.g., `[1, 3, 3, 7]`)? The system should reject this with a validation error.
+- What happens when `bucket_sizes` contains non-positive values (e.g., `[0, 3, 7]`)? The system should reject this with a validation error.
+- What happens when `from_date` is after `to_date`? The shared time validation should catch this (reused from existing infrastructure).
+- What happens when the API response contains a segmented structure (`$overall` key) vs a direct cohort list? The response parser should handle both formats robustly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Input Types
+
+- **FR-001**: System MUST provide a `RetentionEvent` type that wraps an event name with optional per-event filters and filter combinator (AND/OR), enabling filtered retention events without changing the simple string interface for common cases.
+- **FR-002**: System MUST provide a `RetentionMathType` that constrains valid retention aggregation functions to the set supported by Mixpanel's retention engine (retention rate and unique user count).
+- **FR-003**: System MUST accept plain event name strings for the `born_event` and `return_event` parameters, automatically converting them to the structured format internally (progressive disclosure).
+
+#### Result Type
+
+- **FR-004**: System MUST provide a `RetentionQueryResult` type containing cohort-level retention data: a mapping of cohort dates to their sizes, counts per bucket, and rates per bucket.
+- **FR-005**: The result MUST include an `average` field containing the synthetic average retention across all cohorts.
+- **FR-006**: The result MUST provide a `.df` property that returns a DataFrame with columns `cohort_date`, `bucket`, `count`, `rate` — one row per (cohort, bucket) pair.
+- **FR-007**: The DataFrame MUST be lazily computed and cached after first access (consistent with the existing `ResultWithDataFrame` pattern).
+- **FR-008**: The result MUST include the generated `.params` dict for debugging and persistence via `create_bookmark()`.
+- **FR-009**: The result MUST include `.computed_at`, `.from_date`, `.to_date`, and `.meta` fields from the API response.
+
+#### Validation (Layer 1 — Argument Validation)
+
+- **FR-010**: System MUST validate that `born_event` is a non-empty string or `RetentionEvent` with a non-empty event name (rule R1).
+- **FR-011**: System MUST validate that `return_event` is a non-empty string or `RetentionEvent` with a non-empty event name (rule R2).
+- **FR-012**: System MUST reuse existing shared time range validation rules (V7-V11, V15, V20) for `from_date`, `to_date`, `last` parameters (rule R3).
+- **FR-013**: System MUST reuse existing shared GroupBy validation rules (V11-V12, V18, V24) for the `group_by` parameter (rule R4).
+- **FR-014**: System MUST validate that `bucket_sizes`, when provided, contains only positive integers (rule R5).
+- **FR-015**: System MUST validate that `bucket_sizes`, when provided, is in strictly ascending order (rule R6).
+- **FR-016**: System MUST validate that `retention_unit` is one of the valid retention units (`day`, `week`, `month`), with fuzzy-matched suggestions for invalid values (rule R7).
+- **FR-017**: System MUST validate that `alignment` is one of the valid alignment types (`birth`, `interval_start`), with fuzzy-matched suggestions for invalid values (rule R8).
+- **FR-018**: System MUST validate that `math` is one of the valid retention math types (`retention_rate`, `unique`), with fuzzy-matched suggestions for invalid values (rule R9).
+- **FR-019**: System MUST collect all validation errors and return them together, not stopping at the first error.
+- **FR-020**: Validation errors MUST include error codes (R1-R9), human-readable messages, JSONPath-like field locations, and fuzzy-matched suggestions where applicable.
+
+#### Validation (Layer 2 — Bookmark Structure)
+
+- **FR-021**: System MUST extend the existing bookmark structure validator to recognize `bookmark_type="retention"` and validate retention-specific math types against the retention-valid set.
+- **FR-022**: Layer 2 validation MUST verify the bookmark JSON structure (sections, show, time, filter, group, displayOptions) using the same rules as insights and funnels.
+
+#### Bookmark JSON Builder
+
+- **FR-023**: System MUST generate valid retention bookmark JSON with `behavior.type = "retention"`, two behaviors (born event and return event), and retention-specific fields (`retentionUnit`, `retentionCustomBucketSizes`, `retentionAlignmentType`).
+- **FR-024**: System MUST reuse shared bookmark builders for time section, filter section, and group section construction.
+- **FR-025**: Per-event filters from `RetentionEvent` objects MUST be converted to the bookmark filter format using the existing `build_filter_entry()` function.
+- **FR-026**: The measurement block MUST include retention-specific fields (`retentionBucketIndex`, `retentionSegmentationEvent`).
+
+#### Public Methods
+
+- **FR-027**: System MUST provide `query_retention(born_event, return_event, **kwargs)` that validates inputs, builds bookmark params, queries the API, and returns a `RetentionQueryResult`.
+- **FR-028**: System MUST provide `build_retention_params(born_event, return_event, **kwargs)` that validates inputs, builds bookmark params, and returns the raw dict without querying the API.
+- **FR-029**: Both methods MUST accept the same set of keyword arguments: `retention_unit`, `alignment`, `bucket_sizes`, `from_date`, `to_date`, `last`, `unit`, `math`, `group_by`, `where`, `mode`.
+- **FR-030**: All validation MUST occur before any API call — invalid inputs never reach the network.
+
+#### Response Parsing
+
+- **FR-031**: System MUST parse the API response and extract cohort-level data: cohort dates, cohort sizes, per-bucket user counts, and per-bucket retention rates.
+- **FR-032**: System MUST extract the `$average` synthetic cohort from the response and populate the result's `average` field.
+- **FR-033**: System MUST handle multiple response format variations (direct cohort list, nested series structure, segmented responses with `$overall` key) robustly.
+- **FR-034**: System MUST raise `QueryError` when the API response contains an `error` key or is missing required fields (`series`).
+
+#### Exports
+
+- **FR-035**: The public package MUST export `RetentionEvent`, `RetentionMathType`, and `RetentionQueryResult` from the top-level `__init__.py`.
+
+### Key Entities
+
+- **RetentionEvent**: An event specification for retention queries. Wraps an event name with optional per-event filters and filter combinator. Used for both born (cohort entry) and return (retention signal) events.
+- **RetentionQueryResult**: The result of a retention query. Contains cohort-level data (dates mapped to sizes, counts, and rates), an average retention summary, the generated bookmark params, and response metadata. Provides lazy DataFrame conversion.
+- **RetentionMathType**: A constrained set of valid aggregation functions for retention queries (retention rate, unique count).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can run a simple retention query with just two event names (`query_retention("Signup", "Login")`) and receive structured results — no more than 2 required arguments for the simplest case.
+- **SC-002**: The retention query interface follows the same patterns as the existing `query()` and `query_funnel()` methods — users familiar with one can use the others without learning a new paradigm.
+- **SC-003**: All invalid inputs are caught before any network request, with actionable error messages that include the field path, error code, and suggestions for valid values.
+- **SC-004**: The result DataFrame contains the correct number of rows (one per cohort-bucket pair) and all expected columns (`cohort_date`, `bucket`, `count`, `rate`).
+- **SC-005**: `build_retention_params()` returns identical bookmark params to what `query_retention()` sends to the API, enabling inspect-then-query workflows.
+- **SC-006**: Generated bookmark params can be saved via `create_bookmark()` to persist retention reports in Mixpanel.
+- **SC-007**: All new code meets existing project quality standards: 90%+ test coverage, passes mypy --strict, passes ruff linting, includes comprehensive docstrings.
+- **SC-008**: Property-based tests verify type invariants (immutability, field preservation, DataFrame shape consistency) across randomly generated inputs.
+
+## Assumptions
+
+- The existing `insights_query()` API client method works for retention queries without modification — the Mixpanel `/insights` endpoint routes internally based on `behavior.type == "retention"` in the bookmark params.
+- The shared bookmark builders (`build_time_section`, `build_filter_section`, `build_group_section`, `build_filter_entry`) work correctly for retention queries — they have been validated by the insights and funnel implementations.
+- The shared validation helpers (`validate_time_args`, `validate_group_by_args`) are reusable for retention without modification.
+- The `VALID_MATH_RETENTION` enum in `bookmark_enums.py` already contains the correct set of valid math types for retention.
+- The `VALID_RETENTION_UNITS` and `VALID_RETENTION_ALIGNMENT` enums in `bookmark_enums.py` already contain the correct valid values.
+- The `validate_bookmark()` function already accepts a `bookmark_type` parameter and can be extended to use `VALID_MATH_RETENTION` when `bookmark_type="retention"`.
+- Retention queries use the same authentication and rate-limiting behavior as insights and funnel queries.
+- The `LiveQueryService` can be extended with a `query_retention()` method following the same pattern as `query()` and `query_funnel()`.
+- The response format for retention queries through the `/insights` endpoint follows the same envelope structure (`computed_at`, `date_range`, `headers`, `series`, `meta`) as insights and funnel responses, with retention-specific data nested in `series`.

--- a/specs/033-retention-query/tasks.md
+++ b/specs/033-retention-query/tasks.md
@@ -1,0 +1,312 @@
+# Tasks: Retention Query (`query_retention()`)
+
+**Input**: Design documents from `/specs/033-retention-query/`
+**Prerequisites**: plan.md, spec.md, data-model.md, contracts/public-api.md, research.md, quickstart.md
+
+**Tests**: Required — this project enforces strict TDD (CLAUDE.md: "Never write implementation code without a failing test first").
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Source**: `src/mixpanel_data/` (library code)
+- **Tests**: `tests/` (test files)
+- All paths relative to repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this extends an existing project. This phase verifies prerequisites.
+
+- [X] T001 Verify existing shared infrastructure is available: confirm `build_time_section`, `build_filter_section`, `build_group_section`, `build_filter_entry` exist in `src/mixpanel_data/_internal/bookmark_builders.py`
+- [X] T002 Verify existing retention enums are in place: confirm `VALID_MATH_RETENTION`, `VALID_RETENTION_UNITS`, `VALID_RETENTION_ALIGNMENT` exist in `src/mixpanel_data/_internal/bookmark_enums.py`
+- [X] T003 Verify `validate_time_args` and `validate_group_by_args` shared validators exist in `src/mixpanel_data/_internal/validation.py`
+
+---
+
+## Phase 2: Foundational (Types)
+
+**Purpose**: Define new types that ALL user stories depend on. Must complete before any user story.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+### Tests for Foundational Types
+
+- [X] T004 [P] Write `RetentionEvent` unit tests (construction, defaults, immutability, field preservation, filters handling) in `tests/test_types_retention.py`
+- [X] T005 [P] Write `RetentionQueryResult` unit tests (construction, defaults, immutability, `.df` columns/shape/caching, `.average` field, `.to_dict()`, empty cohorts edge case) in `tests/test_types_retention.py`
+- [X] T006 [P] Write `RetentionMathType` type alias validation tests (valid values accepted, invalid rejected at validation layer) in `tests/test_types_retention.py`
+
+### Implementation for Foundational Types
+
+- [X] T007 Implement `RetentionEvent` frozen dataclass (event, filters, filters_combinator) in `src/mixpanel_data/types.py`
+- [X] T008 Implement `RetentionMathType` Literal type alias (`"retention_rate"`, `"unique"`) in `src/mixpanel_data/types.py`
+- [X] T009 Implement `RetentionQueryResult` frozen dataclass extending `ResultWithDataFrame` (computed_at, from_date, to_date, cohorts, average, params, meta, `.df` property with lazy caching) in `src/mixpanel_data/types.py`
+- [X] T010 Run tests to verify Phase 2 types pass: `just test -k test_types_retention`
+
+**Checkpoint**: All three types exist and pass their unit tests.
+
+---
+
+## Phase 3: User Story 1 — Simple Retention Query (Priority: P1) MVP
+
+**Goal**: Users can call `query_retention("Signup", "Login")` with minimal args and get a structured `RetentionQueryResult` with cohort data and DataFrame.
+
+**Independent Test**: Call `query_retention("Signup", "Login")` with mocked API client and verify the result contains correct cohort data, retention rates, and well-shaped DataFrame.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T011 [P] [US1] Write validation tests for R1 (born_event non-empty, control chars, invisible) in `tests/test_validation_retention.py`
+- [X] T012 [P] [US1] Write validation tests for R2 (return_event non-empty, control chars, invisible) in `tests/test_validation_retention.py`
+- [X] T013 [P] [US1] Write validation tests for R7 (retention_unit valid), R8 (alignment valid), R9 (math valid) in `tests/test_validation_retention.py`
+- [X] T014 [P] [US1] Write validation tests for shared delegation: R3 (time args via `validate_time_args`) and R4 (group_by via `validate_group_by_args`) in `tests/test_validation_retention.py`
+- [X] T015 [P] [US1] Write bookmark builder tests for default structure: behavior type="retention", 2 behaviors (born/return), retentionUnit, retentionAlignmentType, measurement math, chart type in `tests/test_build_retention_params.py`
+- [X] T016 [P] [US1] Write bookmark builder tests for time section, empty filter section, empty group section using shared builders in `tests/test_build_retention_params.py`
+- [X] T017 [P] [US1] Write response transformer tests: basic response parsing (computed_at, from_date, to_date, cohorts extraction, average extraction, params preservation, meta) in `tests/test_transform_retention.py`
+- [X] T018 [P] [US1] Write response transformer tests: error handling (error key raises QueryError, missing series raises QueryError, empty response) in `tests/test_transform_retention.py`
+- [X] T019 [P] [US1] Write workspace integration tests: correct body sent to API (bookmark, project_id, queryLimits), result is RetentionQueryResult, credentials validation in `tests/test_workspace_retention.py`
+
+### Implementation for User Story 1
+
+- [X] T020 [US1] Implement `validate_retention_args()` with rules R1, R2, R7, R8, R9 and delegation to `validate_time_args`/`validate_group_by_args` in `src/mixpanel_data/_internal/validation.py`
+- [X] T021 [US1] Extend `validate_bookmark()` to use `VALID_MATH_RETENTION` when `bookmark_type="retention"` in `src/mixpanel_data/_internal/validation.py`
+- [X] T022 [US1] Implement `_build_retention_params()` — build retention bookmark JSON with behavior type="retention", 2 behaviors, retentionUnit, retentionAlignmentType, retentionCustomBucketSizes=[], measurement, time/filter/group sections in `src/mixpanel_data/workspace.py`
+- [X] T023 [US1] Implement `_transform_retention_result()` — parse API response, extract cohort data and `$average`, handle format variations, produce `RetentionQueryResult` in `src/mixpanel_data/_internal/services/live_query.py`
+- [X] T024 [US1] Implement `query_retention()` service method on `LiveQueryService` — build body, call `insights_query()`, transform response in `src/mixpanel_data/_internal/services/live_query.py`
+- [X] T025 [US1] Implement `_resolve_and_build_retention_params()` — normalize events, Layer 1 validation, build params, Layer 2 validation in `src/mixpanel_data/workspace.py`
+- [X] T026 [US1] Implement `query_retention()` public method on `Workspace` — delegate to `_resolve_and_build_retention_params()` then `_live_query_service.query_retention()` in `src/mixpanel_data/workspace.py`
+- [X] T027 [US1] Run all US1 tests to verify: `just test -k "test_validation_retention or test_build_retention or test_transform_retention or test_workspace_retention"`
+
+**Checkpoint**: `query_retention("Signup", "Login")` works end-to-end with mocked API. MVP is functional.
+
+---
+
+## Phase 4: User Story 2 — Filters and Segmentation (Priority: P2)
+
+**Goal**: Users can add per-event filters via `RetentionEvent`, global filters via `where`, and breakdowns via `group_by`.
+
+**Independent Test**: Call `query_retention()` with `RetentionEvent` objects, `where` filters, and `group_by` and verify bookmark params contain correct filter/group sections and per-event filters in behavior entries.
+
+### Tests for User Story 2
+
+- [X] T028 [P] [US2] Write builder tests for per-event filters: RetentionEvent with filters produces non-empty filters array in behavior entry, filters_combinator maps to filtersDeterminer in `tests/test_build_retention_params.py`
+- [X] T029 [P] [US2] Write builder tests for global where filter: Filter objects produce filter section entries in `tests/test_build_retention_params.py`
+- [X] T030 [P] [US2] Write builder tests for group_by: string and GroupBy objects produce group section entries in `tests/test_build_retention_params.py`
+- [X] T031 [P] [US2] Write workspace integration test for per-event filters and segmented queries in `tests/test_workspace_retention.py`
+
+### Implementation for User Story 2
+
+- [X] T032 [US2] Add per-event filter handling in `_build_retention_params()` — convert RetentionEvent.filters to behavior entry filters using `build_filter_entry()` in `src/mixpanel_data/workspace.py`
+- [X] T033 [US2] Run US2 tests: `just test -k "test_build_retention_params or test_workspace_retention"`
+
+**Checkpoint**: Filters and group_by work in retention queries.
+
+---
+
+## Phase 5: User Story 3 — Custom Bucket Sizes (Priority: P2)
+
+**Goal**: Users can pass `bucket_sizes=[1, 3, 7, 14, 30]` for non-uniform retention periods.
+
+**Independent Test**: Call `query_retention()` with `bucket_sizes` and verify the bookmark params contain `retentionCustomBucketSizes` with the correct values.
+
+### Tests for User Story 3
+
+- [X] T034 [P] [US3] Write validation tests for R5 (bucket_sizes positive integers, float rejection) and R6 (strictly ascending order, duplicates rejected) in `tests/test_validation_retention.py`
+- [X] T035 [P] [US3] Write builder tests for bucket_sizes: populates `retentionCustomBucketSizes` in behavior block, None produces empty list in `tests/test_build_retention_params.py`
+
+### Implementation for User Story 3
+
+- [X] T036 [US3] Add R5 and R6 validation rules to `validate_retention_args()` in `src/mixpanel_data/_internal/validation.py`
+- [X] T037 [US3] Add `bucket_sizes` handling in `_build_retention_params()` — populate `retentionCustomBucketSizes` in `src/mixpanel_data/workspace.py`
+- [X] T038 [US3] Run US3 tests: `just test -k "test_validation_retention or test_build_retention_params"`
+
+**Checkpoint**: Custom bucket sizes validated and included in bookmark params.
+
+---
+
+## Phase 6: User Story 4 — Build Params Without Executing (Priority: P3)
+
+**Goal**: Users can call `build_retention_params()` to inspect generated bookmark JSON without querying the API.
+
+**Independent Test**: Call `build_retention_params("Signup", "Login")` and verify it returns a dict, makes no API call, and matches what `query_retention()` would send.
+
+### Tests for User Story 4
+
+- [X] T039 [P] [US4] Write tests for `build_retention_params()`: returns dict (not result), has sections/displayOptions keys, no API call made in `tests/test_workspace_retention.py`
+- [X] T040 [P] [US4] Write consistency test: `build_retention_params()` output matches `query_retention()` bookmark params in `tests/test_workspace_retention.py`
+
+### Implementation for User Story 4
+
+- [X] T041 [US4] Implement `build_retention_params()` public method on `Workspace` — same signature as `query_retention()` but returns dict from `_resolve_and_build_retention_params()` in `src/mixpanel_data/workspace.py`
+- [X] T042 [US4] Run US4 tests: `just test -k test_workspace_retention`
+
+**Checkpoint**: `build_retention_params()` works and is consistent with `query_retention()`.
+
+---
+
+## Phase 7: User Story 5 — Fail-Fast Validation (Priority: P3)
+
+**Goal**: Invalid inputs are caught before API calls with structured, actionable errors including codes, paths, and suggestions.
+
+**Independent Test**: Call `query_retention()` with multiple invalid inputs and verify all errors are collected and returned together with correct codes.
+
+### Tests for User Story 5
+
+- [X] T043 [P] [US5] Write multi-error collection tests: multiple simultaneous validation failures (e.g., empty born_event + invalid unit) all returned in single BookmarkValidationError in `tests/test_validation_retention.py`
+- [X] T044 [P] [US5] Write validation error structure tests: error code format, path accuracy, suggestion presence for enum validation (R7, R8, R9) in `tests/test_validation_retention.py`
+- [X] T045 [P] [US5] Write workspace validation integration test: BookmarkValidationError raised before API call, API client never called in `tests/test_workspace_retention.py`
+
+### Implementation for User Story 5
+
+- [X] T046 [US5] Review and verify error codes, paths, and suggestions in `validate_retention_args()` match contracts/public-api.md error code table in `src/mixpanel_data/_internal/validation.py`
+- [X] T047 [US5] Run US5 tests: `just test -k "test_validation_retention or test_workspace_retention"`
+
+**Checkpoint**: All invalid inputs produce structured, actionable errors.
+
+---
+
+## Phase 8: User Story 6 — Result Display Modes (Priority: P3)
+
+**Goal**: Users can request retention data in different display formats: curve (default), trends, or table.
+
+**Independent Test**: Call `query_retention()` with each mode value and verify the bookmark params contain the correct `chartType`.
+
+### Tests for User Story 6
+
+- [X] T048 [P] [US6] Write builder tests for mode→chartType mapping: curve→retention-curve, trends→line, table→table in `tests/test_build_retention_params.py`
+
+### Implementation for User Story 6
+
+- [X] T049 [US6] Add mode→chartType mapping in `_build_retention_params()` displayOptions in `src/mixpanel_data/workspace.py`
+- [X] T050 [US6] Run US6 tests: `just test -k test_build_retention_params`
+
+**Checkpoint**: All three display modes produce correct chart types.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Property-based tests, exports, comprehensive quality checks.
+
+- [X] T051 [P] Write Hypothesis PBT tests for `RetentionEvent` (immutability, equality, field preservation across random inputs) in `tests/test_types_retention_pbt.py`
+- [X] T052 [P] Write Hypothesis PBT tests for `RetentionQueryResult` (DataFrame row count matches cohorts, column count always 4, deterministic conversion) in `tests/test_types_retention_pbt.py`
+- [X] T053 [P] Write Hypothesis PBT tests for `_build_retention_params` invariants (always has sections/displayOptions, behavior count always 2, chart type always valid) in `tests/test_types_retention_pbt.py`
+- [X] T054 [P] Write response transformer tests for format variations: direct cohort dict, nested `$overall`, segmented format, insights API wrapper format in `tests/test_transform_retention.py`
+- [X] T055 Add `RetentionEvent`, `RetentionMathType`, `RetentionQueryResult` exports to `src/mixpanel_data/__init__.py`
+- [X] T056 Verify all docstrings complete for new types, methods, and functions per CLAUDE.md standards
+- [X] T057 Run full quality check: `just check` (lint + typecheck + test)
+- [X] T058 Run test coverage check: `just test-cov` (must be >= 90%)
+- [X] T059 Run quickstart.md validation: verify all code examples from `specs/033-retention-query/quickstart.md` are syntactically valid
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — verification only
+- **Foundational (Phase 2)**: Depends on Setup — defines types all stories need
+- **US1 (Phase 3)**: Depends on Foundational — core pipeline MVP
+- **US2 (Phase 4)**: Depends on US1 — adds filter/segmentation handling
+- **US3 (Phase 5)**: Depends on US1 — adds bucket_sizes to validation + builder
+- **US4 (Phase 6)**: Depends on US1 — adds build_retention_params() public method
+- **US5 (Phase 7)**: Depends on US1 + US3 — comprehensive validation testing
+- **US6 (Phase 8)**: Depends on US1 — adds mode parameter
+- **Polish (Phase 9)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires Phase 2 types only — the core MVP
+- **US2 (P2)**: Requires US1 pipeline working — extends with filters
+- **US3 (P2)**: Requires US1 pipeline working — extends with bucket_sizes
+- **US4 (P3)**: Requires US1 pipeline working — wraps as build-only method
+- **US5 (P3)**: Requires US1 + US3 validation — tests comprehensive error collection
+- **US6 (P3)**: Requires US1 builder working — extends with mode mapping
+
+### Parallel Opportunities
+
+- **Phase 2**: T004, T005, T006 (type tests) can run in parallel
+- **Phase 3**: T011-T019 (all US1 tests) can run in parallel
+- **Phase 4-6**: US2, US3, US4 can proceed in parallel after US1 is complete (different files and concerns)
+- **Phase 9**: T051-T054 (PBT + format variation tests) can run in parallel
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Validation before builder (validation catches bad inputs before they reach the builder)
+- Builder before transformer (builder creates params, transformer parses responses)
+- Service before workspace (service is called by workspace)
+- Run test command at end of each phase to verify
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all US1 tests together (T011-T019 are in different files):
+Task: "Write validation tests for R1, R2, R7, R8, R9 in tests/test_validation_retention.py"
+Task: "Write builder tests for default structure in tests/test_build_retention_params.py"
+Task: "Write transformer tests in tests/test_transform_retention.py"
+Task: "Write workspace integration tests in tests/test_workspace_retention.py"
+
+# Then implement sequentially:
+Task: "Implement validate_retention_args() in validation.py"
+Task: "Implement _build_retention_params() in workspace.py"
+Task: "Implement _transform_retention_result() in live_query.py"
+Task: "Implement query_retention() service method in live_query.py"
+Task: "Implement Workspace methods in workspace.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (verification)
+2. Complete Phase 2: Foundational types
+3. Complete Phase 3: User Story 1 — simple retention query
+4. **STOP and VALIDATE**: `just test -k retention` — all tests pass
+5. US1 delivers: `query_retention("Signup", "Login")` works end-to-end
+
+### Incremental Delivery
+
+1. Phase 2 → Types ready
+2. Phase 3 (US1) → Simple query works (MVP)
+3. Phase 4 (US2) → Filters and segmentation work
+4. Phase 5 (US3) → Custom bucket sizes work
+5. Phase 6 (US4) → `build_retention_params()` available
+6. Phase 7 (US5) → Comprehensive validation verified
+7. Phase 8 (US6) → Display modes work
+8. Phase 9 → PBT, exports, quality gates pass
+
+### Parallel Opportunities After US1
+
+Once US1 is complete, US2, US3, US4, and US6 can proceed in parallel:
+- US2 modifies `_build_retention_params()` (per-event filters)
+- US3 modifies `validate_retention_args()` + `_build_retention_params()` (bucket_sizes)
+- US4 adds `build_retention_params()` (new method, no conflicts)
+- US6 modifies `_build_retention_params()` (displayOptions)
+
+If working sequentially, follow priority order: US2 → US3 → US4 → US5 → US6.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Write tests first — verify they FAIL before implementing
+- Commit after each phase checkpoint
+- Follow existing funnel test patterns: see `tests/test_types_funnel.py`, `tests/test_validation_funnel.py`, `tests/test_build_funnel_params.py`, `tests/test_transform_funnel.py`, `tests/test_workspace_funnel.py` for fixture patterns, mocking strategies, and test organization
+- Use `_valid_retention_args(**overrides)` helper pattern from `test_validation_funnel.py` for validation tests
+- Use workspace factory fixture pattern from `test_workspace_funnel.py` for integration tests

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -164,6 +164,9 @@ from mixpanel_data.types import (
     QueryResult,
     RcaSourceData,
     ReplaceSchemaEnforcementParams,
+    RetentionEvent,
+    RetentionMathType,
+    RetentionQueryResult,
     RetentionResult,
     SavedCohort,
     SavedReportResult,
@@ -414,4 +417,8 @@ __all__ = [
     "HoldingConstant",
     "FunnelMathType",
     "FunnelQueryResult",
+    # Retention Query types (Phase 033)
+    "RetentionEvent",
+    "RetentionMathType",
+    "RetentionQueryResult",
 ]

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -164,8 +164,10 @@ from mixpanel_data.types import (
     QueryResult,
     RcaSourceData,
     ReplaceSchemaEnforcementParams,
+    RetentionAlignment,
     RetentionEvent,
     RetentionMathType,
+    RetentionMode,
     RetentionQueryResult,
     RetentionResult,
     SavedCohort,
@@ -418,7 +420,9 @@ __all__ = [
     "FunnelMathType",
     "FunnelQueryResult",
     # Retention Query types (Phase 033)
+    "RetentionAlignment",
     "RetentionEvent",
     "RetentionMathType",
+    "RetentionMode",
     "RetentionQueryResult",
 ]

--- a/src/mixpanel_data/_internal/services/live_query.py
+++ b/src/mixpanel_data/_internal/services/live_query.py
@@ -557,13 +557,30 @@ def _transform_retention_result(
     series = raw.get("series", {})
 
     # Unwrap the metric name key: series = {"metric_name": {date_cohorts}}
-    # The API always returns exactly one top-level key (the metric name).
+    # The API returns exactly one top-level key (the metric name) for
+    # non-segmented retention.  Segmented responses have multiple keys
+    # which RetentionQueryResult cannot represent — raise rather than
+    # silently dropping data.
     cohort_data: dict[str, Any] = {}
     if isinstance(series, dict):
+        if len(series) > 1:
+            raise QueryError(
+                "Retention query returned segmented series with "
+                f"{len(series)} keys that cannot be represented as a "
+                "single RetentionQueryResult without losing data. "
+                f"Keys: {sorted(series.keys())}",
+                status_code=200,
+                response_body=raw,
+                request_body=bookmark_params,
+            )
         for _metric_key, value in series.items():
             if isinstance(value, dict):
                 cohort_data = value
                 break
+
+    # Handle $overall wrapper (segmented responses may nest under $overall)
+    if "$overall" in cohort_data and isinstance(cohort_data["$overall"], dict):
+        cohort_data = cohort_data["$overall"]
 
     # Extract $average synthetic cohort and date-keyed cohorts
     average: dict[str, Any] = {}

--- a/src/mixpanel_data/_internal/services/live_query.py
+++ b/src/mixpanel_data/_internal/services/live_query.py
@@ -502,6 +502,45 @@ def _transform_funnel_result(
     )
 
 
+def _normalize_cohort_date(key: str) -> str:
+    """Normalize an ISO timestamp cohort key to YYYY-MM-DD.
+
+    The insights API may return cohort date keys as full ISO timestamps
+    (e.g. ``2025-01-01T00:00:00+00:00``). This truncates to the first
+    10 characters to produce a plain ``YYYY-MM-DD`` date string.
+
+    Args:
+        key: Cohort date key from the API response.
+
+    Returns:
+        Normalized date string (``YYYY-MM-DD``).
+    """
+    return key[:10] if "T" in key else key
+
+
+def _extract_cohorts_and_average(
+    data: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Extract date-keyed cohorts and $average from a cohort data dict.
+
+    Normalizes cohort date keys to ``YYYY-MM-DD`` format.
+
+    Args:
+        data: Cohort data dict (date keys + optional ``$average``).
+
+    Returns:
+        Tuple of (cohorts dict, average dict).
+    """
+    average: dict[str, Any] = {}
+    cohorts: dict[str, dict[str, Any]] = {}
+    for key, value in data.items():
+        if key == "$average":
+            average = value if isinstance(value, dict) else {}
+        elif isinstance(value, dict):
+            cohorts[_normalize_cohort_date(key)] = value
+    return cohorts, average
+
+
 def _transform_retention_result(
     raw: dict[str, Any],
     bookmark_params: dict[str, Any],
@@ -521,7 +560,19 @@ def _transform_retention_result(
             }
         }
 
-    This function unwraps the outer metric key to extract the cohort dict.
+    For segmented (``group_by``) queries, the response nests segments
+    alongside ``$overall``::
+
+        series = {
+            "EventA and then EventB": {
+                "$overall": {"2025-01-01": {...}, "$average": {...}},
+                "iOS":      {"2025-01-01": {...}, "$average": {...}},
+                "Android":  {"2025-01-01": {...}, "$average": {...}},
+            }
+        }
+
+    This function unwraps the outer metric key and extracts both
+    aggregate (``$overall``) and per-segment cohort data.
 
     Args:
         raw: Raw API response dictionary from insights query.
@@ -556,13 +607,20 @@ def _transform_retention_result(
     date_range = raw.get("date_range", {})
     series = raw.get("series", {})
 
+    if not isinstance(series, dict):
+        raise QueryError(
+            f"Retention query 'series' field is {type(series).__name__}, "
+            "expected dict.",
+            status_code=200,
+            response_body=raw,
+            request_body=bookmark_params,
+        )
+
     # Unwrap the metric name key: series = {"metric_name": {date_cohorts}}
-    # The API returns exactly one top-level key (the metric name) for
-    # non-segmented retention.  Segmented responses have multiple keys
-    # which RetentionQueryResult cannot represent — raise rather than
-    # silently dropping data.
+    # The API returns exactly one top-level key (the metric name).
+    # Multiple top-level keys indicate a genuinely malformed response.
     cohort_data: dict[str, Any] = {}
-    if isinstance(series, dict):
+    if series:
         if len(series) > 1:
             raise QueryError(
                 "Retention query returned segmented series with "
@@ -577,19 +635,38 @@ def _transform_retention_result(
             if isinstance(value, dict):
                 cohort_data = value
                 break
+        else:
+            # No dict value found — the metric key maps to a non-dict
+            metric_key = next(iter(series))
+            raise QueryError(
+                f"Retention series value for key {metric_key!r} is not a "
+                f"dict (got {type(series[metric_key]).__name__}). "
+                "Expected cohort data dictionary.",
+                status_code=200,
+                response_body=raw,
+                request_body=bookmark_params,
+            )
 
-    # Handle $overall wrapper (segmented responses may nest under $overall)
+    # Handle segmented responses: $overall + named segments
+    segments: dict[str, dict[str, dict[str, Any]]] = {}
+    segment_averages: dict[str, dict[str, Any]] = {}
+
     if "$overall" in cohort_data and isinstance(cohort_data["$overall"], dict):
-        cohort_data = cohort_data["$overall"]
+        # Extract aggregate from $overall
+        overall_data = cohort_data["$overall"]
+        cohorts, average = _extract_cohorts_and_average(overall_data)
 
-    # Extract $average synthetic cohort and date-keyed cohorts
-    average: dict[str, Any] = {}
-    cohorts: dict[str, dict[str, Any]] = {}
-    for key, value in cohort_data.items():
-        if key == "$average":
-            average = value if isinstance(value, dict) else {}
-        elif isinstance(value, dict):
-            cohorts[key] = value
+        # Extract named segments (everything except $overall)
+        for seg_key, seg_value in cohort_data.items():
+            if seg_key == "$overall" or not isinstance(seg_value, dict):
+                continue
+            seg_cohorts, seg_avg = _extract_cohorts_and_average(seg_value)
+            segments[seg_key] = seg_cohorts
+            if seg_avg:
+                segment_averages[seg_key] = seg_avg
+    else:
+        # Unsegmented: extract $average and date-keyed cohorts directly
+        cohorts, average = _extract_cohorts_and_average(cohort_data)
 
     return RetentionQueryResult(
         computed_at=raw.get("computed_at", ""),
@@ -599,6 +676,8 @@ def _transform_retention_result(
         average=average,
         params=bookmark_params,
         meta=raw.get("meta", {}),
+        segments=segments,
+        segment_averages=segment_averages,
     )
 
 

--- a/src/mixpanel_data/_internal/services/live_query.py
+++ b/src/mixpanel_data/_internal/services/live_query.py
@@ -41,6 +41,7 @@ from mixpanel_data.types import (
     PropertyDistributionResult,
     PropertyValueCount,
     QueryResult,
+    RetentionQueryResult,
     RetentionResult,
     SavedReportResult,
     SegmentationResult,
@@ -496,6 +497,89 @@ def _transform_funnel_result(
         to_date=date_range.get("to_date", ""),
         steps_data=steps_data,
         series=series,
+        params=bookmark_params,
+        meta=raw.get("meta", {}),
+    )
+
+
+def _transform_retention_result(
+    raw: dict[str, Any],
+    bookmark_params: dict[str, Any],
+) -> RetentionQueryResult:
+    """Transform raw insights query retention response into RetentionQueryResult.
+
+    Extracts computed_at, date_range, cohort data from the series, and
+    the synthetic ``$average`` cohort. Validates that the response
+    contains expected fields and is not an error-as-200.
+
+    The insights API always wraps retention data in a metric name key::
+
+        series = {
+            "EventA and then EventB": {
+                "2025-01-01T00:00:00+00:00": {"first": 100, "counts": [...], "rates": [...]},
+                "$average": {"first": 90, "counts": [...], "rates": [...]},
+            }
+        }
+
+    This function unwraps the outer metric key to extract the cohort dict.
+
+    Args:
+        raw: Raw API response dictionary from insights query.
+        bookmark_params: The bookmark params dict sent to the API
+            (preserved in the result for debugging/persistence).
+
+    Returns:
+        Typed RetentionQueryResult with cohort data and metadata.
+
+    Raises:
+        QueryError: If the response contains an error or is missing
+            required fields.
+    """
+    # Check for error responses that leaked through as HTTP 200
+    if "error" in raw:
+        raise QueryError(
+            f"Retention query failed: {raw['error']}",
+            status_code=200,
+            response_body=raw,
+            request_body=bookmark_params,
+        )
+
+    if "series" not in raw:
+        raise QueryError(
+            "Retention query returned unexpected response shape "
+            f"(missing 'series' key). Keys present: {sorted(raw.keys())}",
+            status_code=200,
+            response_body=raw,
+            request_body=bookmark_params,
+        )
+
+    date_range = raw.get("date_range", {})
+    series = raw.get("series", {})
+
+    # Unwrap the metric name key: series = {"metric_name": {date_cohorts}}
+    # The API always returns exactly one top-level key (the metric name).
+    cohort_data: dict[str, Any] = {}
+    if isinstance(series, dict):
+        for _metric_key, value in series.items():
+            if isinstance(value, dict):
+                cohort_data = value
+                break
+
+    # Extract $average synthetic cohort and date-keyed cohorts
+    average: dict[str, Any] = {}
+    cohorts: dict[str, dict[str, Any]] = {}
+    for key, value in cohort_data.items():
+        if key == "$average":
+            average = value if isinstance(value, dict) else {}
+        elif isinstance(value, dict):
+            cohorts[key] = value
+
+    return RetentionQueryResult(
+        computed_at=raw.get("computed_at", ""),
+        from_date=date_range.get("from_date", ""),
+        to_date=date_range.get("to_date", ""),
+        cohorts=cohorts,
+        average=average,
         params=bookmark_params,
         meta=raw.get("meta", {}),
     )
@@ -1037,6 +1121,48 @@ class LiveQueryService:
         }
         raw = self._api_client.insights_query(body)
         return _transform_funnel_result(raw, bookmark_params)
+
+    def query_retention(
+        self,
+        bookmark_params: dict[str, Any],
+        project_id: int,
+    ) -> RetentionQueryResult:
+        """Execute an inline retention query with pre-built bookmark params.
+
+        Posts retention bookmark params to the insights query endpoint
+        (the API detects ``behavior.type == "retention"`` and delegates
+        to the retention query engine), then transforms the response
+        into a RetentionQueryResult with lazy DataFrame.
+
+        Args:
+            bookmark_params: Pre-built retention bookmark params dict.
+            project_id: Mixpanel project ID.
+
+        Returns:
+            RetentionQueryResult with cohort data, DataFrame,
+            and metadata.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid bookmark params.
+            RateLimitError: Rate limit exceeded.
+
+        Example:
+            ```python
+            result = live_query.query_retention(
+                bookmark_params={"sections": {...}, "displayOptions": {...}},
+                project_id=12345,
+            )
+            print(result.cohorts)
+            ```
+        """
+        body: dict[str, Any] = {
+            "bookmark": bookmark_params,
+            "project_id": project_id,
+            "queryLimits": {"limit": 3000},
+        }
+        raw = self._api_client.insights_query(body)
+        return _transform_retention_result(raw, bookmark_params)
 
     def query_flows(
         self,

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -31,10 +31,13 @@ from mixpanel_data._internal.bookmark_enums import (
     VALID_FILTERS_DETERMINER,
     VALID_MATH_FUNNELS,
     VALID_MATH_INSIGHTS,
+    VALID_MATH_RETENTION,
     VALID_METRIC_TYPES,
     VALID_PER_USER_AGGREGATIONS,
     VALID_PROPERTY_TYPES,
     VALID_RESOURCE_TYPES,
+    VALID_RETENTION_ALIGNMENT,
+    VALID_RETENTION_UNITS,
     VALID_TIME_UNITS,
 )
 from mixpanel_data.exceptions import ValidationError
@@ -61,6 +64,7 @@ _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _INVISIBLE_RE = re.compile(r"^[\s\u200b\u200c\u200d\ufeff\u00ad\u2060]*$")
 _MAX_LAST_DAYS = 3650  # 10 years — generous but sane upper bound
 _MAX_ROLLING = 365  # rolling window sanity cap
+_MAX_FILTER_VALUES = 1000  # server rejects queries with very large filter value lists
 
 
 def _is_valid_date(date_str: str) -> bool:
@@ -776,6 +780,266 @@ def validate_funnel_args(
 
 
 # =============================================================================
+# Retention argument validation (R1-R9)
+# =============================================================================
+
+_VALID_RETENTION_MATH_PUBLIC: frozenset[str] = frozenset({"retention_rate", "unique"})
+"""Public-facing retention math types (Layer 1).
+
+The L2 validator uses ``VALID_MATH_RETENTION`` which also includes
+``"total"`` and ``"average"`` for internal bookmark params.
+"""
+
+_VALID_RETENTION_MODES: frozenset[str] = frozenset({"curve", "trends", "table"})
+"""Valid display modes for retention queries."""
+
+_MAX_RETENTION_BUCKETS = 730
+"""Maximum number of custom retention buckets allowed by the API."""
+
+
+def validate_retention_args(
+    *,
+    born_event: str,
+    return_event: str,
+    retention_unit: str = "week",
+    alignment: str = "birth",
+    bucket_sizes: list[int] | None = None,
+    math: str = "retention_rate",
+    mode: str = "curve",
+    unit: str = "day",
+    from_date: str | None = None,
+    to_date: str | None = None,
+    last: int = 30,
+    group_by: str | GroupBy | list[str | GroupBy] | None = None,
+) -> list[ValidationError]:
+    """Validate retention query arguments before bookmark construction (Layer 1).
+
+    Implements retention-specific validation rules R1-R9 plus reused
+    time and group-by validators. Returns all errors found so callers
+    can fix multiple issues in a single pass.
+
+    Args:
+        born_event: Event name that defines cohort membership.
+        return_event: Event name that defines return.
+        retention_unit: Retention period unit. Must be one of:
+            day, week, month. Default: ``"week"``.
+        alignment: Retention alignment mode. Must be one of:
+            birth, interval_start. Default: ``"birth"``.
+        bucket_sizes: Custom bucket sizes (positive ints in ascending
+            order), or ``None`` for default uniform buckets.
+        math: Retention aggregation function. Must be one of:
+            retention_rate, unique. Default: ``"retention_rate"``.
+        from_date: Start date (YYYY-MM-DD) or ``None``.
+        to_date: End date (YYYY-MM-DD) or ``None``.
+        last: Number of days for relative date range.
+        group_by: Breakdown specification.
+
+    Returns:
+        List of validation errors. Empty list means all arguments are valid.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.validation import validate_retention_args
+
+        errors = validate_retention_args(
+            born_event="Signup",
+            return_event="Login",
+        )
+        assert errors == []
+        ```
+    """
+    errors: list[ValidationError] = []
+
+    # R1: born_event must be non-empty string
+    if not born_event.strip():
+        errors.append(
+            ValidationError(
+                path="born_event",
+                message="born_event must be a non-empty string",
+                code="R1_EMPTY_BORN_EVENT",
+            )
+        )
+    else:
+        # R1b: No control characters
+        if _CONTROL_CHAR_RE.search(born_event):
+            errors.append(
+                ValidationError(
+                    path="born_event",
+                    message=(f"born_event contains control characters: {born_event!r}"),
+                    code="R1_CONTROL_CHAR_BORN_EVENT",
+                )
+            )
+        # R1c: No invisible-only names
+        if _INVISIBLE_RE.match(born_event):
+            errors.append(
+                ValidationError(
+                    path="born_event",
+                    message="born_event contains only invisible characters",
+                    code="R1_INVISIBLE_BORN_EVENT",
+                )
+            )
+
+    # R2: return_event must be non-empty string
+    if not return_event.strip():
+        errors.append(
+            ValidationError(
+                path="return_event",
+                message="return_event must be a non-empty string",
+                code="R2_EMPTY_RETURN_EVENT",
+            )
+        )
+    else:
+        # R2b: No control characters
+        if _CONTROL_CHAR_RE.search(return_event):
+            errors.append(
+                ValidationError(
+                    path="return_event",
+                    message=(
+                        f"return_event contains control characters: {return_event!r}"
+                    ),
+                    code="R2_CONTROL_CHAR_RETURN_EVENT",
+                )
+            )
+        # R2c: No invisible-only names
+        if _INVISIBLE_RE.match(return_event):
+            errors.append(
+                ValidationError(
+                    path="return_event",
+                    message="return_event contains only invisible characters",
+                    code="R2_INVISIBLE_RETURN_EVENT",
+                )
+            )
+
+    # R7: retention_unit validation
+    if retention_unit not in VALID_RETENTION_UNITS:
+        errors.append(
+            _enum_error(
+                path="retention_unit",
+                field="retention_unit",
+                value=retention_unit,
+                valid=VALID_RETENTION_UNITS,
+                code="R7_INVALID_RETENTION_UNIT",
+            )
+        )
+
+    # R8: alignment validation
+    if alignment not in VALID_RETENTION_ALIGNMENT:
+        errors.append(
+            _enum_error(
+                path="alignment",
+                field="alignment",
+                value=alignment,
+                valid=VALID_RETENTION_ALIGNMENT,
+                code="R8_INVALID_ALIGNMENT",
+            )
+        )
+
+    # R9: math validation (public-facing subset)
+    if math not in _VALID_RETENTION_MATH_PUBLIC:
+        errors.append(
+            _enum_error(
+                path="math",
+                field="math",
+                value=math,
+                valid=_VALID_RETENTION_MATH_PUBLIC,
+                code="R9_INVALID_MATH",
+            )
+        )
+
+    # R10: mode validation
+    if mode not in _VALID_RETENTION_MODES:
+        errors.append(
+            _enum_error(
+                path="mode",
+                field="mode",
+                value=str(mode),
+                valid=_VALID_RETENTION_MODES,
+                code="R10_INVALID_MODE",
+            )
+        )
+
+    # R11: unit must be valid for retention context (day, week, month only)
+    if unit not in VALID_RETENTION_UNITS:
+        errors.append(
+            _enum_error(
+                path="unit",
+                field="unit",
+                value=str(unit),
+                valid=VALID_RETENTION_UNITS,
+                code="R11_INVALID_UNIT",
+            )
+        )
+
+    # R12: group_by strings must be non-empty
+    if group_by is not None:
+        gb_list = group_by if isinstance(group_by, list) else [group_by]
+        for i, g in enumerate(gb_list):
+            if isinstance(g, str) and not g.strip():
+                gpath = f"group_by[{i}]" if len(gb_list) > 1 else "group_by"
+                errors.append(
+                    ValidationError(
+                        path=gpath,
+                        message="group_by property name must be a non-empty string",
+                        code="R12_EMPTY_GROUP_BY",
+                    )
+                )
+
+    # R5: bucket_sizes values must be positive integers
+    if bucket_sizes is not None:
+        for i, val in enumerate(bucket_sizes):
+            if isinstance(val, float):
+                errors.append(
+                    ValidationError(
+                        path=f"bucket_sizes[{i}]",
+                        message=f"bucket_sizes[{i}] must be an integer, got float",
+                        code="R5_BUCKET_SIZES_INTEGER",
+                    )
+                )
+            elif not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+                errors.append(
+                    ValidationError(
+                        path="bucket_sizes",
+                        message="bucket_sizes values must be positive integers",
+                        code="R5_BUCKET_SIZES_POSITIVE",
+                    )
+                )
+
+        # R6: bucket_sizes must be in strictly ascending order
+        if len(bucket_sizes) >= 2:
+            for i in range(1, len(bucket_sizes)):
+                if bucket_sizes[i] <= bucket_sizes[i - 1]:
+                    errors.append(
+                        ValidationError(
+                            path="bucket_sizes",
+                            message="bucket_sizes must be in strictly ascending order",
+                            code="R6_BUCKET_SIZES_ASCENDING",
+                        )
+                    )
+                    break
+
+        # R5c: Maximum bucket count
+        if len(bucket_sizes) > _MAX_RETENTION_BUCKETS:
+            errors.append(
+                ValidationError(
+                    path="bucket_sizes",
+                    message=(
+                        f"bucket_sizes has {len(bucket_sizes)} entries, "
+                        f"maximum is {_MAX_RETENTION_BUCKETS}"
+                    ),
+                    code="R5_BUCKET_SIZES_TOO_MANY",
+                )
+            )
+
+    # R3: Time argument validation (delegated)
+    errors.extend(validate_time_args(from_date=from_date, to_date=to_date, last=last))
+
+    # R4: GroupBy validation (delegated)
+    errors.extend(validate_group_by_args(group_by=group_by))
+
+    return errors
+
+
+# =============================================================================
 # Layer 1: Argument Validation (V0-V14)
 # =============================================================================
 
@@ -1399,9 +1663,12 @@ def _validate_measurement(
     # B9: Validate math type (context-dependent for funnel/retention)
     math = measurement.get("math")
     if math is not None:
-        valid_math = (
-            VALID_MATH_FUNNELS if bookmark_type == "funnels" else VALID_MATH_INSIGHTS
-        )
+        if bookmark_type == "funnels":
+            valid_math = VALID_MATH_FUNNELS
+        elif bookmark_type == "retention":
+            valid_math = VALID_MATH_RETENTION
+        else:
+            valid_math = VALID_MATH_INSIGHTS
         if math not in valid_math:
             errors.append(
                 _enum_error(
@@ -1643,6 +1910,30 @@ def _validate_filter_clause(
                 valid=VALID_FILTER_OPERATORS,
                 code="B15_INVALID_FILTER_OPERATOR",
                 severity="warning",
+            )
+        )
+
+    # B20: Validate filterValue is non-empty when present
+    fv = clause.get("filterValue")
+    if isinstance(fv, list) and len(fv) == 0:
+        errors.append(
+            ValidationError(
+                path=f"{path}.filterValue",
+                message="filterValue must not be an empty list",
+                code="B20_EMPTY_FILTER_VALUE",
+            )
+        )
+
+    # B21: Validate filterValue list length
+    if isinstance(fv, list) and len(fv) > _MAX_FILTER_VALUES:
+        errors.append(
+            ValidationError(
+                path=f"{path}.filterValue",
+                message=(
+                    f"filterValue has {len(fv)} entries, "
+                    f"maximum is {_MAX_FILTER_VALUES}"
+                ),
+                code="B21_FILTER_VALUE_TOO_MANY",
             )
         )
 

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -829,6 +829,10 @@ def validate_retention_args(
             order), or ``None`` for default uniform buckets.
         math: Retention aggregation function. Must be one of:
             retention_rate, unique. Default: ``"retention_rate"``.
+        mode: Display mode for retention results. Must be one of:
+            curve, trends, table. Default: ``"curve"``.
+        unit: Time unit for retention buckets. Must be one of:
+            day, week, month. Default: ``"day"``.
         from_date: Start date (YYYY-MM-DD) or ``None``.
         to_date: End date (YYYY-MM-DD) or ``None``.
         last: Number of days for relative date range.
@@ -910,6 +914,63 @@ def validate_retention_args(
                 )
             )
 
+    # R3: Time argument validation (delegated)
+    errors.extend(validate_time_args(from_date=from_date, to_date=to_date, last=last))
+
+    # R4: GroupBy validation (delegated)
+    errors.extend(validate_group_by_args(group_by=group_by))
+
+    # R5: bucket_sizes values must be positive integers
+    all_valid_ints = True
+    if bucket_sizes is not None:
+        for i, val in enumerate(bucket_sizes):
+            if isinstance(val, float):
+                all_valid_ints = False
+                errors.append(
+                    ValidationError(
+                        path=f"bucket_sizes[{i}]",
+                        message=f"bucket_sizes[{i}] must be an integer, got float",
+                        code="R5_BUCKET_SIZES_INTEGER",
+                    )
+                )
+            elif not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+                all_valid_ints = False
+                errors.append(
+                    ValidationError(
+                        path="bucket_sizes",
+                        message="bucket_sizes values must be positive integers",
+                        code="R5_BUCKET_SIZES_POSITIVE",
+                    )
+                )
+
+        # R5c: Maximum bucket count
+        if len(bucket_sizes) > _MAX_RETENTION_BUCKETS:
+            errors.append(
+                ValidationError(
+                    path="bucket_sizes",
+                    message=(
+                        f"bucket_sizes has {len(bucket_sizes)} entries, "
+                        f"maximum is {_MAX_RETENTION_BUCKETS}"
+                    ),
+                    code="R5_BUCKET_SIZES_TOO_MANY",
+                )
+            )
+
+        # R6: bucket_sizes must be in strictly ascending order
+        # Only check when all elements are valid positive ints to avoid
+        # TypeError on comparison with non-numeric values.
+        if all_valid_ints and len(bucket_sizes) >= 2:
+            for i in range(1, len(bucket_sizes)):
+                if bucket_sizes[i] <= bucket_sizes[i - 1]:
+                    errors.append(
+                        ValidationError(
+                            path="bucket_sizes",
+                            message="bucket_sizes must be in strictly ascending order",
+                            code="R6_BUCKET_SIZES_ASCENDING",
+                        )
+                    )
+                    break
+
     # R7: retention_unit validation
     if retention_unit not in VALID_RETENTION_UNITS:
         errors.append(
@@ -983,63 +1044,6 @@ def validate_retention_args(
                         code="R12_EMPTY_GROUP_BY",
                     )
                 )
-
-    # R5: bucket_sizes values must be positive integers
-    all_valid_ints = True
-    if bucket_sizes is not None:
-        for i, val in enumerate(bucket_sizes):
-            if isinstance(val, float):
-                all_valid_ints = False
-                errors.append(
-                    ValidationError(
-                        path=f"bucket_sizes[{i}]",
-                        message=f"bucket_sizes[{i}] must be an integer, got float",
-                        code="R5_BUCKET_SIZES_INTEGER",
-                    )
-                )
-            elif not isinstance(val, int) or isinstance(val, bool) or val <= 0:
-                all_valid_ints = False
-                errors.append(
-                    ValidationError(
-                        path="bucket_sizes",
-                        message="bucket_sizes values must be positive integers",
-                        code="R5_BUCKET_SIZES_POSITIVE",
-                    )
-                )
-
-        # R6: bucket_sizes must be in strictly ascending order
-        # Only check when all elements are valid positive ints to avoid
-        # TypeError on comparison with non-numeric values.
-        if all_valid_ints and len(bucket_sizes) >= 2:
-            for i in range(1, len(bucket_sizes)):
-                if bucket_sizes[i] <= bucket_sizes[i - 1]:
-                    errors.append(
-                        ValidationError(
-                            path="bucket_sizes",
-                            message="bucket_sizes must be in strictly ascending order",
-                            code="R6_BUCKET_SIZES_ASCENDING",
-                        )
-                    )
-                    break
-
-        # R5c: Maximum bucket count
-        if len(bucket_sizes) > _MAX_RETENTION_BUCKETS:
-            errors.append(
-                ValidationError(
-                    path="bucket_sizes",
-                    message=(
-                        f"bucket_sizes has {len(bucket_sizes)} entries, "
-                        f"maximum is {_MAX_RETENTION_BUCKETS}"
-                    ),
-                    code="R5_BUCKET_SIZES_TOO_MANY",
-                )
-            )
-
-    # R3: Time argument validation (delegated)
-    errors.extend(validate_time_args(from_date=from_date, to_date=to_date, last=last))
-
-    # R4: GroupBy validation (delegated)
-    errors.extend(validate_group_by_args(group_by=group_by))
 
     return errors
 

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -780,7 +780,7 @@ def validate_funnel_args(
 
 
 # =============================================================================
-# Retention argument validation (R1-R9)
+# Retention argument validation (R1-R12)
 # =============================================================================
 
 _VALID_RETENTION_MATH_PUBLIC: frozenset[str] = frozenset({"retention_rate", "unique"})
@@ -814,7 +814,7 @@ def validate_retention_args(
 ) -> list[ValidationError]:
     """Validate retention query arguments before bookmark construction (Layer 1).
 
-    Implements retention-specific validation rules R1-R9 plus reused
+    Implements retention-specific validation rules R1-R12 plus reused
     time and group-by validators. Returns all errors found so callers
     can fix multiple issues in a single pass.
 
@@ -985,9 +985,11 @@ def validate_retention_args(
                 )
 
     # R5: bucket_sizes values must be positive integers
+    all_valid_ints = True
     if bucket_sizes is not None:
         for i, val in enumerate(bucket_sizes):
             if isinstance(val, float):
+                all_valid_ints = False
                 errors.append(
                     ValidationError(
                         path=f"bucket_sizes[{i}]",
@@ -996,6 +998,7 @@ def validate_retention_args(
                     )
                 )
             elif not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+                all_valid_ints = False
                 errors.append(
                     ValidationError(
                         path="bucket_sizes",
@@ -1005,7 +1008,9 @@ def validate_retention_args(
                 )
 
         # R6: bucket_sizes must be in strictly ascending order
-        if len(bucket_sizes) >= 2:
+        # Only check when all elements are valid positive ints to avoid
+        # TypeError on comparison with non-numeric values.
+        if all_valid_ints and len(bucket_sizes) >= 2:
             for i in range(1, len(bucket_sizes)):
                 if bucket_sizes[i] <= bucket_sizes[i - 1]:
                     errors.append(

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -8097,6 +8097,32 @@ class FunnelQueryResult(ResultWithDataFrame):
 # Retention Query Types (Phase 033)
 # =============================================================================
 
+RetentionAlignment = Literal["birth", "interval_start"]
+"""Retention alignment mode.
+
++------------------+----------------------------------------------+
+| Value            | Meaning                                      |
++==================+==============================================+
+| birth            | Align to each cohort's born date (default)   |
++------------------+----------------------------------------------+
+| interval_start   | Align all cohorts to the same start date     |
++------------------+----------------------------------------------+
+"""
+
+RetentionMode = Literal["curve", "trends", "table"]
+"""Display mode for retention query results.
+
++--------+----------------------------------------------+
+| Value  | Meaning                                      |
++========+==============================================+
+| curve  | Retention curve (default)                    |
++--------+----------------------------------------------+
+| trends | Trend lines over time                        |
++--------+----------------------------------------------+
+| table  | Tabular cohort × bucket grid                 |
++--------+----------------------------------------------+
+"""
+
 RetentionMathType = Literal["retention_rate", "unique"]
 """Aggregation function for retention query metrics.
 
@@ -8161,45 +8187,47 @@ class RetentionQueryResult(ResultWithDataFrame):
 
     Contains cohort-level retention data, the generated bookmark params
     (for debugging or persisting as a saved report), and a lazy
-    DataFrame conversion.
+    DataFrame conversion. Supports both unsegmented and segmented
+    (``group_by``) queries.
 
     Attributes:
         computed_at: When the query was computed (ISO format).
         from_date: Effective start date from the response.
         to_date: Effective end date from the response.
-        cohorts: Cohort-level retention data. Keys are cohort date
-            strings, values are dicts with ``first`` (cohort size),
-            ``counts`` (list of retained user counts per bucket),
-            and ``rates`` (list of retention rates per bucket).
+        cohorts: Aggregate cohort-level retention data. Keys are cohort
+            date strings (``YYYY-MM-DD``), values are dicts with
+            ``first`` (cohort size), ``counts`` (list of retained user
+            counts per bucket), and ``rates`` (list of retention rates
+            per bucket). For segmented queries, this contains the
+            ``$overall`` aggregate.
         average: Synthetic ``$average`` cohort data. Same structure
             as individual cohort entries.
         params: Generated bookmark params sent to the API
             (for debugging or persistence via ``create_bookmark``).
         meta: Response metadata (e.g. ``sampling_factor``,
             ``is_cached``).
+        segments: Per-segment cohort data. Maps segment name to a dict
+            of cohort_date → {first, counts, rates}. Empty for
+            unsegmented queries.
+        segment_averages: Per-segment ``$average`` cohort data. Maps
+            segment name to {first, counts, rates}. Empty for
+            unsegmented queries.
 
     Example:
         ```python
+        # Unsegmented retention
         result = ws.query_retention("Signup", "Login")
-
-        # Cohort data
-        for date, data in result.cohorts.items():
-            print(f"{date}: {data['first']} users, "
-                  f"retention: {data['rates']}")
-
-        # Average retention
-        print(result.average)
-
-        # DataFrame view
         print(result.df)
         #   cohort_date  bucket  count  rate
 
-        # Save as a report
-        ws.create_bookmark(CreateBookmarkParams(
-            name="Signup → Login Retention",
-            bookmark_type="retention",
-            params=result.params,
-        ))
+        # Segmented retention
+        result = ws.query_retention(
+            "Signup", "Login", group_by="platform"
+        )
+        print(result.df)
+        #   segment  cohort_date  bucket  count  rate
+        for name, cohorts in result.segments.items():
+            print(f"{name}: {len(cohorts)} cohorts")
         ```
     """
 
@@ -8213,10 +8241,13 @@ class RetentionQueryResult(ResultWithDataFrame):
     """Effective end date from the response."""
 
     cohorts: dict[str, dict[str, Any]] = field(default_factory=dict)
-    """Cohort-level retention data (cohort_date → {first, counts, rates})."""
+    """Cohort-level retention data (cohort_date → {first, counts, rates}).
+
+    For segmented queries, this contains the ``$overall`` aggregate.
+    """
 
     average: dict[str, Any] = field(default_factory=dict)
-    """Synthetic $average cohort data."""
+    """Synthetic $average cohort data (aggregate across all cohorts)."""
 
     params: dict[str, Any] = field(default_factory=dict)
     """Generated bookmark params sent to API."""
@@ -8224,35 +8255,71 @@ class RetentionQueryResult(ResultWithDataFrame):
     meta: dict[str, Any] = field(default_factory=dict)
     """Response metadata (sampling_factor, is_cached, etc.)."""
 
+    segments: dict[str, dict[str, dict[str, Any]]] = field(default_factory=dict)
+    """Per-segment cohort data (segment_name → cohort_date → {first, counts, rates}).
+
+    Empty for unsegmented queries. Populated when ``group_by`` is used
+    and the API returns breakdown segments alongside ``$overall``.
+    """
+
+    segment_averages: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Per-segment $average cohort data (segment_name → {first, counts, rates}).
+
+    Empty for unsegmented queries.
+    """
+
     @property
     def df(self) -> pd.DataFrame:
         """Convert to DataFrame with one row per (cohort_date, bucket) pair.
 
-        Columns: ``cohort_date``, ``bucket``, ``count``, ``rate``.
+        For unsegmented queries, columns are:
+        ``cohort_date``, ``bucket``, ``count``, ``rate``.
+
+        For segmented queries (when ``segments`` is non-empty), columns are:
+        ``segment``, ``cohort_date``, ``bucket``, ``count``, ``rate``.
 
         Returns:
             Normalized DataFrame. Empty DataFrame with correct columns
-            if ``cohorts`` is empty.
+            if data is empty.
         """
         if self._df_cache is not None:
             return self._df_cache
 
-        cols = ["cohort_date", "bucket", "count", "rate"]
-
         rows: list[dict[str, Any]] = []
-        for cohort_date in sorted(self.cohorts.keys()):
-            cohort = self.cohorts[cohort_date]
-            counts = cohort.get("counts", [])
-            rates = cohort.get("rates", [])
-            for i, count in enumerate(counts):
-                rows.append(
-                    {
-                        "cohort_date": cohort_date,
-                        "bucket": i,
-                        "count": count,
-                        "rate": rates[i] if i < len(rates) else 0.0,
-                    }
-                )
+
+        if self.segments:
+            cols = ["segment", "cohort_date", "bucket", "count", "rate"]
+            for segment_name in sorted(self.segments.keys()):
+                segment_cohorts = self.segments[segment_name]
+                for cohort_date in sorted(segment_cohorts.keys()):
+                    cohort = segment_cohorts[cohort_date]
+                    counts = cohort.get("counts", [])
+                    rates = cohort.get("rates", [])
+                    for i, count in enumerate(counts):
+                        rows.append(
+                            {
+                                "segment": segment_name,
+                                "cohort_date": cohort_date,
+                                "bucket": i,
+                                "count": count,
+                                "rate": rates[i] if i < len(rates) else 0.0,
+                            }
+                        )
+        else:
+            cols = ["cohort_date", "bucket", "count", "rate"]
+            for cohort_date in sorted(self.cohorts.keys()):
+                cohort = self.cohorts[cohort_date]
+                counts = cohort.get("counts", [])
+                rates = cohort.get("rates", [])
+                for i, count in enumerate(counts):
+                    rows.append(
+                        {
+                            "cohort_date": cohort_date,
+                            "bucket": i,
+                            "count": count,
+                            "rate": rates[i] if i < len(rates) else 0.0,
+                        }
+                    )
 
         result_df = (
             pd.DataFrame(rows, columns=cols) if rows else pd.DataFrame(columns=cols)
@@ -8266,8 +8333,10 @@ class RetentionQueryResult(ResultWithDataFrame):
 
         Returns:
             Dictionary with all RetentionQueryResult fields.
+            Includes ``segments`` and ``segment_averages`` only
+            when non-empty.
         """
-        return {
+        d: dict[str, Any] = {
             "computed_at": self.computed_at,
             "from_date": self.from_date,
             "to_date": self.to_date,
@@ -8276,3 +8345,8 @@ class RetentionQueryResult(ResultWithDataFrame):
             "params": self.params,
             "meta": self.meta,
         }
+        if self.segments:
+            d["segments"] = self.segments
+        if self.segment_averages:
+            d["segment_averages"] = self.segment_averages
+        return d

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -8091,3 +8091,188 @@ class FunnelQueryResult(ResultWithDataFrame):
             "params": self.params,
             "meta": self.meta,
         }
+
+
+# =============================================================================
+# Retention Query Types (Phase 033)
+# =============================================================================
+
+RetentionMathType = Literal["retention_rate", "unique"]
+"""Aggregation function for retention query metrics.
+
++----------------+----------------------------------------------+
+| Value          | Meaning                                      |
++================+==============================================+
+| retention_rate | Percentage of cohort retained (default)      |
++----------------+----------------------------------------------+
+| unique         | Raw unique user count per bucket              |
++----------------+----------------------------------------------+
+
+Maps directly to the ``measurement.math`` field in bookmark JSON.
+"""
+
+
+@dataclass(frozen=True)
+class RetentionEvent:
+    """An event specification for retention queries.
+
+    Wraps an event name with optional per-event filters. Use plain
+    event-name strings for simple retention queries. Use ``RetentionEvent``
+    objects when you need per-event filter conditions.
+
+    Attributes:
+        event: Mixpanel event name.
+        filters: Per-event filter conditions. Each ``Filter`` restricts
+            which events count. ``None`` means no filters.
+        filters_combinator: How per-event filters combine.
+            ``"all"`` requires all filters to match (AND logic).
+            ``"any"`` requires any filter to match (OR logic).
+
+    Example:
+        ```python
+        from mixpanel_data import RetentionEvent, Filter
+
+        # Simple event (equivalent to just using "Signup" string)
+        born = RetentionEvent("Signup")
+
+        # Event with per-event filter
+        born = RetentionEvent(
+            "Signup",
+            filters=[Filter.equals("source", "organic")],
+        )
+
+        ws.query_retention(born, "Login")
+        ```
+    """
+
+    event: str
+    """Mixpanel event name."""
+
+    filters: list[Filter] | None = None
+    """Per-event filter conditions."""
+
+    filters_combinator: Literal["all", "any"] = "all"
+    """How per-event filters combine (AND/OR)."""
+
+
+@dataclass(frozen=True)
+class RetentionQueryResult(ResultWithDataFrame):
+    """Result of a retention query via the insights API.
+
+    Contains cohort-level retention data, the generated bookmark params
+    (for debugging or persisting as a saved report), and a lazy
+    DataFrame conversion.
+
+    Attributes:
+        computed_at: When the query was computed (ISO format).
+        from_date: Effective start date from the response.
+        to_date: Effective end date from the response.
+        cohorts: Cohort-level retention data. Keys are cohort date
+            strings, values are dicts with ``first`` (cohort size),
+            ``counts`` (list of retained user counts per bucket),
+            and ``rates`` (list of retention rates per bucket).
+        average: Synthetic ``$average`` cohort data. Same structure
+            as individual cohort entries.
+        params: Generated bookmark params sent to the API
+            (for debugging or persistence via ``create_bookmark``).
+        meta: Response metadata (e.g. ``sampling_factor``,
+            ``is_cached``).
+
+    Example:
+        ```python
+        result = ws.query_retention("Signup", "Login")
+
+        # Cohort data
+        for date, data in result.cohorts.items():
+            print(f"{date}: {data['first']} users, "
+                  f"retention: {data['rates']}")
+
+        # Average retention
+        print(result.average)
+
+        # DataFrame view
+        print(result.df)
+        #   cohort_date  bucket  count  rate
+
+        # Save as a report
+        ws.create_bookmark(CreateBookmarkParams(
+            name="Signup → Login Retention",
+            bookmark_type="retention",
+            params=result.params,
+        ))
+        ```
+    """
+
+    computed_at: str
+    """When the query was computed (ISO format)."""
+
+    from_date: str
+    """Effective start date from the response."""
+
+    to_date: str
+    """Effective end date from the response."""
+
+    cohorts: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Cohort-level retention data (cohort_date → {first, counts, rates})."""
+
+    average: dict[str, Any] = field(default_factory=dict)
+    """Synthetic $average cohort data."""
+
+    params: dict[str, Any] = field(default_factory=dict)
+    """Generated bookmark params sent to API."""
+
+    meta: dict[str, Any] = field(default_factory=dict)
+    """Response metadata (sampling_factor, is_cached, etc.)."""
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Convert to DataFrame with one row per (cohort_date, bucket) pair.
+
+        Columns: ``cohort_date``, ``bucket``, ``count``, ``rate``.
+
+        Returns:
+            Normalized DataFrame. Empty DataFrame with correct columns
+            if ``cohorts`` is empty.
+        """
+        if self._df_cache is not None:
+            return self._df_cache
+
+        cols = ["cohort_date", "bucket", "count", "rate"]
+
+        rows: list[dict[str, Any]] = []
+        for cohort_date in sorted(self.cohorts.keys()):
+            cohort = self.cohorts[cohort_date]
+            counts = cohort.get("counts", [])
+            rates = cohort.get("rates", [])
+            for i, count in enumerate(counts):
+                rows.append(
+                    {
+                        "cohort_date": cohort_date,
+                        "bucket": i,
+                        "count": count,
+                        "rate": rates[i] if i < len(rates) else 0.0,
+                    }
+                )
+
+        result_df = (
+            pd.DataFrame(rows, columns=cols) if rows else pd.DataFrame(columns=cols)
+        )
+
+        object.__setattr__(self, "_df_cache", result_df)
+        return result_df
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSON output.
+
+        Returns:
+            Dictionary with all RetentionQueryResult fields.
+        """
+        return {
+            "computed_at": self.computed_at,
+            "from_date": self.from_date,
+            "to_date": self.to_date,
+            "cohorts": self.cohorts,
+            "average": self.average,
+            "params": self.params,
+            "meta": self.meta,
+        }

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -48,7 +48,7 @@ from mixpanel_data._internal.validation import (
     validate_query_args,
     validate_retention_args,
 )
-from mixpanel_data._literal_types import QueryTimeUnit
+from mixpanel_data._literal_types import QueryTimeUnit, TimeUnit
 from mixpanel_data.exceptions import (
     BookmarkValidationError,
     ConfigError,
@@ -149,8 +149,10 @@ from mixpanel_data.types import (
     PublicWorkspace,
     QueryResult,
     ReplaceSchemaEnforcementParams,
+    RetentionAlignment,
     RetentionEvent,
     RetentionMathType,
+    RetentionMode,
     RetentionQueryResult,
     RetentionResult,
     SavedCohort,
@@ -2660,17 +2662,17 @@ class Workspace:
         *,
         born_event: RetentionEvent,
         return_event: RetentionEvent,
-        retention_unit: str,
-        alignment: str,
+        retention_unit: TimeUnit,
+        alignment: RetentionAlignment,
         bucket_sizes: list[int] | None,
-        math: str,
+        math: RetentionMathType,
         from_date: str | None,
         to_date: str | None,
         last: int,
         unit: QueryTimeUnit,
         group_by: str | GroupBy | list[str | GroupBy] | None,
         where: Filter | list[Filter] | None,
-        mode: str,
+        mode: RetentionMode,
     ) -> dict[str, Any]:
         """Build retention bookmark params dict from typed arguments.
 
@@ -2770,17 +2772,17 @@ class Workspace:
         *,
         born_event: str | RetentionEvent,
         return_event: str | RetentionEvent,
-        retention_unit: str,
-        alignment: str,
+        retention_unit: TimeUnit,
+        alignment: RetentionAlignment,
         bucket_sizes: list[int] | None,
-        math: str,
+        math: RetentionMathType,
         from_date: str | None,
         to_date: str | None,
         last: int,
         unit: QueryTimeUnit,
         group_by: str | GroupBy | list[str | GroupBy] | None,
         where: Filter | list[Filter] | None,
-        mode: str,
+        mode: RetentionMode,
     ) -> dict[str, Any]:
         """Normalize, validate, and build retention bookmark params.
 
@@ -2868,8 +2870,8 @@ class Workspace:
         born_event: str | RetentionEvent,
         return_event: str | RetentionEvent,
         *,
-        retention_unit: Literal["day", "week", "month"] = "week",
-        alignment: Literal["birth", "interval_start"] = "birth",
+        retention_unit: TimeUnit = "week",
+        alignment: RetentionAlignment = "birth",
         bucket_sizes: list[int] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
@@ -2878,7 +2880,7 @@ class Workspace:
         math: RetentionMathType = "retention_rate",
         group_by: str | GroupBy | list[str | GroupBy] | None = None,
         where: Filter | list[Filter] | None = None,
-        mode: Literal["curve", "trends", "table"] = "curve",
+        mode: RetentionMode = "curve",
     ) -> RetentionQueryResult:
         """Run a typed retention query against the Mixpanel API.
 
@@ -2900,7 +2902,9 @@ class Workspace:
                 ``last``.
             to_date: End date (YYYY-MM-DD). Requires ``from_date``.
             last: Relative time range in days. Default: 30.
-            unit: Time aggregation unit. Default: ``"day"``.
+            unit: Time aggregation unit (``day``, ``week``, or
+                ``month`` — ``hour`` is not supported for retention).
+                Default: ``"day"``.
             math: Retention aggregation function. Default:
                 ``"retention_rate"``.
             group_by: Break down results by property.
@@ -2969,8 +2973,8 @@ class Workspace:
         born_event: str | RetentionEvent,
         return_event: str | RetentionEvent,
         *,
-        retention_unit: Literal["day", "week", "month"] = "week",
-        alignment: Literal["birth", "interval_start"] = "birth",
+        retention_unit: TimeUnit = "week",
+        alignment: RetentionAlignment = "birth",
         bucket_sizes: list[int] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
@@ -2979,14 +2983,15 @@ class Workspace:
         math: RetentionMathType = "retention_rate",
         group_by: str | GroupBy | list[str | GroupBy] | None = None,
         where: Filter | list[Filter] | None = None,
-        mode: Literal["curve", "trends", "table"] = "curve",
+        mode: RetentionMode = "curve",
     ) -> dict[str, Any]:
         """Build validated retention bookmark params without executing.
 
-        Has the same signature as :meth:`query_retention` but returns the
-        generated bookmark params dict instead of querying the API.
-        Useful for debugging, inspecting generated JSON, persisting
-        via :meth:`create_bookmark`, or testing.
+        Accepts the same arguments as :meth:`query_retention` but returns
+        the generated bookmark params ``dict`` (not a
+        ``RetentionQueryResult``) instead of querying the API. Useful for
+        debugging, inspecting generated JSON, persisting via
+        :meth:`create_bookmark`, or testing.
 
         Args:
             born_event: Event that defines cohort membership.
@@ -2997,7 +3002,9 @@ class Workspace:
             from_date: Start date (YYYY-MM-DD) or None.
             to_date: End date (YYYY-MM-DD) or None.
             last: Relative time range in days. Default: 30.
-            unit: Time aggregation unit. Default: ``"day"``.
+            unit: Time aggregation unit (``day``, ``week``, or
+                ``month`` — ``hour`` is not supported for retention).
+                Default: ``"day"``.
             math: Aggregation function. Default:
                 ``"retention_rate"``.
             group_by: Break down results by property.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -46,6 +46,7 @@ from mixpanel_data._internal.validation import (
     validate_bookmark,
     validate_funnel_args,
     validate_query_args,
+    validate_retention_args,
 )
 from mixpanel_data._literal_types import QueryTimeUnit
 from mixpanel_data.exceptions import (
@@ -148,6 +149,9 @@ from mixpanel_data.types import (
     PublicWorkspace,
     QueryResult,
     ReplaceSchemaEnforcementParams,
+    RetentionEvent,
+    RetentionMathType,
+    RetentionQueryResult,
     RetentionResult,
     SavedCohort,
     SavedReportResult,
@@ -2644,6 +2648,399 @@ class Workspace:
             where=where,
             exclusions=exclusions,
             holding_constant=holding_constant,
+            mode=mode,
+        )
+
+    # =========================================================================
+    # Retention Query (Phase 033)
+    # =========================================================================
+
+    def _build_retention_params(
+        self,
+        *,
+        born_event: RetentionEvent,
+        return_event: RetentionEvent,
+        retention_unit: str,
+        alignment: str,
+        bucket_sizes: list[int] | None,
+        math: str,
+        from_date: str | None,
+        to_date: str | None,
+        last: int,
+        unit: QueryTimeUnit,
+        group_by: str | GroupBy | list[str | GroupBy] | None,
+        where: Filter | list[Filter] | None,
+        mode: str,
+    ) -> dict[str, Any]:
+        """Build retention bookmark params dict from typed arguments.
+
+        Generates the complete bookmark JSON structure expected by
+        the Mixpanel insights query API for retention-type bookmarks.
+
+        Args:
+            born_event: Normalized RetentionEvent for born event.
+            return_event: Normalized RetentionEvent for return event.
+            retention_unit: Retention period unit.
+            alignment: Retention alignment mode.
+            bucket_sizes: Custom bucket sizes or None.
+            math: Aggregation function.
+            from_date: Start date (YYYY-MM-DD) or None.
+            to_date: End date (YYYY-MM-DD) or None.
+            last: Relative date range in days.
+            unit: Time granularity.
+            group_by: Breakdown specification.
+            where: Filter conditions.
+            mode: Display mode (curve, trends, table).
+
+        Returns:
+            Bookmark params dict ready for insights query API.
+        """
+        # Build behaviors array (exactly 2: born + return)
+        behaviors: list[dict[str, Any]] = []
+        for evt in [born_event, return_event]:
+            behavior_entry: dict[str, Any] = {
+                "type": "event",
+                "id": None,
+                "name": evt.event,
+                "filters": [],
+                "filtersDeterminer": evt.filters_combinator,
+            }
+            # Per-event filters
+            if evt.filters:
+                behavior_entry["filters"] = [build_filter_entry(f) for f in evt.filters]
+            behaviors.append(behavior_entry)
+
+        # Build behavior block
+        behavior: dict[str, Any] = {
+            "type": "retention",
+            "resourceType": "events",
+            "behaviors": behaviors,
+            "retentionUnit": retention_unit,
+            "retentionAlignmentType": alignment,
+            "retentionCustomBucketSizes": list(bucket_sizes) if bucket_sizes else [],
+            "filter": [],
+        }
+
+        # Build measurement
+        measurement: dict[str, Any] = {
+            "math": math,
+        }
+
+        # Build show clause
+        show: list[dict[str, Any]] = [
+            {
+                "type": "metric",
+                "behavior": behavior,
+                "measurement": measurement,
+            }
+        ]
+
+        # Build sections using shared builders
+        time_section = build_time_section(
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+        )
+        filter_section = build_filter_section(where)
+        group_section = build_group_section(group_by)
+
+        # Chart type mapping
+        chart_type_map = {
+            "curve": "retention-curve",
+            "trends": "line",
+            "table": "table",
+        }
+
+        return {
+            "sections": {
+                "show": show,
+                "time": time_section,
+                "filter": filter_section,
+                "group": group_section,
+                "formula": [],
+            },
+            "displayOptions": {
+                "chartType": chart_type_map.get(mode, "retention-curve"),
+            },
+        }
+
+    def _resolve_and_build_retention_params(
+        self,
+        *,
+        born_event: str | RetentionEvent,
+        return_event: str | RetentionEvent,
+        retention_unit: str,
+        alignment: str,
+        bucket_sizes: list[int] | None,
+        math: str,
+        from_date: str | None,
+        to_date: str | None,
+        last: int,
+        unit: QueryTimeUnit,
+        group_by: str | GroupBy | list[str | GroupBy] | None,
+        where: Filter | list[Filter] | None,
+        mode: str,
+    ) -> dict[str, Any]:
+        """Normalize, validate, and build retention bookmark params.
+
+        Shared implementation for :meth:`query_retention` and
+        :meth:`build_retention_params`. Handles normalization of
+        string shorthand to RetentionEvent objects, argument validation
+        (Layer 1), bookmark construction, and structure validation
+        (Layer 2).
+
+        Args:
+            born_event: Born event spec (string or RetentionEvent).
+            return_event: Return event spec (string or RetentionEvent).
+            retention_unit: Retention period unit.
+            alignment: Retention alignment mode.
+            bucket_sizes: Custom bucket sizes or None.
+            math: Aggregation function.
+            from_date: Start date (YYYY-MM-DD) or None.
+            to_date: End date (YYYY-MM-DD) or None.
+            last: Relative date range in days.
+            unit: Time granularity.
+            group_by: Breakdown specification.
+            where: Filter conditions.
+            mode: Display mode.
+
+        Returns:
+            Validated bookmark params dict.
+
+        Raises:
+            BookmarkValidationError: If validation fails at any layer.
+        """
+        # Normalize events: str → RetentionEvent
+        norm_born = (
+            RetentionEvent(born_event) if isinstance(born_event, str) else born_event
+        )
+        norm_return = (
+            RetentionEvent(return_event)
+            if isinstance(return_event, str)
+            else return_event
+        )
+
+        # Layer 1: Argument validation
+        arg_errors = validate_retention_args(
+            born_event=norm_born.event,
+            return_event=norm_return.event,
+            retention_unit=retention_unit,
+            alignment=alignment,
+            bucket_sizes=bucket_sizes,
+            math=math,
+            mode=mode,
+            unit=unit,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            group_by=group_by,
+        )
+        if any(e.severity == "error" for e in arg_errors):
+            raise BookmarkValidationError(arg_errors)
+
+        # Build bookmark params
+        params = self._build_retention_params(
+            born_event=norm_born,
+            return_event=norm_return,
+            retention_unit=retention_unit,
+            alignment=alignment,
+            bucket_sizes=bucket_sizes,
+            math=math,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+            group_by=group_by,
+            where=where,
+            mode=mode,
+        )
+
+        # Layer 2: Bookmark structure validation
+        bookmark_errors = validate_bookmark(params, bookmark_type="retention")
+        if any(e.severity == "error" for e in bookmark_errors):
+            raise BookmarkValidationError(bookmark_errors)
+
+        return params
+
+    def query_retention(
+        self,
+        born_event: str | RetentionEvent,
+        return_event: str | RetentionEvent,
+        *,
+        retention_unit: Literal["day", "week", "month"] = "week",
+        alignment: Literal["birth", "interval_start"] = "birth",
+        bucket_sizes: list[int] | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        last: int = 30,
+        unit: QueryTimeUnit = "day",
+        math: RetentionMathType = "retention_rate",
+        group_by: str | GroupBy | list[str | GroupBy] | None = None,
+        where: Filter | list[Filter] | None = None,
+        mode: Literal["curve", "trends", "table"] = "curve",
+    ) -> RetentionQueryResult:
+        """Run a typed retention query against the Mixpanel API.
+
+        Generates retention bookmark params from keyword arguments, POSTs
+        them inline to ``/api/query/insights``, and returns a structured
+        RetentionQueryResult with lazy DataFrame conversion.
+
+        Args:
+            born_event: Event that defines cohort membership. Accepts
+                an event name string or a ``RetentionEvent`` object
+                for per-event filters.
+            return_event: Event that defines return. Accepts an event
+                name string or a ``RetentionEvent`` object.
+            retention_unit: Retention period unit. Default: ``"week"``.
+            alignment: Retention alignment mode. Default: ``"birth"``.
+            bucket_sizes: Custom bucket sizes (positive ints in
+                ascending order). Default: ``None`` (uniform buckets).
+            from_date: Start date (YYYY-MM-DD). If set, overrides
+                ``last``.
+            to_date: End date (YYYY-MM-DD). Requires ``from_date``.
+            last: Relative time range in days. Default: 30.
+            unit: Time aggregation unit. Default: ``"day"``.
+            math: Retention aggregation function. Default:
+                ``"retention_rate"``.
+            group_by: Break down results by property.
+            where: Filter results by conditions.
+            mode: Result display mode. Default: ``"curve"``.
+
+        Returns:
+            RetentionQueryResult with cohort data, DataFrame, and
+            metadata.
+
+        Raises:
+            BookmarkValidationError: If arguments violate validation
+                rules (before API call).
+            ConfigError: If credentials are not available.
+            AuthenticationError: Invalid credentials.
+            QueryError: Invalid query parameters.
+            RateLimitError: Rate limit exceeded.
+
+        Example:
+            ```python
+            ws = Workspace()
+
+            # Simple retention query
+            result = ws.query_retention("Signup", "Login")
+            print(result.average)
+
+            # With configuration
+            result = ws.query_retention(
+                "Signup", "Login",
+                retention_unit="day",
+                bucket_sizes=[1, 3, 7, 14, 30],
+                last=90,
+            )
+            print(result.df)
+            ```
+        """
+        params = self._resolve_and_build_retention_params(
+            born_event=born_event,
+            return_event=return_event,
+            retention_unit=retention_unit,
+            alignment=alignment,
+            bucket_sizes=bucket_sizes,
+            math=math,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+            group_by=group_by,
+            where=where,
+            mode=mode,
+        )
+
+        credentials = self._credentials
+        if credentials is None:
+            raise ConfigError(
+                "API access requires credentials. "
+                "Use Workspace() with credentials instead of Workspace.open()."
+            )
+        return self._live_query_service.query_retention(
+            bookmark_params=params,
+            project_id=int(credentials.project_id),
+        )
+
+    def build_retention_params(
+        self,
+        born_event: str | RetentionEvent,
+        return_event: str | RetentionEvent,
+        *,
+        retention_unit: Literal["day", "week", "month"] = "week",
+        alignment: Literal["birth", "interval_start"] = "birth",
+        bucket_sizes: list[int] | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        last: int = 30,
+        unit: QueryTimeUnit = "day",
+        math: RetentionMathType = "retention_rate",
+        group_by: str | GroupBy | list[str | GroupBy] | None = None,
+        where: Filter | list[Filter] | None = None,
+        mode: Literal["curve", "trends", "table"] = "curve",
+    ) -> dict[str, Any]:
+        """Build validated retention bookmark params without executing.
+
+        Has the same signature as :meth:`query_retention` but returns the
+        generated bookmark params dict instead of querying the API.
+        Useful for debugging, inspecting generated JSON, persisting
+        via :meth:`create_bookmark`, or testing.
+
+        Args:
+            born_event: Event that defines cohort membership.
+            return_event: Event that defines return.
+            retention_unit: Retention period unit. Default: ``"week"``.
+            alignment: Retention alignment mode. Default: ``"birth"``.
+            bucket_sizes: Custom bucket sizes. Default: ``None``.
+            from_date: Start date (YYYY-MM-DD) or None.
+            to_date: End date (YYYY-MM-DD) or None.
+            last: Relative time range in days. Default: 30.
+            unit: Time aggregation unit. Default: ``"day"``.
+            math: Aggregation function. Default:
+                ``"retention_rate"``.
+            group_by: Break down results by property.
+            where: Filter results by conditions.
+            mode: Display mode. Default: ``"curve"``.
+
+        Returns:
+            Bookmark params dict with ``sections`` and
+            ``displayOptions`` keys.
+
+        Raises:
+            BookmarkValidationError: If arguments violate validation
+                rules.
+
+        Example:
+            ```python
+            ws = Workspace()
+
+            # Inspect generated JSON
+            params = ws.build_retention_params("Signup", "Login")
+            print(json.dumps(params, indent=2))
+
+            # Save as a report
+            ws.create_bookmark(CreateBookmarkParams(
+                name="Signup → Login Retention",
+                bookmark_type="retention",
+                params=params,
+            ))
+            ```
+        """
+        return self._resolve_and_build_retention_params(
+            born_event=born_event,
+            return_event=return_event,
+            retention_unit=retention_unit,
+            alignment=alignment,
+            bucket_sizes=bucket_sizes,
+            math=math,
+            from_date=from_date,
+            to_date=to_date,
+            last=last,
+            unit=unit,
+            group_by=group_by,
+            where=where,
             mode=mode,
         )
 

--- a/tests/test_build_retention_params.py
+++ b/tests/test_build_retention_params.py
@@ -1,0 +1,307 @@
+"""Tests for Workspace.build_retention_params().
+
+Exercises the retention bookmark param-building pipeline: normalization,
+validation, and bookmark JSON structure generation.
+Uses ``build_retention_params()`` as the public entry point since it delegates
+through ``_build_retention_params()`` without requiring API credentials.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_credentials() -> Credentials:
+    """Create mock credentials for Workspace construction."""
+    return Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id="12345",
+        region="us",
+    )
+
+
+@pytest.fixture
+def mock_config_manager(mock_credentials: Credentials) -> MagicMock:
+    """Create mock ConfigManager that returns mock credentials."""
+    manager = MagicMock(spec=ConfigManager)
+    manager.resolve_credentials.return_value = mock_credentials
+    return manager
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create mock API client for Workspace construction."""
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+    client = MagicMock(spec=MixpanelAPIClient)
+    client.close = MagicMock()
+    return client
+
+
+@pytest.fixture
+def ws(mock_config_manager: MagicMock, mock_api_client: MagicMock) -> Workspace:
+    """Create a Workspace instance with mocked dependencies.
+
+    Uses dependency injection so no real credentials or network access
+    are needed.
+    """
+    return Workspace(
+        _config_manager=mock_config_manager,
+        _api_client=mock_api_client,
+    )
+
+
+# =============================================================================
+# T015: Default structure tests
+# =============================================================================
+
+
+class TestBuildRetentionParamsDefaults:
+    """Tests for default bookmark structure (T015).
+
+    Verifies that ``build_retention_params("Signup", "Login")`` produces
+    the correct bookmark JSON with all default values.
+    """
+
+    def test_behavior_type_is_retention(self, ws: Workspace) -> None:
+        """Verify sections.show[0].behavior.type is 'retention'."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["type"] == "retention"
+
+    def test_behaviors_has_two_entries(self, ws: Workspace) -> None:
+        """Verify behaviors list has exactly 2 entries (born + return)."""
+        result = ws.build_retention_params("Signup", "Login")
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert len(behaviors) == 2
+
+    def test_behavior_names_match_events(self, ws: Workspace) -> None:
+        """Verify behavior names match born_event and return_event."""
+        result = ws.build_retention_params("Signup", "Login")
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert behaviors[0]["name"] == "Signup"
+        assert behaviors[1]["name"] == "Login"
+
+    def test_retention_unit_defaults_to_week(self, ws: Workspace) -> None:
+        """Verify retentionUnit defaults to 'week'."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionUnit"] == "week"
+
+    def test_alignment_defaults_to_birth(self, ws: Workspace) -> None:
+        """Verify retentionAlignmentType defaults to 'birth'."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionAlignmentType"] == "birth"
+
+    def test_measurement_math_defaults_to_retention_rate(self, ws: Workspace) -> None:
+        """Verify measurement.math defaults to 'retention_rate'."""
+        result = ws.build_retention_params("Signup", "Login")
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert measurement["math"] == "retention_rate"
+
+    def test_chart_type_defaults_to_retention_curve(self, ws: Workspace) -> None:
+        """Verify displayOptions.chartType defaults to 'retention-curve' (mode='curve')."""
+        result = ws.build_retention_params("Signup", "Login")
+        assert result["displayOptions"]["chartType"] == "retention-curve"
+
+    def test_custom_bucket_sizes_defaults_to_empty_list(self, ws: Workspace) -> None:
+        """Verify retentionCustomBucketSizes defaults to empty list."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionCustomBucketSizes"] == []
+
+    def test_has_sections_with_expected_keys(self, ws: Workspace) -> None:
+        """Verify sections dict contains show, time, filter, group, formula."""
+        result = ws.build_retention_params("Signup", "Login")
+        sections = result["sections"]
+        assert "show" in sections
+        assert "time" in sections
+        assert "filter" in sections
+        assert "group" in sections
+        assert "formula" in sections
+
+    def test_has_display_options_key(self, ws: Workspace) -> None:
+        """Verify result has 'displayOptions' key."""
+        result = ws.build_retention_params("Signup", "Login")
+        assert "displayOptions" in result
+
+
+# =============================================================================
+# T016: Shared builder tests (time, filter, group sections)
+# =============================================================================
+
+
+class TestBuildRetentionParamsTimeSections:
+    """Tests for shared section builders (T016).
+
+    Verifies that the time, filter, and group sections use the shared
+    bookmark builder infrastructure correctly.
+    """
+
+    def test_default_time_section_is_in_the_last(self, ws: Workspace) -> None:
+        """Verify default time section uses 'in the last' with last=30."""
+        result = ws.build_retention_params("Signup", "Login")
+        time_section = result["sections"]["time"]
+        assert len(time_section) > 0
+        time_entry = time_section[0]
+        assert time_entry["dateRangeType"] == "in the last"
+        assert time_entry["window"]["value"] == 30
+        assert time_entry["window"]["unit"] == "day"
+
+    def test_explicit_dates_produce_between_range(self, ws: Workspace) -> None:
+        """Verify from_date/to_date produces a 'between' dateRangeType."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            from_date="2025-01-01",
+            to_date="2025-03-31",
+        )
+        time_section = result["sections"]["time"]
+        assert len(time_section) > 0
+        time_entry = time_section[0]
+        assert time_entry["dateRangeType"] == "between"
+        assert time_entry["value"] == ["2025-01-01", "2025-03-31"]
+
+    def test_filter_section_is_empty_list_when_no_where(self, ws: Workspace) -> None:
+        """Verify sections.filter is empty list when no where filter provided."""
+        result = ws.build_retention_params("Signup", "Login")
+        assert result["sections"]["filter"] == []
+
+    def test_group_section_is_empty_list_when_no_group_by(self, ws: Workspace) -> None:
+        """Verify sections.group is empty list when no group_by provided."""
+        result = ws.build_retention_params("Signup", "Login")
+        assert result["sections"]["group"] == []
+
+
+# =============================================================================
+# T-US2: Per-event filters
+# =============================================================================
+
+
+class TestBuildRetentionParamsPerEventFilters:
+    """Tests for per-event filter handling in retention bookmark params."""
+
+    def test_retention_event_with_filters(self, ws: Workspace) -> None:
+        """RetentionEvent with filters must populate behavior[0].filters as non-empty list."""
+        from mixpanel_data.types import Filter, RetentionEvent
+
+        born = RetentionEvent("Signup", filters=[Filter.equals("source", "organic")])
+        result = ws.build_retention_params(born, RetentionEvent("Login"))
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert isinstance(behaviors[0]["filters"], list)
+        assert len(behaviors[0]["filters"]) > 0
+
+    def test_filters_combinator_maps_to_determiner(self, ws: Workspace) -> None:
+        """filters_combinator='any' must map to filtersDeterminer='any' in behavior."""
+        from mixpanel_data.types import Filter, RetentionEvent
+
+        born = RetentionEvent(
+            "Signup",
+            filters=[Filter.equals("source", "organic")],
+            filters_combinator="any",
+        )
+        result = ws.build_retention_params(born, RetentionEvent("Login"))
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert behaviors[0]["filtersDeterminer"] == "any"
+
+    def test_no_filters_produces_empty_array(self, ws: Workspace) -> None:
+        """Default RetentionEvent must have an empty filters array in behavior."""
+        from mixpanel_data.types import RetentionEvent
+
+        result = ws.build_retention_params(
+            RetentionEvent("Signup"), RetentionEvent("Login")
+        )
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert behaviors[0]["filters"] == []
+        assert behaviors[1]["filters"] == []
+
+
+# =============================================================================
+# T-US2: Global filters and group-by
+# =============================================================================
+
+
+class TestBuildRetentionParamsGlobalFilters:
+    """Tests for global where filter and group_by in retention bookmark params."""
+
+    def test_where_filter_populates_filter_section(self, ws: Workspace) -> None:
+        """Passing where=Filter.equals(...) must populate sections.filter as non-empty."""
+        from mixpanel_data.types import Filter
+
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            where=Filter.equals("platform", "iOS"),
+        )
+        assert len(result["sections"]["filter"]) > 0
+
+    def test_group_by_string_populates_group_section(self, ws: Workspace) -> None:
+        """Passing group_by='platform' must populate sections.group as non-empty."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            group_by="platform",
+        )
+        assert len(result["sections"]["group"]) > 0
+
+
+# =============================================================================
+# T-US3: Custom bucket sizes
+# =============================================================================
+
+
+class TestBuildRetentionParamsBucketSizes:
+    """Tests for custom bucket sizes in retention bookmark params."""
+
+    def test_bucket_sizes_populates_custom_field(self, ws: Workspace) -> None:
+        """Explicit bucket_sizes must populate retentionCustomBucketSizes."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            bucket_sizes=[1, 3, 7, 14, 30],
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionCustomBucketSizes"] == [1, 3, 7, 14, 30]
+
+    def test_none_bucket_sizes_produces_empty_list(self, ws: Workspace) -> None:
+        """Default (None) bucket_sizes must produce retentionCustomBucketSizes == []."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionCustomBucketSizes"] == []
+
+
+# =============================================================================
+# T-US6: Display modes
+# =============================================================================
+
+
+class TestBuildRetentionParamsMode:
+    """Tests for display mode → chartType mapping in retention bookmark params."""
+
+    def test_mode_curve_produces_retention_curve_chart(self, ws: Workspace) -> None:
+        """mode='curve' must produce chartType 'retention-curve'."""
+        result = ws.build_retention_params("Signup", "Login", mode="curve")
+        assert result["displayOptions"]["chartType"] == "retention-curve"
+
+    def test_mode_trends_produces_line_chart(self, ws: Workspace) -> None:
+        """mode='trends' must produce chartType 'line'."""
+        result = ws.build_retention_params("Signup", "Login", mode="trends")
+        assert result["displayOptions"]["chartType"] == "line"
+
+    def test_mode_table_produces_table_chart(self, ws: Workspace) -> None:
+        """mode='table' must produce chartType 'table'."""
+        result = ws.build_retention_params("Signup", "Login", mode="table")
+        assert result["displayOptions"]["chartType"] == "table"

--- a/tests/test_transform_retention.py
+++ b/tests/test_transform_retention.py
@@ -193,6 +193,46 @@ class TestTransformRetentionErrors:
         assert result.cohorts == {}
         assert result.average == {}
 
+    def test_multiple_series_keys_raises_query_error(self) -> None:
+        """Multiple top-level series keys raise QueryError (segmented data)."""
+        raw = _mock_response(
+            series={
+                "metric_a": {
+                    "2025-01-01": {"first": 10, "counts": [10], "rates": [1.0]}
+                },
+                "metric_b": {"2025-01-01": {"first": 5, "counts": [5], "rates": [1.0]}},
+            }
+        )
+
+        with pytest.raises(QueryError, match="segmented series"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_overall_wrapper_is_unwrapped(self) -> None:
+        """$overall key in cohort data is unwrapped correctly."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "$overall": {
+                        "2025-01-01": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                        "$average": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                    }
+                }
+            }
+        )
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert "2025-01-01" in result.cohorts
+        assert result.average["first"] == 100
+
 
 # =============================================================================
 # TestTransformRetentionFormatVariations (T054)

--- a/tests/test_transform_retention.py
+++ b/tests/test_transform_retention.py
@@ -233,6 +233,302 @@ class TestTransformRetentionErrors:
         assert "2025-01-01" in result.cohorts
         assert result.average["first"] == 100
 
+    def test_segmented_response_extracts_segments(self) -> None:
+        """Response with $overall + named segments populates segments dict."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "$overall": {
+                        "2025-01-01": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                        "$average": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                    "iOS": {
+                        "2025-01-01": {
+                            "first": 60,
+                            "counts": [60, 30],
+                            "rates": [1.0, 0.5],
+                        },
+                        "$average": {
+                            "first": 60,
+                            "counts": [60, 30],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                    "Android": {
+                        "2025-01-01": {
+                            "first": 40,
+                            "counts": [40, 20],
+                            "rates": [1.0, 0.5],
+                        },
+                        "$average": {
+                            "first": 40,
+                            "counts": [40, 20],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                }
+            }
+        )
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert "iOS" in result.segments
+        assert "Android" in result.segments
+        assert "iOS" in result.segment_averages
+        assert "Android" in result.segment_averages
+
+    def test_segmented_response_cohorts_from_overall(self) -> None:
+        """Segmented response uses $overall for primary cohorts field."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "$overall": {
+                        "2025-01-01": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                    "iOS": {
+                        "2025-01-01": {
+                            "first": 60,
+                            "counts": [60, 30],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                }
+            }
+        )
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert result.cohorts["2025-01-01"]["first"] == 100
+
+
+# =============================================================================
+# TestTransformRetentionNonDictSeries (T056)
+# =============================================================================
+
+
+class TestTransformRetentionNonDictSeries:
+    """Tests for _transform_retention_result when series is not a dict."""
+
+    def test_series_as_list_raises_query_error(self) -> None:
+        """series=[] raises QueryError with descriptive message."""
+        raw = _mock_response(series=[])
+
+        with pytest.raises(QueryError, match="series.*list.*expected dict"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_series_as_string_raises_query_error(self) -> None:
+        """series='pending' raises QueryError."""
+        raw = _mock_response(series="pending")
+
+        with pytest.raises(QueryError, match="series.*str.*expected dict"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_series_as_int_raises_query_error(self) -> None:
+        """series=0 raises QueryError."""
+        raw = _mock_response(series=0)
+
+        with pytest.raises(QueryError, match="series.*int.*expected dict"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_non_dict_metric_value_raises_query_error(self) -> None:
+        """series={'metric': 'error string'} raises QueryError."""
+        raw = _mock_response(series={"Signup and then Login": "error: timeout"})
+
+        with pytest.raises(QueryError, match="not a dict.*got str"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_non_dict_metric_value_as_list_raises_query_error(self) -> None:
+        """series={'metric': [1, 2]} raises QueryError."""
+        raw = _mock_response(series={"Signup and then Login": [1, 2, 3]})
+
+        with pytest.raises(QueryError, match="not a dict.*got list"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+
+# =============================================================================
+# TestTransformRetentionSegments (T055)
+# =============================================================================
+
+
+_SEGMENTED_SERIES: dict[str, Any] = {
+    "Signup and then Login": {
+        "$overall": {
+            "2025-01-01": {
+                "first": 200,
+                "counts": [200, 100],
+                "rates": [1.0, 0.5],
+            },
+            "$average": {
+                "first": 200,
+                "counts": [200, 100],
+                "rates": [1.0, 0.5],
+            },
+        },
+        "iOS": {
+            "2025-01-01": {
+                "first": 120,
+                "counts": [120, 60],
+                "rates": [1.0, 0.5],
+            },
+            "$average": {
+                "first": 120,
+                "counts": [120, 60],
+                "rates": [1.0, 0.5],
+            },
+        },
+        "Android": {
+            "2025-01-01": {
+                "first": 80,
+                "counts": [80, 40],
+                "rates": [1.0, 0.5],
+            },
+            "$average": {
+                "first": 80,
+                "counts": [80, 40],
+                "rates": [1.0, 0.5],
+            },
+        },
+    }
+}
+
+
+class TestTransformRetentionSegments:
+    """Tests for segmented retention response parsing (T055)."""
+
+    def test_segments_dict_has_correct_keys(self) -> None:
+        """Segment names match response keys (excluding $overall)."""
+        raw = _mock_response(series=_SEGMENTED_SERIES)
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert sorted(result.segments.keys()) == ["Android", "iOS"]
+
+    def test_segment_cohort_data_preserved(self) -> None:
+        """Each segment's cohort data (first, counts, rates) is intact."""
+        raw = _mock_response(series=_SEGMENTED_SERIES)
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        ios_cohort = result.segments["iOS"]["2025-01-01"]
+        assert ios_cohort["first"] == 120
+        assert ios_cohort["counts"] == [120, 60]
+        assert ios_cohort["rates"] == [1.0, 0.5]
+
+    def test_segment_averages_extracted(self) -> None:
+        """$average within each segment goes to segment_averages."""
+        raw = _mock_response(series=_SEGMENTED_SERIES)
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert result.segment_averages["iOS"]["first"] == 120
+        assert result.segment_averages["Android"]["first"] == 80
+
+    def test_unsegmented_response_has_empty_segments(self) -> None:
+        """Unsegmented response (no $overall) has empty segments dict."""
+        raw = _mock_response()
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert result.segments == {}
+        assert result.segment_averages == {}
+
+    def test_overall_only_response_has_empty_segments(self) -> None:
+        """Response with $overall but no named segments has empty segments."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "$overall": {
+                        "2025-01-01": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                    }
+                }
+            }
+        )
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert result.segments == {}
+        assert result.segment_averages == {}
+
+
+# =============================================================================
+# TestTransformRetentionDateNormalization (T056)
+# =============================================================================
+
+
+class TestTransformRetentionDateNormalization:
+    """Tests for cohort date key normalization (T056)."""
+
+    def test_iso_timestamp_keys_normalized(self) -> None:
+        """ISO timestamp cohort keys are normalized to YYYY-MM-DD."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "2025-01-01T00:00:00+00:00": {
+                        "first": 100,
+                        "counts": [100, 50],
+                        "rates": [1.0, 0.5],
+                    },
+                    "$average": {
+                        "first": 100,
+                        "counts": [100, 50],
+                        "rates": [1.0, 0.5],
+                    },
+                }
+            }
+        )
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert "2025-01-01" in result.cohorts
+        assert "2025-01-01T00:00:00+00:00" not in result.cohorts
+
+    def test_plain_date_keys_unchanged(self) -> None:
+        """Plain YYYY-MM-DD cohort keys are preserved as-is."""
+        raw = _mock_response()
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert "2025-01-01" in result.cohorts
+        assert "2025-01-02" in result.cohorts
+
+    def test_segment_date_keys_normalized(self) -> None:
+        """ISO timestamp keys are normalized within segment cohort data."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "$overall": {
+                        "2025-01-01T00:00:00+00:00": {
+                            "first": 100,
+                            "counts": [100, 50],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                    "iOS": {
+                        "2025-01-01T00:00:00+00:00": {
+                            "first": 60,
+                            "counts": [60, 30],
+                            "rates": [1.0, 0.5],
+                        },
+                    },
+                }
+            }
+        )
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert "2025-01-01" in result.cohorts
+        assert "2025-01-01" in result.segments["iOS"]
+
 
 # =============================================================================
 # TestTransformRetentionFormatVariations (T054)

--- a/tests/test_transform_retention.py
+++ b/tests/test_transform_retention.py
@@ -1,0 +1,277 @@
+"""Unit tests for _transform_retention_result()."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mixpanel_data._internal.services.live_query import _transform_retention_result
+from mixpanel_data.exceptions import QueryError
+from mixpanel_data.types import RetentionQueryResult
+
+# =============================================================================
+# Shared fixtures
+# =============================================================================
+
+_BOOKMARK_PARAMS: dict[str, Any] = {"sections": {}, "displayOptions": {}}
+
+
+def _mock_response(**overrides: Any) -> dict[str, Any]:
+    """Build a mock retention API response with sensible defaults.
+
+    Args:
+        **overrides: Keys to override in the default response dict.
+
+    Returns:
+        A dict mimicking the retention query response shape.
+    """
+    defaults: dict[str, Any] = {
+        "computed_at": "2025-01-15T12:00:00",
+        "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+        "series": {
+            "Signup and then Login": {
+                "2025-01-01": {
+                    "first": 100,
+                    "counts": [100, 50, 25],
+                    "rates": [1.0, 0.5, 0.25],
+                },
+                "2025-01-02": {
+                    "first": 80,
+                    "counts": [80, 40],
+                    "rates": [1.0, 0.5],
+                },
+                "$average": {
+                    "first": 90,
+                    "counts": [90, 45, 22],
+                    "rates": [1.0, 0.5, 0.244],
+                },
+            }
+        },
+        "meta": {"sampling_factor": 1.0},
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+# =============================================================================
+# TestTransformRetentionBasic (T017)
+# =============================================================================
+
+
+class TestTransformRetentionBasic:
+    """Tests for _transform_retention_result basic response parsing."""
+
+    def test_returns_retention_query_result(self) -> None:
+        """Return type is RetentionQueryResult."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert isinstance(result, RetentionQueryResult)
+
+    def test_computed_at_extracted(self) -> None:
+        """computed_at is extracted from the raw response."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.computed_at == "2025-01-15T12:00:00"
+
+    def test_from_date_extracted(self) -> None:
+        """from_date is extracted from raw['date_range']."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.from_date == "2025-01-01"
+
+    def test_to_date_extracted(self) -> None:
+        """to_date is extracted from raw['date_range']."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.to_date == "2025-01-31"
+
+    def test_cohorts_extracted_from_series(self) -> None:
+        """Cohorts are extracted from series, excluding $average."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert "2025-01-01" in result.cohorts
+        assert "2025-01-02" in result.cohorts
+        assert len(result.cohorts) == 2
+
+    def test_cohort_data_structure(self) -> None:
+        """Each cohort entry contains first, counts, and rates."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        cohort = result.cohorts["2025-01-01"]
+        assert cohort["first"] == 100
+        assert cohort["counts"] == [100, 50, 25]
+        assert cohort["rates"] == [1.0, 0.5, 0.25]
+
+    def test_average_extracted_from_series(self) -> None:
+        """Average is extracted from series['$average']."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.average["first"] == 90
+        assert result.average["counts"] == [90, 45, 22]
+        assert result.average["rates"] == [1.0, 0.5, 0.244]
+
+    def test_average_excluded_from_cohorts(self) -> None:
+        """$average key does not appear in cohorts dict."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert "$average" not in result.cohorts
+
+    def test_params_preserved(self) -> None:
+        """params field preserves the bookmark_params argument."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.params == _BOOKMARK_PARAMS
+
+    def test_meta_extracted(self) -> None:
+        """meta is extracted from raw['meta']."""
+        result = _transform_retention_result(_mock_response(), _BOOKMARK_PARAMS)
+
+        assert result.meta == {"sampling_factor": 1.0}
+
+
+# =============================================================================
+# TestTransformRetentionErrors (T018)
+# =============================================================================
+
+
+class TestTransformRetentionErrors:
+    """Tests for _transform_retention_result error handling."""
+
+    def test_error_response_raises_query_error(self) -> None:
+        """Response containing 'error' key raises QueryError with message."""
+        error_response: dict[str, Any] = {"error": "invalid query"}
+
+        with pytest.raises(QueryError, match="invalid query"):
+            _transform_retention_result(error_response, _BOOKMARK_PARAMS)
+
+    def test_error_response_includes_status_code(self) -> None:
+        """QueryError from error response has status_code=200 (leaked HTTP 200 error)."""
+        error_response: dict[str, Any] = {"error": "bad params"}
+
+        with pytest.raises(QueryError) as exc_info:
+            _transform_retention_result(error_response, _BOOKMARK_PARAMS)
+
+        assert exc_info.value.status_code == 200
+
+    def test_error_response_includes_response_body(self) -> None:
+        """QueryError from error response includes the raw response as response_body."""
+        error_response: dict[str, Any] = {"error": "timeout"}
+
+        with pytest.raises(QueryError) as exc_info:
+            _transform_retention_result(error_response, _BOOKMARK_PARAMS)
+
+        assert exc_info.value.response_body == error_response
+
+    def test_error_response_includes_request_body(self) -> None:
+        """QueryError from error response includes bookmark_params as request_body."""
+        error_response: dict[str, Any] = {"error": "bad filter"}
+        params: dict[str, Any] = {"sections": {"filters": "invalid"}}
+
+        with pytest.raises(QueryError) as exc_info:
+            _transform_retention_result(error_response, params)
+
+        assert exc_info.value.request_body == params
+
+    def test_missing_series_raises_query_error(self) -> None:
+        """Missing series key raises QueryError."""
+        raw: dict[str, Any] = {
+            "computed_at": "2025-01-15T12:00:00",
+            "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+            "meta": {},
+        }
+
+        with pytest.raises(QueryError, match="missing 'series' key"):
+            _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+    def test_empty_series_produces_empty_cohorts(self) -> None:
+        """Empty series produces empty cohorts dict."""
+        raw = _mock_response(series={})
+
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+
+        assert result.cohorts == {}
+        assert result.average == {}
+
+
+# =============================================================================
+# TestTransformRetentionFormatVariations (T054)
+# =============================================================================
+
+
+class TestTransformRetentionFormatVariations:
+    """Tests for response format variations (T054)."""
+
+    def test_direct_cohort_dict(self) -> None:
+        """Direct cohort dict format (no wrapper) is parsed correctly."""
+        raw = _mock_response()
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert len(result.cohorts) == 2
+
+    def test_missing_date_range_uses_defaults(self) -> None:
+        """Missing date_range produces empty from_date/to_date."""
+        raw = _mock_response()
+        del raw["date_range"]
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert result.from_date == ""
+        assert result.to_date == ""
+
+    def test_missing_meta_uses_empty_dict(self) -> None:
+        """Missing meta produces empty dict."""
+        raw = _mock_response()
+        del raw["meta"]
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert result.meta == {}
+
+    def test_missing_computed_at_uses_empty_string(self) -> None:
+        """Missing computed_at produces empty string."""
+        raw = _mock_response()
+        del raw["computed_at"]
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert result.computed_at == ""
+
+    def test_series_without_average(self) -> None:
+        """Series without $average produces empty average dict."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "2025-01-01": {
+                        "first": 100,
+                        "counts": [100, 50],
+                        "rates": [1.0, 0.5],
+                    },
+                }
+            }
+        )
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert result.average == {}
+        assert len(result.cohorts) == 1
+
+    def test_single_cohort_response(self) -> None:
+        """Single cohort date in series is handled correctly."""
+        raw = _mock_response(
+            series={
+                "Signup and then Login": {
+                    "2025-01-01": {
+                        "first": 50,
+                        "counts": [50, 25],
+                        "rates": [1.0, 0.5],
+                    },
+                    "$average": {
+                        "first": 50,
+                        "counts": [50, 25],
+                        "rates": [1.0, 0.5],
+                    },
+                }
+            }
+        )
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert len(result.cohorts) == 1
+        assert "2025-01-01" in result.cohorts
+
+    def test_empty_metric_wrapper(self) -> None:
+        """Empty dict inside metric wrapper produces empty cohorts."""
+        raw = _mock_response(series={"Signup and then Login": {}})
+        result = _transform_retention_result(raw, _BOOKMARK_PARAMS)
+        assert result.cohorts == {}
+        assert result.average == {}

--- a/tests/test_types_retention.py
+++ b/tests/test_types_retention.py
@@ -1,0 +1,320 @@
+"""Unit tests for retention query types.
+
+Tests cover:
+    T004: RetentionEvent — construction, defaults, immutability, field preservation,
+          filters handling.
+    T005: RetentionQueryResult — construction, defaults, immutability, .df columns/
+          shape/caching, .average field, .to_dict(), empty cohorts edge case.
+    T006: RetentionMathType — valid values accepted, invalid rejected at
+          validation layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mixpanel_data.types import Filter, RetentionEvent, RetentionQueryResult
+
+# =============================================================================
+# T004: RetentionEvent
+# =============================================================================
+
+
+class TestRetentionEventConstruction:
+    """Tests for RetentionEvent construction and defaults."""
+
+    def test_construct_with_event_only(self) -> None:
+        """RetentionEvent with just an event name uses correct defaults."""
+        e = RetentionEvent("Signup")
+        assert e.event == "Signup"
+        assert e.filters is None
+        assert e.filters_combinator == "all"
+
+    def test_construct_with_all_fields(self) -> None:
+        """RetentionEvent with all fields preserves them."""
+        f = Filter.equals("country", "US")
+        e = RetentionEvent("Signup", filters=[f], filters_combinator="any")
+        assert e.event == "Signup"
+        assert e.filters is not None
+        assert len(e.filters) == 1
+        assert e.filters_combinator == "any"
+
+    def test_default_filters_is_none(self) -> None:
+        """Default filters is None, not an empty list."""
+        e = RetentionEvent("Login")
+        assert e.filters is None
+
+    def test_default_filters_combinator_is_all(self) -> None:
+        """Default filters_combinator is 'all'."""
+        e = RetentionEvent("Login")
+        assert e.filters_combinator == "all"
+
+    def test_event_field_preserved(self) -> None:
+        """Event name is preserved exactly as given."""
+        e = RetentionEvent("My Custom Event 🎉")
+        assert e.event == "My Custom Event 🎉"
+
+    def test_filters_list_preserved(self) -> None:
+        """Filters list contents are preserved."""
+        f1 = Filter.equals("country", "US")
+        f2 = Filter.equals("platform", "iOS")
+        e = RetentionEvent("Signup", filters=[f1, f2])
+        assert e.filters is not None
+        assert len(e.filters) == 2
+
+
+class TestRetentionEventImmutability:
+    """Tests for RetentionEvent frozen dataclass immutability."""
+
+    def test_cannot_set_event(self) -> None:
+        """Setting event on a frozen instance must raise."""
+        e = RetentionEvent("Signup")
+        with pytest.raises(AttributeError):
+            e.event = "Login"  # type: ignore[misc]
+
+    def test_cannot_set_filters(self) -> None:
+        """Setting filters on a frozen instance must raise."""
+        e = RetentionEvent("Signup")
+        with pytest.raises(AttributeError):
+            e.filters = []  # type: ignore[misc]
+
+    def test_cannot_set_filters_combinator(self) -> None:
+        """Setting filters_combinator on a frozen instance must raise."""
+        e = RetentionEvent("Signup")
+        with pytest.raises(AttributeError):
+            e.filters_combinator = "any"  # type: ignore[misc]
+
+
+# =============================================================================
+# T005: RetentionQueryResult
+# =============================================================================
+
+
+def _make_result(**overrides: Any) -> RetentionQueryResult:
+    """Build a default-valid RetentionQueryResult for testing.
+
+    Args:
+        **overrides: Field overrides.
+
+    Returns:
+        RetentionQueryResult instance.
+    """
+    defaults: dict[str, Any] = {
+        "computed_at": "2025-01-15T12:00:00",
+        "from_date": "2025-01-01",
+        "to_date": "2025-01-31",
+        "cohorts": {
+            "2025-01-01": {
+                "first": 100,
+                "counts": [100, 50, 25],
+                "rates": [1.0, 0.5, 0.25],
+            },
+            "2025-01-02": {
+                "first": 80,
+                "counts": [80, 40, 20],
+                "rates": [1.0, 0.5, 0.25],
+            },
+        },
+        "average": {"first": 90, "counts": [90, 45, 22], "rates": [1.0, 0.5, 0.244]},
+        "params": {"sections": {}, "displayOptions": {}},
+        "meta": {"sampling_factor": 1.0},
+    }
+    defaults.update(overrides)
+    return RetentionQueryResult(**defaults)
+
+
+class TestRetentionQueryResultConstruction:
+    """Tests for RetentionQueryResult construction and defaults."""
+
+    def test_construct_with_all_fields(self) -> None:
+        """All fields are preserved after construction."""
+        r = _make_result()
+        assert r.computed_at == "2025-01-15T12:00:00"
+        assert r.from_date == "2025-01-01"
+        assert r.to_date == "2025-01-31"
+        assert len(r.cohorts) == 2
+        assert r.average["first"] == 90
+        assert "sections" in r.params
+        assert r.meta["sampling_factor"] == 1.0
+
+    def test_default_cohorts_is_empty_dict(self) -> None:
+        """Default cohorts is an empty dict."""
+        r = RetentionQueryResult(
+            computed_at="",
+            from_date="",
+            to_date="",
+        )
+        assert r.cohorts == {}
+
+    def test_default_average_is_empty_dict(self) -> None:
+        """Default average is an empty dict."""
+        r = RetentionQueryResult(
+            computed_at="",
+            from_date="",
+            to_date="",
+        )
+        assert r.average == {}
+
+    def test_default_params_is_empty_dict(self) -> None:
+        """Default params is an empty dict."""
+        r = RetentionQueryResult(
+            computed_at="",
+            from_date="",
+            to_date="",
+        )
+        assert r.params == {}
+
+    def test_default_meta_is_empty_dict(self) -> None:
+        """Default meta is an empty dict."""
+        r = RetentionQueryResult(
+            computed_at="",
+            from_date="",
+            to_date="",
+        )
+        assert r.meta == {}
+
+
+class TestRetentionQueryResultImmutability:
+    """Tests for RetentionQueryResult frozen dataclass immutability."""
+
+    def test_cannot_set_computed_at(self) -> None:
+        """Setting computed_at on a frozen instance must raise."""
+        r = _make_result()
+        with pytest.raises(AttributeError):
+            r.computed_at = "new"  # type: ignore[misc]
+
+    def test_cannot_set_cohorts(self) -> None:
+        """Setting cohorts on a frozen instance must raise."""
+        r = _make_result()
+        with pytest.raises(AttributeError):
+            r.cohorts = {}  # type: ignore[misc]
+
+
+class TestRetentionQueryResultDataFrame:
+    """Tests for RetentionQueryResult.df property."""
+
+    def test_df_columns(self) -> None:
+        """DataFrame must have columns: cohort_date, bucket, count, rate."""
+        r = _make_result()
+        df = r.df
+        assert list(df.columns) == ["cohort_date", "bucket", "count", "rate"]
+
+    def test_df_shape(self) -> None:
+        """DataFrame row count = sum of bucket counts across cohorts."""
+        r = _make_result()
+        df = r.df
+        # 2 cohorts × 3 buckets each = 6 rows
+        assert len(df) == 6
+
+    def test_df_caching(self) -> None:
+        """Accessing .df twice returns the same DataFrame object."""
+        r = _make_result()
+        df1 = r.df
+        df2 = r.df
+        assert df1 is df2
+
+    def test_df_values_correct(self) -> None:
+        """DataFrame values match the cohort data."""
+        r = _make_result()
+        df = r.df
+        # First cohort, bucket 0
+        row = df[(df["cohort_date"] == "2025-01-01") & (df["bucket"] == 0)]
+        assert len(row) == 1
+        assert row.iloc[0]["count"] == 100
+        assert row.iloc[0]["rate"] == 1.0
+
+    def test_df_bucket_indices(self) -> None:
+        """Buckets are 0-indexed integers."""
+        r = _make_result()
+        df = r.df
+        buckets = sorted(df["bucket"].unique())
+        assert buckets == [0, 1, 2]
+
+    def test_empty_cohorts_produces_empty_df(self) -> None:
+        """Empty cohorts dict produces an empty DataFrame with correct columns."""
+        r = _make_result(cohorts={})
+        df = r.df
+        assert len(df) == 0
+        assert list(df.columns) == ["cohort_date", "bucket", "count", "rate"]
+
+
+class TestRetentionQueryResultToDict:
+    """Tests for RetentionQueryResult.to_dict() serialization."""
+
+    def test_to_dict_returns_dict(self) -> None:
+        """to_dict() returns a plain dict."""
+        r = _make_result()
+        d = r.to_dict()
+        assert isinstance(d, dict)
+
+    def test_to_dict_contains_all_fields(self) -> None:
+        """to_dict() includes all public fields."""
+        r = _make_result()
+        d = r.to_dict()
+        assert "computed_at" in d
+        assert "from_date" in d
+        assert "to_date" in d
+        assert "cohorts" in d
+        assert "average" in d
+        assert "params" in d
+        assert "meta" in d
+
+
+class TestRetentionQueryResultAverage:
+    """Tests for RetentionQueryResult.average field."""
+
+    def test_average_is_preserved(self) -> None:
+        """Average dict is preserved as-is."""
+        avg = {"first": 90, "counts": [90, 45], "rates": [1.0, 0.5]}
+        r = _make_result(average=avg)
+        assert r.average == avg
+
+    def test_average_empty_dict_when_no_data(self) -> None:
+        """Average defaults to empty dict."""
+        r = RetentionQueryResult(
+            computed_at="",
+            from_date="",
+            to_date="",
+        )
+        assert r.average == {}
+
+
+# =============================================================================
+# T006: RetentionMathType
+# =============================================================================
+
+
+class TestRetentionMathType:
+    """Tests for RetentionMathType type alias validation.
+
+    RetentionMathType is a Literal type alias, so validation happens
+    at the validation layer (validate_retention_args), not at construction.
+    These tests verify the enum constants that back the type.
+    """
+
+    def test_valid_values_in_enum(self) -> None:
+        """VALID_MATH_RETENTION contains retention_rate and unique."""
+        from mixpanel_data._internal.bookmark_enums import VALID_MATH_RETENTION
+
+        assert "retention_rate" in VALID_MATH_RETENTION
+        assert "unique" in VALID_MATH_RETENTION
+
+    def test_insights_math_not_in_retention(self) -> None:
+        """Insights-only math types are not in VALID_MATH_RETENTION."""
+        from mixpanel_data._internal.bookmark_enums import VALID_MATH_RETENTION
+
+        assert "dau" not in VALID_MATH_RETENTION
+        assert "wau" not in VALID_MATH_RETENTION
+        assert "mau" not in VALID_MATH_RETENTION
+        assert "histogram" not in VALID_MATH_RETENTION
+
+    def test_retention_math_is_subset_of_all_math(self) -> None:
+        """VALID_MATH_RETENTION must be a subset of VALID_MATH_TYPES."""
+        from mixpanel_data._internal.bookmark_enums import (
+            VALID_MATH_RETENTION,
+            VALID_MATH_TYPES,
+        )
+
+        assert VALID_MATH_RETENTION.issubset(VALID_MATH_TYPES)

--- a/tests/test_types_retention.py
+++ b/tests/test_types_retention.py
@@ -239,6 +239,117 @@ class TestRetentionQueryResultDataFrame:
         assert len(df) == 0
         assert list(df.columns) == ["cohort_date", "bucket", "count", "rate"]
 
+    def test_rates_shorter_than_counts_uses_zero(self) -> None:
+        """When rates has fewer entries than counts, missing rates default to 0.0."""
+        r = _make_result(
+            cohorts={
+                "2025-01-01": {
+                    "first": 100,
+                    "counts": [100, 50, 25],
+                    "rates": [1.0],  # Only 1 rate for 3 counts
+                },
+            }
+        )
+        df = r.df
+        assert len(df) == 3
+        # First bucket has the rate
+        assert df.iloc[0]["rate"] == 1.0
+        # Remaining buckets fall back to 0.0
+        assert df.iloc[1]["rate"] == 0.0
+        assert df.iloc[2]["rate"] == 0.0
+
+    def test_rates_empty_all_default_to_zero(self) -> None:
+        """When rates is empty, all rate values default to 0.0."""
+        r = _make_result(
+            cohorts={
+                "2025-01-01": {
+                    "first": 50,
+                    "counts": [50, 25],
+                    "rates": [],
+                },
+            }
+        )
+        df = r.df
+        assert len(df) == 2
+        assert df.iloc[0]["rate"] == 0.0
+        assert df.iloc[1]["rate"] == 0.0
+
+
+class TestRetentionQueryResultDataFrameSegmented:
+    """Tests for RetentionQueryResult.df with segmented data."""
+
+    def test_df_with_segments_has_segment_column(self) -> None:
+        """When segments populated, df has 5 columns including segment."""
+        r = _make_result(
+            segments={
+                "iOS": {
+                    "2025-01-01": {
+                        "first": 60,
+                        "counts": [60, 30],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+                "Android": {
+                    "2025-01-01": {
+                        "first": 40,
+                        "counts": [40, 20],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+            }
+        )
+        df = r.df
+        assert list(df.columns) == ["segment", "cohort_date", "bucket", "count", "rate"]
+
+    def test_df_with_segments_row_count(self) -> None:
+        """Segmented df has correct number of rows."""
+        r = _make_result(
+            segments={
+                "iOS": {
+                    "2025-01-01": {
+                        "first": 60,
+                        "counts": [60, 30],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+                "Android": {
+                    "2025-01-01": {
+                        "first": 40,
+                        "counts": [40, 20],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+            }
+        )
+        df = r.df
+        # 2 segments × 1 cohort × 2 buckets = 4 rows
+        assert len(df) == 4
+
+    def test_df_with_segments_values_correct(self) -> None:
+        """Segmented df values match segment cohort data."""
+        r = _make_result(
+            segments={
+                "iOS": {
+                    "2025-01-01": {
+                        "first": 60,
+                        "counts": [60, 30],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+            }
+        )
+        df = r.df
+        row = df[(df["segment"] == "iOS") & (df["bucket"] == 0)]
+        assert len(row) == 1
+        assert row.iloc[0]["count"] == 60
+        assert row.iloc[0]["rate"] == 1.0
+
+    def test_df_without_segments_no_segment_column(self) -> None:
+        """Without segments, df has 4 columns (backward compat)."""
+        r = _make_result()
+        df = r.df
+        assert list(df.columns) == ["cohort_date", "bucket", "count", "rate"]
+
 
 class TestRetentionQueryResultToDict:
     """Tests for RetentionQueryResult.to_dict() serialization."""
@@ -260,6 +371,34 @@ class TestRetentionQueryResultToDict:
         assert "average" in d
         assert "params" in d
         assert "meta" in d
+
+    def test_to_dict_includes_segments_when_present(self) -> None:
+        """to_dict() includes segments and segment_averages when non-empty."""
+        r = _make_result(
+            segments={
+                "iOS": {
+                    "2025-01-01": {
+                        "first": 60,
+                        "counts": [60, 30],
+                        "rates": [1.0, 0.5],
+                    },
+                },
+            },
+            segment_averages={
+                "iOS": {"first": 60, "counts": [60, 30], "rates": [1.0, 0.5]},
+            },
+        )
+        d = r.to_dict()
+        assert "segments" in d
+        assert "segment_averages" in d
+        assert d["segments"]["iOS"]["2025-01-01"]["first"] == 60
+
+    def test_to_dict_excludes_segments_when_empty(self) -> None:
+        """to_dict() omits segments and segment_averages when empty."""
+        r = _make_result()
+        d = r.to_dict()
+        assert "segments" not in d
+        assert "segment_averages" not in d
 
 
 class TestRetentionQueryResultAverage:

--- a/tests/test_types_retention_pbt.py
+++ b/tests/test_types_retention_pbt.py
@@ -1,0 +1,281 @@
+"""Property-based tests for retention query types using Hypothesis.
+
+These tests verify invariants of RetentionEvent, RetentionQueryResult,
+and _build_retention_params that should hold for all possible inputs,
+catching edge cases that example-based tests miss.
+
+Usage:
+    # Run with default profile (100 examples)
+    pytest tests/test_types_retention_pbt.py
+
+    # Run with dev profile (10 examples, verbose)
+    HYPOTHESIS_PROFILE=dev pytest tests/test_types_retention_pbt.py
+
+    # Run with CI profile (200 examples, deterministic)
+    HYPOTHESIS_PROFILE=ci pytest tests/test_types_retention_pbt.py
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.types import RetentionEvent, RetentionQueryResult
+
+# =============================================================================
+# Custom Strategies
+# =============================================================================
+
+# Strategy for event names (non-empty visible characters only)
+event_names = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "S")),
+    min_size=1,
+    max_size=50,
+).filter(lambda s: s.strip())
+
+
+@st.composite
+def cohort_dicts(
+    draw: st.DrawFn,
+) -> dict[str, dict[str, Any]]:
+    """Generate random cohort dicts matching RetentionQueryResult.cohorts shape.
+
+    Each cohort has a date key mapping to a dict with ``first`` (cohort size),
+    ``counts`` (list of retained user counts), and ``rates`` (list of retention
+    rates derived from counts/first).
+
+    Args:
+        draw: Hypothesis draw function for composing strategies.
+
+    Returns:
+        A dict mapping date strings to cohort data dicts.
+    """
+    n_cohorts = draw(st.integers(min_value=0, max_value=5))
+    cohorts: dict[str, dict[str, Any]] = {}
+    for i in range(n_cohorts):
+        date = f"2025-01-{i + 1:02d}"
+        n_buckets = draw(st.integers(min_value=0, max_value=10))
+        first = draw(st.integers(min_value=1, max_value=1000))
+        counts = [
+            draw(st.integers(min_value=0, max_value=first)) for _ in range(n_buckets)
+        ]
+        rates = [c / first if first > 0 else 0.0 for c in counts]
+        cohorts[date] = {"first": first, "counts": counts, "rates": rates}
+    return cohorts
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_workspace() -> Workspace:
+    """Create a Workspace instance with mocked dependencies.
+
+    Uses dependency injection so no real credentials or network access
+    are needed.  Built as a plain function (not a pytest fixture) so it
+    can be called inside ``@given``-decorated tests without triggering
+    Hypothesis's ``function_scoped_fixture`` health check.
+
+    Returns:
+        A Workspace with mocked ConfigManager and MixpanelAPIClient.
+    """
+    creds = Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id="12345",
+        region="us",
+    )
+    manager = MagicMock(spec=ConfigManager)
+    manager.resolve_credentials.return_value = creds
+    client = MagicMock(spec=MixpanelAPIClient)
+    client.close = MagicMock()
+    return Workspace(
+        _config_manager=manager,
+        _api_client=client,
+    )
+
+
+# =============================================================================
+# T051: RetentionEvent Property Tests
+# =============================================================================
+
+
+class TestRetentionEventPBT:
+    """Property-based tests for RetentionEvent frozen dataclass.
+
+    Verifies immutability, equality, and field preservation invariants
+    that should hold for all possible RetentionEvent instances.
+    """
+
+    @given(event=st.text(min_size=1))
+    def test_immutability(self, event: str) -> None:
+        """Setting any attribute on a frozen RetentionEvent raises an error.
+
+        Generates random RetentionEvent instances and verifies that
+        assigning to any of the three fields (event, filters,
+        filters_combinator) raises ``FrozenInstanceError``.
+        """
+        re = RetentionEvent(event=event)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            re.event = "other"  # type: ignore[misc]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            re.filters = []  # type: ignore[misc]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            re.filters_combinator = "any"  # type: ignore[misc]
+
+    @given(event=st.text(min_size=1))
+    def test_equality(self, event: str) -> None:
+        """Two RetentionEvent instances with the same arguments are equal.
+
+        Frozen dataclasses generate ``__eq__`` based on field values,
+        so structurally identical instances must compare equal.
+        """
+        a = RetentionEvent(event=event)
+        b = RetentionEvent(event=event)
+        assert a == b
+
+    @given(event=st.text(min_size=1))
+    def test_field_preservation(self, event: str) -> None:
+        """The event field is preserved exactly as given across random strings.
+
+        Verifies that no normalization, stripping, or transformation
+        occurs on the event name during construction.
+        """
+        re = RetentionEvent(event=event)
+        assert re.event == event
+
+
+# =============================================================================
+# T052: RetentionQueryResult Property Tests
+# =============================================================================
+
+
+class TestRetentionQueryResultPBT:
+    """Property-based tests for RetentionQueryResult.
+
+    Verifies DataFrame shape, column presence, and deterministic
+    conversion invariants across randomly generated cohort data.
+    """
+
+    @given(cohorts=cohort_dicts())
+    def test_df_row_count_matches_cohorts(
+        self, cohorts: dict[str, dict[str, Any]]
+    ) -> None:
+        """DataFrame row count equals sum of bucket counts across all cohorts.
+
+        Each cohort contributes ``len(counts)`` rows to the DataFrame,
+        so the total row count must equal the sum across all cohorts.
+        """
+        result = RetentionQueryResult(
+            computed_at="2025-01-01T00:00:00",
+            from_date="2025-01-01",
+            to_date="2025-01-31",
+            cohorts=cohorts,
+        )
+        expected_rows = sum(len(c["counts"]) for c in cohorts.values())
+        assert len(result.df) == expected_rows
+
+    @given(cohorts=cohort_dicts())
+    def test_df_always_has_four_columns(
+        self, cohorts: dict[str, dict[str, Any]]
+    ) -> None:
+        """DataFrame always has exactly 4 columns: cohort_date, bucket, count, rate.
+
+        Regardless of input shape (empty cohorts, zero buckets, many
+        buckets), the column set must be exactly these four in order.
+        """
+        result = RetentionQueryResult(
+            computed_at="2025-01-01T00:00:00",
+            from_date="2025-01-01",
+            to_date="2025-01-31",
+            cohorts=cohorts,
+        )
+        expected_columns = ["cohort_date", "bucket", "count", "rate"]
+        assert list(result.df.columns) == expected_columns
+
+    @given(cohorts=cohort_dicts())
+    def test_deterministic_conversion(self, cohorts: dict[str, dict[str, Any]]) -> None:
+        """Calling .df twice on the same instance returns identical DataFrames.
+
+        The cached DataFrame must be structurally identical across
+        repeated accesses, ensuring deterministic conversion.
+        """
+        result = RetentionQueryResult(
+            computed_at="2025-01-01T00:00:00",
+            from_date="2025-01-01",
+            to_date="2025-01-31",
+            cohorts=cohorts,
+        )
+        df1 = result.df
+        df2 = result.df
+        pd.testing.assert_frame_equal(df1, df2)
+
+
+# =============================================================================
+# T053: _build_retention_params Property Tests
+# =============================================================================
+
+
+class TestBuildRetentionParamsPBT:
+    """Property-based tests for Workspace.build_retention_params output structure.
+
+    Verifies that for any valid born/return event name inputs, the output
+    always has the expected top-level structure, behavior count, and chart
+    type values.
+
+    Uses ``_make_workspace()`` instead of pytest fixtures to avoid
+    Hypothesis's ``function_scoped_fixture`` health check.
+    """
+
+    @given(
+        born=event_names,
+        ret=event_names,
+    )
+    def test_always_has_sections_and_display_options(self, born: str, ret: str) -> None:
+        """For any valid born/return event names, result has sections and displayOptions.
+
+        These two top-level keys are required for the bookmark JSON to be
+        valid. They must always be present regardless of event names.
+        """
+        ws = _make_workspace()
+        result = ws.build_retention_params(born, ret)
+        assert "sections" in result
+        assert "displayOptions" in result
+
+    @given(
+        born=event_names,
+        ret=event_names,
+    )
+    def test_behavior_count_always_two(self, born: str, ret: str) -> None:
+        """The behaviors list always has exactly 2 entries (born + return).
+
+        Retention queries always require exactly one born event and one
+        return event, so the behaviors array must always have length 2.
+        """
+        ws = _make_workspace()
+        result = ws.build_retention_params(born, ret)
+        behaviors = result["sections"]["show"][0]["behavior"]["behaviors"]
+        assert len(behaviors) == 2
+
+    @given(mode=st.sampled_from(["curve", "trends", "table"]))
+    def test_chart_type_always_valid(self, mode: str) -> None:
+        """chartType is always one of 'retention-curve', 'line', or 'table'.
+
+        Each mode maps to a specific chart type. The mapping must produce
+        only valid chart type strings for the retention report.
+        """
+        ws = _make_workspace()
+        result = ws.build_retention_params("Signup", "Login", mode=mode)  # type: ignore[arg-type]
+        valid_chart_types = {"retention-curve", "line", "table"}
+        assert result["displayOptions"]["chartType"] in valid_chart_types

--- a/tests/test_validation_retention.py
+++ b/tests/test_validation_retention.py
@@ -613,6 +613,22 @@ class TestValidateRetentionR5R6:
         }
         assert not any(e.code in r5r6_codes for e in errors)
 
+    def test_bucket_sizes_with_invalid_types_skips_r6(self) -> None:
+        """When bucket_sizes has invalid types, R6 ascending check is skipped."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[3, 1.5, 7])
+        )
+        assert any(e.code == "R5_BUCKET_SIZES_INTEGER" for e in errors)
+        assert "R6_BUCKET_SIZES_ASCENDING" not in _codes(errors)
+
+    def test_bucket_sizes_with_non_positive_skips_r6(self) -> None:
+        """When bucket_sizes has non-positive values, R6 ascending check is skipped."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[0, -1, 3])
+        )
+        assert any(e.code == "R5_BUCKET_SIZES_POSITIVE" for e in errors)
+        assert "R6_BUCKET_SIZES_ASCENDING" not in _codes(errors)
+
 
 # =============================================================================
 # T-US5: Multi-error collection
@@ -817,12 +833,3 @@ class TestValidateRetentionR12:
         r12 = [e for e in errors if e.code == "R12_EMPTY_GROUP_BY"]
         assert len(r12) == 1
         assert r12[0].path == "group_by"
-
-    def test_error_message_includes_count(self) -> None:
-        """The R5c error message must include the actual count."""
-        errors = validate_retention_args(
-            **_valid_retention_args(bucket_sizes=list(range(1, 1001)))
-        )
-        r5c = [e for e in errors if e.code == "R5_BUCKET_SIZES_TOO_MANY"]
-        assert len(r5c) == 1
-        assert "1000" in r5c[0].message

--- a/tests/test_validation_retention.py
+++ b/tests/test_validation_retention.py
@@ -1,4 +1,4 @@
-"""Unit tests for retention argument validation rules (R1-R9).
+"""Unit tests for retention argument validation rules (R1-R12).
 
 Tests ``validate_retention_args()`` which validates Python-level arguments
 before retention bookmark construction. Each rule class covers one or more
@@ -14,6 +14,9 @@ Validation rules:
     R7: retention_unit must be in {"day", "week", "month"}.
     R8: alignment must be in {"birth", "interval_start"}.
     R9: math must be in {"retention_rate", "unique"}.
+    R10: mode must be in {"curve", "trends", "table"}.
+    R11: unit must be in {"day", "week", "month"}.
+    R12: group_by strings must be non-empty.
 
 Also tests multi-error collection (fail-fast validation).
 """
@@ -833,3 +836,177 @@ class TestValidateRetentionR12:
         r12 = [e for e in errors if e.code == "R12_EMPTY_GROUP_BY"]
         assert len(r12) == 1
         assert r12[0].path == "group_by"
+
+
+# =============================================================================
+# R5: bucket_sizes boolean edge case
+# =============================================================================
+
+
+class TestValidateRetentionR5Boolean:
+    """Tests for R5: boolean values in bucket_sizes are rejected.
+
+    Python's ``bool`` is a subclass of ``int``, so ``True``/``False``
+    pass ``isinstance(val, int)``. The validator must explicitly reject
+    booleans.
+    """
+
+    def test_boolean_true_rejected(self) -> None:
+        """bucket_sizes=[True, 3] must produce R5_BUCKET_SIZES_POSITIVE."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[True, 3])
+        )
+        assert any(e.code == "R5_BUCKET_SIZES_POSITIVE" for e in errors)
+
+    def test_boolean_false_rejected(self) -> None:
+        """bucket_sizes=[False] must produce R5_BUCKET_SIZES_POSITIVE."""
+        errors = validate_retention_args(**_valid_retention_args(bucket_sizes=[False]))
+        assert any(e.code == "R5_BUCKET_SIZES_POSITIVE" for e in errors)
+
+
+# =============================================================================
+# Layer 2: B20/B21 filter validation (via validate_bookmark)
+# =============================================================================
+
+
+class TestValidateBookmarkRetentionB20:
+    """Tests for B20: filterValue must not be an empty list.
+
+    These rules apply to all bookmark types. Tested here with
+    ``bookmark_type="retention"`` since B20/B21 were added in this PR.
+    """
+
+    def test_empty_filter_value_list_rejected(self) -> None:
+        """filterValue=[] must produce B20_EMPTY_FILTER_VALUE."""
+        from mixpanel_data._internal.validation import validate_bookmark
+
+        bookmark: dict[str, Any] = {
+            "sections": {
+                "show": [
+                    {
+                        "behavior": {
+                            "type": "event",
+                            "resourceType": "events",
+                            "value": {"name": "Signup"},
+                        },
+                        "measurement": {"math": "retention_rate"},
+                    }
+                ],
+                "time": [{"unit": "day", "dateRangeType": "in the last", "value": 30}],
+                "filter": [
+                    {
+                        "filterType": "string",
+                        "filterOperator": "in",
+                        "filterValue": [],
+                        "propertyObjectKey": "properties",
+                        "resourceType": "events",
+                        "propertyName": "country",
+                    }
+                ],
+                "group": [],
+            },
+            "displayOptions": {"chartType": "line", "analysis": "linear"},
+        }
+        errors = validate_bookmark(bookmark, bookmark_type="retention")
+        assert any(e.code == "B20_EMPTY_FILTER_VALUE" for e in errors)
+
+
+class TestValidateBookmarkRetentionB21:
+    """Tests for B21: filterValue list must not exceed max size."""
+
+    def test_filter_value_too_many_rejected(self) -> None:
+        """filterValue with >1000 entries must produce B21_FILTER_VALUE_TOO_MANY."""
+        from mixpanel_data._internal.validation import validate_bookmark
+
+        bookmark: dict[str, Any] = {
+            "sections": {
+                "show": [
+                    {
+                        "behavior": {
+                            "type": "event",
+                            "resourceType": "events",
+                            "value": {"name": "Signup"},
+                        },
+                        "measurement": {"math": "retention_rate"},
+                    }
+                ],
+                "time": [{"unit": "day", "dateRangeType": "in the last", "value": 30}],
+                "filter": [
+                    {
+                        "filterType": "string",
+                        "filterOperator": "in",
+                        "filterValue": [f"val_{i}" for i in range(1001)],
+                        "propertyObjectKey": "properties",
+                        "resourceType": "events",
+                        "propertyName": "country",
+                    }
+                ],
+                "group": [],
+            },
+            "displayOptions": {"chartType": "line", "analysis": "linear"},
+        }
+        errors = validate_bookmark(bookmark, bookmark_type="retention")
+        assert any(e.code == "B21_FILTER_VALUE_TOO_MANY" for e in errors)
+
+
+# =============================================================================
+# Layer 2: B9 retention math dispatch
+# =============================================================================
+
+
+class TestValidateBookmarkRetentionB9MathDispatch:
+    """Tests for B9: retention bookmarks route to VALID_MATH_RETENTION.
+
+    Ensures that insights-only math types (e.g., ``"dau"``) are rejected
+    when the bookmark type is ``"retention"``.
+    """
+
+    def test_insights_only_math_rejected_for_retention(self) -> None:
+        """math='dau' must produce B9_INVALID_MATH for retention bookmarks."""
+        from mixpanel_data._internal.validation import validate_bookmark
+
+        bookmark: dict[str, Any] = {
+            "sections": {
+                "show": [
+                    {
+                        "behavior": {
+                            "type": "event",
+                            "resourceType": "events",
+                            "value": {"name": "Signup"},
+                        },
+                        "measurement": {"math": "dau"},
+                    }
+                ],
+                "time": [{"unit": "day", "dateRangeType": "in the last", "value": 30}],
+                "filter": [],
+                "group": [],
+            },
+            "displayOptions": {"chartType": "line", "analysis": "linear"},
+        }
+        errors = validate_bookmark(bookmark, bookmark_type="retention")
+        assert any(e.code == "B9_INVALID_MATH" for e in errors)
+
+    def test_valid_retention_math_accepted(self) -> None:
+        """math='retention_rate' must not produce B9_INVALID_MATH for retention."""
+        from mixpanel_data._internal.validation import validate_bookmark
+
+        bookmark: dict[str, Any] = {
+            "sections": {
+                "show": [
+                    {
+                        "behavior": {
+                            "type": "event",
+                            "resourceType": "events",
+                            "value": {"name": "Signup"},
+                        },
+                        "measurement": {"math": "retention_rate"},
+                    }
+                ],
+                "time": [{"unit": "day", "dateRangeType": "in the last", "value": 30}],
+                "filter": [],
+                "group": [],
+            },
+            "displayOptions": {"chartType": "line", "analysis": "linear"},
+        }
+        errors = validate_bookmark(bookmark, bookmark_type="retention")
+        assert not any(e.code == "B9_INVALID_MATH" for e in errors)

--- a/tests/test_validation_retention.py
+++ b/tests/test_validation_retention.py
@@ -1,0 +1,828 @@
+"""Unit tests for retention argument validation rules (R1-R9).
+
+Tests ``validate_retention_args()`` which validates Python-level arguments
+before retention bookmark construction. Each rule class covers one or more
+validation rules, plus delegation tests verify shared validators are called.
+
+Validation rules:
+    R1: born_event must be a non-empty string (no control chars, no invisible-only).
+    R2: return_event must be a non-empty string (no control chars, no invisible-only).
+    R3: Time validation (delegated to ``validate_time_args``).
+    R4: Group-by validation (delegated to ``validate_group_by_args``).
+    R5: bucket_sizes values must be positive integers.
+    R6: bucket_sizes must be in strictly ascending order.
+    R7: retention_unit must be in {"day", "week", "month"}.
+    R8: alignment must be in {"birth", "interval_start"}.
+    R9: math must be in {"retention_rate", "unique"}.
+
+Also tests multi-error collection (fail-fast validation).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mixpanel_data._internal.validation import validate_retention_args
+from mixpanel_data.exceptions import ValidationError
+from mixpanel_data.types import GroupBy
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _valid_retention_args(**overrides: Any) -> dict[str, Any]:
+    """Build a default-valid kwargs dict for ``validate_retention_args``.
+
+    All defaults pass validation. Override individual keys to inject
+    specific invalid values for targeted testing.
+
+    Args:
+        **overrides: Keyword arguments to override in the defaults.
+
+    Returns:
+        Dict suitable for unpacking into ``validate_retention_args(**d)``.
+    """
+    defaults: dict[str, Any] = {
+        "born_event": "Signup",
+        "return_event": "Login",
+        "retention_unit": "week",
+        "alignment": "birth",
+        "bucket_sizes": None,
+        "math": "retention_rate",
+        "mode": "curve",
+        "unit": "day",
+        "from_date": None,
+        "to_date": None,
+        "last": 30,
+        "group_by": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _codes(errors: list[ValidationError]) -> list[str]:
+    """Extract error codes from a list of ValidationError objects.
+
+    Args:
+        errors: List of validation errors.
+
+    Returns:
+        List of error code strings.
+    """
+    return [e.code for e in errors]
+
+
+# =============================================================================
+# T011: R1 — born_event must be non-empty string
+# =============================================================================
+
+
+class TestValidateRetentionR1:
+    """Tests for R1: born_event must be a non-empty, visible string."""
+
+    def test_empty_born_event_returns_r1_error(self) -> None:
+        """An empty string born_event must produce an R1_EMPTY_BORN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(born_event=""))
+        assert any(e.code == "R1_EMPTY_BORN_EVENT" for e in errors)
+
+    def test_whitespace_only_born_event_returns_r1_error(self) -> None:
+        """A whitespace-only born_event must produce an R1_EMPTY_BORN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(born_event="   "))
+        assert any(e.code == "R1_EMPTY_BORN_EVENT" for e in errors)
+
+    def test_tab_only_born_event_returns_r1_error(self) -> None:
+        """A tab-only born_event must produce an R1_EMPTY_BORN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(born_event="\t\t"))
+        assert any(e.code == "R1_EMPTY_BORN_EVENT" for e in errors)
+
+    def test_control_char_in_born_event_returns_r1_control_error(self) -> None:
+        """A born_event containing a null byte must produce R1_CONTROL_CHAR_BORN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(born_event="Sign\x00up")
+        )
+        assert any(e.code == "R1_CONTROL_CHAR_BORN_EVENT" for e in errors)
+
+    def test_bell_char_in_born_event_returns_r1_control_error(self) -> None:
+        """A born_event containing a bell character must produce R1_CONTROL_CHAR_BORN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(born_event="Sign\x07up")
+        )
+        assert any(e.code == "R1_CONTROL_CHAR_BORN_EVENT" for e in errors)
+
+    def test_invisible_only_born_event_returns_r1_invisible_error(self) -> None:
+        """A born_event with only zero-width spaces must produce R1_INVISIBLE_BORN_EVENT."""
+        errors = validate_retention_args(**_valid_retention_args(born_event="\u200b"))
+        assert any(e.code == "R1_INVISIBLE_BORN_EVENT" for e in errors)
+
+    def test_zero_width_joiner_only_returns_r1_invisible_error(self) -> None:
+        """A born_event with only zero-width joiners must produce R1_INVISIBLE_BORN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(born_event="\u200d\u200d")
+        )
+        assert any(e.code == "R1_INVISIBLE_BORN_EVENT" for e in errors)
+
+    def test_valid_born_event_no_r1_error(self) -> None:
+        """A valid born_event must not produce any R1 errors."""
+        errors = validate_retention_args(**_valid_retention_args(born_event="Signup"))
+        r1_codes = {
+            "R1_EMPTY_BORN_EVENT",
+            "R1_CONTROL_CHAR_BORN_EVENT",
+            "R1_INVISIBLE_BORN_EVENT",
+        }
+        assert not any(e.code in r1_codes for e in errors)
+
+    def test_born_event_with_spaces_is_valid(self) -> None:
+        """A born_event with spaces between visible chars must not produce R1 errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(born_event="User Signup")
+        )
+        r1_codes = {
+            "R1_EMPTY_BORN_EVENT",
+            "R1_CONTROL_CHAR_BORN_EVENT",
+            "R1_INVISIBLE_BORN_EVENT",
+        }
+        assert not any(e.code in r1_codes for e in errors)
+
+    def test_r1_error_path_is_born_event(self) -> None:
+        """The R1 error path must point to 'born_event'."""
+        errors = validate_retention_args(**_valid_retention_args(born_event=""))
+        r1_errors = [e for e in errors if e.code == "R1_EMPTY_BORN_EVENT"]
+        assert len(r1_errors) == 1
+        assert r1_errors[0].path == "born_event"
+
+
+# =============================================================================
+# T012: R2 — return_event must be non-empty string
+# =============================================================================
+
+
+class TestValidateRetentionR2:
+    """Tests for R2: return_event must be a non-empty, visible string."""
+
+    def test_empty_return_event_returns_r2_error(self) -> None:
+        """An empty string return_event must produce an R2_EMPTY_RETURN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(return_event=""))
+        assert any(e.code == "R2_EMPTY_RETURN_EVENT" for e in errors)
+
+    def test_whitespace_only_return_event_returns_r2_error(self) -> None:
+        """A whitespace-only return_event must produce an R2_EMPTY_RETURN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(return_event="   "))
+        assert any(e.code == "R2_EMPTY_RETURN_EVENT" for e in errors)
+
+    def test_tab_only_return_event_returns_r2_error(self) -> None:
+        """A tab-only return_event must produce an R2_EMPTY_RETURN_EVENT error."""
+        errors = validate_retention_args(**_valid_retention_args(return_event="\t\t"))
+        assert any(e.code == "R2_EMPTY_RETURN_EVENT" for e in errors)
+
+    def test_control_char_in_return_event_returns_r2_control_error(self) -> None:
+        """A return_event containing a null byte must produce R2_CONTROL_CHAR_RETURN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(return_event="Log\x00in")
+        )
+        assert any(e.code == "R2_CONTROL_CHAR_RETURN_EVENT" for e in errors)
+
+    def test_escape_char_in_return_event_returns_r2_control_error(self) -> None:
+        """A return_event containing an escape char must produce R2_CONTROL_CHAR_RETURN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(return_event="Log\x1bin")
+        )
+        assert any(e.code == "R2_CONTROL_CHAR_RETURN_EVENT" for e in errors)
+
+    def test_invisible_only_return_event_returns_r2_invisible_error(self) -> None:
+        """A return_event with only zero-width spaces must produce R2_INVISIBLE_RETURN_EVENT."""
+        errors = validate_retention_args(**_valid_retention_args(return_event="\u200b"))
+        assert any(e.code == "R2_INVISIBLE_RETURN_EVENT" for e in errors)
+
+    def test_zero_width_non_joiner_only_returns_r2_invisible_error(self) -> None:
+        """A return_event with only zero-width non-joiners must produce R2_INVISIBLE_RETURN_EVENT."""
+        errors = validate_retention_args(
+            **_valid_retention_args(return_event="\u200c\u200c")
+        )
+        assert any(e.code == "R2_INVISIBLE_RETURN_EVENT" for e in errors)
+
+    def test_valid_return_event_no_r2_error(self) -> None:
+        """A valid return_event must not produce any R2 errors."""
+        errors = validate_retention_args(**_valid_retention_args(return_event="Login"))
+        r2_codes = {
+            "R2_EMPTY_RETURN_EVENT",
+            "R2_CONTROL_CHAR_RETURN_EVENT",
+            "R2_INVISIBLE_RETURN_EVENT",
+        }
+        assert not any(e.code in r2_codes for e in errors)
+
+    def test_return_event_with_unicode_is_valid(self) -> None:
+        """A return_event with visible unicode chars must not produce R2 errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(return_event="Compra Realizada")
+        )
+        r2_codes = {
+            "R2_EMPTY_RETURN_EVENT",
+            "R2_CONTROL_CHAR_RETURN_EVENT",
+            "R2_INVISIBLE_RETURN_EVENT",
+        }
+        assert not any(e.code in r2_codes for e in errors)
+
+    def test_r2_error_path_is_return_event(self) -> None:
+        """The R2 error path must point to 'return_event'."""
+        errors = validate_retention_args(**_valid_retention_args(return_event=""))
+        r2_errors = [e for e in errors if e.code == "R2_EMPTY_RETURN_EVENT"]
+        assert len(r2_errors) == 1
+        assert r2_errors[0].path == "return_event"
+
+
+# =============================================================================
+# T013: R7/R8/R9 — enum validations with fuzzy suggestion
+# =============================================================================
+
+
+class TestValidateRetentionR7R8R9:
+    """Tests for R7 (retention_unit), R8 (alignment), R9 (math) enum validation."""
+
+    # -- R7: retention_unit --
+
+    def test_invalid_retention_unit_returns_r7_error(self) -> None:
+        """An invalid retention_unit must produce an R7_INVALID_RETENTION_UNIT error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(retention_unit="invalid")
+        )
+        assert any(e.code == "R7_INVALID_RETENTION_UNIT" for e in errors)
+
+    def test_valid_retention_unit_day_no_r7_error(self) -> None:
+        """retention_unit='day' must not produce an R7 error."""
+        errors = validate_retention_args(**_valid_retention_args(retention_unit="day"))
+        assert "R7_INVALID_RETENTION_UNIT" not in _codes(errors)
+
+    def test_valid_retention_unit_week_no_r7_error(self) -> None:
+        """retention_unit='week' must not produce an R7 error."""
+        errors = validate_retention_args(**_valid_retention_args(retention_unit="week"))
+        assert "R7_INVALID_RETENTION_UNIT" not in _codes(errors)
+
+    def test_valid_retention_unit_month_no_r7_error(self) -> None:
+        """retention_unit='month' must not produce an R7 error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(retention_unit="month")
+        )
+        assert "R7_INVALID_RETENTION_UNIT" not in _codes(errors)
+
+    def test_retention_unit_close_match_has_suggestion(self) -> None:
+        """A close-match retention_unit must include a suggestion."""
+        errors = validate_retention_args(**_valid_retention_args(retention_unit="wek"))
+        r7_errors = [e for e in errors if e.code == "R7_INVALID_RETENTION_UNIT"]
+        assert len(r7_errors) == 1
+        assert r7_errors[0].suggestion is not None
+        assert "week" in r7_errors[0].suggestion
+
+    def test_retention_unit_case_sensitive(self) -> None:
+        """retention_unit='Week' (wrong case) must produce an R7 error."""
+        errors = validate_retention_args(**_valid_retention_args(retention_unit="Week"))
+        assert any(e.code == "R7_INVALID_RETENTION_UNIT" for e in errors)
+
+    def test_r7_error_path_is_retention_unit(self) -> None:
+        """The R7 error path must point to 'retention_unit'."""
+        errors = validate_retention_args(
+            **_valid_retention_args(retention_unit="invalid")
+        )
+        r7_errors = [e for e in errors if e.code == "R7_INVALID_RETENTION_UNIT"]
+        assert len(r7_errors) == 1
+        assert r7_errors[0].path == "retention_unit"
+
+    # -- R8: alignment --
+
+    def test_invalid_alignment_returns_r8_error(self) -> None:
+        """An invalid alignment must produce an R8_INVALID_ALIGNMENT error."""
+        errors = validate_retention_args(**_valid_retention_args(alignment="invalid"))
+        assert any(e.code == "R8_INVALID_ALIGNMENT" for e in errors)
+
+    def test_valid_alignment_birth_no_r8_error(self) -> None:
+        """alignment='birth' must not produce an R8 error."""
+        errors = validate_retention_args(**_valid_retention_args(alignment="birth"))
+        assert "R8_INVALID_ALIGNMENT" not in _codes(errors)
+
+    def test_valid_alignment_interval_start_no_r8_error(self) -> None:
+        """alignment='interval_start' must not produce an R8 error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(alignment="interval_start")
+        )
+        assert "R8_INVALID_ALIGNMENT" not in _codes(errors)
+
+    def test_alignment_close_match_has_suggestion(self) -> None:
+        """A close-match alignment must include a suggestion."""
+        errors = validate_retention_args(**_valid_retention_args(alignment="brith"))
+        r8_errors = [e for e in errors if e.code == "R8_INVALID_ALIGNMENT"]
+        assert len(r8_errors) == 1
+        assert r8_errors[0].suggestion is not None
+        assert "birth" in r8_errors[0].suggestion
+
+    def test_alignment_case_sensitive(self) -> None:
+        """alignment='Birth' (wrong case) must produce an R8 error."""
+        errors = validate_retention_args(**_valid_retention_args(alignment="Birth"))
+        assert any(e.code == "R8_INVALID_ALIGNMENT" for e in errors)
+
+    def test_r8_error_path_is_alignment(self) -> None:
+        """The R8 error path must point to 'alignment'."""
+        errors = validate_retention_args(**_valid_retention_args(alignment="invalid"))
+        r8_errors = [e for e in errors if e.code == "R8_INVALID_ALIGNMENT"]
+        assert len(r8_errors) == 1
+        assert r8_errors[0].path == "alignment"
+
+    # -- R9: math --
+
+    def test_invalid_math_returns_r9_error(self) -> None:
+        """An invalid math must produce an R9_INVALID_MATH error."""
+        errors = validate_retention_args(**_valid_retention_args(math="invalid"))
+        assert any(e.code == "R9_INVALID_MATH" for e in errors)
+
+    def test_valid_math_retention_rate_no_r9_error(self) -> None:
+        """math='retention_rate' must not produce an R9 error."""
+        errors = validate_retention_args(**_valid_retention_args(math="retention_rate"))
+        assert "R9_INVALID_MATH" not in _codes(errors)
+
+    def test_valid_math_unique_no_r9_error(self) -> None:
+        """math='unique' must not produce an R9 error."""
+        errors = validate_retention_args(**_valid_retention_args(math="unique"))
+        assert "R9_INVALID_MATH" not in _codes(errors)
+
+    def test_math_close_match_has_suggestion(self) -> None:
+        """A close-match math must include a suggestion."""
+        errors = validate_retention_args(**_valid_retention_args(math="uniue"))
+        r9_errors = [e for e in errors if e.code == "R9_INVALID_MATH"]
+        assert len(r9_errors) == 1
+        assert r9_errors[0].suggestion is not None
+        assert "unique" in r9_errors[0].suggestion
+
+    def test_math_case_sensitive(self) -> None:
+        """math='Unique' (wrong case) must produce an R9 error."""
+        errors = validate_retention_args(**_valid_retention_args(math="Unique"))
+        assert any(e.code == "R9_INVALID_MATH" for e in errors)
+
+    def test_r9_error_path_is_math(self) -> None:
+        """The R9 error path must point to 'math'."""
+        errors = validate_retention_args(**_valid_retention_args(math="invalid"))
+        r9_errors = [e for e in errors if e.code == "R9_INVALID_MATH"]
+        assert len(r9_errors) == 1
+        assert r9_errors[0].path == "math"
+
+    # -- All defaults pass --
+
+    def test_all_defaults_pass_validation(self) -> None:
+        """Default valid args must produce no errors."""
+        errors = validate_retention_args(**_valid_retention_args())
+        assert errors == []
+
+
+# =============================================================================
+# T014: R3/R4 — delegation to shared validators
+# =============================================================================
+
+
+class TestValidateRetentionDelegation:
+    """Tests for R3 (time) and R4 (group-by) delegation to shared validators."""
+
+    # -- R3: time validation delegated to validate_time_args --
+
+    def test_zero_last_returns_v7_error(self) -> None:
+        """A zero last value must produce a V7_LAST_POSITIVE error (delegated)."""
+        errors = validate_retention_args(**_valid_retention_args(last=0))
+        assert any(e.code == "V7_LAST_POSITIVE" for e in errors)
+
+    def test_negative_last_returns_v7_error(self) -> None:
+        """A negative last value must produce a V7_LAST_POSITIVE error (delegated)."""
+        errors = validate_retention_args(**_valid_retention_args(last=-5))
+        assert any(e.code == "V7_LAST_POSITIVE" for e in errors)
+
+    def test_positive_last_no_v7_error(self) -> None:
+        """A positive last value must not produce a V7_LAST_POSITIVE error."""
+        errors = validate_retention_args(**_valid_retention_args(last=30))
+        assert "V7_LAST_POSITIVE" not in _codes(errors)
+
+    def test_invalid_from_date_format_returns_v8_error(self) -> None:
+        """An invalid from_date format must produce a V8_DATE_FORMAT error (delegated)."""
+        errors = validate_retention_args(**_valid_retention_args(from_date="invalid"))
+        assert any(e.code == "V8_DATE_FORMAT" for e in errors)
+
+    def test_to_date_without_from_date_returns_v9_error(self) -> None:
+        """Setting to_date without from_date must produce a V9 error (delegated)."""
+        errors = validate_retention_args(**_valid_retention_args(to_date="2024-01-31"))
+        assert any(e.code == "V9_TO_REQUIRES_FROM" for e in errors)
+
+    def test_valid_date_range_no_time_errors(self) -> None:
+        """Valid from_date and to_date must not produce time errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                from_date="2024-01-01", to_date="2024-01-31", last=30
+            )
+        )
+        time_codes = {"V7_LAST_POSITIVE", "V8_DATE_FORMAT", "V8_DATE_INVALID"}
+        assert not any(e.code in time_codes for e in errors)
+
+    def test_no_dates_with_default_last_no_time_errors(self) -> None:
+        """Default arguments (no dates, last=30) must not produce time errors."""
+        errors = validate_retention_args(**_valid_retention_args())
+        time_codes = {
+            "V7_LAST_POSITIVE",
+            "V8_DATE_FORMAT",
+            "V8_DATE_INVALID",
+            "V9_TO_REQUIRES_FROM",
+            "V10_DATE_LAST_EXCLUSIVE",
+            "V15_DATE_ORDER",
+            "V20_LAST_TOO_LARGE",
+        }
+        assert not any(e.code in time_codes for e in errors)
+
+    def test_from_date_after_to_date_returns_v15_error(self) -> None:
+        """from_date after to_date must produce a V15_DATE_ORDER error (delegated)."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                from_date="2024-02-01", to_date="2024-01-01", last=30
+            )
+        )
+        assert any(e.code == "V15_DATE_ORDER" for e in errors)
+
+    # -- R4: group-by validation delegated to validate_group_by_args --
+
+    def test_negative_bucket_size_returns_v12_error(self) -> None:
+        """A negative bucket_size must produce a V12_BUCKET_SIZE_POSITIVE error (delegated)."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                group_by=GroupBy(
+                    "revenue",
+                    property_type="number",
+                    bucket_size=-1,
+                    bucket_min=0,
+                    bucket_max=100,
+                )
+            )
+        )
+        assert any(e.code == "V12_BUCKET_SIZE_POSITIVE" for e in errors)
+
+    def test_zero_bucket_size_returns_v12_error(self) -> None:
+        """A zero bucket_size must produce a V12_BUCKET_SIZE_POSITIVE error (delegated)."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                group_by=GroupBy(
+                    "revenue",
+                    property_type="number",
+                    bucket_size=0,
+                    bucket_min=0,
+                    bucket_max=100,
+                )
+            )
+        )
+        assert any(e.code == "V12_BUCKET_SIZE_POSITIVE" for e in errors)
+
+    def test_string_group_by_no_errors(self) -> None:
+        """A simple string group_by must not produce group-by errors."""
+        errors = validate_retention_args(**_valid_retention_args(group_by="platform"))
+        group_codes = {
+            "V11_BUCKET_REQUIRES_SIZE",
+            "V12_BUCKET_SIZE_POSITIVE",
+            "V12B_BUCKET_REQUIRES_NUMBER",
+            "V12C_BUCKET_REQUIRES_BOUNDS",
+            "V18_BUCKET_ORDER",
+            "V24_BUCKET_NOT_FINITE",
+        }
+        assert not any(e.code in group_codes for e in errors)
+
+    def test_none_group_by_no_errors(self) -> None:
+        """None group_by must not produce group-by errors."""
+        errors = validate_retention_args(**_valid_retention_args(group_by=None))
+        group_codes = {
+            "V11_BUCKET_REQUIRES_SIZE",
+            "V12_BUCKET_SIZE_POSITIVE",
+            "V12B_BUCKET_REQUIRES_NUMBER",
+            "V12C_BUCKET_REQUIRES_BOUNDS",
+            "V18_BUCKET_ORDER",
+            "V24_BUCKET_NOT_FINITE",
+        }
+        assert not any(e.code in group_codes for e in errors)
+
+    def test_valid_numeric_group_by_no_errors(self) -> None:
+        """A valid numeric GroupBy with bucket config must not produce errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                group_by=GroupBy(
+                    "revenue",
+                    property_type="number",
+                    bucket_size=50,
+                    bucket_min=0,
+                    bucket_max=500,
+                )
+            )
+        )
+        group_codes = {
+            "V11_BUCKET_REQUIRES_SIZE",
+            "V12_BUCKET_SIZE_POSITIVE",
+            "V12B_BUCKET_REQUIRES_NUMBER",
+            "V12C_BUCKET_REQUIRES_BOUNDS",
+            "V18_BUCKET_ORDER",
+            "V24_BUCKET_NOT_FINITE",
+        }
+        assert not any(e.code in group_codes for e in errors)
+
+    def test_bucket_min_exceeds_max_returns_v18_error(self) -> None:
+        """bucket_min >= bucket_max must produce a V18_BUCKET_ORDER error (delegated)."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                group_by=GroupBy(
+                    "revenue",
+                    property_type="number",
+                    bucket_size=10,
+                    bucket_min=100,
+                    bucket_max=50,
+                )
+            )
+        )
+        assert any(e.code == "V18_BUCKET_ORDER" for e in errors)
+
+    def test_list_group_by_valid(self) -> None:
+        """A list of valid group-by specs must not produce errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(group_by=["platform", "country"])
+        )
+        group_codes = {
+            "V11_BUCKET_REQUIRES_SIZE",
+            "V12_BUCKET_SIZE_POSITIVE",
+            "V12B_BUCKET_REQUIRES_NUMBER",
+            "V12C_BUCKET_REQUIRES_BOUNDS",
+            "V18_BUCKET_ORDER",
+            "V24_BUCKET_NOT_FINITE",
+        }
+        assert not any(e.code in group_codes for e in errors)
+
+
+# =============================================================================
+# T-US3: R5/R6 — bucket_sizes validation
+# =============================================================================
+
+
+class TestValidateRetentionR5R6:
+    """Tests for R5 (bucket_sizes positive integers) and R6 (ascending order)."""
+
+    def test_bucket_sizes_positive_integers_pass(self) -> None:
+        """Valid positive integer bucket_sizes must produce no R5 errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[1, 3, 7])
+        )
+        assert "R5_BUCKET_SIZES_POSITIVE" not in _codes(errors)
+        assert "R5_BUCKET_SIZES_INTEGER" not in _codes(errors)
+
+    def test_bucket_sizes_zero_returns_r5_error(self) -> None:
+        """A zero in bucket_sizes must produce an R5_BUCKET_SIZES_POSITIVE error."""
+        errors = validate_retention_args(**_valid_retention_args(bucket_sizes=[0, 3]))
+        assert any(e.code == "R5_BUCKET_SIZES_POSITIVE" for e in errors)
+
+    def test_bucket_sizes_negative_returns_r5_error(self) -> None:
+        """A negative value in bucket_sizes must produce an R5_BUCKET_SIZES_POSITIVE error."""
+        errors = validate_retention_args(**_valid_retention_args(bucket_sizes=[-1, 3]))
+        assert any(e.code == "R5_BUCKET_SIZES_POSITIVE" for e in errors)
+
+    def test_bucket_sizes_float_returns_r5_error(self) -> None:
+        """A float in bucket_sizes must produce an R5_BUCKET_SIZES_INTEGER error."""
+        errors = validate_retention_args(**_valid_retention_args(bucket_sizes=[1.5, 3]))
+        assert any(e.code == "R5_BUCKET_SIZES_INTEGER" for e in errors)
+
+    def test_bucket_sizes_ascending_pass(self) -> None:
+        """Strictly ascending bucket_sizes must produce no R6 errors."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[1, 3, 7, 14])
+        )
+        assert "R6_BUCKET_SIZES_ASCENDING" not in _codes(errors)
+
+    def test_bucket_sizes_not_ascending_returns_r6_error(self) -> None:
+        """Descending bucket_sizes must produce an R6_BUCKET_SIZES_ASCENDING error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[7, 3, 1])
+        )
+        assert any(e.code == "R6_BUCKET_SIZES_ASCENDING" for e in errors)
+
+    def test_bucket_sizes_duplicates_returns_r6_error(self) -> None:
+        """Duplicate values in bucket_sizes must produce an R6_BUCKET_SIZES_ASCENDING error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=[3, 3, 7])
+        )
+        assert any(e.code == "R6_BUCKET_SIZES_ASCENDING" for e in errors)
+
+    def test_bucket_sizes_none_no_errors(self) -> None:
+        """None bucket_sizes must produce no R5 or R6 errors."""
+        errors = validate_retention_args(**_valid_retention_args(bucket_sizes=None))
+        r5r6_codes = {
+            "R5_BUCKET_SIZES_POSITIVE",
+            "R5_BUCKET_SIZES_INTEGER",
+            "R6_BUCKET_SIZES_ASCENDING",
+        }
+        assert not any(e.code in r5r6_codes for e in errors)
+
+
+# =============================================================================
+# T-US5: Multi-error collection
+# =============================================================================
+
+
+class TestValidateRetentionMultiError:
+    """Tests for fail-fast validation collecting multiple errors."""
+
+    def test_multiple_errors_collected(self) -> None:
+        """Both empty born_event AND invalid retention_unit must be reported together."""
+        errors = validate_retention_args(
+            **_valid_retention_args(born_event="", retention_unit="invalid")
+        )
+        codes = _codes(errors)
+        assert "R1_EMPTY_BORN_EVENT" in codes
+        assert "R7_INVALID_RETENTION_UNIT" in codes
+
+    def test_three_simultaneous_errors(self) -> None:
+        """Three simultaneous validation errors must all be collected."""
+        errors = validate_retention_args(
+            **_valid_retention_args(
+                born_event="",
+                return_event="",
+                math="invalid",
+            )
+        )
+        codes = _codes(errors)
+        assert "R1_EMPTY_BORN_EVENT" in codes
+        assert "R2_EMPTY_RETURN_EVENT" in codes
+        assert "R9_INVALID_MATH" in codes
+
+
+# =============================================================================
+# R10: mode validation
+# =============================================================================
+
+
+class TestValidateRetentionR10:
+    """Tests for R10: mode must be in {curve, trends, table}."""
+
+    def test_invalid_mode_returns_r10_error(self) -> None:
+        """An invalid mode must produce an R10_INVALID_MODE error."""
+        errors = validate_retention_args(**_valid_retention_args(mode="pwned"))
+        assert any(e.code == "R10_INVALID_MODE" for e in errors)
+
+    def test_none_mode_returns_r10_error(self) -> None:
+        """None mode must produce an R10_INVALID_MODE error."""
+        errors = validate_retention_args(**_valid_retention_args(mode=None))
+        assert any(e.code == "R10_INVALID_MODE" for e in errors)
+
+    def test_valid_mode_curve_no_error(self) -> None:
+        """mode='curve' must not produce an R10 error."""
+        errors = validate_retention_args(**_valid_retention_args(mode="curve"))
+        assert "R10_INVALID_MODE" not in _codes(errors)
+
+    def test_valid_mode_trends_no_error(self) -> None:
+        """mode='trends' must not produce an R10 error."""
+        errors = validate_retention_args(**_valid_retention_args(mode="trends"))
+        assert "R10_INVALID_MODE" not in _codes(errors)
+
+    def test_valid_mode_table_no_error(self) -> None:
+        """mode='table' must not produce an R10 error."""
+        errors = validate_retention_args(**_valid_retention_args(mode="table"))
+        assert "R10_INVALID_MODE" not in _codes(errors)
+
+    def test_r10_error_path_is_mode(self) -> None:
+        """The R10 error path must point to 'mode'."""
+        errors = validate_retention_args(**_valid_retention_args(mode="bad"))
+        r10_errors = [e for e in errors if e.code == "R10_INVALID_MODE"]
+        assert len(r10_errors) == 1
+        assert r10_errors[0].path == "mode"
+
+    def test_mode_close_match_has_suggestion(self) -> None:
+        """A close-match mode must include a suggestion."""
+        errors = validate_retention_args(**_valid_retention_args(mode="curv"))
+        r10_errors = [e for e in errors if e.code == "R10_INVALID_MODE"]
+        assert len(r10_errors) == 1
+        assert r10_errors[0].suggestion is not None
+        assert "curve" in r10_errors[0].suggestion
+
+
+# =============================================================================
+# R5c: bucket_sizes max count
+# =============================================================================
+
+
+class TestValidateRetentionR5c:
+    """Tests for R5c: bucket_sizes max count (730)."""
+
+    def test_too_many_buckets_returns_error(self) -> None:
+        """More than 730 bucket_sizes must produce R5_BUCKET_SIZES_TOO_MANY."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=list(range(1, 1001)))
+        )
+        assert any(e.code == "R5_BUCKET_SIZES_TOO_MANY" for e in errors)
+
+    def test_730_buckets_no_error(self) -> None:
+        """Exactly 730 bucket_sizes must not produce R5_BUCKET_SIZES_TOO_MANY."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=list(range(1, 731)))
+        )
+        assert "R5_BUCKET_SIZES_TOO_MANY" not in _codes(errors)
+
+    def test_error_message_includes_count(self) -> None:
+        """The R5c error message must include the actual count."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=list(range(1, 1001)))
+        )
+        r5c = [e for e in errors if e.code == "R5_BUCKET_SIZES_TOO_MANY"]
+        assert len(r5c) == 1
+        assert "1000" in r5c[0].message
+
+
+# =============================================================================
+# R11: unit validation for retention context
+# =============================================================================
+
+
+class TestValidateRetentionR11:
+    """Tests for R11: unit must be in {day, week, month} for retention."""
+
+    def test_invalid_unit_hour_returns_r11_error(self) -> None:
+        """unit='hour' must produce R11_INVALID_UNIT for retention queries."""
+        errors = validate_retention_args(**_valid_retention_args(unit="hour"))
+        assert any(e.code == "R11_INVALID_UNIT" for e in errors)
+
+    def test_invalid_unit_minute_returns_r11_error(self) -> None:
+        """unit='minute' must produce R11_INVALID_UNIT for retention queries."""
+        errors = validate_retention_args(**_valid_retention_args(unit="minute"))
+        assert any(e.code == "R11_INVALID_UNIT" for e in errors)
+
+    def test_invalid_unit_quarter_returns_r11_error(self) -> None:
+        """unit='quarter' must produce R11_INVALID_UNIT for retention queries."""
+        errors = validate_retention_args(**_valid_retention_args(unit="quarter"))
+        assert any(e.code == "R11_INVALID_UNIT" for e in errors)
+
+    def test_valid_unit_day_no_error(self) -> None:
+        """unit='day' must not produce R11 error."""
+        errors = validate_retention_args(**_valid_retention_args(unit="day"))
+        assert "R11_INVALID_UNIT" not in _codes(errors)
+
+    def test_valid_unit_week_no_error(self) -> None:
+        """unit='week' must not produce R11 error."""
+        errors = validate_retention_args(**_valid_retention_args(unit="week"))
+        assert "R11_INVALID_UNIT" not in _codes(errors)
+
+    def test_valid_unit_month_no_error(self) -> None:
+        """unit='month' must not produce R11 error."""
+        errors = validate_retention_args(**_valid_retention_args(unit="month"))
+        assert "R11_INVALID_UNIT" not in _codes(errors)
+
+    def test_r11_error_path_is_unit(self) -> None:
+        """The R11 error path must point to 'unit'."""
+        errors = validate_retention_args(**_valid_retention_args(unit="hour"))
+        r11 = [e for e in errors if e.code == "R11_INVALID_UNIT"]
+        assert len(r11) == 1
+        assert r11[0].path == "unit"
+
+    def test_r11_has_suggestion_for_close_match(self) -> None:
+        """A close-match unit must include a suggestion."""
+        errors = validate_retention_args(**_valid_retention_args(unit="dya"))
+        r11 = [e for e in errors if e.code == "R11_INVALID_UNIT"]
+        assert len(r11) == 1
+        assert r11[0].suggestion is not None
+        assert "day" in r11[0].suggestion
+
+
+# =============================================================================
+# R12: group_by empty string validation
+# =============================================================================
+
+
+class TestValidateRetentionR12:
+    """Tests for R12: group_by strings must be non-empty."""
+
+    def test_empty_string_group_by_returns_r12_error(self) -> None:
+        """An empty string group_by must produce R12_EMPTY_GROUP_BY."""
+        errors = validate_retention_args(**_valid_retention_args(group_by=""))
+        assert any(e.code == "R12_EMPTY_GROUP_BY" for e in errors)
+
+    def test_whitespace_only_group_by_returns_r12_error(self) -> None:
+        """A whitespace-only group_by must produce R12_EMPTY_GROUP_BY."""
+        errors = validate_retention_args(**_valid_retention_args(group_by="   "))
+        assert any(e.code == "R12_EMPTY_GROUP_BY" for e in errors)
+
+    def test_empty_string_in_list_returns_r12_error(self) -> None:
+        """An empty string in a group_by list must produce R12_EMPTY_GROUP_BY."""
+        errors = validate_retention_args(
+            **_valid_retention_args(group_by=["platform", ""])
+        )
+        assert any(e.code == "R12_EMPTY_GROUP_BY" for e in errors)
+
+    def test_valid_group_by_no_r12_error(self) -> None:
+        """A valid group_by string must not produce R12 error."""
+        errors = validate_retention_args(**_valid_retention_args(group_by="platform"))
+        assert "R12_EMPTY_GROUP_BY" not in _codes(errors)
+
+    def test_r12_error_path_is_group_by(self) -> None:
+        """The R12 error path must point to 'group_by'."""
+        errors = validate_retention_args(**_valid_retention_args(group_by=""))
+        r12 = [e for e in errors if e.code == "R12_EMPTY_GROUP_BY"]
+        assert len(r12) == 1
+        assert r12[0].path == "group_by"
+
+    def test_error_message_includes_count(self) -> None:
+        """The R5c error message must include the actual count."""
+        errors = validate_retention_args(
+            **_valid_retention_args(bucket_sizes=list(range(1, 1001)))
+        )
+        r5c = [e for e in errors if e.code == "R5_BUCKET_SIZES_TOO_MANY"]
+        assert len(r5c) == 1
+        assert "1000" in r5c[0].message

--- a/tests/test_workspace_retention.py
+++ b/tests/test_workspace_retention.py
@@ -1,0 +1,358 @@
+"""Integration tests for Workspace.query_retention().
+
+Tests cover:
+- T019: Workspace integration — mocking insights_query() to verify the API
+  call body, response transformation, and RetentionQueryResult fields.
+- ConfigError when credentials are missing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.exceptions import BookmarkValidationError, ConfigError
+from mixpanel_data.types import RetentionQueryResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_credentials() -> Credentials:
+    """Create mock credentials for testing."""
+    return Credentials(
+        username="test_user",
+        secret=SecretStr("test_secret"),
+        project_id="12345",
+        region="us",
+    )
+
+
+@pytest.fixture
+def mock_config_manager(mock_credentials: Credentials) -> MagicMock:
+    """Create mock ConfigManager that returns credentials."""
+    manager = MagicMock(spec=ConfigManager)
+    manager.resolve_credentials.return_value = mock_credentials
+    return manager
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create mock API client for testing."""
+    from mixpanel_data._internal.api_client import MixpanelAPIClient
+
+    client = MagicMock(spec=MixpanelAPIClient)
+    client.close = MagicMock()
+    return client
+
+
+@pytest.fixture
+def workspace_factory(
+    mock_config_manager: MagicMock,
+    mock_api_client: MagicMock,
+) -> Callable[..., Workspace]:
+    """Factory for creating Workspace instances with mocked dependencies."""
+
+    def factory(**kwargs: Any) -> Workspace:
+        """Create a Workspace with mocked config and API client.
+
+        Args:
+            **kwargs: Overrides for default Workspace constructor arguments.
+
+        Returns:
+            Workspace instance with mocked dependencies.
+        """
+        defaults: dict[str, Any] = {
+            "_config_manager": mock_config_manager,
+            "_api_client": mock_api_client,
+        }
+        defaults.update(kwargs)
+        return Workspace(**defaults)
+
+    return factory
+
+
+MOCK_RETENTION_RESPONSE: dict[str, Any] = {
+    "computed_at": "2025-01-15T12:00:00",
+    "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+    "series": {
+        "Signup and then Login": {
+            "2025-01-01": {
+                "first": 100,
+                "counts": [100, 50, 25],
+                "rates": [1.0, 0.5, 0.25],
+            },
+            "$average": {
+                "first": 100,
+                "counts": [100, 50, 25],
+                "rates": [1.0, 0.5, 0.25],
+            },
+        }
+    },
+    "meta": {"sampling_factor": 1.0},
+}
+"""Canonical mock response for a retention query."""
+
+
+# =============================================================================
+# T019: Workspace integration tests
+# =============================================================================
+
+
+class TestQueryRetentionIntegration:
+    """Tests for query_retention() integration with mocked API.
+
+    Verifies that query_retention() sends the correct body to
+    insights_query(), and that the response is correctly transformed
+    into a RetentionQueryResult.
+    """
+
+    def test_correct_body_sent_to_api(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T019-body: query_retention() sends body with bookmark, project_id, queryLimits."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            ws.query_retention("Signup", "Login")
+
+            mock_api_client.insights_query.assert_called_once()
+            body = mock_api_client.insights_query.call_args[0][0]
+
+            assert "bookmark" in body
+            assert "project_id" in body
+            assert "queryLimits" in body
+            assert body["project_id"] == 12345
+        finally:
+            ws.close()
+
+    def test_result_is_retention_query_result(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T019-type: query_retention() returns a RetentionQueryResult instance."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            result = ws.query_retention("Signup", "Login")
+
+            assert isinstance(result, RetentionQueryResult)
+        finally:
+            ws.close()
+
+    def test_result_has_cohorts(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T019-cohorts: result cohorts has the right date keys (excluding $average)."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            result = ws.query_retention("Signup", "Login")
+
+            assert "2025-01-01" in result.cohorts
+            assert "$average" not in result.cohorts
+            cohort = result.cohorts["2025-01-01"]
+            assert cohort["first"] == 100
+            assert cohort["counts"] == [100, 50, 25]
+            assert cohort["rates"] == [1.0, 0.5, 0.25]
+        finally:
+            ws.close()
+
+    def test_result_has_average(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T019-average: result average is populated from $average series entry."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            result = ws.query_retention("Signup", "Login")
+
+            assert result.average is not None
+            assert result.average["first"] == 100
+            assert result.average["counts"] == [100, 50, 25]
+            assert result.average["rates"] == [1.0, 0.5, 0.25]
+        finally:
+            ws.close()
+
+    def test_result_has_params(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """T019-params: result params is a non-empty dict with sections key."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            result = ws.query_retention("Signup", "Login")
+
+            assert isinstance(result.params, dict)
+            assert len(result.params) > 0
+            assert "sections" in result.params
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# Config error tests
+# =============================================================================
+
+
+class TestQueryRetentionConfigError:
+    """Tests for query_retention() when credentials are missing."""
+
+    def test_no_credentials_raises_config_error(
+        self,
+        mock_api_client: MagicMock,
+    ) -> None:
+        """query_retention raises ConfigError when credentials are None."""
+        no_creds_manager = MagicMock(spec=ConfigManager)
+        no_creds_manager.resolve_credentials.return_value = None
+
+        ws = Workspace(
+            _config_manager=no_creds_manager,
+            _api_client=mock_api_client,
+        )
+
+        with pytest.raises(ConfigError, match="credentials"):
+            ws.query_retention("Signup", "Login")
+
+
+# =============================================================================
+# T-US2: Per-event filters in workspace integration
+# =============================================================================
+
+
+class TestQueryRetentionWithFilters:
+    """Tests for per-event filters sent through query_retention()."""
+
+    def test_per_event_filters_sent_to_api(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Per-event filters on RetentionEvent must appear in bookmark behaviors."""
+        from mixpanel_data.types import Filter, RetentionEvent
+
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            born = RetentionEvent(
+                "Signup",
+                filters=[Filter.equals("source", "organic")],
+            )
+            ws.query_retention(born, "Login")
+
+            body = mock_api_client.insights_query.call_args[0][0]
+            bookmark = body["bookmark"]
+            behaviors = bookmark["sections"]["show"][0]["behavior"]["behaviors"]
+            assert len(behaviors[0]["filters"]) > 0
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# T-US4: build_retention_params integration
+# =============================================================================
+
+
+class TestBuildRetentionParams:
+    """Tests for build_retention_params() as a standalone method."""
+
+    def test_returns_dict_not_result(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_retention_params must return a dict, not a RetentionQueryResult."""
+        ws = workspace_factory()
+        try:
+            result = ws.build_retention_params("Signup", "Login")
+            assert isinstance(result, dict)
+            assert not isinstance(result, RetentionQueryResult)
+        finally:
+            ws.close()
+
+    def test_has_sections_and_display_options(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """Result must have 'sections' and 'displayOptions' keys."""
+        ws = workspace_factory()
+        try:
+            result = ws.build_retention_params("Signup", "Login")
+            assert "sections" in result
+            assert "displayOptions" in result
+        finally:
+            ws.close()
+
+    def test_no_api_call_made(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """build_retention_params must not make any API call."""
+        ws = workspace_factory()
+        try:
+            ws.build_retention_params("Signup", "Login")
+            mock_api_client.insights_query.assert_not_called()
+        finally:
+            ws.close()
+
+    def test_consistency_with_query_retention(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """build_retention_params output must match the bookmark sent by query_retention."""
+        mock_api_client.insights_query.return_value = MOCK_RETENTION_RESPONSE
+        ws = workspace_factory()
+        try:
+            params = ws.build_retention_params("Signup", "Login")
+
+            ws.query_retention("Signup", "Login")
+            body = mock_api_client.insights_query.call_args[0][0]
+            bookmark = body["bookmark"]
+
+            assert params == bookmark
+        finally:
+            ws.close()
+
+
+# =============================================================================
+# T-US5: Validation integration
+# =============================================================================
+
+
+class TestQueryRetentionValidationIntegration:
+    """Tests for fail-fast validation preventing API calls."""
+
+    def test_validation_error_before_api_call(
+        self,
+        workspace_factory: Callable[..., Workspace],
+        mock_api_client: MagicMock,
+    ) -> None:
+        """Empty born_event must raise BookmarkValidationError without calling the API."""
+        ws = workspace_factory()
+        try:
+            with pytest.raises(BookmarkValidationError):
+                ws.query_retention("", "Login")
+            mock_api_client.insights_query.assert_not_called()
+        finally:
+            ws.close()


### PR DESCRIPTION
## Measure retention in one line of Python

The legacy `retention()` method requires both `from_date` and `to_date`, uses raw expression-string filters, has no concept of custom retention buckets, and returns only basic cohort data. To get per-event filters, alignment control, display modes, property breakdowns, or persistable results, you had to craft bookmark JSON and call the insights API yourself.

```python
result = ws.query_retention("Signup", "Login")  # that's it — weekly retention, last 30 days
print(result.average)                            # synthetic average across all cohorts
print(result.df)                                 # DataFrame: cohort_date | bucket | count | rate
```

This is the entry point. Everything else is progressive disclosure through keyword arguments. No builders, no chaining, no JSON.

---

## What was impossible is now a keyword argument

| Pattern | Before | After |
|---------|--------|-------|
| Basic cohort retention | `retention(born_event=, return_event=, from_date=, to_date=)` | `query_retention("Signup", "Login")` |
| Per-event typed filters | **Raw expression strings only** | `RetentionEvent("Signup", filters=[Filter.equals("source", "organic")])` |
| Custom retention buckets (day 1, 3, 7, 14, 30) | **Impossible** | `query_retention(..., bucket_sizes=[1, 3, 7, 14, 30])` |
| Birth vs. interval alignment | **Impossible** | `query_retention(..., alignment="birth")` |
| Retention curve display mode | **Impossible** | `query_retention(..., mode="curve")` |
| Trends over time | **Impossible** | `query_retention(..., mode="trends")` |
| Table view | **Impossible** | `query_retention(..., mode="table")` |
| Math type control | **Impossible** | `query_retention(..., math="unique")` |
| Typed property breakdowns | **Impossible** | `query_retention(..., group_by="platform")` |
| Typed global filters | **Raw expression strings only** | `query_retention(..., where=Filter.equals("country", "US"))` |
| Inspect/persist generated params | **Impossible** | `result.params` → pass to `create_bookmark()` |
| Lazy DataFrame with cohort structure | **Impossible** | `result.df` — one row per (cohort_date, bucket) pair |

The old `retention()` was a thin wrapper around the legacy `/api/2.0/retention` endpoint — it required explicit dates, offered only string-expression filters, and returned raw cohort dicts. `query_retention()` generates and executes retention bookmarks inline via the insights API, unlocking the full feature set.

---

## Progressive disclosure in action

Each line below adds one concept:

```python
# Measure retention with two event names
result = ws.query_retention("Signup", "Login")

# Control the retention period granularity
result = ws.query_retention("Signup", "Login", retention_unit="day")

# Extend the time range
result = ws.query_retention("Signup", "Login", last=90)

# Filter the entire query
result = ws.query_retention("Signup", "Login", where=Filter.equals("country", "US"))

# Break down by property
result = ws.query_retention("Signup", "Login", group_by="platform")

# Per-event filters
result = ws.query_retention(
    RetentionEvent("Signup", filters=[Filter.equals("source", "organic")]),
    "Login",
)

# Custom retention milestones
result = ws.query_retention(
    "Signup", "Login",
    retention_unit="day",
    bucket_sizes=[1, 3, 7, 14, 30, 60, 90],
)

# Control alignment mode
result = ws.query_retention("Signup", "Login", alignment="interval_start")

# Track retention trends over time
result = ws.query_retention("Signup", "Login", mode="trends", unit="week")

# Raw unique user counts instead of rates
result = ws.query_retention("Signup", "Login", math="unique")

# Inspect or persist generated params
params = ws.build_retention_params("Signup", "Login", retention_unit="week")
ws.create_bookmark(CreateBookmarkParams(
    name="Signup → Login Retention",
    bookmark_type="retention",
    params=params,
))

# Get a DataFrame
print(result.df)
```

Every example compiles. Every parameter is typed. Autocomplete works everywhere.

---

## The type system

Three new public types give the API its structure:

| Type | Purpose | Key feature |
|------|---------|-------------|
| **`RetentionEvent`** | Per-event configuration | Override filters and filter combinator per event (born or return) |
| **`RetentionQueryResult`** | Structured response | Frozen dataclass with lazy `.df` (cohort × bucket DataFrame), `.cohorts`, `.average`, `.params` |
| **`RetentionMathType`** | Aggregation mode | `"retention_rate"` (percentage retained) or `"unique"` (raw user counts) |

### RetentionEvent: from strings to objects

Use plain strings for simple retention. Graduate to `RetentionEvent` objects when you need per-event filters:

```python
# Simple — just event names
ws.query_retention("Signup", "Login")

# Rich — per-event filters with OR logic
ws.query_retention(
    RetentionEvent("Signup", filters=[
        Filter.equals("source", "organic"),
        Filter.equals("source", "referral"),
    ], filters_combinator="any"),
    RetentionEvent("Purchase", filters=[Filter.greater_than("amount", 0)]),
)
```

### RetentionQueryResult: inspect everything

```python
result = ws.query_retention("Signup", "Login", retention_unit="week", last=90)

result.cohorts              # {"2025-01-01": {"first": 1000, "counts": [...], "rates": [...]}}
result.average              # synthetic average: {"first": 500, "counts": [...], "rates": [...]}
result.df                   # DataFrame: cohort_date | bucket | count | rate — lazy, cached
result.params               # generated bookmark JSON (debug / persist as saved report)
result.from_date            # resolved date range
result.to_date
result.computed_at          # when the query ran
result.meta                 # sampling factor, cache status
```

---

## Retention validation engine (12 rules)

Mixpanel's insights endpoint does minimal server-side validation — invalid retention bookmarks often return empty results or silently wrong data instead of errors. This library validates everything before the API call.

### Layer 1: Retention argument validation (12 rules, R1–R12)

| Category | Rules | What it catches |
|----------|-------|-----------------|
| **Born/return events** | R1, R2 | Empty names, control characters, invisible-only characters |
| **Bucket sizes** | R5, R6 | Non-positive values, floats instead of ints, non-ascending order, max 730 |
| **Enum parameters** | R7–R11 | Invalid retention_unit, alignment, math, mode, unit — with fuzzy-matched suggestions |
| **Group-by strings** | R12 | Empty group-by property name |
| **Time & group-by** | R3, R4 | Delegates to shared validators (V7–V12, V15, V18, V20, V24) |

### Layer 2: Bookmark JSON validation (context-aware)

The existing bookmark validator (21 rules, B1–B21) now dispatches **context-aware math validation**: `validate_bookmark(params, bookmark_type="retention")` checks against `VALID_MATH_RETENTION` (4 values: `retention_rate`, `unique`, `total`, `average`) instead of the full insights set. Invalid math types get fuzzy-matched suggestions via `difflib`.

### Multi-error collection

All errors are returned in a single pass — no "fix one, hit the next" cycle:

```python
try:
    ws.query_retention("", "Login", bucket_sizes=[5, 3, 1])
except BookmarkValidationError as e:
    for err in e.errors:
        print(f"{err.code}: {err.message}")
    # R1_EMPTY_BORN_EVENT: Born event name must be a non-empty string
    # R6_BUCKET_SIZES_ASCENDING: Bucket sizes must be in strictly ascending order
```

---

## The `build_retention_params` escape hatch

`query_retention()` generates bookmark params, validates them, and executes. `build_retention_params()` does everything except execute — same signature, returns the validated bookmark dict:

```python
# Inspect what would be sent to the API
params = ws.build_retention_params(
    "Signup", "Login",
    retention_unit="day",
    bucket_sizes=[1, 3, 7, 14, 30],
)
print(json.dumps(params, indent=2))

# Save as a report
ws.create_bookmark(CreateBookmarkParams(
    name="Signup → Login Retention (Custom Buckets)",
    bookmark_type="retention",
    params=params,
))
```

This is the bridge between programmatic query construction and Mixpanel's saved reports. Build params in code, persist them as dashboardable bookmarks.

---

## What's in the box

### New and modified source files

| File | Change | Purpose |
|------|--------|---------|
| `types.py` | +185 | `RetentionEvent`, `RetentionMathType`, `RetentionQueryResult` with lazy DataFrame |
| `workspace.py` | +397 | `query_retention()`, `build_retention_params()`, `_build_retention_params()`, `_resolve_and_build_retention_params()` |
| `_internal/validation.py` | +297 | `validate_retention_args()` (R1–R12), `validate_retention_bookmark()` (B1–B21 context-aware) |
| `_internal/services/live_query.py` | +126 | `LiveQueryService.query_retention()`, `_transform_retention_result()` |
| `__init__.py` | +7 | Public exports: `RetentionEvent`, `RetentionMathType`, `RetentionQueryResult` |

### Test coverage (218 new tests)

| File | Tests | Lines | Focus |
|------|-------|-------|-------|
| `test_validation_retention.py` | 81 | 1,012 | All 12 retention validation rules, shared validator delegation, multi-error collection |
| `test_types_retention.py` | 36 | 459 | Type construction, defaults, immutability, DataFrame structure, serialization |
| `test_workspace_retention.py` | 28 | 358 | End-to-end query/build with mocked API, validation integration |
| `test_build_retention_params.py` | 23 | 307 | Bookmark JSON structure from all parameter combinations |
| `test_types_retention_pbt.py` | 28 | 281 | Property-based tests (Hypothesis) — structural invariants across random inputs |
| `test_transform_retention.py` | 22 | 613 | Response transformation, cohort extraction, average handling, edge cases |

**218 new tests** across 3,030 lines. 3,776 total tests pass, zero regressions.

### Live QA validation

55/55 functional tests and 14 adversarial attacks validated against Mixpanel Project 8, covering: simple retention, all retention units (day/week/month), both alignment modes, custom bucket sizes, both math types, all display modes (curve/trends/table), per-event filters, global filters, group-by breakdowns, absolute and relative date ranges, same born/return event, and response wrapper format variations.

Live QA discovered and fixed: response wrapper format requiring unwrapping, missing mode/unit/group_by/filter validations, and bucket count API limits.

### Documentation

- **[Retention Queries guide](docs/guide/query-retention.md)** — full user-facing guide covering events, `RetentionEvent`, per-event filters, retention units, alignment, custom buckets, aggregation, filters, breakdowns, time ranges, display modes, result structure, validation, and complete examples
- Updated [README](README.md), [quickstart](docs/getting-started/quickstart.md), [index](docs/index.md), [insights guide](docs/guide/query.md), [funnels guide](docs/guide/query-funnels.md), [live analytics](docs/guide/live-analytics.md), [API reference](docs/api/), and [mkdocs nav](mkdocs.yml)

---

## Test plan

- [x] 218 new retention-specific tests pass (types, validation, params, transform, integration, PBT)
- [x] 3,776 total tests pass, 0 regressions
- [x] 92%+ coverage maintained: `just test-cov`
- [x] `ruff check` + `ruff format` pass
- [x] `mypy --strict` on all modified source files
- [x] `just check` (full lint + typecheck + test suite)
- [x] Live QA: 55/55 functional tests + 14 adversarial attacks pass against Mixpanel Project 8