### PR TITLE
feat: add CohortCriteria and CohortDefinition builder types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,8 @@ Task(subagent_type="mixpanel-data:narrator", prompt="...")
 - N/A — live query only, no local persistence (029-insights-query-api)
 - Python 3.10+ (mypy --strict) + httpx (HTTP), Pydantic v2 (validation), pandas (DataFrames) (031-shared-infra-extraction)
 - Python 3.10+ (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames) (033-retention-query)
+- Python 3.10+ (mypy --strict) + Pydantic v2 (for existing `CreateCohortParams`), pandas (existing), Hypothesis (PBT) (035-cohort-definition-builder)
+- N/A — pure types, no persistence (035-cohort-definition-builder)
 
 ## Recent Changes
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/context/behavior-properties-in-queries-design.md
+++ b/context/behavior-properties-in-queries-design.md
@@ -1,0 +1,1763 @@
+# Behavior-Based Custom Properties in Queries — v2 Supplement
+
+**Date**: 2026-04-06
+**Status**: Design Complete — Ready for TDD Implementation
+**Prerequisite**: `custom-properties-in-queries-design.md` (v1) must be implemented first
+**Reference**: `analytics/backend/util/behaviors/count.py`, `analytics/backend/util/arb_selector.py`
+
+---
+
+## 1. Scope & Goals
+
+### What This Document Covers
+
+Extension of the custom properties query system (v1) to support **behavior-based custom properties** — virtual computed properties that aggregate a user's event history over a time window. These can be defined **inline** (ad-hoc, per-query) or **referenced by ID** (saved via `create_custom_property()`).
+
+Behavior properties answer questions like:
+- "How many purchases has each user made in the last 30 days?"
+- "What is each user's average order value this month?"
+- "What browser does each user use most frequently?"
+- "When did each user first perform this event?"
+
+They can appear in the same three positions as formula-based custom properties:
+1. **Breakdown** (`group_by=`) — Segment by a behavioral metric
+2. **Filter** (`where=`) — Filter to users whose behavior meets a threshold
+3. **Metric measurement** (`Metric.property=`) — Aggregate on a behavioral metric
+
+### What This Document Does NOT Cover
+
+- Multi-attribution models (`multi_attribution` aggregation) — extremely complex config with 10+ attribution types, weights, and offset semantics. Users can create these via `create_custom_property()` and reference by ID.
+- Slowly-changing dimension properties (`scd_value`) — internal/specialized
+- Session replay properties (`session_replay_id_value`) — internal
+- Borrowed properties — these are formula-based CPs with a synthetic behavior at query time; already coverable via `CustomPropertyRef`
+- Flows query support — flows don't support custom properties in breakdowns
+
+### Design Principles
+
+Same as v1, plus:
+- **Consistent with formula CPs** — Same union-typed positions, same builder dispatch pattern
+- **Mirrors Mixpanel UI** — Exposes the same 5 aggregation operators the UI shows, plus 5 additional useful operators
+- **Inferred output types** — Output type is auto-inferred from aggregation operator (matching server behavior), with explicit override available
+
+---
+
+## 2. How Behavior Properties Work
+
+### 2.1 Conceptual Model
+
+A behavior property performs a **per-user aggregation** over an event stream within a time window. At query time, for each user (or each row), the engine:
+
+1. Finds all events matching `event` name + `filters` within `dateRange`
+2. Applies the `aggregation` operator to those events (optionally on a specific `property`)
+3. Returns the computed value as a virtual property
+
+This is fundamentally different from formula-based CPs, which operate on the current event's properties:
+
+| Aspect | Formula CP (v1) | Behavior CP (v2) |
+|--------|----------------|------------------|
+| Input | Current event's properties | A user's event history |
+| Operation | Per-event computation | Per-user aggregation |
+| Time dimension | None | Has a lookback window |
+| SQL analogy | `SELECT price * qty` | `SELECT (SELECT COUNT(*) FROM events WHERE ...)` |
+| Example | `"price * quantity"` | `"Total purchases in last 30 days"` |
+
+### 2.2 Query-Time Resolution
+
+```
+BehaviorProperty in bookmark params
+    ↓
+segment_to_arb_selector() detects customProperty.behavior
+    ↓
+_raw_behavior_to_arb_selector():
+  1. Parse dateRange → DateRange object
+  2. Create EventSelector from event + filters
+  3. Register CohortCountBehavior in QueryBehaviors
+  4. Return selector: behaviors["beh_<sha256_hash>"]
+    ↓
+ARB query engine executes the behavior aggregation
+    ↓
+Result: computed value per user/row
+```
+
+### 2.3 Aggregation Operators
+
+The Mixpanel backend defines aggregation operators in `_per_user_agg_info` (`count.py:84-117`). The v2 scope covers 10 of these:
+
+**Tier 1 — UI-exposed (the 5 operators shown in the Mixpanel custom property modal):**
+
+| Operator | ARB Action | Output Type | Requires Property? | Description |
+|----------|-----------|-------------|-------------------|-------------|
+| `"total"` | `per_user_count` or `per_user_sum` | `"number"` | No (count) / Yes (sum) | Without property: count of matching events. With property: sum of property values. |
+| `"average"` | `per_user_average` | `"number"` | Yes | Average of property values per user |
+| `"unique_values"` | `per_user_count_unique` | `"number"` | Yes | Count of distinct property values per user |
+| `"most_frequent"` | `per_user_most_frequent` | `"string"` | Yes | Most common property value per user |
+| `"first_value"` | `per_user_first_value` | `"string"` | Yes | Value from the user's earliest matching event |
+
+**Tier 2 — Additional useful operators:**
+
+| Operator | ARB Action | Output Type | Requires Property? | Description |
+|----------|-----------|-------------|-------------------|-------------|
+| `"min"` | `per_user_min` | `"number"` | Yes | Minimum property value per user |
+| `"max"` | `per_user_max` | `"number"` | Yes | Maximum property value per user |
+| `"last_value"` | `per_user_last_value` | `"string"` | Yes | Value from the user's most recent matching event |
+| `"first_event_time"` | `per_user_first_event_time` | `"number"` | No | Timestamp of user's first matching event |
+| `"last_event_time"` | `per_user_last_event_time` | `"number"` | No | Timestamp of user's last matching event |
+
+**Output type inference** (mirrors `_behavior_type()` in `views.py:278-283`):
+```python
+def _infer_behavior_output_type(aggregation: str) -> str:
+    return "string" if aggregation in {"most_frequent", "first_value"} else "number"
+```
+
+Note: `last_value` returns `"number"` per the server's inference function, not `"string"`. This is a server-side simplification; the actual output type depends on the input property type. Users can override via `property_type`.
+
+### 2.4 Date Range Formats
+
+The behavior's `dateRange` supports three shapes:
+
+| Mode | JSON Shape | User API |
+|------|-----------|----------|
+| **Relative** (default) | `{"type": "in the last", "window": {"unit": "day", "value": 30}}` | `last=30, last_unit="day"` |
+| **Absolute** | `{"type": "between", "from": "2024-01-01", "to": "2024-12-31"}` | `from_date="2024-01-01", to_date="2024-12-31"` |
+| **Since** | `{"type": "since", "from": "2024-01-01"}` | `since="2024-01-01"` |
+
+Valid `last_unit` values: `"day"`, `"week"`, `"month"` (backend also supports `"minute"`, `"hour"`, `"quarter"`, `"year"` but these are uncommon for behavior CPs).
+
+---
+
+## 3. New Types
+
+### 3.1 `BehaviorAggregation` — Type Alias
+
+```python
+BehaviorAggregation = Literal[
+    # Tier 1: UI-exposed
+    "total",            # Count of events (or sum if property set)
+    "average",          # Average of property per user
+    "unique_values",    # Count of distinct property values per user
+    "most_frequent",    # Most common property value → string
+    "first_value",      # First value seen → string
+
+    # Tier 2: Additional useful operators
+    "min",              # Minimum property value per user
+    "max",              # Maximum property value per user
+    "last_value",       # Last value seen
+    "first_event_time", # Timestamp of first matching event
+    "last_event_time",  # Timestamp of last matching event
+]
+"""Valid aggregation operators for behavior-based custom properties."""
+```
+
+**Operators that require a `property` field:**
+```python
+BEHAVIOR_PROPERTY_REQUIRED: frozenset[str] = frozenset({
+    "average", "min", "max", "unique_values",
+    "most_frequent", "first_value", "last_value",
+})
+"""Aggregation operators that require a property field."""
+```
+
+**Operators that never use a `property` field:**
+```python
+BEHAVIOR_NO_PROPERTY: frozenset[str] = frozenset({
+    "first_event_time", "last_event_time",
+})
+"""Aggregation operators where property is not applicable."""
+```
+
+**Operators that optionally use a `property` field:**
+- `"total"` — Without property: count of events. With property: sum of property values.
+
+### 3.2 `BehaviorDateRange` — Type Alias
+
+```python
+BehaviorDateRangeUnit = Literal["day", "week", "month"]
+"""Valid time units for behavior property lookback windows."""
+```
+
+### 3.3 `BehaviorProperty` — The Main Type
+
+```python
+@dataclass(frozen=True)
+class BehaviorProperty:
+    """A behavior-based custom property that aggregates a user's event history.
+
+    Computes a virtual property by aggregating events matching the
+    specified criteria over a time window. For each user (or row),
+    the query engine finds matching events, applies the aggregation
+    operator, and returns the computed value.
+
+    This is a first-class Mixpanel feature — the query engine natively
+    supports inline behavior-based custom property definitions in
+    bookmark params.
+
+    Attributes:
+        event: Event name to aggregate. Only events with this name
+            are included in the aggregation.
+        aggregation: How to aggregate the matching events. See
+            ``BehaviorAggregation`` for all valid values and their
+            semantics.
+        property: Property to aggregate on. Required for operators like
+            ``"average"``, ``"most_frequent"``, ``"first_value"``.
+            Optional for ``"total"`` (without property = event count;
+            with property = sum of property values). Not applicable
+            for ``"first_event_time"`` and ``"last_event_time"``.
+        property_type: Data type of the aggregation property.
+            Required when ``property`` is set. Default ``"number"``.
+        last: Relative lookback window size. Used when ``from_date``
+            is not set. Default 30.
+        last_unit: Time unit for the lookback window.
+            Default ``"day"``.
+        from_date: Absolute start date (YYYY-MM-DD). When set with
+            ``to_date``, uses an absolute date range instead of
+            relative lookback.
+        to_date: Absolute end date (YYYY-MM-DD). Required if
+            ``from_date`` is set.
+        since: Start date for "since" range (YYYY-MM-DD). Aggregates
+            from this date to now. Mutually exclusive with
+            ``from_date``/``to_date`` and ``last``.
+        filters: Optional filters on the events within the behavior.
+            Only events passing these filters are included in the
+            aggregation. Reuses the same ``Filter`` type as query
+            filters.
+        filters_combinator: How behavior filters combine.
+            ``"all"`` = AND logic, ``"any"`` = OR logic. Default
+            ``"all"``.
+        property_type_override: Explicit output type override. If
+            ``None``, inferred from ``aggregation`` (``"string"``
+            for most_frequent/first_value, ``"number"`` for others).
+            Use when the inferred type doesn't match your needs.
+        resource_type: Which data domain. Default ``"events"``.
+
+    Examples:
+        ```python
+        # Count of purchases in the last 30 days
+        BehaviorProperty(
+            event="Purchase",
+            aggregation="total",
+        )
+
+        # Average order value in the last 90 days
+        BehaviorProperty(
+            event="Purchase",
+            aggregation="average",
+            property="amount",
+            property_type="number",
+            last=90,
+        )
+
+        # Most frequently used browser
+        BehaviorProperty(
+            event="Page View",
+            aggregation="most_frequent",
+            property="$browser",
+            property_type="string",
+        )
+
+        # When the user first signed up
+        BehaviorProperty(
+            event="Signup",
+            aggregation="first_event_time",
+            since="2020-01-01",
+        )
+
+        # Total spend in Q1 2024
+        BehaviorProperty(
+            event="Purchase",
+            aggregation="total",
+            property="amount",
+            property_type="number",
+            from_date="2024-01-01",
+            to_date="2024-03-31",
+        )
+
+        # Users with more than 5 logins this week
+        BehaviorProperty(
+            event="Login",
+            aggregation="total",
+            last=7,
+            last_unit="day",
+        )
+
+        # Total purchases of premium items only
+        BehaviorProperty(
+            event="Purchase",
+            aggregation="total",
+            filters=[Filter.equals("plan", "premium")],
+        )
+        ```
+    """
+
+    event: str
+    aggregation: BehaviorAggregation
+    property: str | None = None
+    property_type: Literal["string", "number", "boolean", "datetime"] = "number"
+    last: int = 30
+    last_unit: BehaviorDateRangeUnit = "day"
+    from_date: str | None = None
+    to_date: str | None = None
+    since: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+    property_type_override: Literal["string", "number", "boolean", "datetime"] | None = None
+    resource_type: Literal["events", "people"] = "events"
+
+    @property
+    def output_type(self) -> str:
+        """Infer the output type of this behavior property.
+
+        Returns ``property_type_override`` if set, otherwise infers
+        from the aggregation operator:
+        - ``"string"`` for ``most_frequent`` and ``first_value``
+        - ``"number"`` for everything else
+
+        Returns:
+            The effective output type string.
+        """
+        if self.property_type_override is not None:
+            return self.property_type_override
+        if self.aggregation in ("most_frequent", "first_value"):
+            return "string"
+        return "number"
+```
+
+**Convenience constructors:**
+
+```python
+    @classmethod
+    def count(
+        cls,
+        event: str,
+        *,
+        last: int = 30,
+        last_unit: BehaviorDateRangeUnit = "day",
+        filters: list[Filter] | None = None,
+    ) -> BehaviorProperty:
+        """Count of events per user (most common use case).
+
+        Shorthand for ``BehaviorProperty(event, aggregation="total")``.
+
+        Args:
+            event: Event name to count.
+            last: Lookback window. Default 30.
+            last_unit: Window unit. Default ``"day"``.
+            filters: Optional event filters.
+
+        Returns:
+            A BehaviorProperty counting event occurrences.
+
+        Examples:
+            ```python
+            BehaviorProperty.count("Login")
+            BehaviorProperty.count("Purchase", last=90)
+            BehaviorProperty.count("Login", filters=[
+                Filter.equals("platform", "iOS"),
+            ])
+            ```
+        """
+        return cls(
+            event=event,
+            aggregation="total",
+            last=last,
+            last_unit=last_unit,
+            filters=filters,
+        )
+
+    @classmethod
+    def aggregate(
+        cls,
+        event: str,
+        aggregation: BehaviorAggregation,
+        property: str,
+        *,
+        property_type: Literal["string", "number", "boolean", "datetime"] = "number",
+        last: int = 30,
+        last_unit: BehaviorDateRangeUnit = "day",
+        filters: list[Filter] | None = None,
+    ) -> BehaviorProperty:
+        """Aggregate a property across a user's events.
+
+        Shorthand for common property aggregations. Use this when you
+        need to aggregate a specific property (average, sum, min, max,
+        etc.).
+
+        Args:
+            event: Event name.
+            aggregation: Aggregation operator.
+            property: Property to aggregate.
+            property_type: Property data type. Default ``"number"``.
+            last: Lookback window. Default 30.
+            last_unit: Window unit. Default ``"day"``.
+            filters: Optional event filters.
+
+        Returns:
+            A BehaviorProperty aggregating the specified property.
+
+        Examples:
+            ```python
+            # Average order value
+            BehaviorProperty.aggregate(
+                "Purchase", "average", "amount",
+            )
+
+            # Most used browser
+            BehaviorProperty.aggregate(
+                "Page View", "most_frequent", "$browser",
+                property_type="string",
+            )
+            ```
+        """
+        return cls(
+            event=event,
+            aggregation=aggregation,
+            property=property,
+            property_type=property_type,
+            last=last,
+            last_unit=last_unit,
+            filters=filters,
+        )
+```
+
+---
+
+## 4. Modified Types — Exact Diffs
+
+### 4.1 `PropertySpec` Type Alias
+
+**Before** (from v1):
+```python
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+```
+
+**After**:
+```python
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty | BehaviorProperty
+"""A property specifier: plain name, saved CP ref, inline formula, or behavioral aggregation."""
+```
+
+### 4.2 `Metric.property`
+
+**Before** (from v1):
+```python
+property: str | CustomPropertyRef | InlineCustomProperty | None = None
+```
+
+**After**:
+```python
+property: str | CustomPropertyRef | InlineCustomProperty | BehaviorProperty | None = None
+```
+
+### 4.3 `GroupBy.property`
+
+**Before** (from v1):
+```python
+property: str | CustomPropertyRef | InlineCustomProperty
+```
+
+**After**:
+```python
+property: str | CustomPropertyRef | InlineCustomProperty | BehaviorProperty
+```
+
+### 4.4 `Filter._property` and Class Methods
+
+**Before** (from v1):
+```python
+_property: str | CustomPropertyRef | InlineCustomProperty
+```
+
+**After**:
+```python
+_property: str | CustomPropertyRef | InlineCustomProperty | BehaviorProperty
+```
+
+All 18 class method `property` parameters expand accordingly.
+
+---
+
+## 5. Builder Changes — Exact Specifications
+
+### 5.1 Shared Helper — `_build_behavior_dict()`
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py` (new function)
+
+```python
+def _build_behavior_dict(bp: BehaviorProperty) -> dict[str, Any]:
+    """Convert a BehaviorProperty to the bookmark behavior JSON format.
+
+    Produces the ``behavior`` dict that goes inside a
+    ``customProperty`` definition. Handles date range construction,
+    property specification, and filter conversion.
+
+    Args:
+        bp: A ``BehaviorProperty`` specification.
+
+    Returns:
+        Behavior dict ready for embedding in ``customProperty``.
+
+    Example:
+        ```python
+        result = _build_behavior_dict(BehaviorProperty(
+            event="Purchase", aggregation="total", last=30,
+        ))
+        # {"event": {"value": "Purchase"}, "aggregationOperator": "total",
+        #  "dateRange": {"type": "in the last", "window": {"unit": "day", "value": 30}},
+        #  "filters": [], "filtersOperator": "and", "property": null}
+        ```
+    """
+    # Build event reference
+    event_ref: dict[str, Any] = {"value": bp.event}
+
+    # Build date range
+    if bp.from_date is not None and bp.to_date is not None:
+        date_range: dict[str, Any] = {
+            "type": "between",
+            "from": bp.from_date,
+            "to": bp.to_date,
+        }
+    elif bp.since is not None:
+        date_range = {
+            "type": "since",
+            "from": bp.since,
+        }
+    else:
+        date_range = {
+            "type": "in the last",
+            "window": {"unit": bp.last_unit, "value": bp.last},
+        }
+
+    # Build property reference (if applicable)
+    prop_ref: dict[str, Any] | None = None
+    if bp.property is not None:
+        prop_ref = {
+            "value": bp.property,
+            "type": bp.property_type,
+            "resourceType": "event",
+        }
+
+    # Build filters
+    behavior_filters: list[dict[str, Any]] = []
+    if bp.filters:
+        behavior_filters = [build_filter_entry(f) for f in bp.filters]
+
+    # Map combinator
+    filters_operator = "and" if bp.filters_combinator == "all" else "or"
+
+    return {
+        "event": event_ref,
+        "aggregationOperator": bp.aggregation,
+        "dateRange": date_range,
+        "filters": behavior_filters,
+        "filtersOperator": filters_operator,
+        "property": prop_ref,
+    }
+```
+
+### 5.2 `build_filter_entry()` — Add BehaviorProperty Branch
+
+**Addition to the existing function** (after the `InlineCustomProperty` branch from v1):
+
+```python
+elif isinstance(prop, BehaviorProperty):
+    output_type = prop.output_type
+    entry["customProperty"] = {
+        "behavior": _build_behavior_dict(prop),
+        "propertyType": output_type,
+        "resourceType": prop.resource_type,
+    }
+    entry["filterType"] = output_type
+    entry["defaultType"] = output_type
+    entry["resourceType"] = prop.resource_type
+```
+
+**Bookmark JSON output — `BehaviorProperty` in filter**:
+```json
+{
+    "customProperty": {
+        "behavior": {
+            "event": {"value": "Purchase"},
+            "aggregationOperator": "total",
+            "dateRange": {"type": "in the last", "window": {"unit": "day", "value": 30}},
+            "filters": [],
+            "filtersOperator": "and",
+            "property": null
+        },
+        "propertyType": "number",
+        "resourceType": "events"
+    },
+    "resourceType": "events",
+    "filterType": "number",
+    "defaultType": "number",
+    "filterValue": 5,
+    "filterOperator": "is greater than"
+}
+```
+
+### 5.3 `build_group_section()` — Add BehaviorProperty Branch
+
+**Addition to the existing function** (after the `InlineCustomProperty` branch from v1):
+
+```python
+elif isinstance(prop, BehaviorProperty):
+    output_type = prop.output_type
+    group_entry = {
+        "customProperty": {
+            "behavior": _build_behavior_dict(prop),
+            "propertyType": output_type,
+            "resourceType": prop.resource_type,
+        },
+        "propertyType": output_type,
+        "propertyDefaultType": output_type,
+        "isHidden": False,
+    }
+```
+
+**Bookmark JSON output — `BehaviorProperty` in group_by with bucketing**:
+```json
+{
+    "customProperty": {
+        "behavior": {
+            "event": {"value": "Purchase"},
+            "aggregationOperator": "total",
+            "dateRange": {"type": "in the last", "window": {"unit": "day", "value": 30}},
+            "filters": [],
+            "filtersOperator": "and",
+            "property": null
+        },
+        "propertyType": "number",
+        "resourceType": "events"
+    },
+    "propertyType": "number",
+    "propertyDefaultType": "number",
+    "isHidden": false,
+    "customBucket": {"bucketSize": 5, "min": 0, "max": 50}
+}
+```
+
+### 5.4 Measurement Property — Add BehaviorProperty Branch
+
+**Addition to `_build_query_params()` and `_build_funnel_params()`** (after the `InlineCustomProperty` branch from v1):
+
+```python
+elif isinstance(item_prop, BehaviorProperty):
+    measurement["property"] = {
+        "customProperty": {
+            "behavior": _build_behavior_dict(item_prop),
+            "propertyType": item_prop.output_type,
+        },
+        "resourceType": item_prop.resource_type,
+    }
+```
+
+**Bookmark JSON output — `BehaviorProperty` in measurement**:
+```json
+{
+    "math": "average",
+    "property": {
+        "customProperty": {
+            "behavior": {
+                "event": {"value": "Purchase"},
+                "aggregationOperator": "total",
+                "dateRange": {"type": "in the last", "window": {"unit": "day", "value": 30}},
+                "filters": [],
+                "filtersOperator": "and",
+                "property": null
+            },
+            "propertyType": "number"
+        },
+        "resourceType": "events"
+    }
+}
+```
+
+### 5.5 Import Updates
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py`:
+
+Add `BehaviorProperty` to the import from `mixpanel_data.types`.
+
+**File**: `src/mixpanel_data/__init__.py`:
+
+Add to exports: `BehaviorProperty`, `BehaviorAggregation`.
+
+---
+
+## 6. Validation Rules
+
+### 6.1 New Rules — Layer 1
+
+| Code | Rule | Condition | Message |
+|------|------|-----------|---------|
+| BP1 | Event name must be non-empty | `not bp.event.strip()` | `behavior property event name must be non-empty` |
+| BP2 | Property required for some operators | `bp.aggregation in BEHAVIOR_PROPERTY_REQUIRED and bp.property is None` | `aggregation '{agg}' requires a property (e.g., property="amount")` |
+| BP3 | Property not applicable for some operators | `bp.aggregation in BEHAVIOR_NO_PROPERTY and bp.property is not None` | `aggregation '{agg}' does not use a property` |
+| BP4 | last must be positive | `bp.last <= 0` | `behavior property last must be a positive integer (got {last})` |
+| BP5 | from_date requires to_date | `bp.from_date is not None and bp.to_date is None` | `behavior property from_date requires to_date` |
+| BP6 | to_date requires from_date | `bp.to_date is not None and bp.from_date is None` | `behavior property to_date requires from_date` |
+| BP7 | since is mutually exclusive with from_date/to_date | `bp.since is not None and (bp.from_date is not None or bp.to_date is not None)` | `behavior property since is mutually exclusive with from_date/to_date` |
+| BP8 | Date format validation | `from_date` or `to_date` or `since` fails YYYY-MM-DD parse | `behavior property {field} must be YYYY-MM-DD format (got '{value}')` |
+| BP9 | Property name must be non-empty when set | `bp.property is not None and not bp.property.strip()` | `behavior property property name must be non-empty` |
+| BP10 | Property type must be non-empty when property set | `bp.property is not None and not bp.property_type` | `behavior property property_type is required when property is set` |
+
+### 6.2 Validation Implementation
+
+**File**: `src/mixpanel_data/_internal/validation.py`
+
+Add a new helper alongside `_validate_custom_property()`:
+
+```python
+def _validate_behavior_property(
+    bp: BehaviorProperty,
+    context: str,
+) -> list[ValidationError]:
+    """Validate a behavior-based custom property specification.
+
+    Args:
+        bp: The behavior property to validate.
+        context: Human-readable location (e.g., "group_by[0]",
+            "where[1]", "events[0].property").
+
+    Returns:
+        List of validation errors (may be empty).
+    """
+    errors: list[ValidationError] = []
+
+    # BP1: Event name
+    if not bp.event.strip():
+        errors.append(ValidationError(
+            path=context,
+            message="behavior property event name must be non-empty",
+            code="BP1",
+            severity="error",
+        ))
+
+    # BP2: Property required
+    if bp.aggregation in BEHAVIOR_PROPERTY_REQUIRED and bp.property is None:
+        errors.append(ValidationError(
+            path=context,
+            message=(
+                f"aggregation '{bp.aggregation}' requires a property "
+                f"(e.g., property=\"amount\")"
+            ),
+            code="BP2",
+            severity="error",
+        ))
+
+    # BP3: Property not applicable
+    if bp.aggregation in BEHAVIOR_NO_PROPERTY and bp.property is not None:
+        errors.append(ValidationError(
+            path=context,
+            message=(
+                f"aggregation '{bp.aggregation}' does not use a property"
+            ),
+            code="BP3",
+            severity="error",
+        ))
+
+    # BP4: last must be positive
+    if bp.last <= 0:
+        errors.append(ValidationError(
+            path=context,
+            message=(
+                f"behavior property last must be a positive integer "
+                f"(got {bp.last})"
+            ),
+            code="BP4",
+            severity="error",
+        ))
+
+    # BP5/BP6: from_date/to_date pairing
+    if bp.from_date is not None and bp.to_date is None:
+        errors.append(ValidationError(
+            path=context,
+            message="behavior property from_date requires to_date",
+            code="BP5",
+            severity="error",
+        ))
+    if bp.to_date is not None and bp.from_date is None:
+        errors.append(ValidationError(
+            path=context,
+            message="behavior property to_date requires from_date",
+            code="BP6",
+            severity="error",
+        ))
+
+    # BP7: since exclusivity
+    if bp.since is not None and (
+        bp.from_date is not None or bp.to_date is not None
+    ):
+        errors.append(ValidationError(
+            path=context,
+            message=(
+                "behavior property since is mutually exclusive "
+                "with from_date/to_date"
+            ),
+            code="BP7",
+            severity="error",
+        ))
+
+    # BP8: Date format validation
+    for field_name, field_value in [
+        ("from_date", bp.from_date),
+        ("to_date", bp.to_date),
+        ("since", bp.since),
+    ]:
+        if field_value is not None:
+            try:
+                datetime.strptime(field_value, "%Y-%m-%d")
+            except ValueError:
+                errors.append(ValidationError(
+                    path=f"{context}.{field_name}",
+                    message=(
+                        f"behavior property {field_name} must be "
+                        f"YYYY-MM-DD format (got '{field_value}')"
+                    ),
+                    code="BP8",
+                    severity="error",
+                ))
+
+    # BP9: Property name
+    if bp.property is not None and not bp.property.strip():
+        errors.append(ValidationError(
+            path=context,
+            message="behavior property property name must be non-empty",
+            code="BP9",
+            severity="error",
+        ))
+
+    return errors
+```
+
+### 6.3 Validation Integration
+
+In `validate_query_args()`, `validate_funnel_args()`, `validate_retention_args()` — extend the existing CP validation to also dispatch on `BehaviorProperty`:
+
+```python
+# Alongside the existing _validate_custom_property() calls:
+if isinstance(prop, BehaviorProperty):
+    errors.extend(_validate_behavior_property(prop, context))
+```
+
+---
+
+## 7. Test Specifications (TDD-First)
+
+### 7.1 Test File Structure
+
+```
+tests/unit/
+├── test_behavior_property_types.py     # Phase 1: Type construction & validation
+├── test_behavior_property_builders.py  # Phase 2: Builder output verification
+├── test_behavior_property_query.py     # Phase 3: End-to-end query method tests
+└── test_behavior_property_pbt.py       # Phase 4: Property-based tests
+```
+
+### 7.2 Phase 1 Tests — Type Construction & Validation
+
+**File**: `tests/unit/test_behavior_property_types.py`
+
+```python
+"""Tests for BehaviorProperty type construction and validation rules BP1-BP10."""
+
+
+class TestBehaviorPropertyConstruction:
+    """BehaviorProperty construction and field defaults."""
+
+    def test_minimal_construction(self) -> None:
+        """Minimal: event + aggregation, all defaults."""
+        bp = BehaviorProperty(event="Purchase", aggregation="total")
+        assert bp.event == "Purchase"
+        assert bp.aggregation == "total"
+        assert bp.property is None
+        assert bp.property_type == "number"
+        assert bp.last == 30
+        assert bp.last_unit == "day"
+        assert bp.from_date is None
+        assert bp.to_date is None
+        assert bp.since is None
+        assert bp.filters is None
+        assert bp.filters_combinator == "all"
+        assert bp.property_type_override is None
+        assert bp.resource_type == "events"
+
+    def test_full_construction(self) -> None:
+        """All fields explicitly set."""
+        bp = BehaviorProperty(
+            event="Purchase",
+            aggregation="average",
+            property="amount",
+            property_type="number",
+            last=90,
+            last_unit="day",
+            filters=[Filter.equals("country", "US")],
+            filters_combinator="all",
+        )
+        assert bp.property == "amount"
+        assert bp.last == 90
+        assert len(bp.filters) == 1
+
+    def test_absolute_date_range(self) -> None:
+        """from_date + to_date for absolute range."""
+        bp = BehaviorProperty(
+            event="Purchase",
+            aggregation="total",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+        assert bp.from_date == "2024-01-01"
+        assert bp.to_date == "2024-12-31"
+
+    def test_since_date_range(self) -> None:
+        """since for open-ended start."""
+        bp = BehaviorProperty(
+            event="Signup",
+            aggregation="first_event_time",
+            since="2020-01-01",
+        )
+        assert bp.since == "2020-01-01"
+
+    def test_frozen(self) -> None:
+        """BehaviorProperty is immutable."""
+        bp = BehaviorProperty(event="Login", aggregation="total")
+        with pytest.raises(FrozenInstanceError):
+            bp.event = "Signup"
+
+
+class TestBehaviorPropertyOutputType:
+    """BehaviorProperty.output_type inference."""
+
+    def test_total_infers_number(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="total")
+        assert bp.output_type == "number"
+
+    def test_average_infers_number(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="average", property="p")
+        assert bp.output_type == "number"
+
+    def test_most_frequent_infers_string(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="most_frequent", property="p")
+        assert bp.output_type == "string"
+
+    def test_first_value_infers_string(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="first_value", property="p")
+        assert bp.output_type == "string"
+
+    def test_min_infers_number(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="min", property="p")
+        assert bp.output_type == "number"
+
+    def test_first_event_time_infers_number(self) -> None:
+        bp = BehaviorProperty(event="X", aggregation="first_event_time")
+        assert bp.output_type == "number"
+
+    def test_override_takes_precedence(self) -> None:
+        bp = BehaviorProperty(
+            event="X", aggregation="total",
+            property_type_override="string",
+        )
+        assert bp.output_type == "string"
+
+
+class TestBehaviorPropertyConvenienceConstructors:
+    """BehaviorProperty.count() and .aggregate() convenience constructors."""
+
+    def test_count_minimal(self) -> None:
+        bp = BehaviorProperty.count("Login")
+        assert bp.event == "Login"
+        assert bp.aggregation == "total"
+        assert bp.property is None
+        assert bp.last == 30
+
+    def test_count_with_options(self) -> None:
+        bp = BehaviorProperty.count(
+            "Purchase", last=90, last_unit="day",
+            filters=[Filter.equals("plan", "pro")],
+        )
+        assert bp.last == 90
+        assert len(bp.filters) == 1
+
+    def test_aggregate_average(self) -> None:
+        bp = BehaviorProperty.aggregate(
+            "Purchase", "average", "amount",
+        )
+        assert bp.event == "Purchase"
+        assert bp.aggregation == "average"
+        assert bp.property == "amount"
+        assert bp.property_type == "number"
+
+    def test_aggregate_most_frequent(self) -> None:
+        bp = BehaviorProperty.aggregate(
+            "Page View", "most_frequent", "$browser",
+            property_type="string",
+        )
+        assert bp.property_type == "string"
+
+
+class TestBehaviorPropertyValidation:
+    """Validation rules BP1-BP10."""
+
+    def test_bp1_empty_event(self, ws: Workspace) -> None:
+        """BP1: Empty event name raises."""
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="", aggregation="total",
+                )),
+            )
+
+    def test_bp2_average_requires_property(self, ws: Workspace) -> None:
+        """BP2: average without property raises."""
+        with pytest.raises(BookmarkValidationError, match="requires a property"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="average",
+                )),
+            )
+
+    def test_bp2_most_frequent_requires_property(self, ws: Workspace) -> None:
+        """BP2: most_frequent without property raises."""
+        with pytest.raises(BookmarkValidationError, match="requires a property"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="most_frequent",
+                )),
+            )
+
+    def test_bp3_first_event_time_rejects_property(self, ws: Workspace) -> None:
+        """BP3: first_event_time with property raises."""
+        with pytest.raises(BookmarkValidationError, match="does not use"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Login", aggregation="first_event_time",
+                    property="x",
+                )),
+            )
+
+    def test_bp4_negative_last(self, ws: Workspace) -> None:
+        """BP4: Negative last raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="total", last=-1,
+                )),
+            )
+
+    def test_bp5_from_without_to(self, ws: Workspace) -> None:
+        """BP5: from_date without to_date raises."""
+        with pytest.raises(BookmarkValidationError, match="requires to_date"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                    from_date="2024-01-01",
+                )),
+            )
+
+    def test_bp6_to_without_from(self, ws: Workspace) -> None:
+        """BP6: to_date without from_date raises."""
+        with pytest.raises(BookmarkValidationError, match="requires from_date"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                    to_date="2024-12-31",
+                )),
+            )
+
+    def test_bp7_since_with_from_date(self, ws: Workspace) -> None:
+        """BP7: since with from_date raises."""
+        with pytest.raises(BookmarkValidationError, match="mutually exclusive"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                    since="2024-01-01", from_date="2024-01-01",
+                    to_date="2024-12-31",
+                )),
+            )
+
+    def test_bp8_bad_date_format(self, ws: Workspace) -> None:
+        """BP8: Invalid date format raises."""
+        with pytest.raises(BookmarkValidationError, match="YYYY-MM-DD"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                    from_date="01/01/2024", to_date="12/31/2024",
+                )),
+            )
+
+    def test_bp9_empty_property_name(self, ws: Workspace) -> None:
+        """BP9: Empty property name raises."""
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=BehaviorProperty(
+                    event="Purchase", aggregation="average",
+                    property="  ",
+                )),
+            )
+
+    def test_total_without_property_valid(self, ws: Workspace) -> None:
+        """total without property is valid (count mode)."""
+        # Should not raise
+        ws.build_params(
+            "Login",
+            group_by=GroupBy(property=BehaviorProperty(
+                event="Purchase", aggregation="total",
+            )),
+        )
+
+    def test_total_with_property_valid(self, ws: Workspace) -> None:
+        """total with property is valid (sum mode)."""
+        ws.build_params(
+            "Login",
+            group_by=GroupBy(property=BehaviorProperty(
+                event="Purchase", aggregation="total",
+                property="amount", property_type="number",
+            )),
+        )
+```
+
+### 7.3 Phase 2 Tests — Builder Output Verification
+
+**File**: `tests/unit/test_behavior_property_builders.py`
+
+```python
+"""Tests for BehaviorProperty bookmark JSON output."""
+
+
+class TestBuildBehaviorDict:
+    """_build_behavior_dict() helper."""
+
+    def test_relative_date_range(self) -> None:
+        """Default relative date range → in the last."""
+        bp = BehaviorProperty(event="Purchase", aggregation="total")
+        result = _build_behavior_dict(bp)
+        assert result["dateRange"]["type"] == "in the last"
+        assert result["dateRange"]["window"]["unit"] == "day"
+        assert result["dateRange"]["window"]["value"] == 30
+
+    def test_absolute_date_range(self) -> None:
+        """from_date + to_date → between."""
+        bp = BehaviorProperty(
+            event="Purchase", aggregation="total",
+            from_date="2024-01-01", to_date="2024-12-31",
+        )
+        result = _build_behavior_dict(bp)
+        assert result["dateRange"]["type"] == "between"
+        assert result["dateRange"]["from"] == "2024-01-01"
+        assert result["dateRange"]["to"] == "2024-12-31"
+
+    def test_since_date_range(self) -> None:
+        """since → since type."""
+        bp = BehaviorProperty(
+            event="Signup", aggregation="first_event_time",
+            since="2020-01-01",
+        )
+        result = _build_behavior_dict(bp)
+        assert result["dateRange"]["type"] == "since"
+        assert result["dateRange"]["from"] == "2020-01-01"
+
+    def test_event_ref(self) -> None:
+        """Event name → event.value."""
+        bp = BehaviorProperty(event="Purchase", aggregation="total")
+        result = _build_behavior_dict(bp)
+        assert result["event"]["value"] == "Purchase"
+
+    def test_aggregation_operator(self) -> None:
+        """aggregation → aggregationOperator."""
+        bp = BehaviorProperty(event="X", aggregation="average", property="p")
+        result = _build_behavior_dict(bp)
+        assert result["aggregationOperator"] == "average"
+
+    def test_property_null_when_none(self) -> None:
+        """No property → property: null."""
+        bp = BehaviorProperty(event="X", aggregation="total")
+        result = _build_behavior_dict(bp)
+        assert result["property"] is None
+
+    def test_property_present(self) -> None:
+        """Property set → property dict with value/type/resourceType."""
+        bp = BehaviorProperty(
+            event="X", aggregation="average",
+            property="amount", property_type="number",
+        )
+        result = _build_behavior_dict(bp)
+        assert result["property"]["value"] == "amount"
+        assert result["property"]["type"] == "number"
+        assert result["property"]["resourceType"] == "event"
+
+    def test_no_filters(self) -> None:
+        """No filters → empty list, filtersOperator and."""
+        bp = BehaviorProperty(event="X", aggregation="total")
+        result = _build_behavior_dict(bp)
+        assert result["filters"] == []
+        assert result["filtersOperator"] == "and"
+
+    def test_with_filters(self) -> None:
+        """Filters → converted via build_filter_entry."""
+        bp = BehaviorProperty(
+            event="Purchase", aggregation="total",
+            filters=[Filter.equals("country", "US")],
+        )
+        result = _build_behavior_dict(bp)
+        assert len(result["filters"]) == 1
+        assert result["filters"][0]["value"] == "country"
+
+    def test_or_combinator(self) -> None:
+        """filters_combinator='any' → filtersOperator='or'."""
+        bp = BehaviorProperty(
+            event="X", aggregation="total",
+            filters=[Filter.equals("a", "b")],
+            filters_combinator="any",
+        )
+        result = _build_behavior_dict(bp)
+        assert result["filtersOperator"] == "or"
+
+    def test_custom_last_unit(self) -> None:
+        """Custom last_unit → window.unit."""
+        bp = BehaviorProperty(
+            event="X", aggregation="total",
+            last=12, last_unit="month",
+        )
+        result = _build_behavior_dict(bp)
+        assert result["dateRange"]["window"]["unit"] == "month"
+        assert result["dateRange"]["window"]["value"] == 12
+
+
+class TestBuildGroupSectionBehaviorProperty:
+    """build_group_section() with BehaviorProperty."""
+
+    def test_emits_custom_property_with_behavior(self) -> None:
+        """BehaviorProperty emits customProperty.behavior dict."""
+        section = build_group_section(
+            GroupBy(property=BehaviorProperty(
+                event="Purchase", aggregation="total",
+            ))
+        )
+        entry = section[0]
+        assert "customProperty" in entry
+        assert "behavior" in entry["customProperty"]
+        assert entry["customProperty"]["behavior"]["aggregationOperator"] == "total"
+        assert entry["propertyType"] == "number"
+
+    def test_string_output_type(self) -> None:
+        """most_frequent → propertyType string."""
+        section = build_group_section(
+            GroupBy(property=BehaviorProperty(
+                event="X", aggregation="most_frequent",
+                property="browser", property_type="string",
+            ))
+        )
+        entry = section[0]
+        assert entry["propertyType"] == "string"
+        assert entry["customProperty"]["propertyType"] == "string"
+
+    def test_with_bucketing(self) -> None:
+        """Bucketing works with BehaviorProperty."""
+        section = build_group_section(
+            GroupBy(
+                property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                ),
+                property_type="number",
+                bucket_size=5,
+                bucket_min=0,
+                bucket_max=50,
+            )
+        )
+        entry = section[0]
+        assert entry["customBucket"]["bucketSize"] == 5
+
+
+class TestBuildFilterEntryBehaviorProperty:
+    """build_filter_entry() with BehaviorProperty."""
+
+    def test_emits_custom_property_with_behavior(self) -> None:
+        """BehaviorProperty in filter emits customProperty.behavior."""
+        f = Filter.greater_than(
+            property=BehaviorProperty(
+                event="Purchase", aggregation="total",
+            ),
+            value=5,
+        )
+        entry = build_filter_entry(f)
+        assert "customProperty" in entry
+        assert "behavior" in entry["customProperty"]
+        assert entry["filterValue"] == 5
+        assert entry["filterOperator"] == "is greater than"
+        assert entry["filterType"] == "number"
+
+    def test_no_value_field(self) -> None:
+        """BehaviorProperty filter has no 'value' key (property name)."""
+        f = Filter.greater_than(
+            property=BehaviorProperty(
+                event="Purchase", aggregation="total",
+            ),
+            value=5,
+        )
+        entry = build_filter_entry(f)
+        assert "value" not in entry
+
+
+class TestMeasurementBehaviorProperty:
+    """Measurement property in _build_query_params() with BehaviorProperty."""
+
+    def test_emits_custom_property_with_behavior(self, ws: Workspace) -> None:
+        """BehaviorProperty in Metric.property emits customProperty.behavior."""
+        params = ws._build_query_params(
+            events=[Metric(
+                "Login", math="average",
+                property=BehaviorProperty(
+                    event="Purchase", aggregation="total",
+                ),
+            )],
+            math="total", math_property=None, per_user=None,
+            from_date=None, to_date=None, last=30, unit="day",
+            group_by=None, where=None, formulas=[], rolling=None,
+            cumulative=False, mode="timeseries",
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert "customProperty" in prop
+        assert "behavior" in prop["customProperty"]
+```
+
+### 7.4 Phase 3 Tests — End-to-End
+
+**File**: `tests/unit/test_behavior_property_query.py`
+
+```python
+"""End-to-end tests for BehaviorProperty in query(), query_funnel(), query_retention()."""
+
+
+class TestQueryWithBehaviorPropertyGroupBy:
+
+    def test_build_params_count_group_by(self, ws: Workspace) -> None:
+        """BehaviorProperty.count() in group_by."""
+        params = ws.build_params(
+            "Login",
+            group_by=GroupBy(
+                property=BehaviorProperty.count("Purchase"),
+                property_type="number",
+                bucket_size=5,
+            ),
+        )
+        group = params["sections"]["group"][0]
+        assert "customProperty" in group
+        beh = group["customProperty"]["behavior"]
+        assert beh["event"]["value"] == "Purchase"
+        assert beh["aggregationOperator"] == "total"
+
+    def test_build_params_aggregate_group_by(self, ws: Workspace) -> None:
+        """BehaviorProperty.aggregate() in group_by."""
+        params = ws.build_params(
+            "Login",
+            group_by=GroupBy(
+                property=BehaviorProperty.aggregate(
+                    "Purchase", "most_frequent", "$browser",
+                    property_type="string",
+                ),
+            ),
+        )
+        group = params["sections"]["group"][0]
+        assert group["propertyType"] == "string"
+
+
+class TestQueryWithBehaviorPropertyFilter:
+
+    def test_build_params_count_filter(self, ws: Workspace) -> None:
+        """Filter users by purchase count > 5."""
+        params = ws.build_params(
+            "Login",
+            where=Filter.greater_than(
+                property=BehaviorProperty.count("Purchase"),
+                value=5,
+            ),
+        )
+        filt = params["sections"]["filter"][0]
+        assert filt["customProperty"]["behavior"]["aggregationOperator"] == "total"
+        assert filt["filterValue"] == 5
+
+
+class TestFunnelWithBehaviorPropertyGroupBy:
+
+    def test_build_funnel_params_with_behavior_group_by(self, ws: Workspace) -> None:
+        """BehaviorProperty in funnel group_by."""
+        params = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            group_by=GroupBy(
+                property=BehaviorProperty.count("Login", last=90),
+                property_type="number",
+                bucket_size=10,
+            ),
+        )
+        group = params["sections"]["group"][0]
+        assert "customProperty" in group
+        assert group["customProperty"]["behavior"]["dateRange"]["window"]["value"] == 90
+
+
+class TestCombinedWithFormulaCP:
+
+    def test_formula_group_behavior_filter(self, ws: Workspace) -> None:
+        """InlineCustomProperty in group_by + BehaviorProperty in filter."""
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(
+                property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+                property_type="number",
+            ),
+            where=Filter.greater_than(
+                property=BehaviorProperty.count("Purchase"),
+                value=3,
+            ),
+        )
+        assert "customProperty" in params["sections"]["group"][0]
+        assert "displayFormula" in params["sections"]["group"][0]["customProperty"]
+        assert "customProperty" in params["sections"]["filter"][0]
+        assert "behavior" in params["sections"]["filter"][0]["customProperty"]
+```
+
+### 7.5 Phase 4 Tests — PBT
+
+**File**: `tests/unit/test_behavior_property_pbt.py`
+
+```python
+"""Property-based tests for BehaviorProperty."""
+
+from hypothesis import given, strategies as st
+
+valid_aggregation = st.sampled_from([
+    "total", "average", "unique_values", "most_frequent", "first_value",
+    "min", "max", "last_value", "first_event_time", "last_event_time",
+])
+
+valid_last_unit = st.sampled_from(["day", "week", "month"])
+
+
+class TestBehaviorPropertyPBT:
+
+    @given(
+        event=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
+        aggregation=valid_aggregation,
+        last=st.integers(min_value=1, max_value=365),
+        last_unit=valid_last_unit,
+    )
+    def test_construction_preserves_fields(
+        self, event: str, aggregation: str, last: int, last_unit: str,
+    ) -> None:
+        """All field values survive construction."""
+        bp = BehaviorProperty(
+            event=event, aggregation=aggregation,
+            last=last, last_unit=last_unit,
+        )
+        assert bp.event == event
+        assert bp.aggregation == aggregation
+        assert bp.last == last
+        assert bp.last_unit == last_unit
+
+    @given(aggregation=valid_aggregation)
+    def test_output_type_is_string_or_number(self, aggregation: str) -> None:
+        """Output type is always string or number."""
+        bp = BehaviorProperty(event="X", aggregation=aggregation)
+        assert bp.output_type in ("string", "number")
+
+
+class TestBuildBehaviorDictPBT:
+
+    @given(
+        event=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
+        last=st.integers(min_value=1, max_value=365),
+    )
+    def test_output_has_required_keys(self, event: str, last: int) -> None:
+        """Builder output always has required keys."""
+        bp = BehaviorProperty(event=event, aggregation="total", last=last)
+        result = _build_behavior_dict(bp)
+        assert "event" in result
+        assert "aggregationOperator" in result
+        assert "dateRange" in result
+        assert "filters" in result
+        assert "filtersOperator" in result
+        assert "property" in result
+```
+
+---
+
+## 8. Usage Examples
+
+### 8.1 Group-By — Segment by User Behavior
+
+```python
+# "Login events, segmented by how many purchases each user made"
+result = ws.query(
+    "Login",
+    group_by=GroupBy(
+        property=BehaviorProperty.count("Purchase"),
+        property_type="number",
+        bucket_size=5,
+        bucket_min=0,
+        bucket_max=50,
+    ),
+)
+
+# "Signups, broken down by each user's most-used browser"
+result = ws.query(
+    "Signup",
+    group_by=GroupBy(
+        property=BehaviorProperty.aggregate(
+            "Page View", "most_frequent", "$browser",
+            property_type="string",
+        ),
+    ),
+)
+
+# "Purchases, segmented by average order value tier"
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=BehaviorProperty.aggregate(
+            "Purchase", "average", "amount", last=90,
+        ),
+        property_type="number",
+        bucket_size=50,
+    ),
+)
+```
+
+### 8.2 Filter — Users Meeting Behavioral Thresholds
+
+```python
+# "Logins from users who made 5+ purchases in the last 30 days"
+result = ws.query(
+    "Login",
+    where=Filter.greater_than(
+        property=BehaviorProperty.count("Purchase"),
+        value=5,
+    ),
+)
+
+# "Signups from users who never logged in (0 logins in 90 days)"
+result = ws.query(
+    "Signup",
+    where=Filter.equals(
+        property=BehaviorProperty.count("Login", last=90),
+        value=0,
+    ),
+)
+
+# "Purchases from users whose average order value exceeds $100"
+result = ws.query(
+    "Purchase",
+    where=Filter.greater_than(
+        property=BehaviorProperty.aggregate(
+            "Purchase", "average", "amount",
+        ),
+        value=100,
+    ),
+)
+```
+
+### 8.3 Metric Measurement — Aggregate on Behavior
+
+```python
+# "Average purchase count per user, by week"
+result = ws.query(
+    Metric(
+        "Login",
+        math="average",
+        property=BehaviorProperty.count("Purchase"),
+    ),
+    unit="week",
+)
+```
+
+### 8.4 Combined — Behavior + Formula + Regular
+
+```python
+# "Purchases from power users (5+ purchases), broken down by
+#  revenue bucket (price * quantity)"
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        property_type="number",
+        bucket_size=100,
+    ),
+    where=Filter.greater_than(
+        property=BehaviorProperty.count("Purchase"),
+        value=5,
+    ),
+)
+```
+
+### 8.5 Funnel — Behavioral Segmentation
+
+```python
+# "Signup → Purchase funnel, segmented by prior login frequency"
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    group_by=GroupBy(
+        property=BehaviorProperty.count("Login", last=90),
+        property_type="number",
+        bucket_size=10,
+    ),
+)
+```
+
+### 8.6 With Behavior Filters
+
+```python
+# "Total iOS purchases in Q1, from users who spent $100+ this year"
+result = ws.query(
+    "Purchase",
+    where=[
+        Filter.equals("platform", "iOS"),
+        Filter.greater_than(
+            property=BehaviorProperty(
+                event="Purchase",
+                aggregation="total",
+                property="amount",
+                property_type="number",
+                from_date="2024-01-01",
+                to_date="2024-12-31",
+            ),
+            value=100,
+        ),
+    ],
+    from_date="2024-01-01",
+    to_date="2024-03-31",
+)
+```
+
+---
+
+## 9. Implementation Phases
+
+Each phase follows strict TDD. **Prerequisite**: v1 (`custom-properties-in-queries-design.md`) is fully implemented.
+
+### Phase 1: New Types (Estimated: ~120 lines impl, ~250 lines tests)
+
+**Tests first**: `tests/unit/test_behavior_property_types.py` — construction, output_type, convenience constructors, validation
+
+**Then implement** in `src/mixpanel_data/types.py`:
+1. Add `BehaviorAggregation` type alias
+2. Add `BEHAVIOR_PROPERTY_REQUIRED` and `BEHAVIOR_NO_PROPERTY` frozensets
+3. Add `BehaviorDateRangeUnit` type alias
+4. Add `BehaviorProperty` frozen dataclass with `output_type` property
+5. Add `count()` and `aggregate()` classmethods
+6. Update `PropertySpec` type alias to include `BehaviorProperty`
+
+**Verify**: All type construction and validation tests pass.
+
+### Phase 2: Modified Types (Estimated: ~20 lines changes)
+
+**Implement** type signature changes:
+1. `Metric.property` — add `BehaviorProperty` to union
+2. `GroupBy.property` — add `BehaviorProperty` to union
+3. `Filter._property` — add `BehaviorProperty` to union
+4. All 18 `Filter` class methods — add `BehaviorProperty` to `property` param union
+
+**Verify**: `just typecheck` passes. All existing tests still pass.
+
+### Phase 3: Builders (Estimated: ~100 lines impl, ~200 lines tests)
+
+**Tests first**: `tests/unit/test_behavior_property_builders.py` — all builder output tests
+
+**Then implement** in `src/mixpanel_data/_internal/bookmark_builders.py`:
+1. Add `_build_behavior_dict()` helper function
+2. Add `BehaviorProperty` branch to `build_filter_entry()`
+3. Add `BehaviorProperty` branch to `build_group_section()`
+4. Update imports
+
+**Then implement** in `src/mixpanel_data/workspace.py`:
+5. Add `BehaviorProperty` branch to measurement builder in `_build_query_params()`
+6. Add `BehaviorProperty` branch to measurement builder in `_build_funnel_params()`
+7. Update imports
+
+**Verify**: All builder output tests pass.
+
+### Phase 4: Validation (Estimated: ~80 lines impl, ~150 lines tests)
+
+**Tests first**: Enable all BP1-BP10 validation tests
+
+**Then implement** in `src/mixpanel_data/_internal/validation.py`:
+1. Add `_validate_behavior_property()` helper function
+2. Add `BehaviorProperty` dispatch in `validate_query_args()`
+3. Add `BehaviorProperty` dispatch in `validate_funnel_args()`
+4. Add `BehaviorProperty` dispatch in `validate_retention_args()`
+
+**Verify**: All validation tests pass.
+
+### Phase 5: E2E, Exports & PBT (Estimated: ~30 lines impl, ~150 lines tests)
+
+**Tests**: `test_behavior_property_query.py` + `test_behavior_property_pbt.py`
+
+**Implement**:
+1. Update `__init__.py` exports
+2. Verify `_resolve_and_build_*_params()` type guards handle `BehaviorProperty`
+
+**Verify**: `just check` green. Coverage >= 90%. PBT passes.
+
+---
+
+## 10. Dependency Graph
+
+```
+v1 Complete (custom-properties-in-queries-design.md)
+    │
+    └── Phase 1: BehaviorProperty type
+            │
+            ├── Phase 2: Modified type unions
+            │       │
+            │       └── Phase 4: Validation (depends on types)
+            │
+            └── Phase 3: Builders (depends on type)
+                    │
+                    └── Phase 5: E2E + Exports + PBT
+```
+
+---
+
+## 11. Files Changed Summary
+
+| File | Change Type | Scope |
+|------|------------|-------|
+| `src/mixpanel_data/types.py` | **Modified** | Add `BehaviorProperty`, `BehaviorAggregation`, `BehaviorDateRangeUnit`, `BEHAVIOR_PROPERTY_REQUIRED`, `BEHAVIOR_NO_PROPERTY`; update `PropertySpec`, `Metric.property`, `GroupBy.property`, `Filter._property` + 18 class methods |
+| `src/mixpanel_data/_internal/bookmark_builders.py` | **Modified** | Add `_build_behavior_dict()`; add `BehaviorProperty` branches in `build_filter_entry()` and `build_group_section()` |
+| `src/mixpanel_data/workspace.py` | **Modified** | Add `BehaviorProperty` branch in measurement builders |
+| `src/mixpanel_data/_internal/validation.py` | **Modified** | Add `_validate_behavior_property()`; add dispatch in 3 validate functions |
+| `src/mixpanel_data/__init__.py` | **Modified** | Add exports |
+| `tests/unit/test_behavior_property_types.py` | **New** | ~350 lines |
+| `tests/unit/test_behavior_property_builders.py` | **New** | ~250 lines |
+| `tests/unit/test_behavior_property_query.py` | **New** | ~150 lines |
+| `tests/unit/test_behavior_property_pbt.py` | **New** | ~80 lines |
+
+**Total implementation**: ~350 lines of production code
+**Total tests**: ~830 lines of test code
+
+---
+
+## 12. Acceptance Criteria
+
+- [ ] `BehaviorProperty` is a frozen dataclass with `output_type` property
+- [ ] `BehaviorProperty.count()` and `.aggregate()` convenience constructors work
+- [ ] `BehaviorAggregation` Literal covers all 10 operators
+- [ ] `PropertySpec` union includes `BehaviorProperty`
+- [ ] `Metric.property`, `GroupBy.property`, `Filter._property` accept `BehaviorProperty`
+- [ ] `_build_behavior_dict()` produces correct JSON for relative, absolute, and since date ranges
+- [ ] `_build_behavior_dict()` produces correct JSON for property and no-property aggregations
+- [ ] `_build_behavior_dict()` converts behavior filters via `build_filter_entry()`
+- [ ] `build_filter_entry()` emits correct JSON for `BehaviorProperty`
+- [ ] `build_group_section()` emits correct JSON for `BehaviorProperty` with bucketing
+- [ ] Measurement builder emits correct JSON for `BehaviorProperty`
+- [ ] Validation rules BP1-BP10 catch all invalid inputs
+- [ ] `BehaviorProperty` works alongside `InlineCustomProperty` and `CustomPropertyRef` in the same query
+- [ ] All existing tests pass unchanged (backward compatibility)
+- [ ] `just check` passes
+- [ ] Coverage >= 90%
+- [ ] New types exported from `mixpanel_data.__init__`

--- a/context/cohort-behaviors-design.md
+++ b/context/cohort-behaviors-design.md
@@ -1,0 +1,1761 @@
+# Cohort Behaviors in the Unified Query System — Design Document
+
+**Date**: 2026-04-07 (revised 2026-04-07)
+**Status**: Research Complete — Design Proposed (v2: with Cohort Definition Builder)
+**Builds on**: `insights-query-api-design.md`, `unified-bookmark-query-design.md`
+**Reference**: `analytics/` repo (Mixpanel canonical implementation)
+
+---
+
+## 1. Executive Summary
+
+This document specifies the design for adding cohort behavior support to `mixpanel_data`'s typed query system. Cohort behaviors are the final missing piece from the original `unified-bookmark-query-design.md` roadmap.
+
+The research reveals that "cohort behaviors" is not a single feature — it is **three orthogonal capabilities** that each integrate differently with the existing query infrastructure:
+
+| Capability | What It Does | Which Query Methods | Integration Point |
+|-----------|-------------|--------------------|--------------------|
+| **Cohort as Metric** | Track cohort size over time | `query()` only | New `CohortMetric` type in `events=` parameter |
+| **Cohort as Filter** | Restrict queries to users in/not in cohort(s) | `query()`, `query_funnel()`, `query_retention()` | Extend `Filter` with cohort class methods |
+| **Cohort as Breakdown** | Segment results by cohort membership | `query()`, `query_funnel()`, `query_retention()` | New `CohortBreakdown` type in `group_by=` parameter |
+
+### Why Not a New `query_cohort()` Method?
+
+Unlike funnels, retention, and flows — which have structurally different `behavior` blocks, different API routing, and different response formats — cohort capabilities are **cross-cutting enhancements** to the existing query methods. A separate `query_cohort()` would only cover "cohort as metric" (insights-only) and would leave cohort filtering and breakdowns stranded.
+
+The correct architecture is to extend the shared infrastructure so that all three existing query methods (`query()`, `query_funnel()`, `query_retention()`) gain cohort capabilities simultaneously.
+
+### Design Principles
+
+1. **Cohort builder first** — A typed `CohortDefinition` builder is the foundation. It produces valid JSON for both cohort CRUD and inline query references.
+2. **Cross-cutting, not siloed** — Cohort filter and breakdown capabilities are shared infrastructure that benefits all query types simultaneously.
+3. **Saved AND inline** — Every cohort integration point accepts both `int` (saved cohort ID) and `CohortDefinition` (inline ad-hoc cohort).
+4. **Progressive disclosure** — `Filter.in_cohort(123)` is as simple as `Filter.equals("browser", "Chrome")`. Inline cohorts add one level of composition.
+5. **Type-safe** — No raw dict construction. `CohortCriteria` class methods produce validated building blocks.
+6. **Fail-fast** — Client-side validation catches invalid definitions before API calls.
+7. **Debuggable** — `result.params` includes the generated cohort JSON for inspection. `CohortDefinition.to_dict()` enables standalone inspection.
+
+---
+
+## 2. Research Findings: How Cohorts Work in Mixpanel
+
+### 2.1 Three Mechanisms, Three JSON Structures
+
+The Mixpanel analytics codebase reveals that cohorts interact with the bookmark query system through three completely different mechanisms, each with its own JSON representation, API routing, and response format.
+
+#### Mechanism 1: Cohort as a Metric ("Cohorts Over Time")
+
+A cohort can be a **metric** in a show clause, tracking how the cohort's size changes over time. This is the "Cohorts Over Time" report type in the Mixpanel UI.
+
+**Bookmark JSON:**
+```json
+{
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "cohort",
+        "resourceType": "cohorts",
+        "name": "Power Users",
+        "dataGroupId": null,
+        "dataset": "$mixpanel"
+      },
+      "measurement": {
+        "math": "unique",
+        "property": null,
+        "perUserAggregation": null
+      },
+      "isHidden": false
+    }]
+  }
+}
+```
+
+**Key characteristics:**
+- `behavior.type: "cohort"` — the discriminator
+- `behavior.resourceType: "cohorts"` (plural) — distinguishes from event metrics
+- References a saved cohort by `behavior.id` (integer) or an inline cohort by `behavior.raw_cohort` (dict)
+- Only valid `math` type is `"unique"` — you can only count unique users in a cohort
+- **Insights only** — funnels, retention, and flows do not support cohort metrics in show clauses
+
+**API routing** (from `analytics/api/version_2_0/insights/params.py:2475`):
+```python
+@staticmethod
+def _is_cohorts_metric(clause):
+    return get_behavior_value_from_show_clause(clause, "resourceType") == "cohorts"
+```
+
+When detected, the insights API routes the query to `cohorts_size_over_time()` (in `insights/cohorts.py`), which queries the **engage binaries** (user profile storage), NOT the event binaries. This is fundamentally different from event metrics.
+
+**Response format:**
+```json
+{
+  "series": {
+    "Power Users [Unique Users]": {
+      "2024-01-01T00:00:00-07:00": 1234,
+      "2024-01-02T00:00:00-07:00": 1256
+    }
+  }
+}
+```
+
+The response is structurally identical to an insights event metric response — same `series` shape, same `computed_at`, `date_range`, `headers`, `meta` fields. This means our existing `QueryResult` type and `_transform_query_result()` parser can handle it without modification.
+
+#### Mechanism 2: Cohort as a Filter
+
+A cohort can **filter** any query to include only users who are in (or not in) specified cohort(s). This works across insights, funnels, and retention.
+
+**Modern bookmark JSON** (in `sections.filter[]`):
+```json
+{
+  "dataset": "$mixpanel",
+  "value": "$cohorts",
+  "resourceType": "events",
+  "filterType": "list",
+  "filterOperator": "contains",
+  "filterValue": [
+    {
+      "cohort": {
+        "id": 123,
+        "name": "Power Users",
+        "negated": false
+      }
+    }
+  ],
+  "propertyObjectKey": null,
+  "dataGroupId": null
+}
+```
+
+**Key characteristics:**
+- Identified by the magic property name `value: "$cohorts"` (constant `INSIGHTS_COHORT_TYPE` in the frontend)
+- `filterType: "list"` — cohorts are treated as List property filters
+- `filterOperator: "contains"` for inclusion, `"does not contain"` for exclusion
+- `filterValue` is an array of `{cohort: {id, name, negated}}` objects — NOT scalar values
+- `resourceType` is `"events"` at the insights level (not `"cohort"`)
+- Multiple cohort entries in `filterValue` combine with OR logic (user is in ANY of these cohorts)
+- Multiple cohort filter entries in `sections.filter[]` combine with AND logic (user is in ALL specified cohort groups)
+
+**Two negation mechanisms:**
+1. `filterOperator: "does not contain"` — negates the entire filter
+2. `cohort.negated: true` — per-cohort negation flag (used internally, the operator is the primary mechanism)
+
+**Legacy format** (funnels/retention v0 bookmarks use `filter_by_cohort`):
+```json
+{
+  "filter_by_cohort": {
+    "operator": "or",
+    "children": [
+      {"cohort": {"id": 123, "name": "Power Users", "negated": false}}
+    ]
+  }
+}
+```
+
+The bookmark parser converts between these formats. Our implementation should only generate the modern `sections.filter[]` format.
+
+**Source references:**
+- `analytics/iron/common/report/insights/models/filter-clause.ts:67-78` — `FilterClause.defaultCohortsAttrs()`
+- `analytics/iron/common/widgets/property-filter-menu/models/insights-filter.ts:76` — `INSIGHTS_COHORT_TYPE = "$cohorts"`
+- `analytics/bookmark_parser/common/property_filter/utils.py:1-15` — `convert_cohort_property_filter_to_tree_filter()`
+- `analytics/api/version_2_0/insights/params_util.py:156-157` — `is_cohort_filter()`
+
+#### Mechanism 3: Cohort as a Breakdown (Group By)
+
+A cohort can serve as a **breakdown dimension**, segmenting results by cohort membership. Users are bucketed into "in cohort" and "not in cohort" groups.
+
+**Modern bookmark JSON** (in `sections.group[]`):
+```json
+{
+  "value": [
+    "Power Users",
+    "Not In Power Users"
+  ],
+  "resourceType": "events",
+  "propertyType": null,
+  "typeCast": null,
+  "cohorts": [
+    {
+      "id": 123,
+      "name": "Power Users",
+      "negated": false,
+      "data_group_id": null,
+      "groups": []
+    },
+    {
+      "id": 123,
+      "name": "Power Users",
+      "negated": true,
+      "data_group_id": null,
+      "groups": []
+    }
+  ]
+}
+```
+
+**Key characteristics:**
+- Identified by the presence of a `cohorts` array in the group entry
+- `value` is an array of display labels (one per cohort entry, including negated variants)
+- Each cohort in the array can be negated independently — a single cohort ID produces TWO segments: "in" and "not in"
+- The `cohorts` array contains full cohort metadata (not just IDs)
+- `propertyType` is `null` (not a property breakdown)
+
+**How it's processed** (from `analytics/api/version_2_0/insights/segmentation_arb.py:427-445`):
+
+When a group entry has a `cohorts` key, the backend calls `get_behaviors_and_individual_selectors_for_cohort_list()` to resolve cohort definitions into ARB selectors, then wraps the query with `segment_by_cohorts_action()`:
+
+```python
+segment_by_cohorts(inner_action, {
+    "Power Users": selector_for_cohort_123,
+    "Not In Power Users": not(selector_for_cohort_123)
+})
+```
+
+**Retention restriction** (from `analytics/api/version_2_0/retention/util.py:270-271`):
+```python
+if ("on" in arb_params or "born_on" in arb_params) and "group_by_cohorts" in arb_params:
+    raise ApiError("cohorts are not supported in segmented retention")
+```
+
+Retention does NOT support simultaneous property breakdowns and cohort breakdowns. They are mutually exclusive.
+
+**Source references:**
+- `analytics/iron/common/report/insights/models/group-clause.ts:81` — `GroupClause.cohorts` field
+- `analytics/iron/common/types/reports/bookmark.ts:288-304` — `GroupByCohort` interface
+- `analytics/api/version_2_0/cohorts/selector.py:4-23` — `segment_by_cohorts_action()`
+- `analytics/api/version_2_0/insights/util.py:387-415` — `get_all_segments_from_groups_and_cohorts()`
+
+### 2.2 Report Type Support Matrix
+
+| Capability | Insights | Funnels | Retention | Flows |
+|-----------|----------|---------|-----------|-------|
+| Cohort as Metric | Yes | No | No | No |
+| Cohort as Filter | Yes | Yes | Yes | Yes (legacy `filter_by_cohort` format) |
+| Cohort as Breakdown | Yes | Yes | Partial* | No |
+
+\* Retention supports cohort breakdowns but they are **mutually exclusive** with property breakdowns (`group_by`). The API raises an error if both are specified.
+
+### 2.3 Cohort Identification
+
+Cohorts can be referenced in two ways:
+
+1. **Saved cohort** — by integer `id` (and optional `name` for display)
+2. **Inline cohort** — by `raw_cohort` dict containing the full cohort definition
+
+For our API, we will only support **saved cohort references** (by ID) in v1. Inline cohorts are complex to construct correctly and are rarely needed programmatically. Users who need inline cohorts can use `build_params()` and modify the dict.
+
+### 2.4 The `dataGroupId` / `data_group_id` Field
+
+This field appears throughout cohort-related structures. It is the **entity group identifier** for Mixpanel's B2B/Group Analytics feature. It scopes a query to a specific group type (e.g., "Company", "Account").
+
+- Stored as `BigIntegerField(null=True)` in the Django model
+- Serialized as a **string** in JSON responses (e.g., `"123"`, not `123`)
+- When a cohort's `data_group_id` differs from the query's global `dataGroupId`, it creates a "cross-join" scenario requiring special handling
+
+For v1, we set `dataGroupId: null` (default Mixpanel project, no B2B groups). B2B group analytics support can be added later.
+
+---
+
+## 3. Cohort Definition Builder (Phase 0 Prerequisite)
+
+### 3.1 Why a Builder is Required
+
+Every cohort integration point — filters, breakdowns, and metrics — needs to reference a cohort. While saved cohorts (by ID) cover the simple case, full cohort power requires **inline ad-hoc cohort definitions**. Without a typed builder, users would construct raw dicts — error-prone, undiscoverable, and hostile to LLM agents.
+
+The builder is a Phase 0 prerequisite because it:
+1. Produces valid JSON for `create_cohort()` (the `definition` field)
+2. Produces valid `raw_cohort` dicts for inline query references
+3. Is the single source of truth for cohort definition construction
+4. Enables agent-friendly progressive disclosure
+
+### 3.2 Cohort Definition Formats in Mixpanel
+
+The Mixpanel API accepts two cohort definition formats:
+
+**Legacy format (`selector` + `behaviors`)** — an expression tree combined with a behavior dictionary:
+```json
+{
+  "selector": {
+    "operator": "and",
+    "children": [
+      {"property": "behaviors", "value": "bhvr_1", "operator": ">=", "operand": 1}
+    ]
+  },
+  "behaviors": {
+    "bhvr_1": {
+      "count": {
+        "event_selector": {"event": "Purchase", "selector": null},
+        "type": "absolute"
+      },
+      "window": {"unit": "day", "value": 30}
+    }
+  }
+}
+```
+
+**Modern format (`groups`)** — an array of group entries with property filters and behavioral filters:
+```json
+{
+  "groups": [
+    {
+      "type": "cohort_group",
+      "filters": [/* PropertyFilter objects */],
+      "behavioralFilters": [/* behavioral PropertyFilter objects */],
+      "behavioralFiltersOperator": "and",
+      "filtersOperator": "and",
+      "groupingOperator": "and"
+    }
+  ]
+}
+```
+
+**Our builder generates the legacy `selector` + `behaviors` format** because:
+1. It works everywhere — both `create_cohort()` and `raw_cohort` in inline queries
+2. The backend parses it natively without conversion
+3. It's more explicit — each behavior is a named entry with clear semantics
+4. The `groups` format is a UI abstraction that the backend converts to `selector` + `behaviors` anyway
+
+### 3.3 `CohortCriteria` — Building Blocks
+
+Each class method produces one atomic condition for cohort membership.
+
+```python
+@dataclass(frozen=True)
+class CohortCriteria:
+    """A single criterion for cohort membership.
+
+    Construct via class methods — do not instantiate directly.
+    Each method produces one condition that can be combined
+    with AND/OR logic via CohortDefinition.
+
+    Examples:
+        ```python
+        # User did event at least N times
+        CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+
+        # User has a specific property value
+        CohortCriteria.has_property("plan", "premium")
+
+        # User is in another cohort
+        CohortCriteria.in_cohort(456)
+        ```
+    """
+
+    _selector_node: dict
+    _behavior_key: str | None = None
+    _behavior: dict | None = None
+
+    # ─── Behavioral criteria ───────────────────────────────────
+
+    @classmethod
+    def did_event(
+        cls,
+        event: str,
+        *,
+        at_least: int | None = None,
+        at_most: int | None = None,
+        exactly: int | None = None,
+        within_days: int | None = None,
+        within_weeks: int | None = None,
+        within_months: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        where: Filter | list[Filter] | None = None,
+    ) -> CohortCriteria:
+        """User performed event matching frequency and time constraints.
+
+        Exactly one frequency param (at_least, at_most, exactly) must
+        be set. Exactly one time constraint (within_* or from_date)
+        must be set.
+
+        Args:
+            event: Mixpanel event name.
+            at_least: Minimum event count (>=).
+            at_most: Maximum event count (<=).
+            exactly: Exact event count (==).
+            within_days: Rolling window in days.
+            within_weeks: Rolling window in weeks.
+            within_months: Rolling window in months.
+            from_date: Absolute start date (YYYY-MM-DD).
+            to_date: Absolute end date (YYYY-MM-DD). Required with from_date.
+            where: Event property filters applied to the counted events.
+
+        Examples:
+            ```python
+            # Purchased at least 3 times in the last 30 days
+            CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+
+            # Did not purchase in the last 7 days
+            CohortCriteria.did_event("Purchase", exactly=0, within_days=7)
+
+            # Purchased premium items at least once this quarter
+            CohortCriteria.did_event(
+                "Purchase",
+                at_least=1,
+                from_date="2024-01-01",
+                to_date="2024-03-31",
+                where=Filter.equals("plan", "premium"),
+            )
+            ```
+        """
+        ...
+
+    @classmethod
+    def did_not_do_event(
+        cls,
+        event: str,
+        *,
+        within_days: int | None = None,
+        within_weeks: int | None = None,
+        within_months: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> CohortCriteria:
+        """Shorthand for did_event(event, exactly=0, ...).
+
+        Example:
+            ```python
+            CohortCriteria.did_not_do_event("Login", within_days=30)
+            ```
+        """
+        ...
+
+    # ─── Property criteria ─────────────────────────────────────
+
+    @classmethod
+    def has_property(
+        cls,
+        property: str,
+        value: str | int | float | bool | list[str],
+        *,
+        operator: Literal[
+            "equals", "not_equals", "contains", "not_contains",
+            "greater_than", "less_than", "is_set", "is_not_set",
+        ] = "equals",
+        property_type: Literal["string", "number", "boolean", "datetime", "list"] = "string",
+    ) -> CohortCriteria:
+        """User profile has a property matching a condition.
+
+        Args:
+            property: User profile property name.
+            value: Value to compare against.
+            operator: Comparison operator. Default "equals".
+            property_type: Data type of the property. Default "string".
+
+        Examples:
+            ```python
+            CohortCriteria.has_property("plan", "premium")
+            CohortCriteria.has_property("age", 18, operator="greater_than",
+                                        property_type="number")
+            CohortCriteria.has_property("email", "@company.com",
+                                        operator="contains")
+            ```
+        """
+        ...
+
+    @classmethod
+    def property_is_set(cls, property: str) -> CohortCriteria:
+        """User profile has the property defined (non-null)."""
+        ...
+
+    @classmethod
+    def property_is_not_set(cls, property: str) -> CohortCriteria:
+        """User profile does not have the property defined."""
+        ...
+
+    # ─── Cohort membership criteria ───────────────────────────
+
+    @classmethod
+    def in_cohort(cls, cohort_id: int) -> CohortCriteria:
+        """User is a member of the specified saved cohort.
+
+        Example:
+            ```python
+            CohortCriteria.in_cohort(456)
+            ```
+        """
+        ...
+
+    @classmethod
+    def not_in_cohort(cls, cohort_id: int) -> CohortCriteria:
+        """User is NOT a member of the specified saved cohort."""
+        ...
+```
+
+### 3.4 `CohortDefinition` — Composing Criteria
+
+Combines one or more `CohortCriteria` with AND/OR logic. Produces the `selector` + `behaviors` dict.
+
+```python
+@dataclass(frozen=True)
+class CohortDefinition:
+    """A typed cohort definition that produces valid Mixpanel JSON.
+
+    Combines CohortCriteria with AND/OR logic. Supports nesting
+    for complex boolean expressions.
+
+    Use directly for single-criterion cohorts, or use all_of() / any_of()
+    for multi-criterion definitions.
+
+    Args:
+        criteria: One or more CohortCriteria to combine with AND logic.
+
+    Examples:
+        ```python
+        # Single criterion
+        cohort = CohortDefinition(
+            CohortCriteria.did_event("Purchase", at_least=1, within_days=30)
+        )
+
+        # Multiple criteria with AND (all must match)
+        cohort = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+        )
+
+        # Multiple criteria with OR (any can match)
+        cohort = CohortDefinition.any_of(
+            CohortCriteria.did_event("Signup", at_least=1, within_days=7),
+            CohortCriteria.in_cohort(456),
+        )
+
+        # Nested: (A AND B) OR C
+        cohort = CohortDefinition.any_of(
+            CohortDefinition.all_of(
+                CohortCriteria.has_property("plan", "premium"),
+                CohortCriteria.did_event("Login", at_least=5, within_days=30),
+            ),
+            CohortCriteria.in_cohort(789),
+        )
+        ```
+    """
+
+    _criteria: tuple[CohortCriteria | CohortDefinition, ...]
+    _operator: Literal["and", "or"] = "and"
+
+    def __init__(self, *criteria: CohortCriteria) -> None:
+        """Create a definition from one or more criteria (AND logic)."""
+        ...
+
+    @classmethod
+    def all_of(
+        cls, *criteria: CohortCriteria | CohortDefinition,
+    ) -> CohortDefinition:
+        """Combine criteria with AND logic (all must match)."""
+        ...
+
+    @classmethod
+    def any_of(
+        cls, *criteria: CohortCriteria | CohortDefinition,
+    ) -> CohortDefinition:
+        """Combine criteria with OR logic (any can match)."""
+        ...
+
+    def to_dict(self) -> dict[str, Any]:
+        """Produce the selector + behaviors dict for the API.
+
+        Returns a dict with ``selector`` (expression tree) and
+        ``behaviors`` (behavior dictionary) keys. This dict can be:
+        - Passed as ``definition`` to ``CreateCohortParams``
+        - Used as ``raw_cohort`` in inline cohort references
+        - Inspected for debugging
+
+        Example:
+            ```python
+            cohort = CohortDefinition(
+                CohortCriteria.did_event("Purchase", at_least=1, within_days=30)
+            )
+            print(cohort.to_dict())
+            # {
+            #   "selector": {"operator": "and", "children": [...]},
+            #   "behaviors": {"bhvr_0": {"count": {...}, "window": {...}}}
+            # }
+            ```
+        """
+        ...
+```
+
+### 3.5 Selector Expression Tree Format
+
+The `selector` field is a recursive expression tree. Our builder constructs these programmatically.
+
+**Behavioral criterion** (references a behavior in the `behaviors` dict):
+```json
+{
+  "property": "behaviors",
+  "value": "bhvr_0",
+  "operator": ">=",
+  "operand": 3
+}
+```
+
+Frequency operators:
+- `at_least=N` → `"operator": ">="`, `"operand": N`
+- `at_most=N` → `"operator": "<="`, `"operand": N`
+- `exactly=N` → `"operator": "=="`, `"operand": N`
+- `exactly=0` → `"operator": "=="`, `"operand": 0` (equivalent to "did not do")
+
+**Property criterion** (user profile property):
+```json
+{
+  "property": "user",
+  "value": "plan",
+  "operator": "==",
+  "operand": "premium",
+  "type": "string"
+}
+```
+
+Operator mapping:
+| `CohortCriteria` operator | Selector `operator` |
+|---------------------------|---------------------|
+| `"equals"` | `"=="` |
+| `"not_equals"` | `"!="` |
+| `"contains"` | `"in"` |
+| `"not_contains"` | `"not in"` |
+| `"greater_than"` | `">"` |
+| `"less_than"` | `"<"` |
+| `"is_set"` | `"defined"` |
+| `"is_not_set"` | `"not defined"` |
+
+**Cohort reference criterion**:
+```json
+{
+  "property": "cohort",
+  "value": 456,
+  "operator": "in"
+}
+```
+
+Negated: `"operator": "not in"`.
+
+**Combining with AND/OR:**
+```json
+{
+  "operator": "and",
+  "children": [
+    {"property": "behaviors", "value": "bhvr_0", "operator": ">=", "operand": 1},
+    {"property": "user", "value": "plan", "operator": "==", "operand": "premium", "type": "string"}
+  ]
+}
+```
+
+### 3.6 Behavior Dictionary Format
+
+Each behavioral criterion produces an entry in the `behaviors` dict.
+
+**Event count with rolling window:**
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": null
+      },
+      "type": "absolute"
+    },
+    "window": {"unit": "day", "value": 30}
+  }
+}
+```
+
+**Event count with absolute date range:**
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": null
+      },
+      "type": "absolute"
+    },
+    "from_date": "2024-01-01",
+    "to_date": "2024-03-31"
+  }
+}
+```
+
+**Event count with event property filters:**
+
+When `where=` is provided, the `event_selector.selector` contains an expression tree filtering the events:
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": {
+          "operator": "and",
+          "children": [
+            {"property": "event", "value": "amount", "operator": ">", "operand": 50, "type": "number"}
+          ]
+        }
+      },
+      "type": "absolute"
+    },
+    "window": {"unit": "day", "value": 30}
+  }
+}
+```
+
+**Behavior count type:**
+- `"absolute"` — total event count across the window (default)
+- `"day"` — per-day event count (used for frequency-based criteria like "at least 3 times per day")
+
+### 3.7 Validation Rules (Phase 0)
+
+| Code | Rule | Message |
+|------|------|---------|
+| CD1 | `did_event`: exactly one frequency param required | `exactly one of at_least, at_most, exactly must be set` |
+| CD2 | `did_event`: frequency param must be non-negative | `frequency value must be >= 0` |
+| CD3 | `did_event`: exactly one time constraint required | `exactly one time constraint required (within_days/weeks/months or from_date+to_date)` |
+| CD4 | `did_event`: `event` must be non-empty | `event name must be non-empty` |
+| CD5 | `did_event`: `from_date` requires `to_date` | `from_date requires to_date` |
+| CD6 | `did_event`: dates must be YYYY-MM-DD | `dates must be YYYY-MM-DD format` |
+| CD7 | `has_property`: `property` must be non-empty | `property name must be non-empty` |
+| CD8 | `in_cohort`/`not_in_cohort`: `cohort_id` must be positive int | `cohort_id must be a positive integer` |
+| CD9 | `CohortDefinition`: at least one criterion required | `CohortDefinition requires at least one criterion` |
+| CD10 | `CohortDefinition.to_dict()`: all behavior keys must be unique | Internal invariant |
+
+### 3.8 Integration with Existing `CreateCohortParams`
+
+The builder integrates seamlessly with the existing cohort CRUD:
+
+```python
+# Build a cohort definition
+cohort_def = CohortDefinition.all_of(
+    CohortCriteria.has_property("plan", "premium"),
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+)
+
+# Create a saved cohort via CRUD
+ws.create_cohort(CreateCohortParams(
+    name="Premium Purchasers",
+    definition=cohort_def.to_dict(),
+))
+
+# Or use inline in queries (no saving required)
+result = ws.query(
+    "Login",
+    where=Filter.in_cohort(cohort_def, name="Premium Purchasers"),
+)
+```
+
+### 3.9 Example Definitions
+
+**Simple behavioral:**
+```python
+# Users who logged in at least once in the last 7 days
+CohortDefinition(
+    CohortCriteria.did_event("Login", at_least=1, within_days=7)
+)
+```
+
+**Simple property:**
+```python
+# Users on the premium plan
+CohortDefinition(
+    CohortCriteria.has_property("plan", "premium")
+)
+```
+
+**Combined AND:**
+```python
+# Premium users who purchased 3+ times in 30 days
+CohortDefinition.all_of(
+    CohortCriteria.has_property("plan", "premium"),
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+)
+```
+
+**Combined OR:**
+```python
+# Users who signed up recently OR are in the Power Users cohort
+CohortDefinition.any_of(
+    CohortCriteria.did_event("Signup", at_least=1, within_days=7),
+    CohortCriteria.in_cohort(456),
+)
+```
+
+**Nested boolean:**
+```python
+# (Premium AND active) OR Enterprise cohort
+CohortDefinition.any_of(
+    CohortDefinition.all_of(
+        CohortCriteria.has_property("plan", "premium"),
+        CohortCriteria.did_event("Login", at_least=5, within_days=30),
+    ),
+    CohortCriteria.in_cohort(789),  # Enterprise cohort
+)
+```
+
+**With event property filters:**
+```python
+# Users who made high-value purchases
+CohortDefinition(
+    CohortCriteria.did_event(
+        "Purchase",
+        at_least=1,
+        within_days=90,
+        where=Filter.greater_than("amount", 100),
+    )
+)
+```
+
+**Inactive users (did NOT do):**
+```python
+# Users who haven't logged in for 30 days
+CohortDefinition(
+    CohortCriteria.did_not_do_event("Login", within_days=30)
+)
+```
+
+---
+
+## 4. Current Infrastructure State (Unchanged from v1)
+
+### 4.1 What Already Exists
+
+The unified query system already has most of the infrastructure needed:
+
+| Component | Status | Extension Needed |
+|-----------|--------|-----------------|
+| `VALID_METRIC_TYPES` | `"cohort"` already included | None |
+| `VALID_RESOURCE_TYPES` | `"cohorts"` already included | None |
+| `Filter` class | 18 class methods for property filters | Add `in_cohort()`, `not_in_cohort()` |
+| `GroupBy` class | Property breakdowns with bucketing | N/A — new `CohortBreakdown` type |
+| `_build_filter_entry()` | Builds `sections.filter[]` dicts | Extend for cohort filter structure |
+| `validate_bookmark()` L2 | Validates `behavior.type` against `VALID_METRIC_TYPES` | Add cohort-specific validation branch |
+| `_validate_show_clause()` | Checks `behavior.name` for event types | Add branch for `behavior.type == "cohort"` checking `behavior.id` |
+| `_transform_query_result()` | Parses insights response | Compatible as-is (cohort response has same shape) |
+| Cohort CRUD | `list_cohorts_full()`, `get_cohort()`, etc. | Can validate cohort IDs exist |
+
+### 4.2 Shared Infrastructure Used By All Query Types
+
+These shared components will gain cohort capabilities:
+
+```
+Filter.in_cohort()          ─→  _build_filter_entry()     ─→  sections.filter[]
+                                  (extended for cohort format)
+
+CohortBreakdown             ─→  _build_group_section()    ─→  sections.group[]
+                                  (extended for cohort format)
+
+CohortMetric                ─→  _build_query_params()     ─→  sections.show[]
+                                  (extended for cohort behavior)
+```
+
+---
+
+## 5. API Design
+
+### 5.1 Cohort as Filter: `Filter.in_cohort()` / `Filter.not_in_cohort()`
+
+The simplest and most broadly useful capability. Works with all three query methods via the existing `where=` parameter. Accepts both saved cohort IDs and inline `CohortDefinition` objects.
+
+```python
+@classmethod
+def in_cohort(
+    cls,
+    cohort: int | CohortDefinition,
+    name: str | None = None,
+) -> Filter:
+    """Filter to users who are members of the specified cohort.
+
+    Args:
+        cohort: Saved cohort ID (integer) or inline CohortDefinition.
+        name: Display name for the cohort. Required for inline
+            definitions; optional for saved cohorts (API resolves).
+
+    Examples:
+        ```python
+        # Saved cohort by ID
+        result = ws.query(
+            "Purchase",
+            where=Filter.in_cohort(123, "Power Users"),
+        )
+
+        # Inline cohort definition (ad-hoc)
+        result = ws.query(
+            "Purchase",
+            where=Filter.in_cohort(
+                CohortDefinition(
+                    CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+                ),
+                name="Frequent Buyers",
+            ),
+        )
+
+        # Combine with property filters
+        result = ws.query(
+            "Purchase",
+            where=[
+                Filter.in_cohort(123),
+                Filter.equals("platform", "iOS"),
+            ],
+        )
+
+        # Also works with funnels and retention
+        result = ws.query_funnel(
+            ["Signup", "Purchase"],
+            where=Filter.in_cohort(456, "Organic Users"),
+        )
+        ```
+    """
+    ...
+
+@classmethod
+def not_in_cohort(
+    cls,
+    cohort: int | CohortDefinition,
+    name: str | None = None,
+) -> Filter:
+    """Filter to users who are NOT members of the specified cohort.
+
+    Args:
+        cohort: Saved cohort ID (integer) or inline CohortDefinition.
+        name: Display name for the cohort.
+
+    Examples:
+        ```python
+        # Exclude saved bot cohort
+        result = ws.query(
+            "Login",
+            where=Filter.not_in_cohort(789, "Bots"),
+        )
+
+        # Exclude ad-hoc inactive users
+        result = ws.query(
+            "Login",
+            where=Filter.not_in_cohort(
+                CohortDefinition(
+                    CohortCriteria.did_not_do_event("Login", within_days=30)
+                ),
+                name="Inactive Users",
+            ),
+        )
+        ```
+    """
+    ...
+```
+
+**Implementation detail:** These class methods produce a `Filter` with special internal fields:
+
+```python
+Filter(
+    _property="$cohorts",
+    _operator="contains",          # or "does not contain"
+    _value=[{"cohort": {"id": cohort_id, "name": name or "", "negated": False}}],
+    _property_type="list",
+    _resource_type="events",
+)
+```
+
+The `_build_filter_entry()` method detects `_property == "$cohorts"` and generates the cohort-specific filter JSON (which differs from property filter JSON in the `filterValue` structure).
+
+### 5.2 Cohort as Breakdown: `CohortBreakdown`
+
+A new type that can be passed alongside `GroupBy` in the `group_by=` parameter. Accepts both saved cohort IDs and inline definitions.
+
+```python
+@dataclass(frozen=True)
+class CohortBreakdown:
+    """Break down query results by cohort membership.
+
+    Segments users into "in cohort" and "not in cohort" groups.
+    Multiple CohortBreakdown entries produce independent segmentation
+    dimensions.
+
+    Args:
+        cohort: Saved cohort ID (integer) or inline CohortDefinition.
+        name: Display name for the cohort. Required for inline
+            definitions; optional for saved cohorts.
+        include_negated: Whether to include a "Not In" segment.
+            Default True. When False, only shows users IN the cohort.
+
+    Examples:
+        ```python
+        # Saved cohort breakdown
+        result = ws.query(
+            "Purchase",
+            group_by=CohortBreakdown(123, "Power Users"),
+        )
+
+        # Inline cohort breakdown
+        result = ws.query(
+            "Purchase",
+            group_by=CohortBreakdown(
+                CohortDefinition(
+                    CohortCriteria.did_event("Purchase", at_least=5, within_days=30)
+                ),
+                name="Frequent Buyers",
+            ),
+        )
+
+        # Mix cohort and property breakdowns (insights/funnels only)
+        result = ws.query(
+            "Purchase",
+            group_by=[
+                CohortBreakdown(123, "Power Users"),
+                GroupBy("platform"),
+            ],
+        )
+
+        # Funnel segmented by cohort
+        result = ws.query_funnel(
+            ["Signup", "Purchase"],
+            group_by=CohortBreakdown(456, "Organic Users"),
+        )
+        ```
+    """
+
+    cohort: int | CohortDefinition
+    name: str | None = None
+    include_negated: bool = True
+```
+
+**`group_by` parameter type expansion:**
+
+The existing `group_by` parameter on `query()`, `query_funnel()`, and `query_retention()` changes from:
+```python
+group_by: str | GroupBy | list[str | GroupBy] | None = None
+```
+to:
+```python
+group_by: str | GroupBy | CohortBreakdown | list[str | GroupBy | CohortBreakdown] | None = None
+```
+
+### 5.3 Cohort as Metric: `CohortMetric`
+
+A new type that can be passed in the `events=` parameter of `query()`, enabling "Cohorts Over Time" queries. Accepts both saved cohort IDs and inline definitions.
+
+```python
+@dataclass(frozen=True)
+class CohortMetric:
+    """A cohort size metric for Workspace.query().
+
+    Tracks the size of a cohort over time. Can be mixed with event
+    Metric objects and Formula objects in the same query.
+
+    The only valid math type for cohort metrics is "unique" — you
+    can only count unique users in a cohort at each time point.
+
+    Args:
+        cohort: Saved cohort ID (integer) or inline CohortDefinition.
+        name: Display name for the cohort. Used as the series label.
+            Required for inline definitions; optional for saved cohorts.
+
+    Examples:
+        ```python
+        # Saved cohort size over time
+        result = ws.query(
+            CohortMetric(123, "Power Users"),
+            last=90,
+        )
+
+        # Inline cohort — track ad-hoc segment size
+        result = ws.query(
+            CohortMetric(
+                CohortDefinition.all_of(
+                    CohortCriteria.has_property("plan", "premium"),
+                    CohortCriteria.did_event("Purchase", at_least=1, within_days=30),
+                ),
+                name="Active Premium Users",
+            ),
+            last=90,
+            unit="week",
+        )
+
+        # Compare saved and inline cohorts
+        result = ws.query([
+            CohortMetric(123, "Power Users"),
+            CohortMetric(
+                CohortDefinition(
+                    CohortCriteria.has_property("plan", "enterprise")
+                ),
+                name="Enterprise Users",
+            ),
+        ])
+
+        # Mix cohort and event metrics with a formula
+        result = ws.query(
+            [
+                CohortMetric(123, "Active Users"),
+                Metric("Purchase", math="unique"),
+            ],
+            formula="(B / A) * 100",
+            formula_label="Purchase Rate",
+            unit="week",
+        )
+
+        # Cohort size as a KPI
+        result = ws.query(
+            CohortMetric(123, "Power Users"),
+            mode="total",
+        )
+        total = result.df["count"].iloc[0]
+        ```
+    """
+
+    cohort: int | CohortDefinition
+    name: str | None = None
+```
+
+**`events` parameter type expansion** (on `query()` only):
+
+From:
+```python
+events: str | Metric | Formula | Sequence[str | Metric | Formula]
+```
+to:
+```python
+events: str | Metric | CohortMetric | Formula | Sequence[str | Metric | CohortMetric | Formula]
+```
+
+**Constraint:** `CohortMetric` is only valid in `query()`, NOT in `query_funnel()`, `query_retention()`, or `query_flow()`. This is enforced by the type system (those methods don't accept `CohortMetric` in their signatures) and by validation.
+
+---
+
+## 6. Bookmark JSON Mapping
+
+### 6.1 Cohort Filter → `sections.filter[]`
+
+```python
+# Filter.in_cohort(123, "Power Users")
+# generates:
+{
+    "dataset": "$mixpanel",
+    "value": "$cohorts",
+    "resourceType": "events",
+    "profileType": null,
+    "search": "",
+    "dataGroupId": null,
+    "filterType": "list",
+    "filterOperator": "contains",
+    "filterValue": [
+        {
+            "cohort": {
+                "id": 123,
+                "name": "Power Users",
+                "negated": false
+            }
+        }
+    ],
+    "propertyObjectKey": null,
+    "isHidden": false,
+    "determiner": "all"
+}
+```
+
+```python
+# Filter.not_in_cohort(789, "Bots")
+# generates:
+{
+    "dataset": "$mixpanel",
+    "value": "$cohorts",
+    "resourceType": "events",
+    "profileType": null,
+    "search": "",
+    "dataGroupId": null,
+    "filterType": "list",
+    "filterOperator": "does not contain",
+    "filterValue": [
+        {
+            "cohort": {
+                "id": 789,
+                "name": "Bots",
+                "negated": false
+            }
+        }
+    ],
+    "propertyObjectKey": null,
+    "isHidden": false,
+    "determiner": "all"
+}
+```
+
+### 6.2 Cohort Breakdown → `sections.group[]`
+
+```python
+# CohortBreakdown(123, "Power Users")
+# generates:
+{
+    "value": ["Power Users", "Not In Power Users"],
+    "resourceType": "events",
+    "profileType": null,
+    "search": "",
+    "dataGroupId": null,
+    "propertyType": null,
+    "typeCast": null,
+    "cohorts": [
+        {
+            "id": 123,
+            "name": "Power Users",
+            "negated": false,
+            "data_group_id": null,
+            "groups": []
+        },
+        {
+            "id": 123,
+            "name": "Power Users",
+            "negated": true,
+            "data_group_id": null,
+            "groups": []
+        }
+    ],
+    "isHidden": false
+}
+```
+
+```python
+# CohortBreakdown(123, "Power Users", include_negated=False)
+# generates only the "in" segment:
+{
+    "value": ["Power Users"],
+    "cohorts": [
+        {
+            "id": 123,
+            "name": "Power Users",
+            "negated": false,
+            "data_group_id": null,
+            "groups": []
+        }
+    ],
+    ...
+}
+```
+
+### 6.3 Cohort Metric → `sections.show[]`
+
+```python
+# CohortMetric(123, "Power Users")
+# generates:
+{
+    "type": "metric",
+    "behavior": {
+        "type": "cohort",
+        "name": "Power Users",
+        "id": 123,
+        "resourceType": "cohorts",
+        "dataGroupId": null,
+        "dataset": "$mixpanel",
+        "filtersDeterminer": "all",
+        "filters": []
+    },
+    "measurement": {
+        "math": "unique",
+        "property": null,
+        "perUserAggregation": null
+    },
+    "isHidden": false
+}
+```
+
+---
+
+## 7. Validation Rules
+
+### 7.1 Cohort Filter Validation (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| CF1 | `cohort_id` must be a positive integer | `cohort_id must be a positive integer (got {value})` |
+| CF2 | `name`, if provided, must be non-empty | `cohort name must be non-empty when provided` |
+
+These rules are enforced in the `Filter.in_cohort()` and `Filter.not_in_cohort()` class methods.
+
+### 7.2 Cohort Breakdown Validation (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| CB1 | `cohort_id` must be a positive integer | `CohortBreakdown cohort_id must be a positive integer` |
+| CB2 | `name`, if provided, must be non-empty | `CohortBreakdown name must be non-empty when provided` |
+| CB3 | Retention: `CohortBreakdown` is mutually exclusive with `GroupBy` | `query_retention does not support mixing CohortBreakdown with property GroupBy` |
+
+### 7.3 Cohort Metric Validation (Layer 1)
+
+| Code | Rule | Message |
+|------|------|---------|
+| CM1 | `cohort_id` must be a positive integer | `CohortMetric cohort_id must be a positive integer` |
+| CM2 | `name`, if provided, must be non-empty | `CohortMetric name must be non-empty when provided` |
+| CM3 | `CohortMetric` cannot use `math`/`math_property`/`per_user` top-level params | `math/math_property/per_user parameters are not applicable to CohortMetric (cohorts always use math="unique")` |
+| CM4 | `CohortMetric` is only valid in `query()`, not other query methods | Enforced by type signature |
+
+### 7.4 Bookmark Structure Validation (Layer 2 Extension)
+
+| Code | Rule | Message |
+|------|------|---------|
+| B22 | Cohort behavior requires `behavior.id` (positive integer) | `cohort behavior requires a positive integer id` |
+| B23 | Cohort behavior `resourceType` must be `"cohorts"` | `cohort behavior resourceType must be "cohorts"` |
+| B24 | Cohort behavior `math` must be `"unique"` | `cohort behavior only supports math="unique"` |
+| B25 | Cohort filter `value` must be `"$cohorts"` | (structural check in `_build_filter_entry`) |
+| B26 | Cohort group entry must have non-empty `cohorts` array | `cohort group_by requires at least one cohort entry` |
+
+---
+
+## 8. Implementation Architecture
+
+### 8.1 Changes to Shared Infrastructure
+
+#### `types.py` — New Types
+
+```python
+# New input types
+CohortMetric        # frozen dataclass — cohort_id, name
+CohortBreakdown     # frozen dataclass — cohort_id, name, include_negated
+
+# Type alias updates
+CohortGroupBy = str | GroupBy | CohortBreakdown
+CohortGroupByParam = CohortGroupBy | list[CohortGroupBy] | None
+```
+
+#### `_build_filter_entry()` — Extended for Cohort Filters
+
+The existing method detects `filter._property == "$cohorts"` and generates the cohort-specific JSON structure instead of the standard property filter structure.
+
+Key difference: cohort filters use `filterValue: [{cohort: {id, name, negated}}]` (array of cohort objects) instead of `filterValue: [scalar_value]`.
+
+#### `_build_group_section()` — Extended for Cohort Breakdowns
+
+When a `CohortBreakdown` is encountered in the `group_by` list, the builder generates a `sections.group[]` entry with:
+- `cohorts` array (with optional negated entry)
+- `value` array of display labels
+- `propertyType: null` (not a property)
+
+When a `GroupBy` or string is encountered, existing behavior is preserved.
+
+#### `_build_query_params()` — Extended for Cohort Metrics
+
+When a `CohortMetric` is encountered in the resolved events list, the builder generates a `sections.show[]` entry with:
+- `behavior.type: "cohort"` and `behavior.resourceType: "cohorts"`
+- `behavior.id` (integer cohort ID) instead of `behavior.name` (event name)
+- `measurement.math: "unique"` (always, ignoring top-level `math` param)
+
+### 8.2 Changes Per Query Method
+
+| Method | Cohort Filter | Cohort Breakdown | Cohort Metric |
+|--------|-------------|-----------------|---------------|
+| `query()` | `where=Filter.in_cohort(...)` | `group_by=CohortBreakdown(...)` | `events=CohortMetric(...)` |
+| `query_funnel()` | `where=Filter.in_cohort(...)` | `group_by=CohortBreakdown(...)` | N/A |
+| `query_retention()` | `where=Filter.in_cohort(...)` | `group_by=CohortBreakdown(...)` (exclusive with `GroupBy`) | N/A |
+| `query_flow()` | `where=Filter.in_cohort(...)` | N/A | N/A |
+
+#### `query_flow()` Cohort Filter — Special Handling
+
+Flows use the legacy `filter_by_cohort` format (tree structure) rather than `sections.filter[]`. When a `Filter.in_cohort()` is detected in `query_flow()`'s `where=` parameter, it is converted to the flows-specific `filter_by_cohort` tree via a new `_build_flow_cohort_filter()` helper:
+
+```python
+# Filter.in_cohort(123, "Power Users") in query_flow()
+# generates (at top level of flow params, not in sections):
+{
+    "filter_by_cohort": {
+        "operator": "or",
+        "children": [
+            {
+                "cohort": {
+                    "id": 123,
+                    "name": "Power Users",
+                    "negated": false
+                }
+            }
+        ]
+    }
+}
+```
+
+### 8.3 Validation Changes
+
+#### `validate_query_args()` — Extended
+
+- Detect `CohortMetric` entries in the events list
+- Skip `math`/`math_property`/`per_user` validation for `CohortMetric` entries (they always use `math="unique"`)
+- Validate `CohortMetric.cohort_id` is a positive integer
+
+#### `validate_funnel_args()` / `validate_retention_args()` — Extended
+
+- Validate `CohortBreakdown` entries in `group_by`
+- Retention: reject mixed `CohortBreakdown` + `GroupBy` in same `group_by` list (CB3)
+
+#### `validate_bookmark()` Layer 2 — Extended
+
+- Add B22-B26 rules for cohort behavior validation
+- When `behavior.type == "cohort"`, check `behavior.id` instead of `behavior.name`
+- Validate `measurement.math == "unique"` for cohort behaviors
+
+### 8.4 No Response Format Changes
+
+All three cohort capabilities produce responses that are structurally compatible with existing result types:
+
+- **Cohort metric**: Same `series` format as event metrics → `QueryResult` handles it
+- **Cohort filter**: Same response shape, just filtered data → no result type changes
+- **Cohort breakdown**: Series keys include cohort labels → DataFrame columns naturally accommodate this
+
+---
+
+## 9. Example Calls
+
+### 9.1 Cohort Filter — Insights
+
+```python
+# "How many purchases did Power Users make last 30 days?"
+result = ws.query(
+    "Purchase",
+    where=Filter.in_cohort(123, "Power Users"),
+)
+
+# "Purchases by non-bot users on iOS"
+result = ws.query(
+    "Purchase",
+    where=[
+        Filter.not_in_cohort(789, "Bots"),
+        Filter.equals("platform", "iOS"),
+    ],
+)
+```
+
+### 9.2 Cohort Filter — Funnels
+
+```python
+# "Signup → Purchase funnel for organic users only"
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    where=Filter.in_cohort(456, "Organic Users"),
+    conversion_window=14,
+)
+```
+
+### 9.3 Cohort Filter — Retention
+
+```python
+# "Week-over-week retention for premium users"
+result = ws.query_retention(
+    "Login", "Login",
+    where=Filter.in_cohort(123, "Premium Users"),
+    retention_unit="week",
+    last=90,
+)
+```
+
+### 9.4 Cohort Breakdown — Insights
+
+```python
+# "Compare purchases between Power Users and everyone else"
+result = ws.query(
+    "Purchase",
+    group_by=CohortBreakdown(123, "Power Users"),
+)
+
+# "Purchases broken down by cohort AND platform"
+result = ws.query(
+    "Purchase",
+    group_by=[
+        CohortBreakdown(123, "Power Users"),
+        GroupBy("platform"),
+    ],
+)
+```
+
+### 9.5 Cohort Breakdown — Funnels
+
+```python
+# "How does funnel conversion differ for Enterprise vs. everyone?"
+result = ws.query_funnel(
+    ["Signup", "Add to Cart", "Purchase"],
+    group_by=CohortBreakdown(456, "Enterprise"),
+)
+```
+
+### 9.6 Cohort Breakdown — Retention (Exclusive)
+
+```python
+# "Retention curve segmented by cohort"
+result = ws.query_retention(
+    "Signup", "Login",
+    group_by=CohortBreakdown(123, "Power Users"),
+    retention_unit="week",
+)
+
+# ERROR: Cannot mix CohortBreakdown with GroupBy in retention
+result = ws.query_retention(
+    "Signup", "Login",
+    group_by=[CohortBreakdown(123), GroupBy("platform")],  # raises ValueError
+)
+```
+
+### 9.7 Cohort Metric — Cohorts Over Time
+
+```python
+# "How is the Power Users cohort growing?"
+result = ws.query(
+    CohortMetric(123, "Power Users"),
+    last=90,
+    unit="week",
+)
+
+# "Compare two cohort sizes over time"
+result = ws.query([
+    CohortMetric(123, "Power Users"),
+    CohortMetric(456, "Enterprise Users"),
+])
+
+# "What percentage of active users are Power Users?"
+result = ws.query(
+    [
+        Metric("Login", math="unique"),
+        CohortMetric(123, "Power Users"),
+    ],
+    formula="(B / A) * 100",
+    formula_label="Power User %",
+    unit="week",
+)
+```
+
+### 9.8 Persisting Cohort Queries
+
+```python
+# Build params and save as a bookmark
+result = ws.query(
+    "Purchase",
+    where=Filter.in_cohort(123, "Power Users"),
+    group_by=CohortBreakdown(456, "Enterprise"),
+)
+
+ws.create_bookmark(CreateBookmarkParams(
+    name="Enterprise Purchases (Power Users)",
+    bookmark_type="insights",
+    params=result.params,
+))
+```
+
+---
+
+## 10. Scope Boundaries
+
+### In Scope
+
+- `CohortCriteria` — typed building blocks for cohort definitions (behavioral, property, cohort-membership criteria)
+- `CohortDefinition` — composable AND/OR builder producing valid `selector` + `behaviors` JSON
+- `Filter.in_cohort(cohort, name)` and `Filter.not_in_cohort(cohort, name)` — cohort membership filters
+- `CohortBreakdown(cohort, name, include_negated)` — cohort-based breakdowns
+- `CohortMetric(cohort, name)` — cohort size over time metrics
+- **Both saved cohort references (by `int` ID) AND inline definitions (via `CohortDefinition`)** — all three integration points accept `int | CohortDefinition`
+- All three capabilities in `query()` (insights)
+- Cohort filter and breakdown in `query_funnel()` and `query_retention()`
+- Cohort filter in `query_flow()` (via `filter_by_cohort` legacy format)
+- Client-side validation (CD1-CD10, CF1-CF2, CB1-CB3, CM1-CM3, B22-B26)
+- `.params` on results includes generated cohort JSON for debugging
+- `CohortDefinition.to_dict()` for standalone definition inspection
+- Integration with `CreateCohortParams(definition=cohort_def.to_dict())` for saving ad-hoc cohorts
+- `build_params()`, `build_funnel_params()`, `build_retention_params()`, `build_flow_params()` all support cohort capabilities
+
+### Could Be Added Later (v2+)
+
+| Feature | Complexity | Trigger |
+|---------|-----------|---------|
+| Multi-cohort filters (multiple cohort IDs in one `Filter`) | Low | `Filter.in_cohorts([id1, id2])` |
+| `data_group_id` / B2B group scoping | Medium | B2B analytics users need entity-group scoping |
+| Cohort breakdown in `query_flow()` | Medium | Flows breakdown uses different top-level structure |
+| Validate cohort ID exists via API | Low | `ws.get_cohort(id)` before query; opt-in |
+| Funnel-based cohort criteria | Medium | `CohortCriteria.completed_funnel(steps=[...])` |
+| Report-based cohort criteria | Medium | `CohortCriteria.from_retention_report(bookmark_id=...)` |
+| Per-day frequency criteria | Low | `CohortCriteria.did_event(..., count_type="day")` |
+
+### Explicitly Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Creating/modifying cohorts via query API | Separate concern — use existing cohort CRUD methods |
+| `data_group_id` / B2B groups | Adds complexity for a niche use case; `null` works for standard projects |
+| Cohort metrics in funnels/retention/flows | Not supported by Mixpanel's API (cohort metric is insights-only) |
+| `sections.cohorts[]` legacy format | Always generate modern `sections.group[]` format for breakdowns |
+| Report-based cohort definitions (funnel_report, retention_report, addiction_report, flows_report) | Complex internal structures; v2+ with dedicated builder methods |
+| `groups` (modern) format generation | Legacy `selector`+`behaviors` format works everywhere; `groups` is a UI abstraction |
+
+---
+
+## 11. Implementation Plan
+
+### Phase 0: Cohort Definition Builder (Prerequisite)
+
+The foundation for all subsequent phases. Produces valid JSON for both CRUD and inline queries.
+
+1. Add `CohortCriteria` frozen dataclass to `types.py`
+   - `did_event()`, `did_not_do_event()` — behavioral criteria with frequency + time window
+   - `has_property()`, `property_is_set()`, `property_is_not_set()` — user profile property criteria
+   - `in_cohort()`, `not_in_cohort()` — cohort membership criteria
+   - Internal `_selector_node`, `_behavior_key`, `_behavior` fields
+2. Add `CohortDefinition` frozen dataclass to `types.py`
+   - `__init__(*criteria)` — single or AND-combined criteria
+   - `all_of()`, `any_of()` — class methods for explicit AND/OR
+   - `to_dict()` — produces `{"selector": {...}, "behaviors": {...}}`
+   - Recursive nesting support for `(A AND B) OR C` patterns
+3. Add `_build_selector_tree()` — constructs expression tree from criteria
+4. Add `_build_event_selector()` — converts `Filter` objects to event selector expressions
+5. Add validation rules CD1-CD10
+6. Tests (TDD): definition construction, serialization round-trip, nested boolean logic, validation edge cases
+7. Property-based tests (Hypothesis) for `CohortDefinition`
+8. Exports in `__init__.py`: `CohortCriteria`, `CohortDefinition`
+
+### Phase 1: Cohort Filters (Shared Infrastructure)
+
+The highest-value query integration. Immediately useful across all query types. Now accepts `int | CohortDefinition`.
+
+1. Add `Filter.in_cohort()` and `Filter.not_in_cohort()` — accept `int | CohortDefinition`
+2. Extend `_build_filter_entry()` to detect `_property == "$cohorts"` and generate cohort filter JSON
+   - For `int` cohort: `filterValue: [{cohort: {id, name, negated: false}}]`
+   - For `CohortDefinition`: `filterValue: [{cohort: {raw_cohort: def.to_dict(), name, negated: false}}]`
+3. Add `_build_flow_cohort_filter()` for flows-specific `filter_by_cohort` tree
+4. Add validation rules CF1-CF2
+5. Extend `_build_flow_params()` to extract cohort filters into `filter_by_cohort`
+6. Tests (TDD): saved + inline filter construction, bookmark validation, flow cohort filter
+
+### Phase 2: Cohort Breakdowns
+
+1. Add `CohortBreakdown` frozen dataclass — `cohort: int | CohortDefinition`
+2. Update `group_by` parameter type on `query()`, `query_funnel()`, `query_retention()`
+3. Extend `_build_group_section()` to handle `CohortBreakdown` entries
+   - For `int`: `cohorts: [{id, name, negated, data_group_id: null, groups: []}]`
+   - For `CohortDefinition`: `cohorts: [{raw_cohort: def.to_dict(), name, negated, ...}]`
+4. Add validation rules CB1-CB3 (including retention mutual exclusivity)
+5. Extend Layer 2 `validate_bookmark()` with B26
+6. Tests (TDD): saved + inline group construction, retention exclusivity, mixed groups
+
+### Phase 3: Cohort Metrics
+
+1. Add `CohortMetric` frozen dataclass — `cohort: int | CohortDefinition`
+2. Update `events` parameter type on `query()` to accept `CohortMetric`
+3. Extend `_resolve_and_build_params()` to handle `CohortMetric` in events list
+4. Extend `_build_query_params()` to generate `behavior.type: "cohort"` show entries
+   - For `int`: `behavior.id = cohort_id`
+   - For `CohortDefinition`: `behavior.raw_cohort = def.to_dict()`
+5. Add validation rules CM1-CM3, B22-B24
+6. Tests (TDD): saved + inline show clause construction, formula interaction, validation
+
+### Phase 4: Polish
+
+- Property-based tests (Hypothesis) for all new types including `CohortDefinition` ↔ query integration
+- Mutation testing on new validation rules (CD1-CD10, CF1-CF2, CB1-CB3, CM1-CM3, B22-B26)
+- Documentation: docstrings, examples in context docs
+- Exports in `__init__.py`
+
+---
+
+## 12. Design Rationale
+
+### 12.1 Why a Cohort Definition Builder as Phase 0
+
+**Decision:** Build `CohortCriteria` + `CohortDefinition` before any query integration.
+
+**Rationale:** Every cohort integration point (filter, breakdown, metric) needs to reference a cohort. Supporting only saved cohort IDs would be a half-measure — LLM agents cannot create saved cohorts interactively. The builder enables:
+1. **Inline ad-hoc cohorts** in queries without pre-saving
+2. **Programmatic cohort creation** via `create_cohort(definition=def.to_dict())`
+3. **Type-safe construction** — no raw dict guessing
+4. **Composability** — combine criteria with AND/OR, nest arbitrarily
+
+Without Phase 0, agents would need a two-step workflow (create cohort, then query) for every ad-hoc segment. With Phase 0, inline cohorts are a single expression.
+
+### 12.2 Why the Legacy `selector` + `behaviors` Format
+
+**Decision:** Generate the legacy expression tree format, not the modern `groups` format.
+
+**Alternatives considered:**
+- (A) Generate `groups` format (modern UI format)
+- (B) Generate `selector` + `behaviors` format (legacy backend format)
+
+**Why (B) wins:**
+1. **Universal compatibility** — works in `create_cohort()` AND `raw_cohort` in inline query references. The `groups` format is not accepted in `raw_cohort` by all code paths.
+2. **Direct backend mapping** — the backend parses `selector` + `behaviors` natively. The `groups` format requires a conversion step (UI → selector/behaviors).
+3. **Explicit semantics** — each behavior is a named, inspectable entry. The `groups` format bundles behaviors inside `PropertyFilter.customProperty` objects.
+4. **Simpler construction** — expression trees are straightforward to build programmatically. The `groups` format requires constructing `PropertyFilter` UI model objects.
+
+### 12.3 Why `Filter.in_cohort()` Instead of a Separate `cohort_filter=` Parameter
+
+**Decision:** Add class methods to the existing `Filter` type.
+
+**Why:** Cohort membership filtering is semantically the same operation as property filtering — restricting which users are included. The `where=` parameter already accepts `Filter | list[Filter]`. Adding `Filter.in_cohort()` lets users combine cohort and property filters naturally:
+
+```python
+where=[Filter.in_cohort(123), Filter.equals("platform", "iOS")]
+```
+
+### 12.4 Why `CohortBreakdown` Instead of Extending `GroupBy`
+
+**Decision:** A new `CohortBreakdown` type, accepted alongside `GroupBy` in `group_by=`.
+
+**Why:** Cohort breakdowns and property breakdowns have fundamentally different JSON structures. `GroupBy` produces `{propertyName, propertyType, value, customBucket}`. A cohort breakdown produces `{cohorts: [...], value: ["name", "Not In name"]}`. A union type keeps each type focused.
+
+### 12.5 Why `CohortMetric` Instead of Extending `Metric`
+
+**Decision:** A new `CohortMetric` type, accepted alongside `Metric` in `events=`.
+
+**Why:** `Metric` wraps an event name with aggregation settings. `CohortMetric` wraps a cohort reference — no event name, no math choice (always `"unique"`), no property. Zero field overlap. A shared type would have mostly-inapplicable fields.
+
+### 12.6 Why `int | CohortDefinition` on All Integration Points
+
+**Decision:** Every cohort parameter accepts both `int` (saved) and `CohortDefinition` (inline).
+
+**Rationale:** This is the core design upgrade from v1. The type union provides:
+1. **Maximum flexibility** — use saved cohorts when they exist, inline when they don't
+2. **Uniform API** — callers don't need separate methods for saved vs. inline
+3. **Agent-friendly** — an LLM can construct an inline cohort in a single expression without a multi-step save-then-reference workflow
+4. **Progressive disclosure** — `Filter.in_cohort(123)` for the simple case, `Filter.in_cohort(CohortDefinition(...))` for the powerful case
+
+### 12.7 Why `name` is Optional for Saved Cohorts, Required for Inline
+
+**Decision:** `name` is optional when referencing saved cohorts (by ID), but effectively required for inline `CohortDefinition` objects.
+
+**Rationale:** Saved cohorts have names in the database — the API resolves them from IDs. Inline cohorts have no stored name, so the caller must provide one for meaningful series labels and bookmark display. The parameter is typed as `str | None` for uniformity, but validation warns when an inline cohort lacks a name.
+
+---
+
+## Appendix A: Source Code References
+
+### Analytics Codebase (Canonical Implementation)
+
+| Area | File | Key Lines | What |
+|------|------|-----------|------|
+| MetricType enum | `iron/common/types/reports/bookmark.ts` | 882-894 | `MetricType.Cohort = "cohort"` |
+| InsightsResourceType | `iron/common/types/reports/bookmark.ts` | 819-829 | `Cohort = "cohort"`, `Cohorts = "cohorts"` |
+| Behavior interface | `iron/common/types/reports/bookmark.ts` | 517-552 | `type`, `id`, `name`, `dataGroupId`, `raw_cohort` |
+| GroupByCohort interface | `iron/common/types/reports/bookmark.ts` | 288-304 | Cohort breakdown entry type |
+| CohortsClause | `iron/common/report/insights/models/cohorts-clause.ts` | 9-16 | `id`, `name`, `negated`, `raw_cohort`, `data_group_id` |
+| Cohort filter default | `iron/common/report/insights/models/filter-clause.ts` | 67-78 | `defaultCohortsAttrs()` |
+| `$cohorts` constant | `iron/common/widgets/property-filter-menu/models/insights-filter.ts` | 76 | `INSIGHTS_COHORT_TYPE = "$cohorts"` |
+| Cohort metric detection | `api/version_2_0/insights/params.py` | 2475-2476 | `_is_cohorts_metric()` |
+| Cohort filter detection | `api/version_2_0/insights/params_util.py` | 156-157 | `is_cohort_filter()` |
+| Cohort query execution | `api/version_2_0/insights/cohorts.py` | 250 | `cohorts_size_over_time()` |
+| Segment by cohorts ARB | `api/version_2_0/cohorts/selector.py` | 4-23 | `segment_by_cohorts_action()` |
+| Cohort group-by processing | `api/version_2_0/insights/segmentation_arb.py` | 427-445 | ARB group action with cohorts |
+| Retention cohort restriction | `api/version_2_0/retention/util.py` | 270-271 | Mutual exclusivity with property breakdowns |
+| Cohort filter → tree | `bookmark_parser/common/property_filter/utils.py` | 1-15 | `convert_cohort_property_filter_to_tree_filter()` |
+| Django Cohort model | `engage/models.py` | 195-355 | `id: int`, `data_group_id: BigIntegerField` |
+
+### mixpanel_data Codebase (Our Implementation)
+
+| Area | File | Key Lines | What |
+|------|------|-----------|------|
+| `VALID_METRIC_TYPES` | `_internal/bookmark_enums.py` | 242-255 | Already includes `"cohort"` |
+| `VALID_RESOURCE_TYPES` | `_internal/bookmark_enums.py` | 224-234 | Already includes `"cohorts"`, `"cohort"` |
+| `_validate_show_clause()` | `_internal/validation.py` | 1936+ | Needs cohort branch for `behavior.id` check |
+| `_build_filter_entry()` | `workspace.py` | varies | Needs cohort filter extension |
+| `_build_query_params()` | `workspace.py` | 1659+ | Needs cohort behavior generation |
+| Cohort CRUD | `workspace.py` | 4499-4669 | `list_cohorts_full()`, `get_cohort()`, etc. |
+| `Cohort` type | `types.py` | 3325+ | Pydantic model for CRUD, not query |
+| `CreateCohortParams` | `types.py` | 3427+ | Accepts `definition` dict (target for `CohortDefinition.to_dict()`) |
+
+### Cohort Definition Builder References (Phase 0)
+
+| Area | File | Key Lines | What |
+|------|------|-----------|------|
+| Cohort model (TS) | `iron/common/query-builder/cohorts-query-builder/models/cohort.ts` | 81-648 | `Cohort` class with `serialize()` producing `selector`+`behaviors` or `groups` |
+| Behavior model (TS) | `iron/common/query-builder/cohorts-query-builder/models/behaviors/behavior.ts` | 32-285 | `Behavior` class: `count`, `funnel`, `report`, `window`, `from_date`/`to_date` |
+| BehaviorCount (TS) | `iron/common/query-builder/cohorts-query-builder/models/behaviors/behavior-count.ts` | 10-50 | `BehaviorCount`: `event_selector` + `type` (absolute/day) |
+| EventSelector (TS) | `iron/common/query-builder/cohorts-query-builder/models/behaviors/event-selector.ts` | 4-18 | `EventSelector`: `event` + `selector` (expression tree) |
+| Expression enums (TS) | `iron/common/query-builder/cohorts-query-builder/models/enums/expression-enums.ts` | 1-51 | `ArithmeticOperator`, `BehaviorCountType`, `Property` enums |
+| Serialized types (TS) | `iron/common/query-builder/cohorts-query-builder/models/types/serialized-cohort-types.ts` | 29-55 | `SerializedCohort`, `SerializedBehavior`, `RawCohort` interfaces |
+| CohortGroupEntry (TS) | `iron/common/query-builder/query-entry-section/types.ts` | 508-512 | Modern `groups` format entry type |
+| FiltersOperator (TS) | `iron/common/query-builder/query-entry-section/types.ts` | 299 | AND/OR/Then operators for group combining |
+| Report-based cohorts (TS) | `iron/common/query-builder/cohorts-query-builder/models/types/serialized-cohort-types.ts` | 100-105 | `ReportBasedCohorts` enum: Addiction, Flows, Funnels, Retention |
+| Cohort Django model | `engage/models.py` | 195-355 | DB schema: `definition` (JSON text), `data_group_id` |

--- a/context/custom-events-properties-query-integration.md
+++ b/context/custom-events-properties-query-integration.md
@@ -1,0 +1,1722 @@
+# Custom Events & Custom Properties — Query Integration Design
+
+**Date**: 2026-04-06
+**Status**: Research Complete — Design Proposal
+**Builds on**: `insights-query-api-design.md`, `unified-bookmark-query-design.md`
+**Reference**: `analytics/` repo (Mixpanel canonical implementation)
+
+---
+
+## 1. Executive Summary
+
+This document synthesizes deep research into Mixpanel's custom events and custom properties systems, analyzes their integration points with the bookmark query engine, and proposes a typed API design for first-class support in `mixpanel_data`'s query system (`query()`, `query_funnel()`, `query_retention()`, `query_flow()`).
+
+### Key Findings
+
+1. **Custom events are virtual event unions** — named groups of real events with optional per-event property filters. They are stored in the database and expanded at query time into constituent event selectors.
+
+2. **Custom properties are virtual computed properties** — calculated at query time from raw properties using either a **formula** (text-based arb-selector expression language) or a **behavioral aggregation** (e.g., "total purchases in last 30 days").
+
+3. **Inline custom properties are a first-class feature** — the Mixpanel query engine natively supports inline `customProperty` definitions in bookmark params alongside persisted `customPropertyId` references. This is not a hack; it's the primary path for "Apply without Save" in the UI.
+
+4. **Inline custom events are NOT supported for insights/retention** — insights and retention queries resolve custom events by database ID only (`$custom_event:{id}`). Funnels have a partial inline path via the `alternatives` key in event selectors, but this is internal plumbing rather than a documented user-facing feature.
+
+5. **The existing query system has clear extension points** — the `_build_*_params()` methods, `build_filter_entry()`, `build_group_section()`, and the `Metric`/`FunnelStep`/`RetentionEvent`/`FlowStep` types all have natural places to accept custom event references and custom property specifications.
+
+### Design Recommendation
+
+- **Custom events**: Reference-by-ID approach across all query types. Add `CustomEventRef` type. Inline custom events for funnels as a stretch goal.
+- **Custom properties**: Dual-path approach — reference saved CPs by ID (`CustomPropertyRef`) AND define inline CPs with formulas (`InlineCustomProperty`). Both are natively supported by the query engine.
+- **CRUD gap**: Add `create_custom_event()` and `get_custom_event()` to Workspace (currently missing) to complete the create-then-reference workflow.
+
+---
+
+## 2. Research Findings: Custom Events
+
+### 2.1 What Custom Events Are
+
+Custom events are **virtual/computed events** that do not exist in the raw event stream. A custom event is a **named union of one or more real events** (called "alternatives"), each optionally filtered by property conditions. They are sometimes called "event groups."
+
+Key characteristics:
+- Canonical name format: `$custom_event:{id}` (e.g., `$custom_event:42`)
+- Stored in the `custom_events_customevent` and `custom_events_alternative` database tables
+- At query time, expanded into constituent event selectors (a list of `{event, selector}` pairs)
+- Can be **nested**: an alternative can reference another custom event via `$custom_event:{id}` as the event name
+- Cycle detection prevents circular references
+- Maximum 25 alternatives per custom event (`MAX_NUMBER_OF_ALTERNATIVES = 25`)
+
+### 2.2 Data Model
+
+**Django Models** (`analytics/webapp/custom_events/models.py`):
+
+| Table | Key Fields |
+|-------|-----------|
+| `CustomEvent` | `id`, `name`, `project`, `workspace`, `creator`, `deleted` (soft), `is_visibility_restricted`, `is_modification_restricted` |
+| `Alternative` | `custom_event` (FK), `event` (str), `serialized` (selector expression), `valid_segfilter` (JSON segfilter) |
+
+**API JSON shape** (from `to_json()`):
+```json
+{
+    "id": 42,
+    "name": "Signup or Login",
+    "deleted": 0,
+    "project_id": 123,
+    "alternatives": [
+        {"event": "Signup"},
+        {"event": "Login", "valid_segfilter": {"op": "and", "filters": [...]}},
+        {"event": "$custom_event:10"}
+    ],
+    "is_collect_everything_event": false,
+    "is_visibility_restricted": false,
+    "user_id": 456
+}
+```
+
+### 2.3 Custom Event Composition
+
+| Composition Type | Example | Semantics |
+|-----------------|---------|-----------|
+| **Event union** | `[{"event": "Signup"}, {"event": "Register"}]` | Match ANY of these events (OR logic) |
+| **Filtered event** | `[{"event": "Purchase", "valid_segfilter": {"op":"and","filters":[...]}}]` | Match event + property conditions |
+| **Nesting** | `[{"event": "$custom_event:10"}, {"event": "Direct Signup"}]` | Include all events from another custom event |
+| **All events with filter** | `[{"event": "$all_events", "valid_segfilter": {...}}]` | Match all events passing filter |
+
+### 2.4 How Custom Events Appear in Bookmark Params
+
+**In `sections.show[].behavior`:**
+```json
+{
+    "behavior": {
+        "type": "custom-event",
+        "name": "$custom_event:42",
+        "id": 42,
+        "resourceType": "events",
+        "filtersDeterminer": "all",
+        "filters": [],
+        "dataGroupId": null,
+        "dataset": "$mixpanel"
+    },
+    "measurement": {
+        "math": "total",
+        "property": null
+    }
+}
+```
+
+**Differences from a regular event:**
+
+| Field | Regular Event | Custom Event |
+|-------|--------------|-------------|
+| `behavior.type` | `"event"` | `"custom-event"` |
+| `behavior.name` | `"Login"` | `"$custom_event:{id}"` |
+| `behavior.id` | absent | integer DB ID |
+
+**In funnel sub-behaviors** (steps referencing custom events):
+```json
+{
+    "type": "event",
+    "name": "$custom_event:42",
+    "funnelOrder": "loose"
+}
+```
+Note: funnel sub-behaviors use `type: "event"` with the `$custom_event:{id}` name pattern, not `type: "custom-event"`.
+
+### 2.5 Query-Time Resolution
+
+The expansion happens in `api/version_2_0/custom_events/util.py`:
+
+```
+Bookmark param: behavior.name = "$custom_event:42"
+    ↓
+process_event_selectors() detects $custom_event:\d+ regex
+    ↓
+get_custom_event(42) — DB lookup (cached)
+    ↓
+generate_custom_event_selectors() — recursive expansion
+    ↓
+Result: [{event: "Signup", selector: "..."}, {event: "Login", selector: "..."}]
+```
+
+Nested custom events are recursively resolved. Deleted custom events produce `{event: "$deleted_custom_event", selector: "false"}` (always-empty result).
+
+### 2.6 Inline Custom Events — Capability Analysis
+
+| Query Type | Inline Custom Events? | Mechanism |
+|-----------|----------------------|-----------|
+| **Insights** | **No** | Must be pre-created. `insights_query()` → `process_event_selectors()` resolves by DB ID only. |
+| **Funnels** | **Partial** | `funnel_metric_params_util.py:72` passes `alternatives` through in event selectors. This is internal plumbing — the UI always creates/saves first. |
+| **Retention** | **No** | Same insights endpoint, same resolution path. |
+| **Flows** | **No** | `show_custom_events: True` displays saved custom events in flow graphs but doesn't define them inline. |
+
+**Bottom line**: Custom events must be created and saved (via App API) before they can be used in queries. The reference-by-ID approach is the only reliable path across all query types.
+
+---
+
+## 3. Research Findings: Custom Properties
+
+### 3.1 What Custom Properties Are
+
+Custom properties are **virtual computed properties** that do not exist in raw event or profile data. They are calculated at query time from raw properties using one of two definition types:
+
+1. **Formula-based** (`displayFormula` + `composedProperties`): A text expression in the arb-selector formula language that references raw properties via letter variables (A, B, C...).
+
+2. **Behavior-based** (`behavior`): A behavioral aggregation that computes a value from a user's event stream (e.g., "total count of Login events in the last 30 days").
+
+These two types are **mutually exclusive** — enforced by validation.
+
+### 3.2 Data Model
+
+**Django Model** (`analytics/webapp/custom_properties/models.py`):
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `id` | int PK | Unique identifier (`customPropertyId` in API) |
+| `name` | str(255) | Display name |
+| `description` | str(255) | Optional description |
+| `resource_type` | `"events"` or `"people"` | Which data domain (immutable after creation) |
+| `property_type` | str | Inferred type: `"string"`, `"number"`, `"boolean"`, `"datetime"`, `"list"` |
+| `definition` | JSON | Either `{displayFormula, composedProperties}` or `{behavior}` |
+| `data_group_id` | int | For B2B group properties (immutable) |
+| `active` | bool | Soft delete flag |
+| `is_visible`, `is_locked` | bool | Visibility/lock controls |
+| `referenced_custom_properties` | M2M self | Dependency graph (cycle prevention) |
+
+### 3.3 Formula Language (arb-selector)
+
+The formula language is a **text-based expression language** with spreadsheet-like syntax. It is NOT a JSON expression tree. Key capabilities:
+
+| Category | Functions |
+|----------|-----------|
+| **Arithmetic** | `+`, `-`, `*`, `/`, `%`, `CEIL()`, `FLOOR()`, `ROUND()`, `MAX()`, `MIN()`, `NUMBER()` |
+| **String** | `STRING()`, `UPPER()`, `LOWER()`, `LEFT()`, `RIGHT()`, `MID()`, `LEN()`, `SPLIT()`, `HAS_PREFIX()`, `HAS_SUFFIX()`, `REGEX_EXTRACT()`, `REGEX_MATCH()`, `REGEX_REPLACE()`, `PARSE_URL()` |
+| **Conditional** | `IF()`, `IFS()` |
+| **Boolean** | `AND`, `OR`, `NOT`, `AND()`, `OR()`, `TRUE`, `FALSE`, `IN` |
+| **Type** | `BOOLEAN()`, `STRING()`, `NUMBER()`, `TYPEOF()`, `DEFINED()`, `UNDEFINED` |
+| **Date/Time** | `TODAY()`, `DATEDIF()` |
+| **List** | `ANY()`, `ALL()`, `MAP()`, `FILTER()`, `SUM()`, `LEN()` |
+| **Variable** | `LET()` — assign intermediate values |
+| **Comparison** | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+
+**Formula + composedProperties example:**
+```json
+{
+    "displayFormula": "A * B",
+    "composedProperties": {
+        "A": {"resourceType": "event", "type": "number", "value": "price"},
+        "B": {"resourceType": "event", "type": "number", "value": "quantity"}
+    }
+}
+```
+
+The letter variables (A, B, C...) in the formula map to entries in `composedProperties`. Each entry specifies the raw property name (`value`), its data type (`type`), and its resource domain (`resourceType`).
+
+### 3.4 Behavior-Based Custom Properties
+
+A behavioral property computes a value from a user's event history:
+
+```json
+{
+    "behavior": {
+        "aggregationOperator": "sum",
+        "event": {"value": "Purchase"},
+        "property": {"value": "amount"},
+        "dateRange": {"type": "in the last", "window": {"unit": "day", "value": 30}},
+        "filters": [],
+        "filtersOperator": "and"
+    }
+}
+```
+
+| `aggregationOperator` | Output Type | Description |
+|----------------------|-------------|-------------|
+| `"total"` | number | Count of matching events |
+| `"sum"` | number | Sum of property values |
+| `"most_frequent"` | string | Most common property value |
+| `"first_value"` | string | First occurrence of property value |
+| `"first_event_time"` | datetime | Timestamp of first matching event |
+| `"scd_value"` | varies | Slowly-changing dimension value |
+| `"multi_attribution"` | varies | Attribution model (last touch, participation, etc.) |
+
+### 3.5 Where Custom Properties Appear in Bookmark Params
+
+Custom properties can appear in **three positions**:
+
+**1. In `sections.group[]` (breakdowns):**
+```json
+{
+    "group": [{
+        "customPropertyId": 42,
+        "customProperty": {"displayFormula": "A * B", "composedProperties": {...}},
+        "propertyType": "number",
+        "value": null
+    }]
+}
+```
+
+**2. In `sections.filter[]` (filters):**
+```json
+{
+    "filter": [{
+        "customPropertyId": "$temp-abc123",
+        "customProperty": {"displayFormula": "A", "composedProperties": {...}, "propertyType": "string"},
+        "filterOperator": "equals",
+        "filterValue": ["Chrome"]
+    }]
+}
+```
+
+**3. In `sections.show[].measurement.property` (metric measurement):**
+```json
+{
+    "measurement": {
+        "math": "average",
+        "property": {
+            "name": "Revenue",
+            "resourceType": "events",
+            "customPropertyId": 42,
+            "customProperty": {"displayFormula": "A * B", "composedProperties": {...}}
+        }
+    }
+}
+```
+
+### 3.6 Inline Custom Properties — Capability Analysis
+
+**Inline custom properties are a first-class, natively supported feature.** Evidence:
+
+1. **Frontend `InlineCustomPropertiesStore`** (`iron/common/report/stores/inline-custom-properties-store.ts`): Dedicated store for inline/unsaved custom properties with temporary `$temp-*` IDs.
+
+2. **Detection utilities** (`iron/common/widgets/custom-property-modal/util.ts`): `isPersistedCustomProperty()` (numeric ID) vs `isInlineCustomProperty()` (temp string ID).
+
+3. **Query resolution** (`backend/util/arb_selector.py:630-643`): The `segment_to_arb_selector()` function first checks for `customPropertyId` (DB lookup), then falls through to the inline `customProperty` dict. Both paths produce identical arb-selector expansion.
+
+4. **Internal usage**: Revenue change properties, SCD "any" queries, and experiment properties all dynamically construct inline `customProperty` definitions at query time — proving the inline path is production-grade.
+
+5. **UI workflow**: "Apply without Save" → property is used inline with `$temp-*` ID. "Save" → property gets a real numeric ID. Either way, the query engine handles it identically.
+
+| Query Type | Inline Custom Properties? | Mechanism |
+|-----------|--------------------------|-----------|
+| **Insights** | **Yes** | `customProperty` field in group/filter/measurement |
+| **Funnels** | **Yes** | Same `customProperty` field |
+| **Retention** | **Yes** | Same `customProperty` field |
+| **Flows** | **No** | Flows use segfilter format; custom properties aren't supported in flows breakdowns |
+
+### 3.7 Query-Time Resolution
+
+For **formula-based** custom properties:
+```
+customProperty: {displayFormula: "A * B", composedProperties: {A: {value: "price"}, B: {value: "quantity"}}}
+    ↓
+segment_to_arb_selector() detects customPropertyId or customProperty
+    ↓
+_expand_formula_property() recursively expands composedProperties
+    ↓
+substitute_variables() (C parser) replaces A, B with arb-selector expressions
+    ↓
+Result: arb selector string computing the formula inline
+```
+
+For **behavior-based** custom properties:
+```
+customProperty: {behavior: {aggregationOperator: "sum", event: {value: "Purchase"}, ...}}
+    ↓
+_raw_behavior_to_arb_selector() converts to computed behavior
+    ↓
+Registers in QueryBehaviors, returns computed_event reference
+    ↓
+Result: behavior-backed arb selector
+```
+
+---
+
+## 4. Current System Extension Points
+
+### 4.1 Types That Need Extension
+
+| Type | Current `event` Field | Custom Event Support |
+|------|----------------------|---------------------|
+| `Metric` | `event: str` | Accept `str \| CustomEventRef` |
+| `FunnelStep` | `event: str` | Accept `str \| CustomEventRef` |
+| `RetentionEvent` | `event: str` | Accept `str \| CustomEventRef` |
+| `FlowStep` | `event: str` | Accept `str \| CustomEventRef` |
+
+| Type | Current `property` Field | Custom Property Support |
+|------|-------------------------|------------------------|
+| `Metric` | `property: str \| None` | Accept `str \| CustomPropertyRef \| InlineCustomProperty \| None` |
+| `GroupBy` | `property: str` | Accept `str \| CustomPropertyRef \| InlineCustomProperty` |
+| `Filter` class methods | `property: str` (1st arg) | Accept `str \| CustomPropertyRef \| InlineCustomProperty` |
+
+### 4.2 Builders That Need Extension
+
+| Builder | Change Needed |
+|---------|--------------|
+| `_build_query_params()` | Emit `behavior.type = "custom-event"` and `behavior.id` when `Metric.event` is `CustomEventRef` |
+| `_build_funnel_params()` | Emit `$custom_event:{id}` name in funnel sub-behaviors |
+| `_build_retention_params()` | Emit `$custom_event:{id}` name in retention behaviors |
+| `build_filter_entry()` | Emit `customPropertyId` / `customProperty` when filter uses CP |
+| `build_group_section()` | Emit `customPropertyId` / `customProperty` in group clause |
+| Metric measurement builder | Emit `customPropertyId` / `customProperty` in measurement.property |
+
+### 4.3 Validation Already Supports `"custom-event"`
+
+The `bookmark_enums.py` already includes `"custom-event"` in `VALID_METRIC_TYPES`:
+```python
+VALID_METRIC_TYPES = frozenset({
+    "event", "simple", "custom-event", "cohort", "people",
+    "funnel", "retention", "addiction", "formula", "metric",
+})
+```
+
+And `validate_bookmark()` Layer 2 already handles it:
+```python
+if btype in ("event", "simple", "custom-event"):
+    # validates behavior has a name
+```
+
+### 4.4 CRUD Gap
+
+| Domain | Capability | Status |
+|--------|-----------|--------|
+| Custom Events | `list_custom_events()` | Exists (via Lexicon data-definitions) |
+| Custom Events | `get_custom_event(id)` | **Missing** |
+| Custom Events | `create_custom_event(name, alternatives)` | **Missing** |
+| Custom Events | `update_custom_event()` | Partial — only Lexicon metadata, NOT alternatives |
+| Custom Events | `delete_custom_event()` | Exists |
+| Custom Properties | Full CRUD | Complete (`list`, `create`, `get`, `update`, `delete`, `validate`) |
+
+The CRUD gap for custom events is a prerequisite for the reference-by-ID approach. Users need `create_custom_event()` to create the custom event before referencing it in queries.
+
+---
+
+## 5. Proposed Design
+
+### 5.1 New Types
+
+#### `CustomEventRef` — Reference a Saved Custom Event
+
+```python
+@dataclass(frozen=True)
+class CustomEventRef:
+    """Reference to a saved custom event for use in queries.
+
+    Custom events are virtual events that combine multiple real events
+    (with optional property filters) into a single queryable entity.
+    They must be created first via ``create_custom_event()`` or the
+    Mixpanel UI, then referenced by their integer ID.
+
+    Attributes:
+        id: The custom event's database ID (from ``create_custom_event()``
+            response or ``list_custom_events()``).
+        label: Optional display label for query results. If omitted,
+            the custom event's saved name is used.
+
+    Examples:
+        ```python
+        # Reference in a simple query
+        result = ws.query(CustomEventRef(42))
+
+        # Reference with aggregation settings
+        result = ws.query(Metric(event=CustomEventRef(42), math="unique"))
+
+        # In a funnel
+        result = ws.query_funnel([CustomEventRef(42), "Purchase"])
+
+        # In retention
+        result = ws.query_retention(
+            born_event=CustomEventRef(42),
+            return_event="Login",
+        )
+        ```
+    """
+
+    id: int
+    label: str | None = None
+```
+
+#### `CustomPropertyRef` — Reference a Saved Custom Property
+
+```python
+@dataclass(frozen=True)
+class CustomPropertyRef:
+    """Reference to a saved custom property by ID.
+
+    Use when the custom property already exists in the project
+    (created via ``create_custom_property()`` or the Mixpanel UI).
+    The query engine fetches the definition by ID at execution time.
+
+    Attributes:
+        id: The custom property's ID (``customPropertyId``).
+        label: Optional display label. If omitted, uses the saved name.
+
+    Examples:
+        ```python
+        # As a breakdown dimension
+        result = ws.query("Purchase", group_by=GroupBy(
+            property=CustomPropertyRef(42)
+        ))
+
+        # As an aggregation property
+        result = ws.query(Metric(
+            "Purchase", math="average",
+            property=CustomPropertyRef(42),
+        ))
+
+        # As a filter target
+        result = ws.query("Purchase", where=Filter.greater_than(
+            property=CustomPropertyRef(42), value=100,
+        ))
+        ```
+    """
+
+    id: int
+    label: str | None = None
+```
+
+#### `PropertyInput` — Input Property for an Inline Custom Property Formula
+
+```python
+@dataclass(frozen=True)
+class PropertyInput:
+    """An input property reference for an inline custom property formula.
+
+    Maps a letter variable in the formula to a raw event or user property.
+
+    Attributes:
+        name: The raw property name (e.g., ``"price"``, ``"$browser"``).
+        type: Property data type. Default ``"string"``.
+        resource_type: Property domain. ``"event"`` for event properties,
+            ``"user"`` for user/people properties. Default ``"event"``.
+
+    Examples:
+        ```python
+        PropertyInput("price", type="number")
+        PropertyInput("$browser", type="string")
+        PropertyInput("plan", type="string", resource_type="user")
+        ```
+    """
+
+    name: str
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    resource_type: Literal["event", "user"] = "event"
+```
+
+#### `InlineCustomProperty` — Define an Ad-Hoc Computed Property Inline
+
+```python
+@dataclass(frozen=True)
+class InlineCustomProperty:
+    """An inline (ephemeral) custom property defined directly in a query.
+
+    Defines a computed property using the arb-selector formula language.
+    The formula uses single-letter variables (A, B, C...) that map to
+    entries in ``inputs``. The property is computed at query time without
+    being saved to the project.
+
+    This is a first-class Mixpanel feature — the query engine natively
+    supports inline custom property definitions in bookmark params.
+
+    Attributes:
+        formula: Expression in arb-selector formula language. Uses
+            single-letter variables (A, B, C...) referencing ``inputs``.
+        inputs: Mapping from letter variables to property references.
+            Keys must be single uppercase letters A-Z matching the
+            formula variables.
+        property_type: Result type of the formula. If ``None``, the
+            server infers it. Explicit typing improves validation.
+        resource_type: Which data domain this property applies to.
+            Default ``"events"``.
+
+    Formula Language Reference:
+        - Arithmetic: ``+``, ``-``, ``*``, ``/``, ``%``, ``CEIL()``,
+          ``FLOOR()``, ``ROUND()``, ``NUMBER()``
+        - String: ``UPPER()``, ``LOWER()``, ``LEFT()``, ``RIGHT()``,
+          ``MID()``, ``LEN()``, ``SPLIT()``, ``REGEX_EXTRACT()``,
+          ``REGEX_MATCH()``, ``REGEX_REPLACE()``, ``PARSE_URL()``
+        - Conditional: ``IF(condition, then, else)``,
+          ``IFS(c1, v1, c2, v2, ..., TRUE, default)``
+        - Boolean: ``AND``, ``OR``, ``NOT``, ``TRUE``, ``FALSE``, ``IN``
+        - Type: ``BOOLEAN()``, ``STRING()``, ``NUMBER()``, ``TYPEOF()``,
+          ``DEFINED()``, ``UNDEFINED``
+        - Date: ``TODAY()``, ``DATEDIF()``
+        - List: ``ANY()``, ``ALL()``, ``MAP()``, ``FILTER()``, ``SUM()``
+
+    Examples:
+        ```python
+        # Revenue = price * quantity
+        InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+        )
+
+        # Extract email domain
+        InlineCustomProperty(
+            formula='REGEX_EXTRACT(A, "@(.+)$")',
+            inputs={"A": PropertyInput("email", type="string")},
+            property_type="string",
+        )
+
+        # Tiered pricing
+        InlineCustomProperty(
+            formula='IFS(A > 1000, "Enterprise", A > 100, "Pro", TRUE, "Free")',
+            inputs={"A": PropertyInput("amount", type="number")},
+            property_type="string",
+        )
+
+        # Use a user property
+        InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("plan", type="string", resource_type="user")},
+            property_type="string",
+        )
+        ```
+    """
+
+    formula: str
+    inputs: dict[str, PropertyInput]
+    property_type: Literal["string", "number", "boolean", "datetime"] | None = None
+    resource_type: Literal["events", "people"] = "events"
+
+    @classmethod
+    def numeric(
+        cls,
+        formula: str,
+        /,
+        **properties: str,
+    ) -> InlineCustomProperty:
+        """Create a numeric formula from named properties.
+
+        Convenience constructor where all inputs are numeric event properties.
+        Property names are mapped to formula variables in the order provided.
+
+        Args:
+            formula: Formula expression using single-letter variables.
+            **properties: Mapping of letter variable to property name.
+
+        Returns:
+            An InlineCustomProperty with all-numeric inputs.
+
+        Examples:
+            ```python
+            # Revenue = price * quantity
+            InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+            # Profit margin
+            InlineCustomProperty.numeric(
+                "(A - B) / A * 100", A="revenue", B="cost"
+            )
+            ```
+        """
+        return cls(
+            formula=formula,
+            inputs={k: PropertyInput(v, type="number") for k, v in properties.items()},
+            property_type="number",
+        )
+```
+
+### 5.2 Type Aliases
+
+```python
+# Union type for event specification in queries
+EventSpec = str | CustomEventRef
+"""An event specifier: either a plain event name string or a custom event reference."""
+
+# Union type for property specification in queries
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+"""A property specifier: plain name, saved custom property reference, or inline formula."""
+```
+
+### 5.3 Modified Types
+
+#### `Metric` — Accept Custom Events and Custom Properties
+
+```python
+@dataclass(frozen=True)
+class Metric:
+    event: str | CustomEventRef          # CHANGED from str
+    math: MathType = "total"
+    property: str | CustomPropertyRef | InlineCustomProperty | None = None  # CHANGED from str | None
+    per_user: PerUserAggregation | None = None
+    percentile_value: int | float | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+```
+
+**Backward-compatible**: `Metric("Login")` still works (str is in the union). New usage: `Metric(CustomEventRef(42), math="unique")`.
+
+#### `FunnelStep` — Accept Custom Events
+
+```python
+@dataclass(frozen=True)
+class FunnelStep:
+    event: str | CustomEventRef          # CHANGED from str
+    label: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+    order: Literal["loose", "any"] | None = None
+```
+
+#### `RetentionEvent` — Accept Custom Events
+
+```python
+@dataclass(frozen=True)
+class RetentionEvent:
+    event: str | CustomEventRef          # CHANGED from str
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+```
+
+#### `FlowStep` — Accept Custom Events
+
+```python
+@dataclass(frozen=True)
+class FlowStep:
+    event: str | CustomEventRef          # CHANGED from str
+    forward: int | None = None
+    reverse: int | None = None
+    label: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+```
+
+#### `GroupBy` — Accept Custom Properties
+
+```python
+@dataclass(frozen=True)
+class GroupBy:
+    property: str | CustomPropertyRef | InlineCustomProperty  # CHANGED from str
+    property_type: Literal["string", "number", "boolean", "datetime"] = "string"
+    bucket_size: int | float | None = None
+    bucket_min: int | float | None = None
+    bucket_max: int | float | None = None
+```
+
+When `property` is a `CustomPropertyRef` or `InlineCustomProperty`, the `property_type` field is still used for bucketing decisions. For `InlineCustomProperty`, if `property_type` is set on the CP, it takes precedence.
+
+#### `Filter` Class Methods — Accept Custom Properties
+
+All `Filter` class methods change their first positional `property` parameter type:
+
+```python
+@classmethod
+def equals(
+    cls,
+    property: str | CustomPropertyRef | InlineCustomProperty,  # CHANGED from str
+    value: str | list[str],
+    *,
+    resource_type: Literal["events", "people"] = "events",
+) -> Filter:
+    """Property equals value (or any value in list)."""
+    ...
+
+# Same pattern for: not_equals, contains, not_contains, greater_than,
+# less_than, between, is_set, is_not_set, is_true, is_false,
+# on, not_on, before, since, in_the_last, not_in_the_last, date_between
+```
+
+**Internal storage change**: `_property` field changes from `str` to `str | CustomPropertyRef | InlineCustomProperty`. The builder (`build_filter_entry()`) detects the type and emits the appropriate JSON.
+
+#### `query()` Method Signature — Accept Custom Events
+
+```python
+def query(
+    self,
+    events: str | Metric | CustomEventRef | Sequence[str | Metric | CustomEventRef],  # CHANGED
+    *,
+    # ... all other params unchanged
+) -> QueryResult:
+```
+
+**Resolution rules update**:
+- `str` → `Metric(event=str, math=<top-level math>, ...)` (unchanged)
+- `Metric` → used as-is (unchanged)
+- `CustomEventRef` → `Metric(event=CustomEventRef, math=<top-level math>, ...)` (new)
+
+#### `query_funnel()` Method Signature
+
+```python
+def query_funnel(
+    self,
+    steps: Sequence[str | FunnelStep | CustomEventRef],  # CHANGED
+    *,
+    # ... all other params unchanged
+) -> FunnelQueryResult:
+```
+
+#### `query_retention()` Method Signature
+
+```python
+def query_retention(
+    self,
+    born_event: str | RetentionEvent | CustomEventRef,   # CHANGED
+    return_event: str | RetentionEvent | CustomEventRef,  # CHANGED
+    *,
+    # ... all other params unchanged
+) -> RetentionQueryResult:
+```
+
+#### `query_flow()` Method Signature
+
+```python
+def query_flow(
+    self,
+    event: str | FlowStep | CustomEventRef | Sequence[str | FlowStep | CustomEventRef],  # CHANGED
+    *,
+    # ... all other params unchanged
+) -> FlowQueryResult:
+```
+
+### 5.4 Bookmark Builder Changes
+
+#### `_build_query_params()` — Custom Event Behavior Block
+
+```python
+# Current (regular event only):
+behavior = {
+    "type": "event",
+    "name": event_name,
+    "resourceType": "events",
+    ...
+}
+
+# New (handles both):
+if isinstance(resolved_event, CustomEventRef):
+    behavior = {
+        "type": "custom-event",
+        "name": f"$custom_event:{resolved_event.id}",
+        "id": resolved_event.id,
+        "resourceType": "events",
+        ...
+    }
+else:
+    behavior = {
+        "type": "event",
+        "name": event_name,
+        "resourceType": "events",
+        ...
+    }
+```
+
+#### `_build_funnel_params()` — Custom Event in Funnel Steps
+
+```python
+# Funnel sub-behaviors use "event" type with $custom_event:{id} name:
+if isinstance(step_event, CustomEventRef):
+    sub_behavior = {
+        "type": "event",
+        "name": f"$custom_event:{step_event.id}",
+        "funnelOrder": order,
+        ...
+    }
+```
+
+#### `_build_retention_params()` — Custom Event in Retention Behaviors
+
+Same pattern as funnels — use `$custom_event:{id}` as the behavior name.
+
+#### `_build_flow_params()` — Custom Event in Flow Steps
+
+```python
+# Flows use flat event selectors:
+if isinstance(step_event, CustomEventRef):
+    step_dict = {
+        "event": f"$custom_event:{step_event.id}",
+        ...
+    }
+```
+
+#### `build_filter_entry()` — Custom Property in Filters
+
+```python
+# Current:
+entry = {
+    "resourceType": f._resource_type,
+    "filterType": f._property_type,
+    "value": f._property,
+    ...
+}
+
+# New (when _property is a CustomPropertyRef):
+if isinstance(f._property, CustomPropertyRef):
+    entry = {
+        "customPropertyId": f._property.id,
+        "filterType": f._property_type,
+        ...
+    }
+
+# New (when _property is an InlineCustomProperty):
+elif isinstance(f._property, InlineCustomProperty):
+    entry = {
+        "customProperty": {
+            "displayFormula": f._property.formula,
+            "composedProperties": _build_composed_properties(f._property.inputs),
+            "propertyType": f._property.property_type,
+        },
+        "filterType": f._property.property_type or f._property_type,
+        ...
+    }
+```
+
+#### `build_group_section()` — Custom Property in Group-By
+
+```python
+# Current:
+group_entry = {
+    "value": g.property,
+    "propertyName": g.property,
+    "resourceType": "events",
+    "propertyType": g.property_type,
+    ...
+}
+
+# New (CustomPropertyRef):
+if isinstance(g.property, CustomPropertyRef):
+    group_entry = {
+        "customPropertyId": g.property.id,
+        "propertyType": g.property_type,
+        ...
+    }
+
+# New (InlineCustomProperty):
+elif isinstance(g.property, InlineCustomProperty):
+    group_entry = {
+        "customProperty": {
+            "displayFormula": g.property.formula,
+            "composedProperties": _build_composed_properties(g.property.inputs),
+            "propertyType": g.property.property_type or g.property_type,
+        },
+        "propertyType": g.property.property_type or g.property_type,
+        ...
+    }
+```
+
+#### Measurement Property — Custom Property in Metric Aggregation
+
+```python
+# Current:
+measurement = {
+    "math": math,
+    "property": {"name": prop_name, "resourceType": "events", "type": "number"},
+    ...
+}
+
+# New (CustomPropertyRef):
+if isinstance(metric.property, CustomPropertyRef):
+    measurement = {
+        "math": math,
+        "property": {
+            "customPropertyId": metric.property.id,
+            "resourceType": "events",
+        },
+        ...
+    }
+
+# New (InlineCustomProperty):
+elif isinstance(metric.property, InlineCustomProperty):
+    measurement = {
+        "math": math,
+        "property": {
+            "customProperty": {
+                "displayFormula": metric.property.formula,
+                "composedProperties": _build_composed_properties(metric.property.inputs),
+            },
+            "resourceType": metric.property.resource_type,
+        },
+        ...
+    }
+```
+
+#### Shared Helper — `_build_composed_properties()`
+
+```python
+def _build_composed_properties(
+    inputs: dict[str, PropertyInput],
+) -> dict[str, dict[str, str]]:
+    """Convert PropertyInput dict to bookmark composedProperties format.
+
+    Args:
+        inputs: Letter-variable to PropertyInput mapping.
+
+    Returns:
+        Bookmark-format composedProperties dict.
+    """
+    return {
+        letter: {
+            "value": prop_input.name,
+            "type": prop_input.type,
+            "resourceType": prop_input.resource_type,
+        }
+        for letter, prop_input in inputs.items()
+    }
+```
+
+### 5.5 Validation Changes
+
+#### Layer 1 — Argument Validation
+
+New validation rules:
+
+| Code | Rule | Message |
+|------|------|---------|
+| CE1 | `CustomEventRef.id` must be a positive integer | `custom event ID must be a positive integer` |
+| CP1 | `CustomPropertyRef.id` must be a positive integer | `custom property ID must be a positive integer` |
+| CP2 | `InlineCustomProperty.formula` must be non-empty | `inline custom property formula must be non-empty` |
+| CP3 | `InlineCustomProperty.inputs` must be non-empty | `inline custom property must have at least one input` |
+| CP4 | `InlineCustomProperty.inputs` keys must be single uppercase letters A-Z | `inline custom property input keys must be single uppercase letters (A-Z)` |
+| CP5 | All formula variables must have matching inputs | `formula references variable '{var}' but no matching input was provided` |
+| CP6 | Formula max length 20,000 characters | `formula exceeds maximum length of 20,000 characters` |
+
+Modified validation rules:
+
+| Code | Change |
+|------|--------|
+| V17 | Skip "event name must be a string" check when event is `CustomEventRef` |
+| V22 | Skip "event name must be non-empty" check when event is `CustomEventRef` |
+
+#### Layer 2 — Bookmark Structure Validation
+
+- B7 already validates `behavior.type` against `VALID_METRIC_TYPES` which includes `"custom-event"` — no change needed.
+- B8 already handles `"custom-event"` behavior type — validates name presence.
+- Add: When `behavior.type == "custom-event"`, validate that `behavior.id` is present and is a positive integer.
+
+---
+
+## 6. Usage Examples
+
+### 6.1 Custom Events in Insights
+
+```python
+# List available custom events
+custom_events = ws.list_custom_events()
+# [EventDefinition(name="All Signups", custom_event_id=42), ...]
+
+# Simple query with a custom event
+result = ws.query(CustomEventRef(42))
+
+# Custom event with aggregation
+result = ws.query(CustomEventRef(42), math="unique", last=90)
+
+# Custom event as a Metric (per-event math control)
+result = ws.query(Metric(
+    event=CustomEventRef(42),
+    math="unique",
+))
+
+# Multi-metric: custom event + regular event
+result = ws.query([
+    Metric(event=CustomEventRef(42), math="unique"),
+    Metric("Purchase", math="unique"),
+])
+
+# Formula with custom event
+result = ws.query(
+    [CustomEventRef(42), "Purchase"],
+    formula="(B / A) * 100",
+    formula_label="Conversion Rate",
+)
+
+# Custom event with breakdown and filter
+result = ws.query(
+    CustomEventRef(42),
+    math="unique",
+    group_by="platform",
+    where=[Filter.equals("country", "US")],
+)
+```
+
+### 6.2 Custom Events in Funnels
+
+```python
+# Custom event as a funnel step
+result = ws.query_funnel([
+    CustomEventRef(42),  # "All Signups"
+    "Add to Cart",
+    "Purchase",
+])
+
+# Custom event with per-step filters
+result = ws.query_funnel([
+    FunnelStep(event=CustomEventRef(42)),
+    FunnelStep("Purchase", filters=[Filter.greater_than("amount", 50)]),
+])
+
+# Mixed custom events and regular events
+result = ws.query_funnel([
+    CustomEventRef(42),   # "All Signups"
+    CustomEventRef(43),   # "Engagement" (another custom event)
+    "Purchase",
+])
+```
+
+### 6.3 Custom Events in Retention
+
+```python
+# Custom event as born event
+result = ws.query_retention(
+    born_event=CustomEventRef(42),  # "All Signups"
+    return_event="Login",
+    retention_unit="week",
+)
+
+# Both events as custom events
+result = ws.query_retention(
+    born_event=CustomEventRef(42),
+    return_event=CustomEventRef(43),
+)
+```
+
+### 6.4 Custom Events in Flows
+
+```python
+# Custom event as flow anchor
+result = ws.query_flow(CustomEventRef(42), forward=3, reverse=2)
+```
+
+### 6.5 Custom Properties — Saved Reference
+
+```python
+# As breakdown
+result = ws.query("Purchase", group_by=GroupBy(
+    property=CustomPropertyRef(99),
+    property_type="number",
+    bucket_size=100,
+))
+
+# As filter
+result = ws.query("Purchase", where=Filter.greater_than(
+    property=CustomPropertyRef(99),
+    value=1000,
+))
+
+# As aggregation property
+result = ws.query(Metric(
+    "Purchase",
+    math="average",
+    property=CustomPropertyRef(99),
+))
+```
+
+### 6.6 Custom Properties — Inline Formula
+
+```python
+# Revenue = price * quantity (breakdown by revenue bucket)
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+        ),
+        property_type="number",
+        bucket_size=100,
+        bucket_min=0,
+        bucket_max=1000,
+    ),
+)
+
+# Using the convenience constructor
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        property_type="number",
+        bucket_size=100,
+    ),
+)
+
+# Extract email domain (filter by domain)
+result = ws.query(
+    "Signup",
+    where=Filter.equals(
+        property=InlineCustomProperty(
+            formula='REGEX_EXTRACT(A, "@(.+)$")',
+            inputs={"A": PropertyInput("email", type="string")},
+            property_type="string",
+        ),
+        value="company.com",
+    ),
+)
+
+# Tiered pricing breakdown
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty(
+            formula='IFS(A > 1000, "Enterprise", A > 100, "Pro", TRUE, "Free")',
+            inputs={"A": PropertyInput("amount", type="number")},
+            property_type="string",
+        ),
+    ),
+)
+
+# Average of computed property
+result = ws.query(Metric(
+    "Purchase",
+    math="average",
+    property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+))
+
+# Inline CP in funnel breakdown
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    group_by=GroupBy(
+        property=InlineCustomProperty(
+            formula='IF(A == "mobile", "Mobile", "Desktop")',
+            inputs={"A": PropertyInput("platform", type="string")},
+            property_type="string",
+        ),
+    ),
+)
+```
+
+### 6.7 Create-Then-Reference Workflow
+
+```python
+# Step 1: Create a custom event
+ce = ws.create_custom_event(
+    name="All Signups",
+    alternatives=[
+        EventAlternative("Signup"),
+        EventAlternative("Register"),
+        EventAlternative("OAuth Login", filters=[
+            Filter.equals("provider", ["Google", "GitHub"]),
+        ]),
+    ],
+)
+# ce.id = 42
+
+# Step 2: Use in queries
+result = ws.query(CustomEventRef(ce.id), math="unique", last=90)
+
+# Step 3: Create a custom property
+cp = ws.create_custom_property(CreateCustomPropertyParams(
+    name="Revenue per Item",
+    resource_type="events",
+    display_formula="A * B",
+    composed_properties={
+        "A": ComposedPropertyValue(resource_type="event", type="number", value="price"),
+        "B": ComposedPropertyValue(resource_type="event", type="number", value="quantity"),
+    },
+))
+# cp.custom_property_id = 99
+
+# Step 4: Use in queries
+result = ws.query("Purchase", group_by=GroupBy(
+    property=CustomPropertyRef(cp.custom_property_id),
+    property_type="number",
+    bucket_size=100,
+))
+```
+
+### 6.8 Combined: Custom Event + Custom Property
+
+```python
+# Query a custom event, broken down by an inline custom property,
+# filtered by a saved custom property
+result = ws.query(
+    CustomEventRef(42),
+    math="unique",
+    group_by=GroupBy(
+        property=InlineCustomProperty(
+            formula='IF(A == "iOS", "Mobile", IF(A == "Android", "Mobile", "Desktop"))',
+            inputs={"A": PropertyInput("platform", type="string")},
+            property_type="string",
+        ),
+    ),
+    where=Filter.greater_than(
+        property=CustomPropertyRef(99),  # "Revenue per Item"
+        value=50,
+    ),
+    last=30,
+)
+```
+
+---
+
+## 7. New CRUD Methods
+
+### 7.1 `create_custom_event()`
+
+```python
+def create_custom_event(
+    self,
+    name: str,
+    alternatives: Sequence[str | EventAlternative],
+) -> CustomEventResult:
+    """Create a custom event (virtual event union).
+
+    A custom event combines multiple real events into a single queryable
+    entity. Each alternative specifies an event name with optional
+    property filters.
+
+    Args:
+        name: Display name for the custom event.
+        alternatives: Event alternatives. Plain strings are shorthand
+            for ``EventAlternative(event_name)`` with no filters.
+
+    Returns:
+        The created custom event with its assigned ID.
+
+    Raises:
+        APIError: If the custom event could not be created.
+        ValueError: If fewer than 1 alternative or more than 25.
+
+    Examples:
+        ```python
+        ce = ws.create_custom_event("All Signups", [
+            "Signup",
+            "Register",
+            EventAlternative("OAuth Login", filters=[
+                Filter.equals("provider", ["Google", "GitHub"]),
+            ]),
+        ])
+        ```
+    """
+```
+
+### 7.2 `get_custom_event()`
+
+```python
+def get_custom_event(
+    self,
+    custom_event_id: int,
+) -> CustomEventResult:
+    """Get a custom event by ID.
+
+    Args:
+        custom_event_id: The custom event's database ID.
+
+    Returns:
+        The custom event definition including all alternatives.
+
+    Raises:
+        APIError: If the custom event is not found or access is denied.
+    """
+```
+
+### 7.3 Supporting Types
+
+```python
+@dataclass(frozen=True)
+class EventAlternative:
+    """An alternative event within a custom event definition.
+
+    Each alternative specifies an event name to include in the custom
+    event union, with optional property filters.
+
+    Attributes:
+        event: Event name to include. Can also be ``"$custom_event:{id}"``
+            to nest another custom event.
+        filters: Optional property filters for this alternative.
+        filters_combinator: How filters combine. Default ``"all"`` (AND).
+
+    Examples:
+        ```python
+        EventAlternative("Signup")
+        EventAlternative("Purchase", filters=[
+            Filter.greater_than("amount", 50),
+        ])
+        ```
+    """
+
+    event: str
+    filters: list[Filter] | None = None
+    filters_combinator: Literal["all", "any"] = "all"
+
+
+@dataclass(frozen=True)
+class CustomEventResult:
+    """Result of a custom event CRUD operation.
+
+    Attributes:
+        id: Server-assigned custom event ID.
+        name: Display name.
+        alternatives: List of alternative event definitions.
+        project_id: Project the custom event belongs to.
+        deleted: Whether the custom event is soft-deleted.
+    """
+
+    id: int
+    name: str
+    alternatives: list[dict[str, Any]]
+    project_id: int
+    deleted: bool = False
+```
+
+---
+
+## 8. Design Decisions and Rationale
+
+### 8.1 Why Reference-by-ID for Custom Events Instead of Auto-Create
+
+**Decision**: Custom events in queries are always referenced by their saved ID. No auto-creation.
+
+**Alternatives considered**:
+- (A) Accept inline `InlineCustomEvent` definitions, auto-create via App API, then reference by ID.
+- (B) Accept inline definitions and pass them through to the query engine (if supported).
+
+**Why (A) was rejected**: Auto-creation has hidden side effects — it creates persistent entities in the project. This violates the principle that `query()` should be a read-only operation. Users would accumulate orphaned custom events. Cleanup would require separate delete calls. The behavior is surprising for an LLM agent that expects `query()` to be idempotent.
+
+**Why (B) was rejected**: The insights query engine does NOT support inline custom event definitions. The `process_event_selectors()` function always resolves `$custom_event:{id}` by database lookup. There is no inline expansion path for insights or retention. Funnels have a partial `alternatives` path, but it's internal plumbing, not a documented feature.
+
+**Why reference-by-ID wins**: It's explicit, predictable, and works consistently across all query types. The create-then-reference workflow matches how custom events work in the Mixpanel UI. The minor friction of calling `create_custom_event()` first is offset by clarity and debuggability.
+
+### 8.2 Why Inline Support for Custom Properties
+
+**Decision**: Support both `CustomPropertyRef` (saved) and `InlineCustomProperty` (ad-hoc) in queries.
+
+**Rationale**: Unlike custom events, inline custom properties are a **first-class, production-grade feature** of the Mixpanel query engine. The `segment_to_arb_selector()` function natively handles inline `customProperty` definitions. The UI's "Apply without Save" workflow relies on this. Revenue change properties, SCD queries, and experiment properties all use inline custom properties internally.
+
+Supporting inline custom properties adds significant value for LLM agents:
+- **No pre-creation step**: An agent can compute derived metrics in a single query call.
+- **Exploration**: Try different formulas without creating persistent entities.
+- **Composability**: Build complex analytics from raw properties without CRUD overhead.
+
+### 8.3 Why `PropertyInput` Instead of Reusing `ComposedPropertyValue`
+
+**Decision**: Introduce a new `PropertyInput` frozen dataclass instead of reusing the existing Pydantic `ComposedPropertyValue` model.
+
+**Rationale**: `ComposedPropertyValue` is a Pydantic model designed for App API request/response serialization. It has `extra="allow"`, camelCase alias generation, and a loosely-typed `behavior: Any` field. For the query API, we want a tight, frozen dataclass with explicit typing and no extra baggage — consistent with the existing `Metric`, `Filter`, `GroupBy` pattern. The builder converts `PropertyInput` to the bookmark JSON format at build time.
+
+### 8.4 Why Union Types on Existing Fields Instead of Separate Parameters
+
+**Decision**: Extend `Metric.event` from `str` to `str | CustomEventRef`, and `GroupBy.property` from `str` to `str | CustomPropertyRef | InlineCustomProperty`.
+
+**Alternatives considered**:
+- (A) Add separate fields: `Metric.custom_event_id: int | None = None`, `GroupBy.custom_property_id: int | None = None`
+- (B) Add separate parameters to query methods: `custom_events=`, `custom_properties=`
+- (C) Use union types on existing fields
+
+**Why (C) wins**: It's the most natural for LLMs and the most consistent with the progressive disclosure pattern already established. `Metric("Login")` and `Metric(CustomEventRef(42))` are analogous — both specify "which event to query." The field name `event` remains semantically correct for custom events (they ARE events, just virtual ones). Separate fields or parameters would create ambiguity: "Do I use `event` or `custom_event_id`? What if both are set?"
+
+### 8.5 Why `CustomEventRef` Instead of String Convention
+
+**Decision**: Use a typed `CustomEventRef(42)` instead of accepting `"$custom_event:42"` as a string.
+
+**Rationale**: String conventions are fragile and error-prone. An LLM might write `"custom_event:42"` or `"$custom_event_42"` or `"ce:42"`. A typed class with an `id: int` field is unambiguous, self-documenting, and validated at construction time. It also enables IDE autocompletion and type-checker support.
+
+### 8.6 Why Not Support Behavior-Based Inline Custom Properties (v1)
+
+**Decision**: `InlineCustomProperty` supports formula-based definitions only. Behavior-based custom properties must be created and referenced by ID.
+
+**Rationale**: Behavior-based custom properties (e.g., "total purchases in last 30 days") have a complex JSON structure with nested event references, date ranges, aggregation operators, and filter lists. Supporting them inline would require defining several additional types (`BehaviorSpec`, `BehaviorDateRange`, etc.) and significantly increase the API surface. The formula path covers the vast majority of inline use cases (arithmetic, string manipulation, conditionals). Behavior-based CPs are less common for ad-hoc queries and more naturally suited to pre-creation and reuse.
+
+### 8.7 Why `InlineCustomProperty.numeric()` Convenience Constructor
+
+**Decision**: Provide a `numeric()` classmethod for the most common formula pattern.
+
+**Rationale**: Numeric arithmetic on two properties (revenue = price * quantity, margin = (revenue - cost) / revenue) is by far the most common custom property use case. The full constructor requires specifying `PropertyInput(name, type="number")` for each input, plus `property_type="number"`. The `numeric()` classmethod reduces this to a single line: `InlineCustomProperty.numeric("A * B", A="price", B="quantity")`. This is particularly valuable for LLM agents, which can generate this one-liner more reliably than the full constructor.
+
+### 8.8 What Was Excluded and Why
+
+| Excluded Feature | Reason |
+|-----------------|--------|
+| Inline custom events for insights | Not supported by query engine — always resolves by DB ID |
+| Behavior-based inline custom properties | Complex JSON structure; formula covers 90% of inline use cases |
+| Auto-create custom events on query | Hidden side effects; violates query idempotency |
+| Custom property nesting in inline CPs | Adds complexity; composedProperties can reference other CPs by ID but this is rarely needed inline |
+| Flows custom property breakdowns | Flows don't support custom properties in breakdowns (different query engine) |
+| `InlineCustomEvent` for funnels | Partial internal support exists but isn't a documented feature; risks fragility |
+| Formula validation (client-side) | The arb-selector formula language is parsed by a C implementation on the server; client-side validation would be incomplete and fragile |
+
+---
+
+## 9. Implementation Plan
+
+### Phase 1: CRUD Gap — Custom Event Create/Get
+
+**Goal**: Enable the create-then-reference workflow.
+
+- Add `create_custom_event()` to Workspace (POST to `/api/app/workspaces/{wid}/custom_events/`)
+- Add `get_custom_event()` to Workspace (GET by ID)
+- Add `EventAlternative` and `CustomEventResult` types
+- Add `update_custom_event_full()` — full update including alternatives (current `update_custom_event()` only updates Lexicon metadata)
+- Tests: Unit + integration with wiremock mocks
+
+**Estimated scope**: ~300 lines of implementation + ~300 lines of tests.
+
+### Phase 2: New Query Types
+
+**Goal**: Define the new types and type aliases.
+
+- Add `CustomEventRef`, `CustomPropertyRef`, `PropertyInput`, `InlineCustomProperty` to `types.py`
+- Add `EventSpec`, `PropertySpec` type aliases
+- Add `InlineCustomProperty.numeric()` convenience constructor
+- Validation for new types (CE1, CP1-CP6)
+- Tests: Unit tests for type construction and validation
+
+**Estimated scope**: ~200 lines of types + ~200 lines of tests.
+
+### Phase 3: Custom Events in Queries
+
+**Goal**: Support `CustomEventRef` across all query methods.
+
+- Modify `Metric.event`, `FunnelStep.event`, `RetentionEvent.event`, `FlowStep.event` type annotations
+- Update `_build_query_params()` — emit `behavior.type = "custom-event"` for `CustomEventRef`
+- Update `_build_funnel_params()` — emit `$custom_event:{id}` in funnel sub-behaviors
+- Update `_build_retention_params()` — emit `$custom_event:{id}` in retention behaviors
+- Update `_build_flow_params()` — emit `$custom_event:{id}` in flow steps
+- Update query method signatures to accept `CustomEventRef`
+- Update resolution logic in `_resolve_and_build_params()` variants
+- Relax validation rules V17/V22 for `CustomEventRef`
+- Tests: Builder output tests, validation tests, PBT for type combinations
+
+**Estimated scope**: ~400 lines of changes + ~500 lines of tests.
+
+### Phase 4: Custom Properties in Queries
+
+**Goal**: Support `CustomPropertyRef` and `InlineCustomProperty` in group-by, filter, and metric measurement.
+
+- Modify `GroupBy.property` type annotation
+- Modify `Filter._property` type annotation and all class methods
+- Modify `Metric.property` type annotation
+- Update `build_group_section()` — emit `customPropertyId` or `customProperty`
+- Update `build_filter_entry()` — emit `customPropertyId` or `customProperty`
+- Update measurement builder in `_build_query_params()` — emit custom property in measurement
+- Add `_build_composed_properties()` helper
+- Add custom property support to `_build_funnel_params()` and `_build_retention_params()` group/filter builders
+- Tests: Builder output tests, validation tests, round-trip PBT
+
+**Estimated scope**: ~500 lines of changes + ~600 lines of tests.
+
+### Phase 5: Polish and Documentation
+
+- Property-based tests (Hypothesis) for all new types
+- Mutation testing on new validation rules
+- Docstrings for all new types and methods
+- Update `__init__.py` exports
+- Integration testing with real Mixpanel API (if available)
+
+---
+
+## 10. Summary: API Surface
+
+### New Public Types
+
+| Type | Purpose |
+|------|---------|
+| `CustomEventRef` | Reference a saved custom event by ID |
+| `CustomPropertyRef` | Reference a saved custom property by ID |
+| `PropertyInput` | Input property for inline custom property formulas |
+| `InlineCustomProperty` | Ad-hoc computed property defined inline in a query |
+| `EventAlternative` | Alternative event within a custom event definition |
+| `CustomEventResult` | Result of custom event CRUD operations |
+| `EventSpec` | Type alias: `str \| CustomEventRef` |
+| `PropertySpec` | Type alias: `str \| CustomPropertyRef \| InlineCustomProperty` |
+
+### New Public Methods
+
+| Method | Purpose |
+|--------|---------|
+| `create_custom_event(name, alternatives)` | Create a custom event (fills CRUD gap) |
+| `get_custom_event(id)` | Get a custom event by ID (fills CRUD gap) |
+| `update_custom_event_full(id, name, alternatives)` | Full update including alternatives |
+
+### Modified Types
+
+| Type | Field | Change |
+|------|-------|--------|
+| `Metric` | `event` | `str` → `str \| CustomEventRef` |
+| `Metric` | `property` | `str \| None` → `str \| CustomPropertyRef \| InlineCustomProperty \| None` |
+| `FunnelStep` | `event` | `str` → `str \| CustomEventRef` |
+| `RetentionEvent` | `event` | `str` → `str \| CustomEventRef` |
+| `FlowStep` | `event` | `str` → `str \| CustomEventRef` |
+| `GroupBy` | `property` | `str` → `str \| CustomPropertyRef \| InlineCustomProperty` |
+| `Filter` class methods | `property` param | `str` → `str \| CustomPropertyRef \| InlineCustomProperty` |
+
+### Modified Method Signatures
+
+| Method | Parameter | Change |
+|--------|-----------|--------|
+| `query()` | `events` | Accept `CustomEventRef` in union |
+| `query_funnel()` | `steps` | Accept `CustomEventRef` in union |
+| `query_retention()` | `born_event`, `return_event` | Accept `CustomEventRef` in union |
+| `query_flow()` | `event` | Accept `CustomEventRef` in union |
+
+---
+
+## Appendix A: Bookmark JSON Examples
+
+### A.1 Custom Event in Insights
+
+```json
+{
+    "sections": {
+        "show": [{
+            "type": "metric",
+            "behavior": {
+                "type": "custom-event",
+                "name": "$custom_event:42",
+                "id": 42,
+                "resourceType": "events",
+                "filtersDeterminer": "all",
+                "filters": [],
+                "dataGroupId": null,
+                "dataset": "$mixpanel"
+            },
+            "measurement": {
+                "math": "unique",
+                "property": null,
+                "perUserAggregation": null
+            },
+            "isHidden": false
+        }],
+        "filter": [],
+        "group": [],
+        "time": [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}],
+        "formula": []
+    },
+    "displayOptions": {
+        "chartType": "line",
+        "plotStyle": "standard",
+        "analysis": "linear"
+    }
+}
+```
+
+### A.2 Inline Custom Property in Group-By
+
+```json
+{
+    "sections": {
+        "show": [{
+            "type": "metric",
+            "behavior": {
+                "type": "event",
+                "name": "Purchase",
+                "resourceType": "events"
+            },
+            "measurement": {"math": "total"}
+        }],
+        "filter": [],
+        "group": [{
+            "customProperty": {
+                "displayFormula": "A * B",
+                "composedProperties": {
+                    "A": {"value": "price", "type": "number", "resourceType": "event"},
+                    "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+                },
+                "propertyType": "number"
+            },
+            "propertyType": "number",
+            "customBucket": {"bucketSize": 100, "min": 0, "max": 1000},
+            "isHidden": false
+        }],
+        "time": [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}],
+        "formula": []
+    }
+}
+```
+
+### A.3 Saved Custom Property in Filter
+
+```json
+{
+    "sections": {
+        "filter": [{
+            "customPropertyId": 99,
+            "filterType": "number",
+            "filterOperator": "is greater than",
+            "filterValue": 100,
+            "determiner": "all",
+            "isHidden": false
+        }]
+    }
+}
+```
+
+### A.4 Custom Event in Funnel Sub-Behavior
+
+```json
+{
+    "sections": {
+        "show": [{
+            "behavior": {
+                "type": "funnel",
+                "behaviors": [
+                    {
+                        "type": "event",
+                        "name": "$custom_event:42",
+                        "filters": [],
+                        "filtersDeterminer": "all",
+                        "funnelOrder": "loose"
+                    },
+                    {
+                        "type": "event",
+                        "name": "Purchase",
+                        "filters": [],
+                        "filtersDeterminer": "all",
+                        "funnelOrder": "loose"
+                    }
+                ],
+                "conversionWindowDuration": 14,
+                "conversionWindowUnit": "day",
+                "funnelOrder": "loose"
+            },
+            "measurement": {"math": "conversion_rate_unique"}
+        }]
+    }
+}
+```
+
+### A.5 Inline Custom Property in Measurement
+
+```json
+{
+    "sections": {
+        "show": [{
+            "type": "metric",
+            "behavior": {
+                "type": "event",
+                "name": "Purchase",
+                "resourceType": "events"
+            },
+            "measurement": {
+                "math": "average",
+                "property": {
+                    "customProperty": {
+                        "displayFormula": "A * B",
+                        "composedProperties": {
+                            "A": {"value": "price", "type": "number", "resourceType": "event"},
+                            "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+                        }
+                    },
+                    "resourceType": "events"
+                },
+                "perUserAggregation": null
+            }
+        }]
+    }
+}
+```
+
+---
+
+## Appendix B: Key Source Files in analytics/
+
+| File | Purpose |
+|------|---------|
+| `webapp/custom_events/models.py` | Django models: `CustomEvent`, `Alternative` |
+| `webapp/custom_events/views.py` | Custom event CRUD API |
+| `webapp/custom_events/constants.py` | `MAX_NUMBER_OF_ALTERNATIVES = 25` |
+| `api/version_2_0/custom_events/util.py` | Query expansion: `generate_custom_event_selectors()` |
+| `api/version_2_0/segmentation/models.py` | `process_event_selectors()` — expansion entry point |
+| `backend/app_helpers/projects.py` | `get_custom_event()`, `custom_property_from_id()` — DB lookups |
+| `webapp/custom_properties/models.py` | Django model: `CustomProperty` |
+| `webapp/app_api/projects/custom_properties/views.py` | Custom property CRUD API |
+| `webapp/custom_properties/serialization.py` | API serialization |
+| `backend/util/arb_selector.py` | Custom property resolution: `segment_to_arb_selector()`, `_expand_formula_property()` |
+| `api/version_2_0/properties_util/__init__.py` | `populate_custom_property()` — hydrates CP definitions |
+| `iron/common/types/reports/bookmark.ts` | TypeScript: `MetricType.CustomEvent`, `Behavior`, `GroupClause` |
+| `iron/common/types/reports/query.ts` | TypeScript: `CustomProperty`, `Segmentation` |
+| `iron/common/util/tern/definitions/arb-selector.json` | Formula language function catalog |
+| `iron/common/report/stores/inline-custom-properties-store.ts` | Inline CP store |
+| `iron/common/widgets/custom-property-modal/util.ts` | `isPersistedCustomProperty()`, `isInlineCustomProperty()` |
+| `api/version_2_0/insights/funnel_metric_params_util.py` | Funnel step event selector passthrough (line 72) |

--- a/context/custom-properties-in-queries-design.md
+++ b/context/custom-properties-in-queries-design.md
@@ -1,0 +1,1918 @@
+# Custom Properties in Queries — Design, Specification & Implementation Plan
+
+**Date**: 2026-04-06
+**Status**: Design Complete — Ready for TDD Implementation
+**Builds on**: `insights-query-api-design.md`, `unified-bookmark-query-design.md`, `custom-events-properties-query-integration.md`
+**Reference**: `analytics/backend/util/arb_selector.py`, `analytics/iron/common/types/reports/bookmark.ts`
+
+---
+
+## 1. Scope & Goals
+
+### What This Document Covers
+
+First-class support for **custom properties** (both saved and inline/ad-hoc) in the unified query system: `query()`, `query_funnel()`, `query_retention()`, and their `build_*_params()` counterparts. Custom properties can appear in three positions:
+
+1. **Breakdown** (`group_by=`) — Segment results by a computed property
+2. **Filter** (`where=`) — Filter events by a computed property value
+3. **Metric measurement** (`Metric.property=`) — Aggregate on a computed property (e.g., average of price * quantity)
+
+### What This Document Does NOT Cover
+
+- Custom **events** (`CustomEventRef`) — separate implementation phase
+- Behavior-based inline custom properties — v2 enhancement
+- Flows query custom property support — flows use segfilter format and don't support custom properties in breakdowns
+- Custom property CRUD — already implemented (`create_custom_property()`, etc.)
+
+### Design Principles
+
+1. **Backward-compatible** — All changes add union members to existing types; existing code is unaffected
+2. **Progressive disclosure** — Plain strings for simple cases, typed objects for advanced
+3. **Fail-fast** — Client-side validation catches mistakes before API calls
+4. **Consistent with existing patterns** — Follows the `Metric`/`Filter`/`GroupBy` frozen dataclass pattern
+5. **LLM-friendly** — Self-documenting types, keyword arguments, clear error messages
+
+---
+
+## 2. New Types
+
+### 2.1 `PropertyInput`
+
+Represents a single raw property that feeds into an inline custom property formula. Maps to one entry in the bookmark's `composedProperties` dict.
+
+```python
+@dataclass(frozen=True)
+class PropertyInput:
+    """An input property reference for an inline custom property formula.
+
+    Maps a letter variable (A, B, C...) in the formula to a raw event
+    or user property. Each PropertyInput becomes one entry in the
+    bookmark's ``composedProperties`` dict.
+
+    Attributes:
+        name: The raw property name (e.g., ``"price"``, ``"$browser"``).
+            This is the Mixpanel property name as it appears in event data.
+        type: Property data type. Determines how the query engine
+            interprets the property value. Default ``"string"``.
+        resource_type: Property domain. ``"event"`` for event properties
+            (the common case), ``"user"`` for user/people profile properties.
+            Default ``"event"``.
+
+    Examples:
+        ```python
+        PropertyInput("price", type="number")
+        PropertyInput("$browser", type="string")
+        PropertyInput("plan", type="string", resource_type="user")
+        PropertyInput("created_at", type="datetime")
+        ```
+    """
+
+    name: str
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    resource_type: Literal["event", "user"] = "event"
+```
+
+**Bookmark JSON mapping:**
+```python
+PropertyInput("price", type="number", resource_type="event")
+# → composedProperties entry:
+{"value": "price", "type": "number", "resourceType": "event"}
+```
+
+**Field mapping:**
+
+| `PropertyInput` field | Bookmark JSON field | Notes |
+|----------------------|--------------------|----|
+| `name` | `value` | The property name — called `value` in Mixpanel's schema |
+| `type` | `type` | Direct passthrough |
+| `resource_type` | `resourceType` | `"event"` maps to `"event"`, `"user"` maps to `"user"` |
+
+### 2.2 `InlineCustomProperty`
+
+Defines an ad-hoc computed property directly in a query using the arb-selector formula language. Not saved to the project — computed at query time.
+
+```python
+@dataclass(frozen=True)
+class InlineCustomProperty:
+    """An inline (ephemeral) custom property defined directly in a query.
+
+    Defines a computed property using the arb-selector formula language.
+    The formula uses single-letter variables (A, B, C...) that map to
+    entries in ``inputs``. The property is computed at query time without
+    being saved to the project.
+
+    This is a first-class Mixpanel feature — the query engine natively
+    supports inline custom property definitions in bookmark params.
+
+    Attributes:
+        formula: Expression in arb-selector formula language. Uses
+            single-letter variables (A, B, C...) referencing ``inputs``.
+            Maximum 20,000 characters.
+        inputs: Mapping from letter variables to property references.
+            Keys must be single uppercase letters A-Z matching the
+            formula variables. At least one input is required.
+        property_type: Result type of the formula. Determines how the
+            computed value is interpreted (e.g., for bucketing in
+            group-by, or for comparison in filters). If ``None``, the
+            server infers the type. Explicit typing is recommended.
+        resource_type: Which data domain this property applies to.
+            ``"events"`` for event properties (default),
+            ``"people"`` for user profile properties.
+
+    Formula Language Reference:
+        - Arithmetic: ``A + B``, ``A - B``, ``A * B``, ``A / B``,
+          ``A % B``, ``CEIL(A)``, ``FLOOR(A)``, ``ROUND(A, 2)``,
+          ``NUMBER(A)``
+        - String: ``UPPER(A)``, ``LOWER(A)``, ``LEFT(A, 3)``,
+          ``RIGHT(A, 3)``, ``MID(A, 2, 5)``, ``LEN(A)``,
+          ``SPLIT(A, ",")``, ``REGEX_EXTRACT(A, pattern)``,
+          ``REGEX_MATCH(A, pattern)``, ``REGEX_REPLACE(A, pattern, repl)``,
+          ``PARSE_URL(A)``
+        - Conditional: ``IF(cond, then_val, else_val)``,
+          ``IFS(c1, v1, c2, v2, ..., TRUE, default)``
+        - Boolean: ``AND``, ``OR``, ``NOT``, ``TRUE``, ``FALSE``, ``IN``
+        - Type checking: ``DEFINED(A)``, ``TYPEOF(A)``, ``UNDEFINED``
+        - Type casting: ``BOOLEAN(A)``, ``STRING(A)``, ``NUMBER(A)``
+        - Date: ``TODAY()``, ``DATEDIF(A, B, "D")``
+        - List: ``ANY(A, x, x > 0)``, ``ALL(A, x, x > 0)``,
+          ``MAP(A, x, x * 2)``, ``FILTER(A, x, x > 0)``, ``SUM(A)``
+
+    Examples:
+        ```python
+        # Revenue = price * quantity
+        InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+        )
+
+        # Extract email domain
+        InlineCustomProperty(
+            formula='REGEX_EXTRACT(A, "@(.+)$")',
+            inputs={"A": PropertyInput("email", type="string")},
+            property_type="string",
+        )
+
+        # Tiered pricing
+        InlineCustomProperty(
+            formula='IFS(A > 1000, "Enterprise", A > 100, "Pro", TRUE, "Free")',
+            inputs={"A": PropertyInput("amount", type="number")},
+            property_type="string",
+        )
+        ```
+    """
+
+    formula: str
+    inputs: dict[str, PropertyInput]
+    property_type: Literal["string", "number", "boolean", "datetime"] | None = None
+    resource_type: Literal["events", "people"] = "events"
+```
+
+**Convenience constructor:**
+
+```python
+    @classmethod
+    def numeric(
+        cls,
+        formula: str,
+        /,
+        **properties: str,
+    ) -> InlineCustomProperty:
+        """Create a numeric formula from named properties.
+
+        Convenience constructor where all inputs are numeric event
+        properties. Keyword argument names are used as formula variables
+        and values as property names.
+
+        Args:
+            formula: Formula expression using single-letter variables
+                (A, B, C...) that match the keyword argument names.
+            **properties: Mapping of formula variable (single uppercase
+                letter) to raw property name. All are typed as
+                ``"number"`` with ``resource_type="event"``.
+
+        Returns:
+            An InlineCustomProperty with all-numeric inputs and
+            ``property_type="number"``.
+
+        Examples:
+            ```python
+            # Revenue = price * quantity
+            InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+            # Profit margin percentage
+            InlineCustomProperty.numeric(
+                "(A - B) / A * 100", A="revenue", B="cost"
+            )
+
+            # Simple property reference as number
+            InlineCustomProperty.numeric("A", A="amount")
+            ```
+        """
+        return cls(
+            formula=formula,
+            inputs={
+                k: PropertyInput(v, type="number")
+                for k, v in properties.items()
+            },
+            property_type="number",
+        )
+```
+
+### 2.3 `CustomPropertyRef`
+
+Reference to a saved (persisted) custom property by its integer ID.
+
+```python
+@dataclass(frozen=True)
+class CustomPropertyRef:
+    """Reference to a saved custom property by ID.
+
+    Use when the custom property already exists in the project (created
+    via ``create_custom_property()`` or the Mixpanel UI). The query
+    engine fetches the full definition from the database at execution
+    time using this ID.
+
+    Attributes:
+        id: The custom property's ID (``customPropertyId`` in API
+            responses). Obtain from ``create_custom_property()``
+            return value or ``list_custom_properties()``.
+
+    Examples:
+        ```python
+        # As a breakdown dimension
+        ws.query("Purchase", group_by=GroupBy(
+            property=CustomPropertyRef(42)
+        ))
+
+        # As a filter target
+        ws.query("Purchase", where=Filter.greater_than(
+            property=CustomPropertyRef(42), value=100,
+        ))
+
+        # As aggregation property
+        ws.query(Metric("Purchase", math="average",
+                        property=CustomPropertyRef(42)))
+        ```
+    """
+
+    id: int
+```
+
+### 2.4 Type Alias
+
+```python
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+"""A property specifier: plain name, saved custom property ref, or inline formula.
+
+Used as the type for ``property`` fields in ``Metric``, ``GroupBy``, and
+``Filter`` to accept any of the three property specification forms.
+"""
+```
+
+---
+
+## 3. Modified Types — Exact Diffs
+
+### 3.1 `Metric.property` Field
+
+**File**: `src/mixpanel_data/types.py`, `Metric` class
+
+**Before** (line ~6924):
+```python
+property: str | None = None
+"""Property name for property-based math ..."""
+```
+
+**After**:
+```python
+property: str | CustomPropertyRef | InlineCustomProperty | None = None
+"""Property for property-based math.
+
+Plain string for raw properties. ``CustomPropertyRef`` for saved
+custom properties. ``InlineCustomProperty`` for ad-hoc formulas.
+Required when math is average/median/min/max/p25/p75/p90/p99.
+"""
+```
+
+### 3.2 `GroupBy.property` Field
+
+**File**: `src/mixpanel_data/types.py`, `GroupBy` class
+
+**Before** (line ~7599):
+```python
+property: str
+```
+
+**After**:
+```python
+property: str | CustomPropertyRef | InlineCustomProperty
+"""Property to break down by.
+
+Plain string for raw properties. ``CustomPropertyRef`` for saved
+custom properties. ``InlineCustomProperty`` for ad-hoc formulas.
+"""
+```
+
+### 3.3 `Filter` Internal Storage and Class Methods
+
+**File**: `src/mixpanel_data/types.py`, `Filter` class
+
+**Before** (line ~7029):
+```python
+_property: str
+"""Property name to filter on."""
+```
+
+**After**:
+```python
+_property: str | CustomPropertyRef | InlineCustomProperty
+"""Property to filter on.
+
+Plain string for raw properties. ``CustomPropertyRef`` for saved
+custom properties. ``InlineCustomProperty`` for ad-hoc formulas.
+"""
+```
+
+**All 18 class methods** (`equals`, `not_equals`, `contains`, `not_contains`, `greater_than`, `less_than`, `between`, `is_set`, `is_not_set`, `is_true`, `is_false`, `on`, `not_on`, `before`, `since`, `in_the_last`, `not_in_the_last`, `date_between`) change their first positional parameter:
+
+**Before** (example — `equals`):
+```python
+@classmethod
+def equals(
+    cls,
+    property: str,
+    value: str | list[str],
+    *,
+    resource_type: Literal["events", "people"] = "events",
+) -> Filter:
+```
+
+**After**:
+```python
+@classmethod
+def equals(
+    cls,
+    property: str | CustomPropertyRef | InlineCustomProperty,
+    value: str | list[str],
+    *,
+    resource_type: Literal["events", "people"] = "events",
+) -> Filter:
+```
+
+**Backward-compatible**: All existing calls pass `str`, which is still in the union.
+
+---
+
+## 4. Builder Changes — Exact Specifications
+
+### 4.1 `build_filter_entry()` — Custom Property in Filters
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py`
+
+**Current implementation** (line 220-253):
+```python
+def build_filter_entry(f: Filter) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "resourceType": f._resource_type,
+        "filterType": f._property_type,
+        "defaultType": f._property_type,
+        "value": f._property,
+        "filterValue": f._value,
+        "filterOperator": f._operator,
+    }
+    if f._date_unit is not None:
+        entry["filterDateUnit"] = f._date_unit
+    return entry
+```
+
+**New implementation**:
+```python
+def build_filter_entry(f: Filter) -> dict[str, Any]:
+    """Convert a Filter object to a bookmark filter dict.
+
+    Handles three property types:
+    - ``str``: Raw property name → standard filter entry
+    - ``CustomPropertyRef``: Saved CP → adds ``customPropertyId``
+    - ``InlineCustomProperty``: Ad-hoc CP → adds ``customProperty`` dict
+
+    Args:
+        f: A ``Filter`` object constructed via its class methods.
+
+    Returns:
+        Bookmark filter dict.
+    """
+    entry: dict[str, Any] = {
+        "filterType": f._property_type,
+        "defaultType": f._property_type,
+        "filterValue": f._value,
+        "filterOperator": f._operator,
+    }
+
+    prop = f._property
+    if isinstance(prop, CustomPropertyRef):
+        entry["customPropertyId"] = prop.id
+        entry["resourceType"] = f._resource_type
+    elif isinstance(prop, InlineCustomProperty):
+        cp_type = prop.property_type or f._property_type
+        entry["customProperty"] = {
+            "displayFormula": prop.formula,
+            "composedProperties": _build_composed_properties(prop.inputs),
+            "propertyType": cp_type,
+            "resourceType": prop.resource_type,
+        }
+        entry["filterType"] = cp_type
+        entry["defaultType"] = cp_type
+        entry["resourceType"] = prop.resource_type
+    else:
+        # Plain string property
+        entry["value"] = prop
+        entry["resourceType"] = f._resource_type
+
+    if f._date_unit is not None:
+        entry["filterDateUnit"] = f._date_unit
+    return entry
+```
+
+**Bookmark JSON output — plain string** (unchanged):
+```json
+{
+    "resourceType": "events",
+    "filterType": "number",
+    "defaultType": "number",
+    "value": "amount",
+    "filterValue": 100,
+    "filterOperator": "is greater than"
+}
+```
+
+**Bookmark JSON output — `CustomPropertyRef(42)`**:
+```json
+{
+    "customPropertyId": 42,
+    "resourceType": "events",
+    "filterType": "number",
+    "defaultType": "number",
+    "filterValue": 100,
+    "filterOperator": "is greater than"
+}
+```
+
+**Bookmark JSON output — `InlineCustomProperty`**:
+```json
+{
+    "customProperty": {
+        "displayFormula": "A * B",
+        "composedProperties": {
+            "A": {"value": "price", "type": "number", "resourceType": "event"},
+            "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+        },
+        "propertyType": "number",
+        "resourceType": "events"
+    },
+    "resourceType": "events",
+    "filterType": "number",
+    "defaultType": "number",
+    "filterValue": 100,
+    "filterOperator": "is greater than"
+}
+```
+
+### 4.2 `build_group_section()` — Custom Property in Group-By
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py`
+
+**Current `GroupBy` branch** (line 194-210):
+```python
+elif isinstance(g, GroupBy):
+    group_entry: dict[str, Any] = {
+        "value": g.property,
+        "propertyName": g.property,
+        "resourceType": "events",
+        "propertyType": g.property_type,
+        "propertyDefaultType": g.property_type,
+    }
+    if g.bucket_size is not None:
+        group_entry["customBucket"] = {"bucketSize": g.bucket_size}
+        if g.bucket_min is not None:
+            group_entry["customBucket"]["min"] = g.bucket_min
+        if g.bucket_max is not None:
+            group_entry["customBucket"]["max"] = g.bucket_max
+    group_section.append(group_entry)
+```
+
+**New `GroupBy` branch**:
+```python
+elif isinstance(g, GroupBy):
+    prop = g.property
+
+    if isinstance(prop, CustomPropertyRef):
+        group_entry: dict[str, Any] = {
+            "customPropertyId": prop.id,
+            "propertyType": g.property_type,
+            "propertyDefaultType": g.property_type,
+            "isHidden": False,
+        }
+    elif isinstance(prop, InlineCustomProperty):
+        cp_type = prop.property_type or g.property_type
+        group_entry = {
+            "customProperty": {
+                "displayFormula": prop.formula,
+                "composedProperties": _build_composed_properties(
+                    prop.inputs
+                ),
+                "propertyType": cp_type,
+                "resourceType": prop.resource_type,
+            },
+            "propertyType": cp_type,
+            "propertyDefaultType": cp_type,
+            "isHidden": False,
+        }
+    else:
+        # Plain string property
+        group_entry = {
+            "value": prop,
+            "propertyName": prop,
+            "resourceType": "events",
+            "propertyType": g.property_type,
+            "propertyDefaultType": g.property_type,
+        }
+
+    # Bucketing applies to all property types
+    if g.bucket_size is not None:
+        group_entry["customBucket"] = {"bucketSize": g.bucket_size}
+        if g.bucket_min is not None:
+            group_entry["customBucket"]["min"] = g.bucket_min
+        if g.bucket_max is not None:
+            group_entry["customBucket"]["max"] = g.bucket_max
+
+    group_section.append(group_entry)
+```
+
+**Bookmark JSON output — plain string** (unchanged):
+```json
+{
+    "value": "country",
+    "propertyName": "country",
+    "resourceType": "events",
+    "propertyType": "string",
+    "propertyDefaultType": "string"
+}
+```
+
+**Bookmark JSON output — `CustomPropertyRef(42)`**:
+```json
+{
+    "customPropertyId": 42,
+    "propertyType": "number",
+    "propertyDefaultType": "number",
+    "isHidden": false
+}
+```
+
+**Bookmark JSON output — `InlineCustomProperty` with bucketing**:
+```json
+{
+    "customProperty": {
+        "displayFormula": "A * B",
+        "composedProperties": {
+            "A": {"value": "price", "type": "number", "resourceType": "event"},
+            "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+        },
+        "propertyType": "number",
+        "resourceType": "events"
+    },
+    "propertyType": "number",
+    "propertyDefaultType": "number",
+    "isHidden": false,
+    "customBucket": {"bucketSize": 100, "min": 0, "max": 1000}
+}
+```
+
+### 4.3 Measurement Property — Custom Property in Metric Aggregation
+
+**File**: `src/mixpanel_data/workspace.py`, `_build_query_params()` method
+
+**Current measurement property construction** (line ~1727-1732):
+```python
+measurement: dict[str, Any] = {"math": bookmark_math}
+if item_prop is not None:
+    measurement["property"] = {
+        "name": item_prop,
+        "resourceType": "events",
+    }
+```
+
+**New measurement property construction**:
+```python
+measurement: dict[str, Any] = {"math": bookmark_math}
+if item_prop is not None:
+    if isinstance(item_prop, CustomPropertyRef):
+        measurement["property"] = {
+            "customPropertyId": item_prop.id,
+            "resourceType": "events",
+        }
+    elif isinstance(item_prop, InlineCustomProperty):
+        measurement["property"] = {
+            "customProperty": {
+                "displayFormula": item_prop.formula,
+                "composedProperties": _build_composed_properties(
+                    item_prop.inputs
+                ),
+                "propertyType": item_prop.property_type,
+            },
+            "resourceType": item_prop.resource_type,
+        }
+    else:
+        # Plain string property
+        measurement["property"] = {
+            "name": item_prop,
+            "resourceType": "events",
+        }
+```
+
+**Same pattern applies to** `_build_funnel_params()` (line ~2321-2331) measurement block.
+
+**Bookmark JSON output — plain string** (unchanged):
+```json
+{
+    "math": "average",
+    "property": {"name": "amount", "resourceType": "events"}
+}
+```
+
+**Bookmark JSON output — `CustomPropertyRef(42)`**:
+```json
+{
+    "math": "average",
+    "property": {"customPropertyId": 42, "resourceType": "events"}
+}
+```
+
+**Bookmark JSON output — `InlineCustomProperty`**:
+```json
+{
+    "math": "average",
+    "property": {
+        "customProperty": {
+            "displayFormula": "A * B",
+            "composedProperties": {
+                "A": {"value": "price", "type": "number", "resourceType": "event"},
+                "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+            },
+            "propertyType": "number"
+        },
+        "resourceType": "events"
+    }
+}
+```
+
+### 4.4 Shared Helper — `_build_composed_properties()`
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py` (new function)
+
+```python
+def _build_composed_properties(
+    inputs: dict[str, PropertyInput],
+) -> dict[str, dict[str, str]]:
+    """Convert PropertyInput dict to bookmark composedProperties format.
+
+    Each ``PropertyInput`` is mapped to its bookmark JSON representation
+    with field name translation: ``name`` → ``value``,
+    ``resource_type`` → ``resourceType``.
+
+    Args:
+        inputs: Letter-variable to PropertyInput mapping.
+            Keys must be single uppercase letters (A-Z).
+
+    Returns:
+        Dict mapping letter variables to bookmark-format property dicts.
+
+    Example:
+        ```python
+        result = _build_composed_properties({
+            "A": PropertyInput("price", type="number"),
+            "B": PropertyInput("quantity", type="number"),
+        })
+        # {"A": {"value": "price", "type": "number", "resourceType": "event"},
+        #  "B": {"value": "quantity", "type": "number", "resourceType": "event"}}
+        ```
+    """
+    return {
+        letter: {
+            "value": prop_input.name,
+            "type": prop_input.type,
+            "resourceType": prop_input.resource_type,
+        }
+        for letter, prop_input in inputs.items()
+    }
+```
+
+### 4.5 Import Updates
+
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py` — import line
+
+**Before**:
+```python
+from mixpanel_data.types import Filter, GroupBy
+```
+
+**After**:
+```python
+from mixpanel_data.types import (
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    PropertyInput,
+)
+```
+
+**File**: `src/mixpanel_data/workspace.py` — import from types
+
+Add `CustomPropertyRef`, `InlineCustomProperty`, `PropertyInput` to the existing import block.
+
+**File**: `src/mixpanel_data/__init__.py` — public exports
+
+Add to the existing import and `__all__`:
+```python
+from mixpanel_data.types import (
+    # ... existing imports ...
+    CustomPropertyRef,
+    InlineCustomProperty,
+    PropertyInput,
+)
+```
+
+---
+
+## 5. Validation Rules
+
+### 5.1 New Rules — Layer 1 (Argument Validation)
+
+All rules raise `ValueError` via `BookmarkValidationError` with a descriptive message at call time, before any API request.
+
+| Code | Rule | Condition | Message |
+|------|------|-----------|---------|
+| CP1 | CustomPropertyRef.id must be positive | `isinstance(prop, CustomPropertyRef) and prop.id <= 0` | `custom property ID must be a positive integer (got {id})` |
+| CP2 | InlineCustomProperty.formula must be non-empty | `isinstance(prop, InlineCustomProperty) and not prop.formula.strip()` | `inline custom property formula must be non-empty` |
+| CP3 | InlineCustomProperty.inputs must be non-empty | `isinstance(prop, InlineCustomProperty) and not prop.inputs` | `inline custom property must have at least one input` |
+| CP4 | InlineCustomProperty.inputs keys must be single uppercase A-Z | `any(not (len(k) == 1 and k.isupper() and k.isalpha()) for k in prop.inputs)` | `inline custom property input keys must be single uppercase letters (A-Z), got '{key}'` |
+| CP5 | Formula max length 20,000 chars | `len(prop.formula) > 20_000` | `inline custom property formula exceeds maximum length of 20,000 characters (got {len})` |
+| CP6 | PropertyInput.name must be non-empty | `any(not pi.name.strip() for pi in prop.inputs.values())` | `inline custom property input '{key}' has an empty property name` |
+
+### 5.2 Where Validation Is Applied
+
+Custom property validation must run in **all** resolve-and-build pipelines:
+
+| Pipeline | Where CPs Can Appear | Validation Applied |
+|----------|---------------------|--------------------|
+| `_resolve_and_build_params()` | `Metric.property`, `group_by`, `where` | CP1-CP6 for each CP found |
+| `_resolve_and_build_funnel_params()` | `group_by`, `where` | CP1-CP6 for each CP found |
+| `_resolve_and_build_retention_params()` | `group_by`, `where` | CP1-CP6 for each CP found |
+
+### 5.3 Validation Implementation
+
+**File**: `src/mixpanel_data/_internal/validation.py`
+
+Add a new shared helper:
+
+```python
+def _validate_custom_property(
+    prop: CustomPropertyRef | InlineCustomProperty,
+    context: str,
+) -> list[ValidationError]:
+    """Validate a custom property specification.
+
+    Args:
+        prop: The custom property to validate.
+        context: Human-readable location (e.g., "group_by[0]",
+            "where[1]", "events[0].property").
+
+    Returns:
+        List of validation errors (may be empty).
+    """
+    errors: list[ValidationError] = []
+
+    if isinstance(prop, CustomPropertyRef):
+        if prop.id <= 0:
+            errors.append(ValidationError(
+                path=context,
+                message=(
+                    f"custom property ID must be a positive integer "
+                    f"(got {prop.id})"
+                ),
+                code="CP1",
+                severity="error",
+            ))
+
+    elif isinstance(prop, InlineCustomProperty):
+        if not prop.formula.strip():
+            errors.append(ValidationError(
+                path=context,
+                message="inline custom property formula must be non-empty",
+                code="CP2",
+                severity="error",
+            ))
+
+        if not prop.inputs:
+            errors.append(ValidationError(
+                path=context,
+                message=(
+                    "inline custom property must have at least one input"
+                ),
+                code="CP3",
+                severity="error",
+            ))
+
+        for key in prop.inputs:
+            if not (len(key) == 1 and key.isupper() and key.isalpha()):
+                errors.append(ValidationError(
+                    path=f"{context}.inputs",
+                    message=(
+                        f"inline custom property input keys must be "
+                        f"single uppercase letters (A-Z), got '{key}'"
+                    ),
+                    code="CP4",
+                    severity="error",
+                ))
+
+        if len(prop.formula) > 20_000:
+            errors.append(ValidationError(
+                path=context,
+                message=(
+                    f"inline custom property formula exceeds maximum "
+                    f"length of 20,000 characters "
+                    f"(got {len(prop.formula)})"
+                ),
+                code="CP5",
+                severity="error",
+            ))
+
+        for key, pi in prop.inputs.items():
+            if not pi.name.strip():
+                errors.append(ValidationError(
+                    path=f"{context}.inputs[{key}]",
+                    message=(
+                        f"inline custom property input '{key}' has "
+                        f"an empty property name"
+                    ),
+                    code="CP6",
+                    severity="error",
+                ))
+
+    return errors
+```
+
+This helper is called from `validate_query_args()`, `validate_funnel_args()`, and `validate_retention_args()` for each custom property found in `group_by`, `where`, or `Metric.property`.
+
+### 5.4 Validation Integration Points
+
+**In `validate_query_args()`** — add after existing group_by/filter validation:
+
+```python
+# Validate custom properties in group_by
+if group_by is not None:
+    groups = group_by if isinstance(group_by, list) else [group_by]
+    for i, g in enumerate(groups):
+        if isinstance(g, GroupBy) and isinstance(
+            g.property, (CustomPropertyRef, InlineCustomProperty)
+        ):
+            errors.extend(
+                _validate_custom_property(g.property, f"group_by[{i}]")
+            )
+
+# Validate custom properties in where
+if where is not None:
+    filters = where if isinstance(where, list) else [where]
+    for i, f in enumerate(filters):
+        if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
+            errors.extend(
+                _validate_custom_property(f._property, f"where[{i}]")
+            )
+
+# Validate custom properties in Metric.property
+for i, item in enumerate(events_list):
+    if isinstance(item, Metric) and isinstance(
+        item.property, (CustomPropertyRef, InlineCustomProperty)
+    ):
+        errors.extend(
+            _validate_custom_property(
+                item.property, f"events[{i}].property"
+            )
+        )
+```
+
+Same pattern for `validate_funnel_args()` and `validate_retention_args()`.
+
+### 5.5 Modified Existing Rules
+
+| Code | Current Rule | Change |
+|------|-------------|--------|
+| V1 | `math` in `PROPERTY_MATH_TYPES` and `math_property` is `None` | Also check `Metric.property` — allow `CustomPropertyRef` or `InlineCustomProperty` as valid alternatives to `math_property` string |
+| V2 | `math_property is not None` and `math` not in `PROPERTY_MATH_TYPES` | Also apply when `Metric.property` is a `CustomPropertyRef` or `InlineCustomProperty` |
+
+---
+
+## 6. Test Specifications (TDD-First)
+
+Tests are organized by implementation phase. **Write all tests in a phase BEFORE implementing the code.**
+
+### 6.1 Test File Structure
+
+```
+tests/
+├── unit/
+│   ├── test_custom_property_types.py     # Phase 1: Type construction & validation
+│   ├── test_custom_property_builders.py  # Phase 2: Builder output verification
+│   ├── test_custom_property_query.py     # Phase 3: End-to-end query method tests
+│   └── test_custom_property_pbt.py       # Phase 4: Property-based tests
+```
+
+### 6.2 Phase 1 Tests — Type Construction & Validation
+
+**File**: `tests/unit/test_custom_property_types.py`
+
+```python
+"""Tests for custom property types: PropertyInput, InlineCustomProperty, CustomPropertyRef.
+
+TDD Phase 1: Type construction, field defaults, validation rules CP1-CP6.
+"""
+
+
+class TestPropertyInput:
+    """PropertyInput construction and field defaults."""
+
+    def test_minimal_construction(self) -> None:
+        """PropertyInput with just name uses string/event defaults."""
+        pi = PropertyInput("browser")
+        assert pi.name == "browser"
+        assert pi.type == "string"
+        assert pi.resource_type == "event"
+
+    def test_numeric_type(self) -> None:
+        """PropertyInput with explicit number type."""
+        pi = PropertyInput("price", type="number")
+        assert pi.type == "number"
+
+    def test_user_resource_type(self) -> None:
+        """PropertyInput with user resource type for profile properties."""
+        pi = PropertyInput("plan", resource_type="user")
+        assert pi.resource_type == "user"
+
+    def test_all_valid_types(self) -> None:
+        """All five property types are accepted."""
+        for t in ("string", "number", "boolean", "datetime", "list"):
+            pi = PropertyInput("x", type=t)
+            assert pi.type == t
+
+    def test_frozen(self) -> None:
+        """PropertyInput is immutable."""
+        pi = PropertyInput("x")
+        with pytest.raises(FrozenInstanceError):
+            pi.name = "y"
+
+
+class TestInlineCustomProperty:
+    """InlineCustomProperty construction and convenience methods."""
+
+    def test_minimal_construction(self) -> None:
+        """Formula + single input, defaults for property_type and resource_type."""
+        cp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("browser")},
+        )
+        assert cp.formula == "A"
+        assert cp.property_type is None
+        assert cp.resource_type == "events"
+
+    def test_full_construction(self) -> None:
+        """All fields explicitly set."""
+        cp = InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+            resource_type="events",
+        )
+        assert cp.formula == "A * B"
+        assert len(cp.inputs) == 2
+        assert cp.property_type == "number"
+
+    def test_numeric_convenience_constructor(self) -> None:
+        """InlineCustomProperty.numeric() creates all-number inputs."""
+        cp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        assert cp.formula == "A * B"
+        assert cp.property_type == "number"
+        assert cp.inputs["A"].name == "price"
+        assert cp.inputs["A"].type == "number"
+        assert cp.inputs["A"].resource_type == "event"
+        assert cp.inputs["B"].name == "quantity"
+
+    def test_numeric_single_property(self) -> None:
+        """numeric() works with a single property reference."""
+        cp = InlineCustomProperty.numeric("A", A="amount")
+        assert cp.formula == "A"
+        assert len(cp.inputs) == 1
+
+    def test_frozen(self) -> None:
+        """InlineCustomProperty is immutable."""
+        cp = InlineCustomProperty(
+            formula="A", inputs={"A": PropertyInput("x")}
+        )
+        with pytest.raises(FrozenInstanceError):
+            cp.formula = "B"
+
+
+class TestCustomPropertyRef:
+    """CustomPropertyRef construction."""
+
+    def test_construction(self) -> None:
+        """CustomPropertyRef stores integer ID."""
+        ref = CustomPropertyRef(42)
+        assert ref.id == 42
+
+    def test_frozen(self) -> None:
+        """CustomPropertyRef is immutable."""
+        ref = CustomPropertyRef(42)
+        with pytest.raises(FrozenInstanceError):
+            ref.id = 99
+
+
+class TestCustomPropertyValidation:
+    """Validation rules CP1-CP6 for custom properties."""
+
+    def test_cp1_ref_id_must_be_positive(self, ws: Workspace) -> None:
+        """CP1: CustomPropertyRef.id <= 0 raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=CustomPropertyRef(0)),
+            )
+
+    def test_cp1_ref_negative_id(self, ws: Workspace) -> None:
+        """CP1: Negative ID also fails."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(property=CustomPropertyRef(-1)),
+            )
+
+    def test_cp2_empty_formula(self, ws: Workspace) -> None:
+        """CP2: Empty formula string raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="",
+                        inputs={"A": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp2_whitespace_only_formula(self, ws: Workspace) -> None:
+        """CP2: Whitespace-only formula fails."""
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="   ",
+                        inputs={"A": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp3_empty_inputs(self, ws: Workspace) -> None:
+        """CP3: Empty inputs dict raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="at least one input"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(formula="A", inputs={})
+                ),
+            )
+
+    def test_cp4_lowercase_key(self, ws: Workspace) -> None:
+        """CP4: Lowercase input key raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="a",
+                        inputs={"a": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp4_multi_char_key(self, ws: Workspace) -> None:
+        """CP4: Multi-character input key raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="AB",
+                        inputs={"AB": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp4_numeric_key(self, ws: Workspace) -> None:
+        """CP4: Numeric input key raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="1",
+                        inputs={"1": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp5_formula_too_long(self, ws: Workspace) -> None:
+        """CP5: Formula exceeding 20,000 chars raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="20,000"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="A" * 20_001,
+                        inputs={"A": PropertyInput("x")},
+                    )
+                ),
+            )
+
+    def test_cp6_empty_property_name(self, ws: Workspace) -> None:
+        """CP6: Empty property name in input raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="empty property name"):
+            ws.build_params(
+                "Login",
+                group_by=GroupBy(
+                    property=InlineCustomProperty(
+                        formula="A",
+                        inputs={"A": PropertyInput("")},
+                    )
+                ),
+            )
+
+    def test_valid_inline_cp_passes(self, ws: Workspace) -> None:
+        """Valid InlineCustomProperty passes validation."""
+        # Should not raise
+        ws.build_params(
+            "Login",
+            group_by=GroupBy(
+                property=InlineCustomProperty(
+                    formula="A * B",
+                    inputs={
+                        "A": PropertyInput("price", type="number"),
+                        "B": PropertyInput("quantity", type="number"),
+                    },
+                    property_type="number",
+                ),
+                property_type="number",
+            ),
+        )
+
+    def test_valid_ref_passes(self, ws: Workspace) -> None:
+        """Valid CustomPropertyRef passes validation."""
+        ws.build_params(
+            "Login",
+            group_by=GroupBy(property=CustomPropertyRef(42)),
+        )
+
+    # --- Position-specific validation ---
+
+    def test_cp_validation_in_where(self, ws: Workspace) -> None:
+        """CP validation runs on Filter custom properties."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Login",
+                where=Filter.greater_than(
+                    property=CustomPropertyRef(0), value=100,
+                ),
+            )
+
+    def test_cp_validation_in_metric_property(self, ws: Workspace) -> None:
+        """CP validation runs on Metric.property custom properties."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric("Login", math="average",
+                       property=CustomPropertyRef(-5)),
+            )
+
+    def test_cp_validation_in_funnel_group_by(self, ws: Workspace) -> None:
+        """CP validation runs in query_funnel group_by."""
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_funnel_params(
+                ["Signup", "Purchase"],
+                group_by=GroupBy(
+                    property=InlineCustomProperty(formula="", inputs={"A": PropertyInput("x")}),
+                ),
+            )
+
+    def test_cp_validation_in_retention_where(self, ws: Workspace) -> None:
+        """CP validation runs in query_retention where."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                "Signup", "Login",
+                where=Filter.equals(
+                    property=CustomPropertyRef(0), value="x",
+                ),
+            )
+```
+
+### 6.3 Phase 2 Tests — Builder Output Verification
+
+**File**: `tests/unit/test_custom_property_builders.py`
+
+```python
+"""Tests for custom property bookmark JSON output.
+
+TDD Phase 2: Verify build_filter_entry, build_group_section, and
+measurement builder produce correct bookmark JSON for custom properties.
+"""
+
+
+class TestBuildFilterEntryCustomProperty:
+    """build_filter_entry() with custom property inputs."""
+
+    def test_plain_string_unchanged(self) -> None:
+        """Plain string filter produces unchanged output (backward compat)."""
+        f = Filter.equals("country", "US")
+        entry = build_filter_entry(f)
+        assert entry["value"] == "country"
+        assert "customPropertyId" not in entry
+        assert "customProperty" not in entry
+
+    def test_custom_property_ref(self) -> None:
+        """CustomPropertyRef emits customPropertyId in filter entry."""
+        f = Filter.greater_than(
+            property=CustomPropertyRef(42), value=100,
+        )
+        entry = build_filter_entry(f)
+        assert entry["customPropertyId"] == 42
+        assert "value" not in entry
+        assert entry["filterOperator"] == "is greater than"
+        assert entry["filterValue"] == 100
+
+    def test_inline_custom_property(self) -> None:
+        """InlineCustomProperty emits customProperty dict in filter entry."""
+        f = Filter.greater_than(
+            property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+            value=1000,
+        )
+        entry = build_filter_entry(f)
+        assert "customProperty" in entry
+        cp = entry["customProperty"]
+        assert cp["displayFormula"] == "A * B"
+        assert "A" in cp["composedProperties"]
+        assert cp["composedProperties"]["A"]["value"] == "price"
+        assert cp["composedProperties"]["B"]["value"] == "qty"
+        assert cp["propertyType"] == "number"
+        assert "value" not in entry
+        assert entry["filterValue"] == 1000
+
+    def test_inline_cp_filter_type_uses_cp_property_type(self) -> None:
+        """When InlineCustomProperty has property_type, filter uses it."""
+        f = Filter.equals(
+            property=InlineCustomProperty(
+                formula='REGEX_EXTRACT(A, "@(.+)$")',
+                inputs={"A": PropertyInput("email")},
+                property_type="string",
+            ),
+            value="company.com",
+        )
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "string"
+        assert entry["customProperty"]["propertyType"] == "string"
+
+    def test_ref_preserves_resource_type(self) -> None:
+        """CustomPropertyRef preserves the Filter's resource_type."""
+        f = Filter.equals(
+            property=CustomPropertyRef(42),
+            value="Pro",
+            resource_type="people",
+        )
+        entry = build_filter_entry(f)
+        assert entry["resourceType"] == "people"
+
+    def test_inline_cp_uses_its_own_resource_type(self) -> None:
+        """InlineCustomProperty's resource_type is used."""
+        f = Filter.equals(
+            property=InlineCustomProperty(
+                formula="A",
+                inputs={"A": PropertyInput("plan", resource_type="user")},
+                resource_type="people",
+            ),
+            value="Pro",
+        )
+        entry = build_filter_entry(f)
+        assert entry["resourceType"] == "people"
+
+
+class TestBuildGroupSectionCustomProperty:
+    """build_group_section() with custom property inputs."""
+
+    def test_plain_string_unchanged(self) -> None:
+        """Plain string group-by produces unchanged output."""
+        section = build_group_section("country")
+        assert section[0]["value"] == "country"
+        assert section[0]["propertyName"] == "country"
+        assert "customPropertyId" not in section[0]
+
+    def test_groupby_plain_property_unchanged(self) -> None:
+        """GroupBy with plain string property produces unchanged output."""
+        section = build_group_section(
+            GroupBy("country", property_type="string")
+        )
+        assert section[0]["value"] == "country"
+        assert "customPropertyId" not in section[0]
+
+    def test_groupby_custom_property_ref(self) -> None:
+        """GroupBy with CustomPropertyRef emits customPropertyId."""
+        section = build_group_section(
+            GroupBy(property=CustomPropertyRef(42), property_type="number")
+        )
+        entry = section[0]
+        assert entry["customPropertyId"] == 42
+        assert entry["propertyType"] == "number"
+        assert "value" not in entry
+        assert "propertyName" not in entry
+
+    def test_groupby_inline_custom_property(self) -> None:
+        """GroupBy with InlineCustomProperty emits customProperty dict."""
+        section = build_group_section(
+            GroupBy(
+                property=InlineCustomProperty.numeric(
+                    "A * B", A="price", B="quantity"
+                ),
+                property_type="number",
+            )
+        )
+        entry = section[0]
+        assert "customProperty" in entry
+        cp = entry["customProperty"]
+        assert cp["displayFormula"] == "A * B"
+        assert cp["composedProperties"]["A"]["value"] == "price"
+        assert entry["propertyType"] == "number"
+        assert "value" not in entry
+        assert "propertyName" not in entry
+
+    def test_groupby_inline_cp_with_bucketing(self) -> None:
+        """Bucketing works with inline custom property."""
+        section = build_group_section(
+            GroupBy(
+                property=InlineCustomProperty.numeric("A", A="revenue"),
+                property_type="number",
+                bucket_size=100,
+                bucket_min=0,
+                bucket_max=1000,
+            )
+        )
+        entry = section[0]
+        assert "customProperty" in entry
+        assert entry["customBucket"]["bucketSize"] == 100
+        assert entry["customBucket"]["min"] == 0
+        assert entry["customBucket"]["max"] == 1000
+
+    def test_groupby_ref_with_bucketing(self) -> None:
+        """Bucketing works with CustomPropertyRef."""
+        section = build_group_section(
+            GroupBy(
+                property=CustomPropertyRef(42),
+                property_type="number",
+                bucket_size=50,
+            )
+        )
+        entry = section[0]
+        assert entry["customPropertyId"] == 42
+        assert entry["customBucket"]["bucketSize"] == 50
+
+    def test_inline_cp_property_type_overrides_groupby_type(self) -> None:
+        """InlineCustomProperty.property_type takes precedence over GroupBy.property_type."""
+        section = build_group_section(
+            GroupBy(
+                property=InlineCustomProperty(
+                    formula='IF(A > 100, "High", "Low")',
+                    inputs={"A": PropertyInput("amount", type="number")},
+                    property_type="string",
+                ),
+                property_type="number",  # GroupBy says number
+            )
+        )
+        entry = section[0]
+        # CP's property_type ("string") should win
+        assert entry["propertyType"] == "string"
+        assert entry["customProperty"]["propertyType"] == "string"
+
+    def test_multiple_groups_mixed_types(self) -> None:
+        """List of mixed plain/ref/inline groups all build correctly."""
+        section = build_group_section([
+            "country",
+            GroupBy(property=CustomPropertyRef(42), property_type="number"),
+            GroupBy(
+                property=InlineCustomProperty.numeric("A", A="revenue"),
+                property_type="number",
+            ),
+        ])
+        assert len(section) == 3
+        assert section[0]["value"] == "country"
+        assert section[1]["customPropertyId"] == 42
+        assert "customProperty" in section[2]
+
+
+class TestMeasurementPropertyCustomProperty:
+    """Measurement property in _build_query_params() with custom properties."""
+
+    def test_plain_string_property_unchanged(self, ws: Workspace) -> None:
+        """Plain string math_property produces unchanged measurement."""
+        params = ws._build_query_params(
+            events=[Metric("Purchase", math="average", property="amount")],
+            math="total", math_property=None, per_user=None,
+            from_date=None, to_date=None, last=30, unit="day",
+            group_by=None, where=None, formulas=[], rolling=None,
+            cumulative=False, mode="timeseries",
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert prop["name"] == "amount"
+        assert prop["resourceType"] == "events"
+        assert "customPropertyId" not in prop
+
+    def test_custom_property_ref_in_measurement(self, ws: Workspace) -> None:
+        """CustomPropertyRef in Metric.property emits customPropertyId."""
+        params = ws._build_query_params(
+            events=[Metric("Purchase", math="average",
+                           property=CustomPropertyRef(42))],
+            math="total", math_property=None, per_user=None,
+            from_date=None, to_date=None, last=30, unit="day",
+            group_by=None, where=None, formulas=[], rolling=None,
+            cumulative=False, mode="timeseries",
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert prop["customPropertyId"] == 42
+        assert prop["resourceType"] == "events"
+        assert "name" not in prop
+
+    def test_inline_cp_in_measurement(self, ws: Workspace) -> None:
+        """InlineCustomProperty in Metric.property emits customProperty dict."""
+        params = ws._build_query_params(
+            events=[Metric(
+                "Purchase", math="average",
+                property=InlineCustomProperty.numeric(
+                    "A * B", A="price", B="quantity",
+                ),
+            )],
+            math="total", math_property=None, per_user=None,
+            from_date=None, to_date=None, last=30, unit="day",
+            group_by=None, where=None, formulas=[], rolling=None,
+            cumulative=False, mode="timeseries",
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert "customProperty" in prop
+        assert prop["customProperty"]["displayFormula"] == "A * B"
+        assert prop["resourceType"] == "events"
+        assert "name" not in prop
+
+    def test_top_level_math_property_str_unchanged(self, ws: Workspace) -> None:
+        """Top-level math_property as str still works (backward compat)."""
+        params = ws._build_query_params(
+            events=["Purchase"],
+            math="average", math_property="amount", per_user=None,
+            from_date=None, to_date=None, last=30, unit="day",
+            group_by=None, where=None, formulas=[], rolling=None,
+            cumulative=False, mode="timeseries",
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert prop["name"] == "amount"
+
+
+class TestBuildComposedProperties:
+    """_build_composed_properties() helper."""
+
+    def test_single_input(self) -> None:
+        """Single input produces single-entry dict."""
+        result = _build_composed_properties({
+            "A": PropertyInput("browser", type="string"),
+        })
+        assert result == {
+            "A": {"value": "browser", "type": "string", "resourceType": "event"},
+        }
+
+    def test_multiple_inputs(self) -> None:
+        """Multiple inputs produce multi-entry dict."""
+        result = _build_composed_properties({
+            "A": PropertyInput("price", type="number"),
+            "B": PropertyInput("quantity", type="number"),
+        })
+        assert len(result) == 2
+        assert result["A"]["value"] == "price"
+        assert result["B"]["value"] == "quantity"
+
+    def test_user_resource_type(self) -> None:
+        """User resource type is preserved."""
+        result = _build_composed_properties({
+            "A": PropertyInput("plan", type="string", resource_type="user"),
+        })
+        assert result["A"]["resourceType"] == "user"
+```
+
+### 6.4 Phase 3 Tests — End-to-End Query Method Tests
+
+**File**: `tests/unit/test_custom_property_query.py`
+
+```python
+"""End-to-end tests for custom properties in query(), query_funnel(), query_retention().
+
+TDD Phase 3: Verify the full pipeline from public API → build_params → bookmark JSON.
+"""
+
+
+class TestQueryWithCustomPropertyGroupBy:
+    """query()/build_params() with custom properties in group_by."""
+
+    def test_build_params_with_ref_group_by(self, ws: Workspace) -> None:
+        """build_params() accepts CustomPropertyRef in group_by."""
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+        group = params["sections"]["group"][0]
+        assert group["customPropertyId"] == 42
+
+    def test_build_params_with_inline_cp_group_by(self, ws: Workspace) -> None:
+        """build_params() accepts InlineCustomProperty in group_by."""
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(
+                property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+                property_type="number",
+                bucket_size=100,
+            ),
+        )
+        group = params["sections"]["group"][0]
+        assert "customProperty" in group
+        assert group["customBucket"]["bucketSize"] == 100
+
+
+class TestQueryWithCustomPropertyFilter:
+    """query()/build_params() with custom properties in where."""
+
+    def test_build_params_with_ref_filter(self, ws: Workspace) -> None:
+        """build_params() accepts CustomPropertyRef in where."""
+        params = ws.build_params(
+            "Purchase",
+            where=Filter.greater_than(
+                property=CustomPropertyRef(42), value=100,
+            ),
+        )
+        filt = params["sections"]["filter"][0]
+        assert filt["customPropertyId"] == 42
+
+    def test_build_params_with_inline_cp_filter(self, ws: Workspace) -> None:
+        """build_params() accepts InlineCustomProperty in where."""
+        params = ws.build_params(
+            "Purchase",
+            where=Filter.greater_than(
+                property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+                value=1000,
+            ),
+        )
+        filt = params["sections"]["filter"][0]
+        assert "customProperty" in filt
+
+
+class TestQueryWithCustomPropertyMeasurement:
+    """query()/build_params() with custom properties in Metric.property."""
+
+    def test_build_params_with_ref_metric_property(self, ws: Workspace) -> None:
+        """build_params() accepts CustomPropertyRef in Metric.property."""
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=CustomPropertyRef(42)),
+        )
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"]["customPropertyId"] == 42
+
+    def test_build_params_with_inline_cp_metric_property(self, ws: Workspace) -> None:
+        """build_params() accepts InlineCustomProperty in Metric.property."""
+        params = ws.build_params(
+            Metric(
+                "Purchase", math="average",
+                property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+            ),
+        )
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert "customProperty" in measurement["property"]
+
+
+class TestFunnelWithCustomPropertyGroupBy:
+    """query_funnel()/build_funnel_params() with custom properties."""
+
+    def test_build_funnel_params_with_ref_group_by(self, ws: Workspace) -> None:
+        """build_funnel_params() accepts CustomPropertyRef in group_by."""
+        params = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+        group = params["sections"]["group"][0]
+        assert group["customPropertyId"] == 42
+
+    def test_build_funnel_params_with_inline_cp_group_by(self, ws: Workspace) -> None:
+        """build_funnel_params() accepts InlineCustomProperty in group_by."""
+        params = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            group_by=GroupBy(
+                property=InlineCustomProperty.numeric("A", A="revenue"),
+                property_type="number",
+            ),
+        )
+        group = params["sections"]["group"][0]
+        assert "customProperty" in group
+
+
+class TestRetentionWithCustomPropertyGroupBy:
+    """query_retention()/build_retention_params() with custom properties."""
+
+    def test_build_retention_params_with_ref_group_by(self, ws: Workspace) -> None:
+        """build_retention_params() accepts CustomPropertyRef in group_by."""
+        params = ws.build_retention_params(
+            "Signup", "Login",
+            group_by=GroupBy(property=CustomPropertyRef(42)),
+        )
+        group = params["sections"]["group"][0]
+        assert group["customPropertyId"] == 42
+
+
+class TestCombinedCustomProperties:
+    """Multiple custom properties in different positions."""
+
+    def test_ref_in_group_and_inline_in_filter(self, ws: Workspace) -> None:
+        """CustomPropertyRef in group_by + InlineCustomProperty in where."""
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+            where=Filter.greater_than(
+                property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+                value=100,
+            ),
+        )
+        assert params["sections"]["group"][0]["customPropertyId"] == 42
+        assert "customProperty" in params["sections"]["filter"][0]
+
+    def test_all_three_positions(self, ws: Workspace) -> None:
+        """Custom properties in group_by, where, AND Metric.property."""
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=CustomPropertyRef(99)),
+            group_by=GroupBy(
+                property=InlineCustomProperty.numeric("A", A="revenue"),
+                property_type="number",
+            ),
+            where=Filter.equals(
+                property=CustomPropertyRef(42),
+                value="Premium",
+            ),
+        )
+        assert params["sections"]["show"][0]["measurement"]["property"]["customPropertyId"] == 99
+        assert "customProperty" in params["sections"]["group"][0]
+        assert params["sections"]["filter"][0]["customPropertyId"] == 42
+```
+
+### 6.5 Phase 4 Tests — Property-Based Tests (Hypothesis)
+
+**File**: `tests/unit/test_custom_property_pbt.py`
+
+```python
+"""Property-based tests for custom property types.
+
+TDD Phase 4: Verify invariants across randomly generated inputs.
+"""
+
+from hypothesis import given, strategies as st
+
+
+# Strategy for valid PropertyInput
+valid_property_input = st.builds(
+    PropertyInput,
+    name=st.text(min_size=1, max_size=50).filter(lambda s: s.strip()),
+    type=st.sampled_from(["string", "number", "boolean", "datetime", "list"]),
+    resource_type=st.sampled_from(["event", "user"]),
+)
+
+# Strategy for valid input letter keys (A-Z)
+valid_input_key = st.sampled_from(list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+
+# Strategy for valid inputs dict (1-5 entries)
+valid_inputs = st.dictionaries(
+    keys=valid_input_key,
+    values=valid_property_input,
+    min_size=1,
+    max_size=5,
+)
+
+
+class TestPropertyInputPBT:
+    """Property-based tests for PropertyInput."""
+
+    @given(
+        name=st.text(min_size=1, max_size=100),
+        type_=st.sampled_from(["string", "number", "boolean", "datetime", "list"]),
+        resource_type=st.sampled_from(["event", "user"]),
+    )
+    def test_round_trip_fields(self, name: str, type_: str, resource_type: str) -> None:
+        """All field values survive construction."""
+        pi = PropertyInput(name=name, type=type_, resource_type=resource_type)
+        assert pi.name == name
+        assert pi.type == type_
+        assert pi.resource_type == resource_type
+
+
+class TestInlineCustomPropertyPBT:
+    """Property-based tests for InlineCustomProperty."""
+
+    @given(
+        formula=st.text(min_size=1, max_size=100),
+        inputs=valid_inputs,
+    )
+    def test_construction_preserves_fields(
+        self, formula: str, inputs: dict[str, PropertyInput]
+    ) -> None:
+        """Construction preserves formula and inputs."""
+        cp = InlineCustomProperty(formula=formula, inputs=inputs)
+        assert cp.formula == formula
+        assert cp.inputs == inputs
+
+
+class TestBuildComposedPropertiesPBT:
+    """Property-based tests for _build_composed_properties."""
+
+    @given(inputs=valid_inputs)
+    def test_output_keys_match_input_keys(
+        self, inputs: dict[str, PropertyInput]
+    ) -> None:
+        """Output dict has exactly the same keys as input dict."""
+        result = _build_composed_properties(inputs)
+        assert set(result.keys()) == set(inputs.keys())
+
+    @given(inputs=valid_inputs)
+    def test_output_values_have_required_fields(
+        self, inputs: dict[str, PropertyInput]
+    ) -> None:
+        """Each output entry has value, type, resourceType fields."""
+        result = _build_composed_properties(inputs)
+        for key, entry in result.items():
+            assert "value" in entry
+            assert "type" in entry
+            assert "resourceType" in entry
+            assert entry["value"] == inputs[key].name
+            assert entry["type"] == inputs[key].type
+            assert entry["resourceType"] == inputs[key].resource_type
+```
+
+---
+
+## 7. Implementation Phases
+
+Each phase follows strict TDD: write tests first, then implement until green, then refactor.
+
+### Phase 1: New Types (Estimated: ~150 lines impl, ~200 lines tests)
+
+**Tests first**: `tests/unit/test_custom_property_types.py` — `TestPropertyInput`, `TestInlineCustomProperty`, `TestCustomPropertyRef`
+
+**Then implement** in `src/mixpanel_data/types.py`:
+1. Add `PropertyInput` frozen dataclass (after existing type aliases, before `Metric`)
+2. Add `InlineCustomProperty` frozen dataclass with `numeric()` classmethod
+3. Add `CustomPropertyRef` frozen dataclass
+4. Add `PropertySpec` type alias
+
+**Verify**: All type construction and field-default tests pass. Freeze tests pass.
+
+### Phase 2: Modified Types (Estimated: ~50 lines changes, ~100 lines tests)
+
+**Tests first**: `tests/unit/test_custom_property_types.py` — `TestCustomPropertyValidation` (at least the tests that verify `build_params` accepts the new types — these will fail until builders are updated, so mark them `@pytest.mark.skip` initially and unskip in Phase 4)
+
+**Then implement** type signature changes:
+1. `Metric.property`: `str | None` → `str | CustomPropertyRef | InlineCustomProperty | None`
+2. `GroupBy.property`: `str` → `str | CustomPropertyRef | InlineCustomProperty`
+3. `Filter._property`: `str` → `str | CustomPropertyRef | InlineCustomProperty`
+4. All 18 `Filter` class methods: `property: str` → `property: str | CustomPropertyRef | InlineCustomProperty`
+
+**Verify**: `just typecheck` passes (mypy). Existing tests still pass (backward-compatible).
+
+### Phase 3: Builders (Estimated: ~150 lines impl, ~250 lines tests)
+
+**Tests first**: `tests/unit/test_custom_property_builders.py` — all builder output tests
+
+**Then implement** in `src/mixpanel_data/_internal/bookmark_builders.py`:
+1. Add `_build_composed_properties()` helper function
+2. Update `build_filter_entry()` — three-branch isinstance dispatch
+3. Update `build_group_section()` — three-branch isinstance dispatch in `GroupBy` case
+4. Update imports
+
+**Then implement** in `src/mixpanel_data/workspace.py`:
+5. Update measurement property construction in `_build_query_params()` — three-branch isinstance dispatch
+6. Update measurement property construction in `_build_funnel_params()` — same pattern
+7. Update imports
+
+**Verify**: All builder output tests pass. Existing builder tests still pass.
+
+### Phase 4: Validation (Estimated: ~100 lines impl, ~200 lines tests)
+
+**Tests first**: Unskip validation tests from Phase 2. Add remaining validation tests.
+
+**Then implement** in `src/mixpanel_data/_internal/validation.py`:
+1. Add `_validate_custom_property()` helper function
+2. Add custom property validation calls in `validate_query_args()`
+3. Add custom property validation calls in `validate_funnel_args()`
+4. Add custom property validation calls in `validate_retention_args()`
+5. Update imports
+
+**Verify**: All validation tests (CP1-CP6) pass. All position-specific validation tests pass.
+
+### Phase 5: End-to-End & Exports (Estimated: ~30 lines impl, ~200 lines tests)
+
+**Tests first**: `tests/unit/test_custom_property_query.py` — all end-to-end tests
+
+**Then implement**:
+1. Update `src/mixpanel_data/__init__.py` — add exports
+2. Verify `_resolve_and_build_params()` type guards accept the new union types (may need to update isinstance checks)
+3. Same for `_resolve_and_build_funnel_params()` and `_resolve_and_build_retention_params()`
+
+**Verify**: All end-to-end tests pass. All existing tests still pass. `just check` green.
+
+### Phase 6: PBT & Polish (Estimated: ~150 lines tests)
+
+**Implement**: `tests/unit/test_custom_property_pbt.py` — all Hypothesis tests
+
+**Then**:
+1. Run `just test-pbt` — verify PBT passes
+2. Run `just test-cov` — verify coverage >= 90%
+3. Run `just mutate` on new code — target 80%+ mutation score
+4. Final `just check` — all green
+
+---
+
+## 8. Dependency Graph
+
+```
+Phase 1: New Types
+    │
+    ├─── Phase 2: Modified Types (depends on Phase 1 types)
+    │        │
+    │        └─── Phase 4: Validation (depends on modified types)
+    │
+    └─── Phase 3: Builders (depends on Phase 1 types)
+             │
+             └─── Phase 5: E2E & Exports (depends on builders + validation)
+                      │
+                      └─── Phase 6: PBT & Polish (depends on everything)
+```
+
+Phases 2 and 3 can proceed in parallel after Phase 1 is complete.
+
+---
+
+## 9. Files Changed Summary
+
+| File | Change Type | Scope |
+|------|------------|-------|
+| `src/mixpanel_data/types.py` | **Modified** | Add 3 new types, 1 type alias; modify `Metric.property`, `GroupBy.property`, `Filter._property` + 18 class methods |
+| `src/mixpanel_data/_internal/bookmark_builders.py` | **Modified** | Add `_build_composed_properties()`; modify `build_filter_entry()`, `build_group_section()`; update imports |
+| `src/mixpanel_data/workspace.py` | **Modified** | Modify measurement property builder in `_build_query_params()` and `_build_funnel_params()`; update imports |
+| `src/mixpanel_data/_internal/validation.py` | **Modified** | Add `_validate_custom_property()`; add CP validation calls in 3 validate functions |
+| `src/mixpanel_data/__init__.py` | **Modified** | Add exports: `CustomPropertyRef`, `InlineCustomProperty`, `PropertyInput` |
+| `tests/unit/test_custom_property_types.py` | **New** | ~400 lines |
+| `tests/unit/test_custom_property_builders.py` | **New** | ~300 lines |
+| `tests/unit/test_custom_property_query.py` | **New** | ~200 lines |
+| `tests/unit/test_custom_property_pbt.py` | **New** | ~100 lines |
+
+**Total implementation**: ~480 lines of production code
+**Total tests**: ~1,000 lines of test code
+
+---
+
+## 10. Acceptance Criteria
+
+- [ ] `PropertyInput`, `InlineCustomProperty`, `CustomPropertyRef` types are frozen dataclasses
+- [ ] `InlineCustomProperty.numeric()` convenience constructor works
+- [ ] `Metric.property` accepts `str | CustomPropertyRef | InlineCustomProperty | None`
+- [ ] `GroupBy.property` accepts `str | CustomPropertyRef | InlineCustomProperty`
+- [ ] All 18 `Filter` class methods accept `str | CustomPropertyRef | InlineCustomProperty` as first arg
+- [ ] `build_filter_entry()` emits correct JSON for all 3 property types
+- [ ] `build_group_section()` emits correct JSON for all 3 property types
+- [ ] Measurement property in `_build_query_params()` emits correct JSON for all 3 property types
+- [ ] Measurement property in `_build_funnel_params()` emits correct JSON for all 3 property types
+- [ ] Validation rules CP1-CP6 catch all invalid inputs with descriptive messages
+- [ ] Validation runs in `validate_query_args()`, `validate_funnel_args()`, `validate_retention_args()`
+- [ ] All existing tests pass unchanged (backward compatibility)
+- [ ] `just check` passes (lint + typecheck + test)
+- [ ] Coverage >= 90%
+- [ ] New types exported from `mixpanel_data.__init__`
+- [ ] All docstrings complete with examples

--- a/specs/035-cohort-definition-builder/checklists/requirements.md
+++ b/specs/035-cohort-definition-builder/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Cohort Definition Builder
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-07  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - *Note*: Spec references Python types (`CohortCriteria`, `Filter`, `ValueError`, `mypy`) because this is a **library API feature** — the typed API surface IS the deliverable. Developer-consumers are the stakeholders. Accepted as appropriate for this feature type.
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+  - *Note*: Stakeholders for this feature ARE developers and LLM agents consuming a typed Python API. Language is appropriate for that audience.
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+  - *Note*: SC-007 references `mypy --strict` and SC-008 references `Hypothesis` — these are project quality gates, not implementation choices. The project mandates these tools (see CLAUDE.md). Accepted.
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The "implementation details" items are flagged but accepted because this feature specifies a **library API surface** — the types, methods, and validation rules are the user-facing product, not internal implementation choices.
+- 13 functional requirements, 8 success criteria, 7 edge cases, 7 assumptions — comprehensive coverage for Phase 0 scope.

--- a/specs/035-cohort-definition-builder/contracts/public-api.md
+++ b/specs/035-cohort-definition-builder/contracts/public-api.md
@@ -1,0 +1,107 @@
+# Public API Contract: Cohort Definition Builder
+
+**Date**: 2026-04-07  
+**Module**: `mixpanel_data`
+
+## Exports
+
+The following types are added to `mixpanel_data.__init__` public exports:
+
+- `CohortCriteria`
+- `CohortDefinition`
+
+## CohortCriteria
+
+Frozen dataclass. No public fields — constructed exclusively via class methods.
+
+### Class Methods
+
+#### `did_event(event, *, at_least, at_most, exactly, within_days, within_weeks, within_months, from_date, to_date, where) -> CohortCriteria`
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `event` | `str` | Yes | — |
+| `at_least` | `int \| None` | No | `None` |
+| `at_most` | `int \| None` | No | `None` |
+| `exactly` | `int \| None` | No | `None` |
+| `within_days` | `int \| None` | No | `None` |
+| `within_weeks` | `int \| None` | No | `None` |
+| `within_months` | `int \| None` | No | `None` |
+| `from_date` | `str \| None` | No | `None` |
+| `to_date` | `str \| None` | No | `None` |
+| `where` | `Filter \| list[Filter] \| None` | No | `None` |
+
+**Constraints**: Exactly one of `at_least`/`at_most`/`exactly` required. Exactly one time constraint required (`within_*` or `from_date`+`to_date`). `from_date` requires `to_date`. Dates must be YYYY-MM-DD.
+
+**Raises**: `ValueError` on constraint violations (CD1-CD6).
+
+#### `did_not_do_event(event, *, within_days, within_weeks, within_months, from_date, to_date) -> CohortCriteria`
+
+Shorthand for `did_event(event, exactly=0, ...)`.
+
+#### `has_property(property, value, *, operator, property_type) -> CohortCriteria`
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `property` | `str` | Yes | — |
+| `value` | `str \| int \| float \| bool \| list[str]` | Yes | — |
+| `operator` | `Literal["equals", "not_equals", "contains", "not_contains", "greater_than", "less_than", "is_set", "is_not_set"]` | No | `"equals"` |
+| `property_type` | `Literal["string", "number", "boolean", "datetime", "list"]` | No | `"string"` |
+
+**Raises**: `ValueError` if `property` is empty (CD7).
+
+#### `property_is_set(property) -> CohortCriteria`
+
+Shorthand for `has_property(property, "", operator="is_set")`.
+
+#### `property_is_not_set(property) -> CohortCriteria`
+
+Shorthand for `has_property(property, "", operator="is_not_set")`.
+
+#### `in_cohort(cohort_id) -> CohortCriteria`
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `cohort_id` | `int` | Yes |
+
+**Raises**: `ValueError` if `cohort_id` is not a positive integer (CD8).
+
+#### `not_in_cohort(cohort_id) -> CohortCriteria`
+
+Same as `in_cohort` but produces `"not in"` selector.
+
+## CohortDefinition
+
+Frozen dataclass.
+
+### Constructor
+
+#### `__init__(*criteria: CohortCriteria) -> None`
+
+Combines one or more criteria with AND logic. Raises `ValueError` if no criteria provided (CD9).
+
+### Class Methods
+
+#### `all_of(*criteria: CohortCriteria | CohortDefinition) -> CohortDefinition`
+
+Combines criteria/definitions with AND logic. Raises `ValueError` if no criteria provided.
+
+#### `any_of(*criteria: CohortCriteria | CohortDefinition) -> CohortDefinition`
+
+Combines criteria/definitions with OR logic. Raises `ValueError` if no criteria provided.
+
+### Instance Methods
+
+#### `to_dict() -> dict[str, Any]`
+
+Returns `{"selector": {...}, "behaviors": {...}}` dict. Behavior keys are globally re-indexed to ensure uniqueness.
+
+## Compatibility
+
+`CohortDefinition.to_dict()` output is directly compatible with:
+
+```python
+CreateCohortParams(name="...", definition=cohort_def.to_dict())
+```
+
+The `_DefinitionFlatteningModel.model_dump()` flattens `selector` and `behaviors` to top-level keys in the API payload.

--- a/specs/035-cohort-definition-builder/data-model.md
+++ b/specs/035-cohort-definition-builder/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Cohort Definition Builder
+
+**Date**: 2026-04-07  
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Entities
+
+### CohortCriteria
+
+A single atomic condition for cohort membership. Frozen dataclass constructed exclusively via class methods.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_selector_node` | `dict[str, Any]` | Expression tree leaf node (behavioral, property, or cohort reference) |
+| `_behavior_key` | `str \| None` | Placeholder behavior key (e.g., `"bhvr_0"`). `None` for non-behavioral criteria. |
+| `_behavior` | `dict[str, Any] \| None` | Behavior dict entry (event selector + window/dates). `None` for non-behavioral criteria. |
+
+**Construction Methods**:
+
+| Method | Produces Behavior? | Selector `property` | Description |
+|--------|-------------------|---------------------|-------------|
+| `did_event()` | Yes | `"behaviors"` | Event frequency within time window |
+| `did_not_do_event()` | Yes | `"behaviors"` | Shorthand for `did_event(exactly=0)` |
+| `has_property()` | No | `"user"` | User profile property match |
+| `property_is_set()` | No | `"user"` | Property existence check |
+| `property_is_not_set()` | No | `"user"` | Property non-existence check |
+| `in_cohort()` | No | `"cohort"` | Cohort membership (inclusion) |
+| `not_in_cohort()` | No | `"cohort"` | Cohort membership (exclusion) |
+
+### CohortDefinition
+
+A composed set of criteria combined with AND/OR logic. Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_criteria` | `tuple[CohortCriteria \| CohortDefinition, ...]` | One or more criteria or nested definitions |
+| `_operator` | `Literal["and", "or"]` | Boolean combinator (default: `"and"`) |
+
+**Methods**:
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `__init__(*criteria)` | Constructor | AND-combined criteria |
+| `all_of(*criteria)` | Classmethod | Explicit AND combination |
+| `any_of(*criteria)` | Classmethod | Explicit OR combination |
+| `to_dict()` | Instance | Serialize to `{"selector": {...}, "behaviors": {...}}` |
+
+## Serialization Formats
+
+### Selector Node Variants
+
+**Behavioral** (references behavior dict entry):
+```json
+{
+  "property": "behaviors",
+  "value": "bhvr_0",
+  "operator": ">=",
+  "operand": 3
+}
+```
+
+**Property** (user profile property):
+```json
+{
+  "property": "user",
+  "value": "plan",
+  "operator": "==",
+  "operand": "premium",
+  "type": "string"
+}
+```
+
+**Cohort reference**:
+```json
+{
+  "property": "cohort",
+  "value": 456,
+  "operator": "in"
+}
+```
+
+**Boolean combinator** (AND/OR wrapper):
+```json
+{
+  "operator": "and",
+  "children": [/* selector nodes */]
+}
+```
+
+### Behavior Entry
+
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": null
+      },
+      "type": "absolute"
+    },
+    "window": {"unit": "day", "value": 30}
+  }
+}
+```
+
+With event property filters:
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": {
+          "operator": "and",
+          "children": [
+            {"property": "event", "value": "amount", "operator": ">", "operand": 50, "type": "number"}
+          ]
+        }
+      },
+      "type": "absolute"
+    },
+    "window": {"unit": "day", "value": 30}
+  }
+}
+```
+
+With absolute date range (instead of rolling window):
+```json
+{
+  "bhvr_0": {
+    "count": {
+      "event_selector": {
+        "event": "Purchase",
+        "selector": null
+      },
+      "type": "absolute"
+    },
+    "from_date": "2024-01-01",
+    "to_date": "2024-03-31"
+  }
+}
+```
+
+## Validation Rules
+
+| Code | When | Rule | Error Message |
+|------|------|------|---------------|
+| CD1 | `did_event()` | Exactly one frequency param required | `exactly one of at_least, at_most, exactly must be set` |
+| CD2 | `did_event()` | Frequency param must be non-negative | `frequency value must be >= 0` |
+| CD3 | `did_event()` | Exactly one time constraint required | `exactly one time constraint required (within_days/weeks/months or from_date+to_date)` |
+| CD4 | `did_event()` | Event name must be non-empty | `event name must be non-empty` |
+| CD5 | `did_event()` | `from_date` requires `to_date` | `from_date requires to_date` |
+| CD6 | `did_event()` | Dates must be YYYY-MM-DD | `dates must be YYYY-MM-DD format` |
+| CD7 | `has_property()` | Property name must be non-empty | `property name must be non-empty` |
+| CD8 | `in_cohort()` / `not_in_cohort()` | Cohort ID must be positive integer | `cohort_id must be a positive integer` |
+| CD9 | `CohortDefinition` | At least one criterion required | `CohortDefinition requires at least one criterion` |
+| CD10 | `to_dict()` | All behavior keys must be unique | Internal invariant (enforced by re-indexing) |
+
+## Relationships
+
+```text
+CohortDefinition 1──* CohortCriteria | CohortDefinition (recursive)
+                                         │
+CohortCriteria ──0..1── Behavior Entry   (only behavioral criteria)
+                                         │
+CohortCriteria ──1── Selector Node       (always present)
+                                         │
+Behavior Entry ──0..1── Filter(s)        (via did_event where= parameter)
+```
+
+## Integration Points
+
+- **CreateCohortParams**: `CohortDefinition.to_dict()` → `CreateCohortParams(definition=...)` → `model_dump()` flattens `selector` and `behaviors` to top level
+- **Filter**: `CohortCriteria.did_event(where=Filter.equals(...))` reads Filter's internal fields to build event selector expressions
+- **__init__.py**: `CohortCriteria` and `CohortDefinition` added to public exports

--- a/specs/035-cohort-definition-builder/plan.md
+++ b/specs/035-cohort-definition-builder/plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Cohort Definition Builder
+
+**Branch**: `035-cohort-definition-builder` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/035-cohort-definition-builder/spec.md`
+
+## Summary
+
+Add `CohortCriteria` and `CohortDefinition` frozen dataclasses to `types.py` that produce valid Mixpanel cohort definition JSON (legacy `selector` + `behaviors` format). These types are the foundation for cohort filter, breakdown, and metric capabilities in Phases 1-3. Phase 0 is standalone — no query method integration yet.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (mypy --strict)  
+**Primary Dependencies**: Pydantic v2 (for existing `CreateCohortParams`), pandas (existing), Hypothesis (PBT)  
+**Storage**: N/A — pure types, no persistence  
+**Testing**: pytest + Hypothesis (property-based testing)  
+**Target Platform**: Library (PyPI package `mixpanel_data`)  
+**Project Type**: Library  
+**Performance Goals**: N/A — construction-time only, no runtime performance concerns  
+**Constraints**: Must pass `mypy --strict`, `ruff check`, `ruff format`; 90%+ test coverage  
+**Scale/Scope**: ~2 new classes, ~7 class methods on `CohortCriteria`, ~4 methods on `CohortDefinition`, ~10 validation rules
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | Pass | Pure library types — no CLI in Phase 0 |
+| II. Agent-Native | Pass | Frozen dataclasses, structured `to_dict()` output, no interactivity |
+| III. Context Window Efficiency | Pass | Typed builders reduce token cost vs raw dict construction |
+| IV. Two Data Paths | N/A | Type definitions only, no data retrieval |
+| V. Explicit Over Implicit | Pass | Fail-fast validation at construction, immutable after creation |
+| VI. Unix Philosophy | Pass | Composable building blocks, single responsibility per class |
+| VII. Secure by Default | N/A | No credentials involved |
+
+**Result**: All applicable gates pass. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/035-cohort-definition-builder/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (minimal — design doc covers all decisions)
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── contracts/           # Phase 1 output (public API contract)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── __init__.py              # Add CohortCriteria, CohortDefinition exports
+└── types.py                 # Add CohortCriteria, CohortDefinition classes
+                             # (after GroupBy at ~line 7649)
+
+tests/
+├── unit/
+│   └── test_cohort_definition.py    # Unit tests for both classes
+└── test_cohort_definition_pbt.py    # Property-based tests (Hypothesis)
+```
+
+**Structure Decision**: Minimal footprint — two new classes in existing `types.py`, two new test files. No new modules, packages, or infrastructure changes.

--- a/specs/035-cohort-definition-builder/quickstart.md
+++ b/specs/035-cohort-definition-builder/quickstart.md
@@ -1,0 +1,115 @@
+# Quickstart: Cohort Definition Builder
+
+## Basic Usage
+
+```python
+from mixpanel_data import CohortCriteria, CohortDefinition
+
+# Simple behavioral cohort: users who purchased 3+ times in 30 days
+cohort = CohortDefinition(
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+)
+print(cohort.to_dict())
+# {"selector": {"operator": "and", "children": [...]}, "behaviors": {"bhvr_0": {...}}}
+```
+
+## Combining Criteria (AND)
+
+```python
+# Premium users who purchased 3+ times in 30 days
+cohort = CohortDefinition.all_of(
+    CohortCriteria.has_property("plan", "premium"),
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+)
+```
+
+## Combining Criteria (OR)
+
+```python
+# Users who signed up recently OR are in the Power Users cohort
+cohort = CohortDefinition.any_of(
+    CohortCriteria.did_event("Signup", at_least=1, within_days=7),
+    CohortCriteria.in_cohort(456),
+)
+```
+
+## Nested Boolean Logic
+
+```python
+# (Premium AND active) OR Enterprise cohort
+cohort = CohortDefinition.any_of(
+    CohortDefinition.all_of(
+        CohortCriteria.has_property("plan", "premium"),
+        CohortCriteria.did_event("Login", at_least=5, within_days=30),
+    ),
+    CohortCriteria.in_cohort(789),  # Enterprise cohort
+)
+```
+
+## With Event Property Filters
+
+```python
+from mixpanel_data import Filter
+
+# Users who made high-value purchases
+cohort = CohortDefinition(
+    CohortCriteria.did_event(
+        "Purchase",
+        at_least=1,
+        within_days=90,
+        where=Filter.greater_than("amount", 100),
+    )
+)
+```
+
+## Inactive Users
+
+```python
+# Users who haven't logged in for 30 days
+cohort = CohortDefinition(
+    CohortCriteria.did_not_do_event("Login", within_days=30)
+)
+```
+
+## Absolute Date Ranges
+
+```python
+# Users who purchased in Q1 2024
+cohort = CohortDefinition(
+    CohortCriteria.did_event(
+        "Purchase",
+        at_least=1,
+        from_date="2024-01-01",
+        to_date="2024-03-31",
+    )
+)
+```
+
+## Creating a Saved Cohort
+
+```python
+from mixpanel_data import Workspace, CreateCohortParams
+
+ws = Workspace()
+
+cohort_def = CohortDefinition.all_of(
+    CohortCriteria.has_property("plan", "premium"),
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+)
+
+ws.create_cohort(CreateCohortParams(
+    name="Premium Purchasers",
+    definition=cohort_def.to_dict(),
+))
+```
+
+## Inspecting the Output
+
+```python
+import json
+
+cohort = CohortDefinition(
+    CohortCriteria.did_event("Purchase", at_least=1, within_days=30)
+)
+print(json.dumps(cohort.to_dict(), indent=2))
+```

--- a/specs/035-cohort-definition-builder/research.md
+++ b/specs/035-cohort-definition-builder/research.md
@@ -1,0 +1,81 @@
+# Research: Cohort Definition Builder
+
+**Date**: 2026-04-07  
+**Status**: Complete — all decisions resolved by design document
+
+## Summary
+
+No NEEDS CLARIFICATION items exist. The design document (`context/cohort-behaviors-design.md`) thoroughly researched the Mixpanel analytics codebase and resolved all technical decisions before this feature specification was created.
+
+## Decisions
+
+### 1. Cohort Definition Format
+
+**Decision**: Generate the legacy `selector` + `behaviors` format.  
+**Rationale**: Universal compatibility — works in both `create_cohort()` and inline `raw_cohort` query references. The backend parses it natively without conversion. The modern `groups` format is a UI abstraction that the backend converts to `selector` + `behaviors` anyway.  
+**Alternatives considered**: Modern `groups` format — rejected because it's not accepted in all code paths (particularly `raw_cohort` inline references).
+
+### 2. Behavior Count Type
+
+**Decision**: Default to `"absolute"` (total count across window).  
+**Rationale**: Covers the vast majority of use cases. Per-day frequency (`"day"`) is a niche feature that can be added later without breaking changes.  
+**Alternatives considered**: Supporting both `"absolute"` and `"day"` in v1 — rejected to minimize scope.
+
+### 3. Behavior Key Strategy
+
+**Decision**: Use `bhvr_N` keys with global re-indexing during `to_dict()`.  
+**Rationale**: Each `CohortCriteria.did_event()` creates a placeholder key. When `CohortDefinition.to_dict()` serializes the tree, it re-indexes all behavior keys sequentially (`bhvr_0`, `bhvr_1`, ...) and updates the corresponding selector node references. This ensures uniqueness across arbitrary nesting.  
+**Alternatives considered**: UUID-based keys — rejected because Mixpanel's backend expects `bhvr_N` pattern. Pre-allocated sequential keys — rejected because nesting makes pre-allocation impractical.
+
+### 4. Filter-to-Event-Selector Conversion
+
+**Decision**: Read `Filter` internal fields (`_property`, `_operator`, `_value`, `_property_type`) and map to event selector expression tree format.  
+**Rationale**: Reuses the existing `Filter` class without modification. The operator mapping is a simple dict lookup (e.g., `"equals"` → `"=="`, `"is greater than"` → `">`).  
+**Alternatives considered**: Adding a `to_selector()` method to `Filter` — rejected to avoid coupling Filter to cohort-specific concerns.
+
+### 5. Validation Strategy
+
+**Decision**: Fail-fast at construction time using `ValueError`, not the `ValidationError` collector pattern.  
+**Rationale**: Follows the `Filter._validate_date()` precedent. The collector pattern (`validate_query_args()`) is for Layer 1/Layer 2 bookmark validation where multiple errors are useful. For type construction, immediate `ValueError` is simpler and more Pythonic.  
+**Alternatives considered**: Using `ValidationError` with codes — deferred to Phases 1-3 where cohort parameters are validated as part of bookmark construction.
+
+### 6. Class Placement
+
+**Decision**: Both classes go in `types.py` after `GroupBy` (~line 7649).  
+**Rationale**: Follows the established pattern — `Metric`, `Formula`, `Filter`, `GroupBy` are all in `types.py`. No new modules needed. Helper functions (`_build_selector_tree`, `_build_event_selector`) are private module-level functions in the same file.  
+**Alternatives considered**: Separate `cohort_types.py` module — rejected because it breaks the single-import pattern and creates artificial separation.
+
+### 7. Operator Mapping Table
+
+**Decision**: Use a module-level `_PROPERTY_OPERATOR_MAP` dict for `has_property()` operator-to-selector mapping.
+
+| `CohortCriteria` operator | Selector operator |
+|---------------------------|-------------------|
+| `"equals"` | `"=="` |
+| `"not_equals"` | `"!="` |
+| `"contains"` | `"in"` |
+| `"not_contains"` | `"not in"` |
+| `"greater_than"` | `">"` |
+| `"less_than"` | `"<"` |
+| `"is_set"` | `"defined"` |
+| `"is_not_set"` | `"not defined"` |
+
+**Rationale**: Explicit mapping dict is testable and discoverable. Follows the pattern of `VALID_FILTER_OPERATORS` in `bookmark_enums.py`.
+
+### 8. Filter Operator Mapping for Event Selectors
+
+**Decision**: Use a separate `_FILTER_TO_SELECTOR_MAP` dict for converting `Filter._operator` strings to event selector operators.
+
+| `Filter._operator` | Event selector operator |
+|---------------------|------------------------|
+| `"equals"` | `"=="` |
+| `"does not equal"` | `"!="` |
+| `"contains"` | `"in"` |
+| `"does not contain"` | `"not in"` |
+| `"is greater than"` | `">"` |
+| `"is less than"` | `"<"` |
+| `"is set"` | `"defined"` |
+| `"is not set"` | `"not defined"` |
+| `"is between"` | `"between"` |
+
+**Rationale**: `Filter` uses human-readable operator strings (e.g., `"is greater than"`) while event selectors use symbolic operators (e.g., `">"`). The mapping is a direct translation.

--- a/specs/035-cohort-definition-builder/spec.md
+++ b/specs/035-cohort-definition-builder/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Cohort Definition Builder
+
+**Feature Branch**: `035-cohort-definition-builder`  
+**Created**: 2026-04-07  
+**Status**: Draft  
+**Input**: User description: "Phase 0: Cohort Definition Builder — Add CohortCriteria and CohortDefinition frozen dataclasses for constructing valid Mixpanel cohort definition JSON. Foundation for cohort filter, breakdown, and metric query capabilities."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Define a Behavioral Cohort Criterion (Priority: P1)
+
+A developer or LLM agent needs to define a cohort based on event behavior — for example, "users who purchased at least 3 times in the last 30 days." They construct this using a typed class method rather than manually building raw JSON dicts.
+
+**Why this priority**: Behavioral criteria (event frequency within a time window) are the most common cohort definition pattern in Mixpanel. Without this, the builder has no core capability.
+
+**Independent Test**: Can be fully tested by constructing a `CohortCriteria.did_event("Purchase", at_least=3, within_days=30)` and verifying the internal state is correctly set. Delivers value as a validated building block.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer wants to define a behavioral criterion, **When** they call `CohortCriteria.did_event("Purchase", at_least=3, within_days=30)`, **Then** a frozen `CohortCriteria` is returned with a valid selector node referencing a behavior entry, and a behavior dict containing the event count and rolling window.
+2. **Given** a developer specifies conflicting frequency params (e.g., both `at_least` and `at_most`), **When** they call `did_event()`, **Then** a `ValueError` is raised immediately with a clear message indicating exactly one frequency param is required.
+3. **Given** a developer omits all time constraints, **When** they call `did_event("Purchase", at_least=1)`, **Then** a `ValueError` is raised indicating exactly one time constraint is required.
+4. **Given** a developer provides event property filters via `where=`, **When** they call `did_event("Purchase", at_least=1, within_days=30, where=Filter.equals("plan", "premium"))`, **Then** the behavior's event selector includes the filter as an expression tree.
+
+---
+
+### User Story 2 - Compose a Multi-Criteria Cohort Definition (Priority: P1)
+
+A developer needs to combine multiple criteria with boolean logic — for example, "premium users who purchased 3+ times in 30 days" (AND) or "users who signed up recently OR are in the Power Users cohort" (OR). They compose criteria into a `CohortDefinition` and serialize it to valid JSON.
+
+**Why this priority**: Composition is the core value proposition of the builder. Without it, individual criteria are isolated building blocks with no way to produce complete cohort definitions.
+
+**Independent Test**: Can be fully tested by constructing `CohortDefinition.all_of(criterion_a, criterion_b)`, calling `.to_dict()`, and verifying the output dict has valid `selector` and `behaviors` keys with correct structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer has two criteria, **When** they call `CohortDefinition.all_of(criteria_a, criteria_b)`, **Then** a frozen `CohortDefinition` is returned. Calling `.to_dict()` produces `{"selector": {"operator": "and", "children": [...]}, "behaviors": {...}}` with all behavior entries merged and behavior keys globally unique.
+2. **Given** a developer uses `any_of()`, **When** the definition is serialized, **Then** the selector tree uses `"operator": "or"`.
+3. **Given** nested definitions like `any_of(all_of(A, B), C)`, **When** serialized, **Then** the selector tree correctly nests AND inside OR, and all behavior keys across the tree are unique (no collisions).
+4. **Given** zero criteria are provided, **When** constructing a `CohortDefinition`, **Then** a `ValueError` is raised indicating at least one criterion is required.
+
+---
+
+### User Story 3 - Define a Property-Based Cohort Criterion (Priority: P2)
+
+A developer defines a cohort based on user profile properties — for example, "users on the premium plan" or "users whose age is greater than 18."
+
+**Why this priority**: Property criteria are simpler than behavioral criteria (no behavior dict needed) and cover a common use case, but are less complex to implement.
+
+**Independent Test**: Can be fully tested by constructing `CohortCriteria.has_property("plan", "premium")` and verifying the selector node has the correct property, value, operator, and type fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer wants a simple property match, **When** they call `CohortCriteria.has_property("plan", "premium")`, **Then** the returned criterion has a selector node with `property: "user"`, `value: "plan"`, `operator: "=="`, `operand: "premium"`, `type: "string"`.
+2. **Given** a developer uses a comparison operator, **When** they call `CohortCriteria.has_property("age", 18, operator="greater_than", property_type="number")`, **Then** the selector node has `operator: ">"`, `operand: 18`, `type: "number"`.
+3. **Given** a developer calls `CohortCriteria.property_is_set("email")`, **Then** the selector node uses `operator: "defined"`.
+4. **Given** an empty property name is provided, **When** calling `has_property("", "value")`, **Then** a `ValueError` is raised.
+
+---
+
+### User Story 4 - Reference a Saved Cohort in a Definition (Priority: P2)
+
+A developer builds a cohort that references another saved cohort — for example, "users who are in the Enterprise cohort AND purchased recently."
+
+**Why this priority**: Cohort composition (referencing other cohorts) is a powerful feature but depends on the behavioral and property criteria being established first.
+
+**Independent Test**: Can be fully tested by constructing `CohortCriteria.in_cohort(456)` and verifying the selector node references the cohort ID correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer wants to reference a saved cohort, **When** they call `CohortCriteria.in_cohort(456)`, **Then** the selector node has `property: "cohort"`, `value: 456`, `operator: "in"`.
+2. **Given** a developer wants the negation, **When** they call `CohortCriteria.not_in_cohort(456)`, **Then** the selector node has `operator: "not in"`.
+3. **Given** an invalid cohort ID (zero or negative), **When** calling `in_cohort(0)`, **Then** a `ValueError` is raised.
+
+---
+
+### User Story 5 - Use Definition with Cohort CRUD (Priority: P2)
+
+A developer creates a saved cohort in Mixpanel using the typed builder instead of hand-crafting JSON, passing `CohortDefinition.to_dict()` as the `definition` parameter to `CreateCohortParams`.
+
+**Why this priority**: Integration with the existing CRUD system validates that the builder produces JSON the API accepts. This is the primary consumption path for Phase 0.
+
+**Independent Test**: Can be fully tested by constructing a `CohortDefinition`, calling `.to_dict()`, passing it to `CreateCohortParams(name="Test", definition=def.to_dict())`, and verifying `model_dump()` produces a valid flattened payload with `selector` and `behaviors` at the top level.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `CohortDefinition` with behavioral and property criteria, **When** its `.to_dict()` output is passed to `CreateCohortParams(definition=...)`, **Then** `model_dump(exclude_none=True)` produces a dict with `name`, `selector`, and `behaviors` keys at the top level (definition is flattened).
+2. **Given** a definition with nested boolean logic, **When** serialized and passed to CRUD, **Then** the `selector` tree and `behaviors` dict are structurally valid per Mixpanel's legacy format.
+
+---
+
+### User Story 6 - Convenience Shorthand for "Did Not Do" (Priority: P3)
+
+A developer uses the `did_not_do_event()` shorthand for the common pattern of defining inactive users (event count = 0 within a window).
+
+**Why this priority**: This is syntactic sugar over `did_event(exactly=0)` — useful but not essential.
+
+**Independent Test**: Can be fully tested by verifying `CohortCriteria.did_not_do_event("Login", within_days=30)` produces the same internal state as `CohortCriteria.did_event("Login", exactly=0, within_days=30)`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer wants inactive users, **When** they call `CohortCriteria.did_not_do_event("Login", within_days=30)`, **Then** the result is equivalent to `did_event("Login", exactly=0, within_days=30)`.
+
+---
+
+### Edge Cases
+
+- What happens when a developer provides both a rolling window AND absolute dates to `did_event()`? A `ValueError` is raised — exactly one time constraint is required.
+- What happens when `from_date` is provided without `to_date`? A `ValueError` is raised — `from_date` requires `to_date`.
+- What happens when dates are not in YYYY-MM-DD format? A `ValueError` is raised with a format hint.
+- What happens when `did_event()` receives a negative frequency value? A `ValueError` is raised — frequency must be non-negative.
+- What happens when an empty event name is passed? A `ValueError` is raised.
+- What happens when a `CohortDefinition` contains only non-behavioral criteria? `to_dict()` produces a `behaviors` dict that is empty `{}` — the selector tree stands alone.
+- What happens when deeply nested definitions (3+ levels) are serialized? Behavior keys remain globally unique across all nesting levels via re-indexing during `to_dict()`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `CohortCriteria` type with class methods for constructing behavioral criteria (`did_event`, `did_not_do_event`), property criteria (`has_property`, `property_is_set`, `property_is_not_set`), and cohort reference criteria (`in_cohort`, `not_in_cohort`).
+- **FR-002**: System MUST provide a `CohortDefinition` type that combines one or more `CohortCriteria` (or nested `CohortDefinition`) with AND or OR logic via `all_of()` and `any_of()` class methods.
+- **FR-003**: `CohortDefinition.to_dict()` MUST produce a dict with `selector` (expression tree) and `behaviors` (behavior dictionary) keys in Mixpanel's legacy cohort definition format.
+- **FR-004**: Behavioral criteria MUST accept exactly one frequency parameter (`at_least`, `at_most`, or `exactly`) and exactly one time constraint (`within_days`, `within_weeks`, `within_months`, or `from_date`+`to_date`).
+- **FR-005**: Behavioral criteria MUST support event property filters via an optional `where` parameter that accepts `Filter` or `list[Filter]` objects from the existing query system.
+- **FR-006**: Property criteria MUST support operators: `equals`, `not_equals`, `contains`, `not_contains`, `greater_than`, `less_than`, `is_set`, `is_not_set`, mapping to the corresponding selector tree operators.
+- **FR-007**: Cohort reference criteria MUST accept a positive integer cohort ID and produce `in`/`not in` selector nodes.
+- **FR-008**: Both `CohortCriteria` and `CohortDefinition` MUST be frozen (immutable after construction).
+- **FR-009**: All validation MUST happen at construction time (fail-fast), raising `ValueError` with clear messages per rules CD1-CD10.
+- **FR-010**: `CohortDefinition.to_dict()` MUST produce globally unique behavior keys (`bhvr_0`, `bhvr_1`, ...) across the entire definition tree, including nested sub-definitions.
+- **FR-011**: Both types MUST be exported from the package's public API.
+- **FR-012**: `CohortDefinition.to_dict()` output MUST be directly usable as the `definition` parameter of the existing `CreateCohortParams` for cohort CRUD operations.
+- **FR-013**: Behavioral criteria MUST support both rolling windows (`within_days/weeks/months`) and absolute date ranges (`from_date`+`to_date`), but not both simultaneously.
+
+### Key Entities
+
+- **CohortCriteria**: A single atomic condition for cohort membership. Contains an internal selector node (expression tree leaf) and optionally a behavior key + behavior dict (for event-based criteria). Constructed exclusively via class methods.
+- **CohortDefinition**: A composed set of one or more criteria or nested definitions, combined with AND/OR logic. Produces the complete `selector` + `behaviors` JSON via `to_dict()`.
+- **Selector Node**: A dict representing one leaf in the expression tree — references either a behavior (`property: "behaviors"`), a user property (`property: "user"`), or a cohort (`property: "cohort"`).
+- **Behavior Entry**: A dict describing an event count condition with event selector, count type, and time window. Keyed by `bhvr_N` in the behaviors dictionary.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 7 `CohortCriteria` class methods (`did_event`, `did_not_do_event`, `has_property`, `property_is_set`, `property_is_not_set`, `in_cohort`, `not_in_cohort`) produce valid, inspectable criterion objects.
+- **SC-002**: `CohortDefinition.to_dict()` produces structurally valid JSON for single criteria, AND-combined criteria, OR-combined criteria, and nested boolean expressions (3+ levels deep).
+- **SC-003**: All 10 validation rules (CD1-CD10) are enforced at construction or serialization time with clear error messages, and every rule has at least one test exercising the error path.
+- **SC-004**: `CohortDefinition.to_dict()` output is accepted by `CreateCohortParams(definition=...)` without modification — verified by `model_dump()` producing a valid flattened payload.
+- **SC-005**: Behavior keys are globally unique across arbitrarily nested definitions — verified by property-based tests with randomized nesting structures.
+- **SC-006**: Test coverage for new code meets or exceeds the project's 90% threshold.
+- **SC-007**: All new code passes `mypy --strict` type checking with zero errors.
+- **SC-008**: Property-based tests (Hypothesis) verify serialization invariants across randomized inputs — no crashes, no duplicate keys, valid JSON structure.
+
+## Assumptions
+
+- The builder generates Mixpanel's **legacy `selector` + `behaviors` format** (not the modern `groups` format). This format is universally accepted by both `create_cohort()` and inline query references.
+- **Behavior count type** defaults to `"absolute"` (total count across window). Per-day frequency (`"day"`) is deferred to a future version.
+- **B2B group analytics** (`data_group_id`) is out of scope — all generated JSON uses `null` for group identifiers.
+- Report-based cohort criteria (funnel, retention, addiction, flows report references) are out of scope for this phase.
+- The existing `Filter` class is consumed read-only — `CohortCriteria.did_event(where=...)` reads Filter's internal `_property`, `_operator`, `_value`, and `_property_type` fields to construct event selector expressions, but does not modify Filter.
+- `CohortCriteria` and `CohortDefinition` are standalone types in Phase 0 — they do not yet integrate with `query()`, `query_funnel()`, `query_retention()`, or `query_flow()`. That integration happens in Phases 1-3.
+- `did_not_do_event()` is a pure convenience shorthand that delegates to `did_event(exactly=0, ...)`.

--- a/specs/035-cohort-definition-builder/tasks.md
+++ b/specs/035-cohort-definition-builder/tasks.md
@@ -1,0 +1,298 @@
+# Tasks: Cohort Definition Builder
+
+**Input**: Design documents from `/specs/035-cohort-definition-builder/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/public-api.md  
+**Tests**: Included (TDD — project mandate per CLAUDE.md)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project setup needed — existing codebase. This phase ensures the test file scaffolding exists.
+
+- [X] T001 Create test file scaffold at tests/unit/test_cohort_definition.py with imports and empty test classes
+- [X] T002 [P] Create PBT test file scaffold at tests/test_cohort_definition_pbt.py with Hypothesis imports and profile configuration
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Base dataclass shells and operator mapping dicts that ALL user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Add `CohortCriteria` frozen dataclass shell to src/mixpanel_data/types.py with internal fields `_selector_node`, `_behavior_key`, `_behavior` (no class methods yet)
+- [X] T004 Add `CohortDefinition` frozen dataclass shell to src/mixpanel_data/types.py with internal fields `_criteria`, `_operator` and placeholder `to_dict()` raising NotImplementedError
+- [X] T005 [P] Add `_PROPERTY_OPERATOR_MAP` dict to src/mixpanel_data/types.py mapping CohortCriteria operator strings to selector tree operators (equals→==, not_equals→!=, contains→in, not_contains→not in, greater_than→>, less_than→<, is_set→defined, is_not_set→not defined)
+- [X] T006 [P] Add `_FILTER_TO_SELECTOR_MAP` dict to src/mixpanel_data/types.py mapping Filter._operator strings to event selector operators (equals→==, does not equal→!=, contains→in, does not contain→not in, is greater than→>, is less than→<, is set→defined, is not set→not defined, is between→between)
+
+**Checkpoint**: Base types exist — user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 - Define a Behavioral Cohort Criterion (Priority: P1)
+
+**Goal**: `CohortCriteria.did_event()` produces valid behavioral criteria with frequency + time window + optional event property filters.
+
+**Independent Test**: Construct `CohortCriteria.did_event("Purchase", at_least=3, within_days=30)` and verify internal `_selector_node`, `_behavior_key`, and `_behavior` fields.
+
+### Tests for User Story 1
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [US1] Write tests for `did_event()` construction with `at_least` + `within_days` in tests/unit/test_cohort_definition.py — verify `_selector_node` has `property: "behaviors"`, `operator: ">="`, `operand: 3`; verify `_behavior` has event_selector with event name, window with unit+value; verify `_behavior_key` is set
+- [X] T008 [P] [US1] Write tests for `did_event()` with `at_most`, `exactly` frequency params and `within_weeks`, `within_months` time constraints in tests/unit/test_cohort_definition.py — verify correct operator mapping (at_most→<=, exactly→==) and window unit mapping (weeks→week, months→month)
+- [X] T009 [P] [US1] Write tests for `did_event()` with `from_date`+`to_date` absolute date range in tests/unit/test_cohort_definition.py — verify behavior has from_date/to_date instead of window
+- [X] T010 [P] [US1] Write tests for `did_event()` with `where=Filter.equals("plan", "premium")` in tests/unit/test_cohort_definition.py — verify behavior's event_selector.selector contains expression tree with Filter converted to event selector format
+- [X] T011 [P] [US1] Write tests for `did_event()` with `where=[Filter.equals("plan", "premium"), Filter.greater_than("amount", 100)]` (multiple filters) in tests/unit/test_cohort_definition.py — verify selector has AND-combined children
+- [X] T012 [P] [US1] Write validation error tests for `did_event()` in tests/unit/test_cohort_definition.py — CD1: conflicting frequency params (both at_least and at_most); CD2: negative frequency; CD3: no time constraint; CD3: both within_days and from_date; CD4: empty event name; CD5: from_date without to_date; CD6: invalid date format
+- [X] T013 [US1] Write immutability test for CohortCriteria in tests/unit/test_cohort_definition.py — verify frozen dataclass rejects attribute assignment
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Implement `_build_event_selector()` helper function in src/mixpanel_data/types.py — converts Filter objects to event selector expression tree dicts using `_FILTER_TO_SELECTOR_MAP`, reads Filter._property, _operator, _value, _property_type
+- [X] T015 [US1] Implement `CohortCriteria.did_event()` class method in src/mixpanel_data/types.py — validate CD1-CD6, build selector node (property: "behaviors", value: behavior_key, operator from frequency param, operand from frequency value), build behavior dict (event_selector with optional where filters, count type "absolute", window or from_date/to_date)
+- [X] T016 [US1] Run tests for US1 and verify all pass in tests/unit/test_cohort_definition.py
+
+**Checkpoint**: `CohortCriteria.did_event()` fully functional with all frequency params, time constraints, event filters, and validation.
+
+---
+
+## Phase 4: User Story 2 - Compose a Multi-Criteria Cohort Definition (Priority: P1)
+
+**Goal**: `CohortDefinition` combines criteria with AND/OR logic and serializes to valid `selector` + `behaviors` JSON via `to_dict()`.
+
+**Independent Test**: Construct `CohortDefinition.all_of(criterion_a, criterion_b)`, call `.to_dict()`, verify output has `selector` and `behaviors` keys with correct structure and globally unique behavior keys.
+
+**Depends on**: US1 (needs at least one criterion type for test inputs)
+
+### Tests for User Story 2
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T017 [US2] Write tests for `CohortDefinition.__init__()` with single criterion in tests/unit/test_cohort_definition.py — verify `_criteria` tuple, `_operator` is "and", `.to_dict()` produces dict with `selector` and `behaviors` keys
+- [X] T018 [P] [US2] Write tests for `CohortDefinition.all_of()` with two behavioral criteria in tests/unit/test_cohort_definition.py — verify selector has operator "and" with two children, behaviors dict has two entries (bhvr_0, bhvr_1)
+- [X] T019 [P] [US2] Write tests for `CohortDefinition.any_of()` in tests/unit/test_cohort_definition.py — verify selector has operator "or"
+- [X] T020 [P] [US2] Write tests for nested definitions `any_of(all_of(A, B), C)` in tests/unit/test_cohort_definition.py — verify selector tree nests AND inside OR, verify all behavior keys are globally unique (bhvr_0, bhvr_1, bhvr_2 — no duplicates)
+- [X] T021 [P] [US2] Write tests for deeply nested definitions (3+ levels) in tests/unit/test_cohort_definition.py — verify behavior key uniqueness across all levels
+- [X] T022 [P] [US2] Write test for `CohortDefinition()` with zero criteria in tests/unit/test_cohort_definition.py — verify ValueError raised (CD9)
+- [X] T023 [P] [US2] Write immutability test for CohortDefinition in tests/unit/test_cohort_definition.py — verify frozen dataclass rejects attribute assignment
+
+### Implementation for User Story 2
+
+- [X] T025 [US2] Implement `CohortDefinition.__init__()` in src/mixpanel_data/types.py — accept `*criteria: CohortCriteria`, validate CD9 (at least one), store as tuple, set operator to "and"
+- [X] T026 [US2] Implement `CohortDefinition.all_of()` classmethod in src/mixpanel_data/types.py — accept `*criteria: CohortCriteria | CohortDefinition`, validate CD9, set operator to "and"
+- [X] T027 [US2] Implement `CohortDefinition.any_of()` classmethod in src/mixpanel_data/types.py — same as all_of but operator "or"
+- [X] T028 [US2] Implement `CohortDefinition.to_dict()` in src/mixpanel_data/types.py — recursively collect all behaviors with global re-indexing (bhvr_0, bhvr_1, ...), build selector expression tree by walking criteria/nested definitions, update selector node behavior references to match re-indexed keys, return {"selector": tree, "behaviors": merged_dict}
+- [X] T029 [US2] Run tests for US2 and verify all pass in tests/unit/test_cohort_definition.py
+
+**Checkpoint**: `CohortDefinition` fully functional with AND/OR composition, nesting, and serialization.
+
+---
+
+## Phase 5: User Story 3 - Define a Property-Based Cohort Criterion (Priority: P2)
+
+**Goal**: `CohortCriteria.has_property()`, `property_is_set()`, `property_is_not_set()` produce valid property selector nodes.
+
+**Independent Test**: Construct `CohortCriteria.has_property("plan", "premium")` and verify selector node has correct property, value, operator, operand, and type fields.
+
+### Tests for User Story 3
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T030 [P] [US3] Write tests for `has_property()` with default operator ("equals") in tests/unit/test_cohort_definition.py — verify selector node: property="user", value="plan", operator="==", operand="premium", type="string"; verify _behavior_key is None, _behavior is None
+- [X] T031 [P] [US3] Write tests for `has_property()` with all operators (not_equals, contains, not_contains, greater_than, less_than) in tests/unit/test_cohort_definition.py — verify operator mapping via `_PROPERTY_OPERATOR_MAP`
+- [X] T032 [P] [US3] Write tests for `has_property()` with property_type="number" in tests/unit/test_cohort_definition.py — verify type field in selector node
+- [X] T033 [P] [US3] Write tests for `property_is_set()` and `property_is_not_set()` in tests/unit/test_cohort_definition.py — verify operators "defined" and "not defined"
+- [X] T034 [P] [US3] Write validation error test for `has_property("", "value")` in tests/unit/test_cohort_definition.py — verify ValueError raised (CD7)
+- [X] T035 [P] [US3] Write test for property criteria in CohortDefinition.to_dict() in tests/unit/test_cohort_definition.py — verify property-only definition produces empty behaviors dict
+- [X] T035b [P] [US3] Write test for definition with only non-behavioral criteria (property criteria) in tests/unit/test_cohort_definition.py — verify `behaviors` dict is empty `{}` (moved from US2 — requires property criteria to exist)
+
+### Implementation for User Story 3
+
+- [X] T036 [US3] Implement `CohortCriteria.has_property()` class method in src/mixpanel_data/types.py — validate CD7, build selector node with property="user", map operator via `_PROPERTY_OPERATOR_MAP`, set _behavior_key=None, _behavior=None
+- [X] T037 [US3] Implement `CohortCriteria.property_is_set()` and `property_is_not_set()` class methods in src/mixpanel_data/types.py — delegate to has_property with appropriate operator
+- [X] T038 [US3] Run tests for US3 and verify all pass in tests/unit/test_cohort_definition.py
+
+**Checkpoint**: All three property criteria methods functional. Property-only definitions serialize correctly.
+
+---
+
+## Phase 6: User Story 4 - Reference a Saved Cohort in a Definition (Priority: P2)
+
+**Goal**: `CohortCriteria.in_cohort()` and `not_in_cohort()` produce valid cohort reference selector nodes.
+
+**Independent Test**: Construct `CohortCriteria.in_cohort(456)` and verify selector node has `property: "cohort"`, `value: 456`, `operator: "in"`.
+
+### Tests for User Story 4
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T039 [P] [US4] Write tests for `in_cohort(456)` in tests/unit/test_cohort_definition.py — verify selector node: property="cohort", value=456, operator="in"; verify _behavior_key is None, _behavior is None
+- [X] T040 [P] [US4] Write tests for `not_in_cohort(456)` in tests/unit/test_cohort_definition.py — verify operator="not in"
+- [X] T041 [P] [US4] Write validation error tests for `in_cohort(0)`, `in_cohort(-1)` in tests/unit/test_cohort_definition.py — verify ValueError raised (CD8)
+- [X] T042 [P] [US4] Write test for cohort criteria in CohortDefinition.to_dict() in tests/unit/test_cohort_definition.py — verify cohort-only definition produces correct selector and empty behaviors
+
+### Implementation for User Story 4
+
+- [X] T043 [US4] Implement `CohortCriteria.in_cohort()` and `not_in_cohort()` class methods in src/mixpanel_data/types.py — validate CD8 (positive integer), build selector node with property="cohort", value=cohort_id, operator "in"/"not in", set _behavior_key=None, _behavior=None
+- [X] T044 [US4] Run tests for US4 and verify all pass in tests/unit/test_cohort_definition.py
+
+**Checkpoint**: All cohort reference methods functional. Mixed definitions (behavioral + property + cohort) serialize correctly.
+
+---
+
+## Phase 7: User Story 5 - Use Definition with Cohort CRUD (Priority: P2)
+
+**Goal**: `CohortDefinition.to_dict()` output integrates with existing `CreateCohortParams` — `model_dump()` flattens `selector` and `behaviors` to top level.
+
+**Independent Test**: Construct a definition, pass `to_dict()` to `CreateCohortParams(name="Test", definition=...)`, verify `model_dump(exclude_none=True)` has `name`, `selector`, `behaviors` at top level.
+
+**Depends on**: US1 (behavioral criteria) and US3 (property criteria) for realistic test inputs
+
+### Tests for User Story 5
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T045 [US5] Write integration test in tests/unit/test_cohort_definition.py — construct CohortDefinition with behavioral + property criteria, pass to_dict() to CreateCohortParams(name="Test", definition=...), verify model_dump(exclude_none=True) has keys: name, selector, behaviors at top level (no definition key)
+- [X] T046 [P] [US5] Write integration test for nested boolean definition with CRUD in tests/unit/test_cohort_definition.py — verify complex nested definition flattens correctly
+- [X] T047 [P] [US5] Write test that to_dict() output is JSON-serializable in tests/unit/test_cohort_definition.py — json.dumps(cohort.to_dict()) succeeds without errors
+
+### Implementation for User Story 5
+
+- [X] T048 [US5] No new implementation needed — this phase validates existing functionality. Run tests and verify all pass. Fix any integration issues discovered.
+
+**Checkpoint**: Builder output confirmed compatible with existing CRUD pipeline.
+
+---
+
+## Phase 8: User Story 6 - Convenience Shorthand for "Did Not Do" (Priority: P3)
+
+**Goal**: `CohortCriteria.did_not_do_event()` is equivalent to `did_event(exactly=0, ...)`.
+
+**Independent Test**: Verify `did_not_do_event("Login", within_days=30)` produces same internal state as `did_event("Login", exactly=0, within_days=30)`.
+
+**Depends on**: US1 (`did_event`)
+
+### Tests for User Story 6
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T049 [US6] Write test for `did_not_do_event("Login", within_days=30)` in tests/unit/test_cohort_definition.py — verify result is equivalent to `did_event("Login", exactly=0, within_days=30)` by comparing _selector_node, _behavior_key, _behavior
+- [X] T050 [P] [US6] Write test for `did_not_do_event()` with all time constraint variants (within_weeks, within_months, from_date+to_date) in tests/unit/test_cohort_definition.py
+
+### Implementation for User Story 6
+
+- [X] T051 [US6] Implement `CohortCriteria.did_not_do_event()` class method in src/mixpanel_data/types.py — delegate to `did_event(event, exactly=0, ...)`
+- [X] T052 [US6] Run tests for US6 and verify all pass in tests/unit/test_cohort_definition.py
+
+**Checkpoint**: All 7 CohortCriteria class methods fully implemented and tested.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Property-based tests, public exports, type checking, and final validation.
+
+- [X] T053 [P] Write Hypothesis PBT tests for CohortCriteria construction in tests/test_cohort_definition_pbt.py — generate random valid did_event params, verify no crashes, valid selector structure, behavior key always set
+- [X] T054 [P] Write Hypothesis PBT tests for CohortDefinition.to_dict() in tests/test_cohort_definition_pbt.py — generate random trees of criteria (varying depth, mix of types), verify: no duplicate behavior keys, selector tree is valid (has operator+children or property+value), behaviors dict keys match selector references, output is JSON-serializable
+- [X] T055 [P] Write Hypothesis PBT tests for validation rules in tests/test_cohort_definition_pbt.py — generate invalid inputs (multiple frequency params, missing time constraints, empty names, non-positive IDs), verify ValueError always raised
+- [X] T056 Add `CohortCriteria` and `CohortDefinition` to public exports in src/mixpanel_data/__init__.py
+- [X] T057 Run `just typecheck` and fix any mypy --strict errors in src/mixpanel_data/types.py
+- [X] T058 Run `just lint` and fix any ruff errors
+- [X] T059 Run `just test-cov` and verify 90%+ coverage for new code
+- [X] T060 Run `just test-pbt` to verify all Hypothesis tests pass
+- [X] T061 Validate quickstart.md examples — run each code snippet from specs/035-cohort-definition-builder/quickstart.md in a Python REPL (imports + construction + to_dict() calls)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — behavioral criteria
+- **US2 (Phase 4)**: Depends on US1 — needs criteria for composition tests
+- **US3 (Phase 5)**: Depends on Phase 2 — independent of US1/US2
+- **US4 (Phase 6)**: Depends on Phase 2 — independent of US1/US2/US3
+- **US5 (Phase 7)**: Depends on US1 + US3 — needs mixed criteria for realistic tests
+- **US6 (Phase 8)**: Depends on US1 — extends did_event()
+- **Polish (Phase 9)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+```text
+Phase 2 (Foundational)
+    ├──→ US1 (P1: Behavioral) ──→ US2 (P1: Composition) ──→ US5 (P2: CRUD)
+    │                          └──→ US6 (P3: Did Not Do)
+    ├──→ US3 (P2: Property) ──────────────────────────────→ US5 (P2: CRUD)
+    └──→ US4 (P2: Cohort Ref) ─── independent
+```
+
+### Parallel Opportunities
+
+- **Phase 2**: T003-T006 all in parallel (different sections of types.py, but non-overlapping)
+- **Phase 3**: T007-T013 test tasks in parallel (same file, different test classes)
+- **Phase 5 + Phase 6**: US3 and US4 can run in parallel after Phase 2 (independent criteria types)
+- **Phase 9**: T053-T055 PBT tests in parallel, T057-T060 checks in parallel
+
+---
+
+## Parallel Example: US3 + US4 (after Phase 2)
+
+```text
+# These two user stories are independent and can run in parallel:
+
+Agent 1 — US3 (Property Criteria):
+  T030-T035: Write property criteria tests
+  T036-T037: Implement has_property, property_is_set, property_is_not_set
+  T038: Verify
+
+Agent 2 — US4 (Cohort References):
+  T039-T042: Write cohort reference tests
+  T043: Implement in_cohort, not_in_cohort
+  T044: Verify
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2)
+
+1. Complete Phase 1: Setup (test scaffolds)
+2. Complete Phase 2: Foundational (dataclass shells, operator maps)
+3. Complete Phase 3: US1 — `did_event()` with full validation
+4. Complete Phase 4: US2 — `CohortDefinition` composition + `to_dict()`
+5. **STOP and VALIDATE**: Build a cohort definition and inspect JSON output
+6. At this point, `CohortDefinition(CohortCriteria.did_event(...)).to_dict()` works end-to-end
+
+### Incremental Delivery
+
+1. Setup + Foundational → Shells exist
+2. US1 → Behavioral criteria work → Can construct criteria
+3. US2 → Composition works → Can produce valid JSON
+4. US3 + US4 (parallel) → Property and cohort criteria → Full criteria coverage
+5. US5 → CRUD integration verified → Builder usable with existing API
+6. US6 → Convenience shorthand → Polish
+7. Polish → PBT, exports, type safety → Production ready
+
+---
+
+## Notes
+
+- [P] tasks = different files or non-overlapping file sections, no dependencies
+- [Story] label maps task to specific user story for traceability
+- TDD workflow: write failing tests → implement → verify → commit
+- Commit after each completed user story phase
+- All validation raises `ValueError` directly (not `ValidationError` collector pattern)
+- Behavior keys are placeholder during construction, globally re-indexed in `to_dict()`

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -76,6 +76,8 @@ from mixpanel_data.types import (
     BulkUpdatePropertiesParams,
     Cohort,
     CohortCreator,
+    CohortCriteria,
+    CohortDefinition,
     CohortInfo,
     ComposedPropertyValue,
     CreateAlertParams,
@@ -315,6 +317,10 @@ __all__ = [
     "BulkUpdateBookmarkEntry",
     "BookmarkHistoryResponse",
     "BookmarkHistoryPagination",
+    # Cohort Definition Builder (Phase 035)
+    "CohortCriteria",
+    "CohortDefinition",
+    # Cohort CRUD (Phase 024)
     "Cohort",
     "CohortCreator",
     "CreateCohortParams",

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7638,7 +7638,7 @@ class GroupBy:
 
 
 # =============================================================================
-# Cohort Definition Builder Types (Phase 035)
+# Cohort Definition Builder Types
 # =============================================================================
 
 _PROPERTY_OPERATOR_MAP: dict[str, str] = {
@@ -7681,7 +7681,9 @@ def _validate_cohort_date(date_str: str) -> None:
     try:
         dt_date.fromisoformat(date_str)
     except ValueError:
-        raise ValueError("dates must be YYYY-MM-DD format") from None
+        raise ValueError(
+            f"date '{date_str}' has correct format but is not a valid calendar date"
+        ) from None
 
 
 def _build_event_selector(
@@ -7706,7 +7708,11 @@ def _build_event_selector(
     for f in filter_list:
         mapped_op = _FILTER_TO_SELECTOR_MAP.get(f._operator)
         if mapped_op is None:
-            msg = f"unsupported filter operator for cohort selector: {f._operator}"
+            supported = ", ".join(sorted(_FILTER_TO_SELECTOR_MAP.keys()))
+            msg = (
+                f"unsupported filter operator for cohort selector: {f._operator!r}. "
+                f"Supported operators: {supported}"
+            )
             raise ValueError(msg)
         node: dict[str, Any] = {
             "property": "event",
@@ -7785,7 +7791,9 @@ class CohortCriteria:
             CohortCriteria with behavioral selector node and behavior entry.
 
         Raises:
-            ValueError: On constraint violations (CD1-CD6).
+            ValueError: If no frequency param or multiple are set, frequency is
+                negative, event name is empty/whitespace, time constraints are
+                missing or conflicting, or dates are malformed/misordered.
         """
         # CD4: Event name must be non-empty
         if not event or not event.strip():

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -16,6 +16,7 @@ without recomputation.
 
 from __future__ import annotations
 
+import copy
 import math
 import re
 import warnings
@@ -7634,6 +7635,594 @@ class GroupBy:
 
     bucket_max: int | float | None = None
     """Maximum value for numeric buckets."""
+
+
+# =============================================================================
+# Cohort Definition Builder Types (Phase 035)
+# =============================================================================
+
+_PROPERTY_OPERATOR_MAP: dict[str, str] = {
+    "equals": "==",
+    "not_equals": "!=",
+    "contains": "in",
+    "not_contains": "not in",
+    "greater_than": ">",
+    "less_than": "<",
+    "is_set": "defined",
+    "is_not_set": "not defined",
+}
+"""Maps ``CohortCriteria.has_property()`` operator names to selector tree operators."""
+
+_FILTER_TO_SELECTOR_MAP: dict[str, str] = {
+    "equals": "==",
+    "does not equal": "!=",
+    "contains": "in",
+    "does not contain": "not in",
+    "is greater than": ">",
+    "is less than": "<",
+    "is set": "defined",
+    "is not set": "not defined",
+    "is between": "between",
+}
+"""Maps ``Filter._operator`` strings to event selector expression operators."""
+
+
+def _validate_cohort_date(date_str: str) -> None:
+    """Validate that a date string is in YYYY-MM-DD format.
+
+    Args:
+        date_str: Date string to validate.
+
+    Raises:
+        ValueError: If format is not YYYY-MM-DD or date is invalid.
+    """
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+        raise ValueError("dates must be YYYY-MM-DD format")
+    try:
+        dt_date.fromisoformat(date_str)
+    except ValueError:
+        raise ValueError("dates must be YYYY-MM-DD format")  # noqa: B904
+
+
+def _build_event_selector(
+    filters: Filter | list[Filter],
+) -> dict[str, Any]:
+    """Convert Filter objects to an event selector expression tree.
+
+    Reads internal fields from ``Filter`` instances and maps operators
+    via ``_FILTER_TO_SELECTOR_MAP`` to produce selector tree nodes.
+
+    Args:
+        filters: Single Filter or list of Filters to convert.
+
+    Returns:
+        Expression tree dict with ``operator`` and ``children`` keys.
+
+    Raises:
+        ValueError: If a filter uses an unsupported operator.
+    """
+    filter_list = [filters] if isinstance(filters, Filter) else filters
+    children: list[dict[str, Any]] = []
+    for f in filter_list:
+        mapped_op = _FILTER_TO_SELECTOR_MAP.get(f._operator)
+        if mapped_op is None:
+            msg = f"unsupported filter operator for cohort selector: {f._operator}"
+            raise ValueError(msg)
+        node: dict[str, Any] = {
+            "property": "event",
+            "value": f._property,
+            "operator": mapped_op,
+        }
+        if f._value is not None:
+            node["operand"] = f._value
+        node["type"] = f._property_type
+        children.append(node)
+    return {"operator": "and", "children": children}
+
+
+@dataclass(frozen=True)
+class CohortCriteria:
+    """A single atomic condition for cohort membership.
+
+    Constructed exclusively via class methods — never instantiate directly.
+    Produces selector nodes and behavior entries for the Mixpanel cohort
+    definition format (legacy ``selector`` + ``behaviors`` JSON).
+
+    Example:
+        ```python
+        from mixpanel_data import CohortCriteria
+
+        # Behavioral criterion
+        c = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+
+        # Property criterion
+        c = CohortCriteria.has_property("plan", "premium")
+
+        # Cohort reference
+        c = CohortCriteria.in_cohort(456)
+        ```
+    """
+
+    _selector_node: dict[str, Any]
+    """Expression tree leaf node (behavioral, property, or cohort reference)."""
+
+    _behavior_key: str | None
+    """Placeholder behavior key (e.g., ``"bhvr_0"``). ``None`` for non-behavioral."""
+
+    _behavior: dict[str, Any] | None
+    """Behavior dict entry (event selector + window/dates). ``None`` for non-behavioral."""
+
+    @classmethod
+    def did_event(
+        cls,
+        event: str,
+        *,
+        at_least: int | None = None,
+        at_most: int | None = None,
+        exactly: int | None = None,
+        within_days: int | None = None,
+        within_weeks: int | None = None,
+        within_months: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        where: Filter | list[Filter] | None = None,
+    ) -> CohortCriteria:
+        """Create a behavioral criterion based on event frequency.
+
+        Args:
+            event: Event name (must be non-empty).
+            at_least: Minimum event count (``>=``).
+            at_most: Maximum event count (``<=``).
+            exactly: Exact event count (``==``).
+            within_days: Rolling window in days.
+            within_weeks: Rolling window in weeks.
+            within_months: Rolling window in months.
+            from_date: Absolute start date (YYYY-MM-DD).
+            to_date: Absolute end date (YYYY-MM-DD).
+            where: Event property filter(s).
+
+        Returns:
+            CohortCriteria with behavioral selector node and behavior entry.
+
+        Raises:
+            ValueError: On constraint violations (CD1-CD6).
+        """
+        # CD4: Event name must be non-empty
+        if not event or not event.strip():
+            raise ValueError("event name must be non-empty")
+
+        # CD1: Exactly one frequency param required
+        freq_params = {
+            "at_least": at_least,
+            "at_most": at_most,
+            "exactly": exactly,
+        }
+        set_freqs = {k: v for k, v in freq_params.items() if v is not None}
+        if len(set_freqs) != 1:
+            raise ValueError("exactly one of at_least, at_most, exactly must be set")
+
+        freq_name, freq_value = next(iter(set_freqs.items()))
+
+        # CD2: Frequency param must be non-negative
+        if freq_value < 0:
+            raise ValueError("frequency value must be >= 0")
+
+        # Map frequency param to selector operator
+        freq_operator_map = {
+            "at_least": ">=",
+            "at_most": "<=",
+            "exactly": "==",
+        }
+        selector_operator = freq_operator_map[freq_name]
+
+        # CD3: Exactly one time constraint required
+        rolling_params = {
+            "within_days": within_days,
+            "within_weeks": within_weeks,
+            "within_months": within_months,
+        }
+        set_rolling = {k: v for k, v in rolling_params.items() if v is not None}
+        has_date_range = from_date is not None or to_date is not None
+
+        if not set_rolling and not has_date_range:
+            raise ValueError(
+                "exactly one time constraint required "
+                "(within_days/weeks/months or from_date+to_date)"
+            )
+        if set_rolling and has_date_range:
+            raise ValueError(
+                "exactly one time constraint required "
+                "(within_days/weeks/months or from_date+to_date)"
+            )
+        if len(set_rolling) > 1:
+            raise ValueError(
+                "exactly one time constraint required "
+                "(within_days/weeks/months or from_date+to_date)"
+            )
+
+        # Build behavior entry
+        behavior_key = "bhvr_0"  # placeholder, re-indexed by to_dict()
+
+        event_selector: dict[str, Any] = {
+            "event": event,
+            "selector": None,
+        }
+        if where is not None:
+            where_list = [where] if isinstance(where, Filter) else where
+            if where_list:
+                event_selector["selector"] = _build_event_selector(where_list)
+
+        behavior: dict[str, Any] = {
+            "count": {
+                "event_selector": event_selector,
+                "type": "absolute",
+            },
+        }
+
+        if set_rolling:
+            rolling_name, rolling_value = next(iter(set_rolling.items()))
+            if rolling_value <= 0:
+                raise ValueError("time window value must be positive")
+            unit_map = {
+                "within_days": "day",
+                "within_weeks": "week",
+                "within_months": "month",
+            }
+            behavior["window"] = {
+                "unit": unit_map[rolling_name],
+                "value": rolling_value,
+            }
+        else:
+            # Absolute date range
+            # CD5: from_date requires to_date (and vice versa)
+            if from_date is not None and to_date is None:
+                raise ValueError("from_date requires to_date")
+            if to_date is not None and from_date is None:
+                raise ValueError("to_date requires from_date")
+
+            # CD6: Dates must be YYYY-MM-DD
+            assert from_date is not None  # guaranteed by has_date_range check
+            assert to_date is not None
+            _validate_cohort_date(from_date)
+            _validate_cohort_date(to_date)
+            if dt_date.fromisoformat(from_date) > dt_date.fromisoformat(to_date):
+                raise ValueError("from_date must be before or equal to to_date")
+
+            behavior["from_date"] = from_date
+            behavior["to_date"] = to_date
+
+        selector_node: dict[str, Any] = {
+            "property": "behaviors",
+            "value": behavior_key,
+            "operator": selector_operator,
+            "operand": freq_value,
+        }
+
+        return cls(
+            _selector_node=selector_node,
+            _behavior_key=behavior_key,
+            _behavior=behavior,
+        )
+
+    @classmethod
+    def did_not_do_event(
+        cls,
+        event: str,
+        *,
+        within_days: int | None = None,
+        within_weeks: int | None = None,
+        within_months: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> CohortCriteria:
+        """Create a criterion for users who did NOT perform an event.
+
+        Shorthand for ``did_event(event, exactly=0, ...)``.
+
+        Args:
+            event: Event name.
+            within_days: Rolling window in days.
+            within_weeks: Rolling window in weeks.
+            within_months: Rolling window in months.
+            from_date: Absolute start date (YYYY-MM-DD).
+            to_date: Absolute end date (YYYY-MM-DD).
+
+        Returns:
+            CohortCriteria equivalent to ``did_event(event, exactly=0, ...)``.
+
+        Raises:
+            ValueError: On constraint violations.
+        """
+        return cls.did_event(
+            event,
+            exactly=0,
+            within_days=within_days,
+            within_weeks=within_weeks,
+            within_months=within_months,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+    @classmethod
+    def has_property(
+        cls,
+        property: str,
+        value: str | int | float | bool | list[str],
+        *,
+        operator: Literal[
+            "equals",
+            "not_equals",
+            "contains",
+            "not_contains",
+            "greater_than",
+            "less_than",
+            "is_set",
+            "is_not_set",
+        ] = "equals",
+        property_type: Literal[
+            "string",
+            "number",
+            "boolean",
+            "datetime",
+            "list",
+        ] = "string",
+    ) -> CohortCriteria:
+        """Create a property-based criterion.
+
+        Args:
+            property: Property name (must be non-empty).
+            value: Value to compare against.
+            operator: Comparison operator. Default: ``"equals"``.
+            property_type: Data type of the property. Default: ``"string"``.
+
+        Returns:
+            CohortCriteria with property selector node.
+
+        Raises:
+            ValueError: If property name is empty (CD7).
+        """
+        # CD7: Property name must be non-empty
+        if not property or not property.strip():
+            raise ValueError("property name must be non-empty")
+
+        selector_operator = _PROPERTY_OPERATOR_MAP[operator]
+
+        selector_node: dict[str, Any] = {
+            "property": "user",
+            "value": property,
+            "operator": selector_operator,
+            "operand": value,
+            "type": property_type,
+        }
+
+        return cls(
+            _selector_node=selector_node,
+            _behavior_key=None,
+            _behavior=None,
+        )
+
+    @classmethod
+    def property_is_set(cls, property: str) -> CohortCriteria:
+        """Check if a user property exists.
+
+        Shorthand for ``has_property(property, "", operator="is_set")``.
+
+        Args:
+            property: Property name.
+
+        Returns:
+            CohortCriteria checking property existence.
+
+        Raises:
+            ValueError: If property name is empty (CD7).
+        """
+        return cls.has_property(property, "", operator="is_set")
+
+    @classmethod
+    def property_is_not_set(cls, property: str) -> CohortCriteria:
+        """Check if a user property does not exist.
+
+        Shorthand for ``has_property(property, "", operator="is_not_set")``.
+
+        Args:
+            property: Property name.
+
+        Returns:
+            CohortCriteria checking property non-existence.
+
+        Raises:
+            ValueError: If property name is empty (CD7).
+        """
+        return cls.has_property(property, "", operator="is_not_set")
+
+    @classmethod
+    def in_cohort(cls, cohort_id: int) -> CohortCriteria:
+        """Create a criterion for membership in a saved cohort.
+
+        Args:
+            cohort_id: Cohort ID (must be positive integer).
+
+        Returns:
+            CohortCriteria with cohort reference selector node.
+
+        Raises:
+            ValueError: If cohort_id is not a positive integer (CD8).
+        """
+        if cohort_id <= 0:
+            raise ValueError("cohort_id must be a positive integer")
+
+        selector_node: dict[str, Any] = {
+            "property": "cohort",
+            "value": cohort_id,
+            "operator": "in",
+        }
+
+        return cls(
+            _selector_node=selector_node,
+            _behavior_key=None,
+            _behavior=None,
+        )
+
+    @classmethod
+    def not_in_cohort(cls, cohort_id: int) -> CohortCriteria:
+        """Create a criterion for non-membership in a saved cohort.
+
+        Args:
+            cohort_id: Cohort ID (must be positive integer).
+
+        Returns:
+            CohortCriteria with cohort exclusion selector node.
+
+        Raises:
+            ValueError: If cohort_id is not a positive integer (CD8).
+        """
+        if cohort_id <= 0:
+            raise ValueError("cohort_id must be a positive integer")
+
+        selector_node: dict[str, Any] = {
+            "property": "cohort",
+            "value": cohort_id,
+            "operator": "not in",
+        }
+
+        return cls(
+            _selector_node=selector_node,
+            _behavior_key=None,
+            _behavior=None,
+        )
+
+
+@dataclass(frozen=True, init=False)
+class CohortDefinition:
+    """A composed set of criteria combined with AND/OR logic.
+
+    Produces valid Mixpanel cohort definition JSON (legacy ``selector`` +
+    ``behaviors`` format) via ``to_dict()``. Behavior keys are globally
+    re-indexed to ensure uniqueness across arbitrary nesting.
+
+    Example:
+        ```python
+        from mixpanel_data import CohortCriteria, CohortDefinition
+
+        cohort = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+        )
+        result = cohort.to_dict()
+        # {"selector": {...}, "behaviors": {"bhvr_0": {...}}}
+        ```
+    """
+
+    _criteria: tuple[CohortCriteria | CohortDefinition, ...]
+    """One or more criteria or nested definitions."""
+
+    _operator: Literal["and", "or"]
+    """Boolean combinator."""
+
+    def __init__(
+        self,
+        *criteria: CohortCriteria,
+    ) -> None:
+        """Create a definition combining criteria with AND logic.
+
+        Args:
+            *criteria: One or more CohortCriteria to combine.
+
+        Raises:
+            ValueError: If no criteria are provided (CD9).
+        """
+        if not criteria:
+            raise ValueError("CohortDefinition requires at least one criterion")
+        object.__setattr__(self, "_criteria", criteria)
+        object.__setattr__(self, "_operator", "and")
+
+    @classmethod
+    def all_of(
+        cls,
+        *criteria: CohortCriteria | CohortDefinition,
+    ) -> CohortDefinition:
+        """Combine criteria and/or definitions with AND logic.
+
+        Args:
+            *criteria: One or more criteria or nested definitions.
+
+        Returns:
+            CohortDefinition with AND combinator.
+
+        Raises:
+            ValueError: If no criteria are provided (CD9).
+        """
+        if not criteria:
+            raise ValueError("CohortDefinition requires at least one criterion")
+        instance = cls.__new__(cls)
+        object.__setattr__(instance, "_criteria", criteria)
+        object.__setattr__(instance, "_operator", "and")
+        return instance
+
+    @classmethod
+    def any_of(
+        cls,
+        *criteria: CohortCriteria | CohortDefinition,
+    ) -> CohortDefinition:
+        """Combine criteria and/or definitions with OR logic.
+
+        Args:
+            *criteria: One or more criteria or nested definitions.
+
+        Returns:
+            CohortDefinition with OR combinator.
+
+        Raises:
+            ValueError: If no criteria are provided (CD9).
+        """
+        if not criteria:
+            raise ValueError("CohortDefinition requires at least one criterion")
+        instance = cls.__new__(cls)
+        object.__setattr__(instance, "_criteria", criteria)
+        object.__setattr__(instance, "_operator", "or")
+        return instance
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to Mixpanel cohort definition format.
+
+        Produces ``{"selector": {...}, "behaviors": {...}}`` with globally
+        re-indexed behavior keys (``bhvr_0``, ``bhvr_1``, ...) ensuring
+        uniqueness across arbitrary nesting depth.
+
+        Returns:
+            Dict with ``selector`` expression tree and ``behaviors`` map.
+        """
+        behaviors: dict[str, Any] = {}
+        counter = [0]  # mutable container for closure
+
+        def _collect_and_build(
+            item: CohortCriteria | CohortDefinition,
+        ) -> dict[str, Any]:
+            """Recursively build selector tree and collect behaviors.
+
+            Args:
+                item: Criterion or nested definition to process.
+
+            Returns:
+                Selector node dict (leaf or combinator).
+            """
+            if isinstance(item, CohortCriteria):
+                node = dict(item._selector_node)
+                if item._behavior_key is not None and item._behavior is not None:
+                    new_key = f"bhvr_{counter[0]}"
+                    counter[0] += 1
+                    behaviors[new_key] = copy.deepcopy(item._behavior)
+                    node["value"] = new_key
+                return node
+            # CohortDefinition: recurse into children
+            children = [_collect_and_build(c) for c in item._criteria]
+            return {
+                "operator": item._operator,
+                "children": children,
+            }
+
+        selector = _collect_and_build(self)
+        return {"selector": selector, "behaviors": behaviors}
 
 
 @dataclass(frozen=True)

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7681,7 +7681,7 @@ def _validate_cohort_date(date_str: str) -> None:
     try:
         dt_date.fromisoformat(date_str)
     except ValueError:
-        raise ValueError("dates must be YYYY-MM-DD format")  # noqa: B904
+        raise ValueError("dates must be YYYY-MM-DD format") from None
 
 
 def _build_event_selector(
@@ -7881,8 +7881,13 @@ class CohortCriteria:
                 raise ValueError("to_date requires from_date")
 
             # CD6: Dates must be YYYY-MM-DD
-            assert from_date is not None  # guaranteed by has_date_range check
-            assert to_date is not None
+            # from_date and to_date are guaranteed non-None here:
+            # has_date_range is True and CD5 guards above reject mismatched pairs.
+            if from_date is None or to_date is None:  # pragma: no cover
+                raise ValueError(
+                    "exactly one time constraint required "
+                    "(within_days/weeks/months or from_date+to_date)"
+                )
             _validate_cohort_date(from_date)
             _validate_cohort_date(to_date)
             if dt_date.fromisoformat(from_date) > dt_date.fromisoformat(to_date):
@@ -8121,12 +8126,14 @@ class CohortDefinition:
 
     def __init__(
         self,
-        *criteria: CohortCriteria,
+        *criteria: CohortCriteria | CohortDefinition,
     ) -> None:
         """Create a definition combining criteria with AND logic.
 
+        Equivalent to ``CohortDefinition.all_of(*criteria)``.
+
         Args:
-            *criteria: One or more CohortCriteria to combine.
+            *criteria: One or more criteria or nested definitions.
 
         Raises:
             ValueError: If no criteria are provided (CD9).
@@ -8191,7 +8198,26 @@ class CohortDefinition:
 
         Returns:
             Dict with ``selector`` expression tree and ``behaviors`` map.
+
+        Example:
+            ```python
+            cohort = CohortDefinition.all_of(
+                CohortCriteria.has_property("plan", "premium"),
+                CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+            )
+            data = cohort.to_dict()
+            # {"selector": {"operator": "and", "children": [...]},
+            #  "behaviors": {"bhvr_0": {...}}}
+
+            # Pass directly to cohort CRUD:
+            ws.create_cohort(CreateCohortParams(
+                name="Premium Purchasers",
+                definition=data,
+            ))
+            ```
         """
+        # CD10: Behavior key uniqueness is enforced by sequential re-indexing
+        # (bhvr_0, bhvr_1, ...) during tree traversal below.
         behaviors: dict[str, Any] = {}
         counter = [0]  # mutable container for closure
 
@@ -8207,7 +8233,9 @@ class CohortDefinition:
                 Selector node dict (leaf or combinator).
             """
             if isinstance(item, CohortCriteria):
-                node = dict(item._selector_node)
+                # Deep copy: operand may be a mutable list (e.g. has_property
+                # with list value), so shallow dict() is not sufficient.
+                node = copy.deepcopy(item._selector_node)
                 if item._behavior_key is not None and item._behavior is not None:
                     new_key = f"bhvr_{counter[0]}"
                     counter[0] += 1

--- a/tests/test_cohort_definition_pbt.py
+++ b/tests/test_cohort_definition_pbt.py
@@ -69,15 +69,14 @@ property_operators = st.sampled_from(
     ["equals", "not_equals", "contains", "not_contains", "greater_than", "less_than"]
 )
 
-# Property type choices
-property_types = st.sampled_from(["string", "number", "boolean", "datetime", "list"])
-
 
 @st.composite
 def valid_did_event_params(
     draw: st.DrawFn,
 ) -> dict[str, Any]:
     """Generate valid parameters for CohortCriteria.did_event().
+
+    Generates either rolling-window or absolute date-range time constraints.
 
     Args:
         draw: Hypothesis draw function.
@@ -88,14 +87,28 @@ def valid_did_event_params(
     event = draw(event_names)
     freq_type = draw(freq_param_choice)
     freq_value = draw(frequencies)
-    time_type = draw(time_constraint_choice)
-    time_value = draw(time_values)
 
     params: dict[str, Any] = {
         "event": event,
         freq_type: freq_value,
-        time_type: time_value,
     }
+
+    use_date_range = draw(st.booleans())
+    if use_date_range:
+        # Generate valid date range (2020-01-01 to 2025-12-31)
+        start_ordinal = draw(st.integers(min_value=737425, max_value=739250))
+        end_ordinal = draw(
+            st.integers(min_value=start_ordinal, max_value=start_ordinal + 365)
+        )
+        from datetime import date as dt_date
+
+        params["from_date"] = dt_date.fromordinal(start_ordinal).isoformat()
+        params["to_date"] = dt_date.fromordinal(end_ordinal).isoformat()
+    else:
+        time_type = draw(time_constraint_choice)
+        time_value = draw(time_values)
+        params[time_type] = time_value
+
     return params
 
 
@@ -128,7 +141,17 @@ def property_criteria(
         Valid CohortCriteria instance.
     """
     name = draw(property_names)
-    value = draw(st.text(min_size=1, max_size=20))
+    value = draw(
+        st.one_of(
+            st.text(min_size=1, max_size=20),
+            st.integers(min_value=-1000, max_value=1000),
+            st.floats(
+                allow_nan=False, allow_infinity=False, min_value=-1e6, max_value=1e6
+            ),
+            st.booleans(),
+            st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=5),
+        )
+    )
     op = cast(
         Literal[
             "equals",

--- a/tests/test_cohort_definition_pbt.py
+++ b/tests/test_cohort_definition_pbt.py
@@ -1,0 +1,403 @@
+"""Property-based tests for Cohort Definition Builder using Hypothesis.
+
+These tests verify invariants of CohortCriteria and CohortDefinition
+that should hold for all possible inputs, catching edge cases that
+example-based tests miss.
+
+Usage:
+    # Run with default profile (100 examples)
+    pytest tests/test_cohort_definition_pbt.py
+
+    # Run with dev profile (10 examples, verbose)
+    HYPOTHESIS_PROFILE=dev pytest tests/test_cohort_definition_pbt.py
+
+    # Run with CI profile (200 examples, deterministic)
+    HYPOTHESIS_PROFILE=ci pytest tests/test_cohort_definition_pbt.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal, cast
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mixpanel_data.types import (
+    CohortCriteria,
+    CohortDefinition,
+)
+
+# =============================================================================
+# Custom Strategies
+# =============================================================================
+
+# Non-empty event names (visible characters)
+event_names = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "S")),
+    min_size=1,
+    max_size=50,
+).filter(lambda s: s.strip())
+
+# Non-empty property names
+property_names = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "S")),
+    min_size=1,
+    max_size=50,
+).filter(lambda s: s.strip())
+
+# Non-negative integers for frequency params
+frequencies = st.integers(min_value=0, max_value=10000)
+
+# Positive integers for time windows
+time_values = st.integers(min_value=1, max_value=365)
+
+# Positive integers for cohort IDs
+cohort_ids = st.integers(min_value=1, max_value=1000000)
+
+# Frequency param choices
+freq_param_choice = st.sampled_from(["at_least", "at_most", "exactly"])
+
+# Time constraint choices
+time_constraint_choice = st.sampled_from(
+    ["within_days", "within_weeks", "within_months"]
+)
+
+# Property operator choices
+property_operators = st.sampled_from(
+    ["equals", "not_equals", "contains", "not_contains", "greater_than", "less_than"]
+)
+
+# Property type choices
+property_types = st.sampled_from(["string", "number", "boolean", "datetime", "list"])
+
+
+@st.composite
+def valid_did_event_params(
+    draw: st.DrawFn,
+) -> dict[str, Any]:
+    """Generate valid parameters for CohortCriteria.did_event().
+
+    Args:
+        draw: Hypothesis draw function.
+
+    Returns:
+        Dict of valid did_event keyword arguments.
+    """
+    event = draw(event_names)
+    freq_type = draw(freq_param_choice)
+    freq_value = draw(frequencies)
+    time_type = draw(time_constraint_choice)
+    time_value = draw(time_values)
+
+    params: dict[str, Any] = {
+        "event": event,
+        freq_type: freq_value,
+        time_type: time_value,
+    }
+    return params
+
+
+@st.composite
+def behavioral_criteria(
+    draw: st.DrawFn,
+) -> CohortCriteria:
+    """Generate valid CohortCriteria via did_event().
+
+    Args:
+        draw: Hypothesis draw function.
+
+    Returns:
+        Valid CohortCriteria instance.
+    """
+    params = draw(valid_did_event_params())
+    return CohortCriteria.did_event(**params)
+
+
+@st.composite
+def property_criteria(
+    draw: st.DrawFn,
+) -> CohortCriteria:
+    """Generate valid CohortCriteria via has_property().
+
+    Args:
+        draw: Hypothesis draw function.
+
+    Returns:
+        Valid CohortCriteria instance.
+    """
+    name = draw(property_names)
+    value = draw(st.text(min_size=1, max_size=20))
+    op = cast(
+        Literal[
+            "equals",
+            "not_equals",
+            "contains",
+            "not_contains",
+            "greater_than",
+            "less_than",
+        ],
+        draw(property_operators),
+    )
+    return CohortCriteria.has_property(name, value, operator=op)
+
+
+@st.composite
+def cohort_ref_criteria(
+    draw: st.DrawFn,
+) -> CohortCriteria:
+    """Generate valid CohortCriteria via in_cohort() or not_in_cohort().
+
+    Args:
+        draw: Hypothesis draw function.
+
+    Returns:
+        Valid CohortCriteria instance.
+    """
+    cid = draw(cohort_ids)
+    if draw(st.booleans()):
+        return CohortCriteria.in_cohort(cid)
+    return CohortCriteria.not_in_cohort(cid)
+
+
+# Any valid criterion
+any_criteria = st.one_of(
+    behavioral_criteria(), property_criteria(), cohort_ref_criteria()
+)
+
+
+@st.composite
+def definition_trees(
+    draw: st.DrawFn,
+    max_depth: int = 3,
+) -> CohortDefinition:
+    """Generate CohortDefinition trees with varying depth and criteria types.
+
+    Args:
+        draw: Hypothesis draw function.
+        max_depth: Maximum nesting depth.
+
+    Returns:
+        Valid CohortDefinition instance.
+    """
+    if max_depth <= 1 or draw(st.booleans()):
+        # Leaf level: 1-3 criteria
+        n = draw(st.integers(min_value=1, max_value=3))
+        criteria = [draw(any_criteria) for _ in range(n)]
+        op = draw(st.sampled_from(["all_of", "any_of"]))
+        if op == "all_of":
+            return CohortDefinition.all_of(*criteria)
+        return CohortDefinition.any_of(*criteria)
+
+    # Branch: mix of criteria and nested definitions
+    children: list[CohortCriteria | CohortDefinition] = []
+    n = draw(st.integers(min_value=2, max_value=3))
+    for _ in range(n):
+        if draw(st.booleans()):
+            children.append(draw(any_criteria))
+        else:
+            children.append(draw(definition_trees(max_depth=max_depth - 1)))
+
+    op = draw(st.sampled_from(["all_of", "any_of"]))
+    if op == "all_of":
+        return CohortDefinition.all_of(*children)
+    return CohortDefinition.any_of(*children)
+
+
+# =============================================================================
+# PBT Tests for CohortCriteria Construction (T053)
+# =============================================================================
+
+
+class TestCohortCriteriaPBT:
+    """Property-based tests for CohortCriteria construction."""
+
+    @given(params=valid_did_event_params())
+    def test_did_event_never_crashes(self, params: dict[str, Any]) -> None:
+        """did_event with valid params never raises."""
+        c = CohortCriteria.did_event(**params)
+        assert c._selector_node is not None
+
+    @given(params=valid_did_event_params())
+    def test_did_event_always_behavioral(self, params: dict[str, Any]) -> None:
+        """did_event always produces behavioral criteria with behavior key."""
+        c = CohortCriteria.did_event(**params)
+        assert c._selector_node["property"] == "behaviors"
+        assert c._behavior_key is not None
+        assert c._behavior is not None
+
+    @given(params=valid_did_event_params())
+    def test_did_event_selector_structure(self, params: dict[str, Any]) -> None:
+        """did_event selector node always has required fields."""
+        c = CohortCriteria.did_event(**params)
+        node = c._selector_node
+        assert "property" in node
+        assert "value" in node
+        assert "operator" in node
+        assert "operand" in node
+        assert node["operator"] in (">=", "<=", "==")
+
+    @given(name=property_names, value=st.text(min_size=1, max_size=20))
+    def test_has_property_never_crashes(self, name: str, value: str) -> None:
+        """has_property with valid name/value never raises."""
+        c = CohortCriteria.has_property(name, value)
+        assert c._selector_node["property"] == "user"
+        assert c._behavior_key is None
+        assert c._behavior is None
+
+    @given(cid=cohort_ids)
+    def test_in_cohort_never_crashes(self, cid: int) -> None:
+        """in_cohort with positive ID never raises."""
+        c = CohortCriteria.in_cohort(cid)
+        assert c._selector_node["property"] == "cohort"
+        assert c._selector_node["value"] == cid
+
+
+# =============================================================================
+# PBT Tests for CohortDefinition.to_dict() (T054)
+# =============================================================================
+
+
+class TestCohortDefinitionToDictPBT:
+    """Property-based tests for CohortDefinition.to_dict()."""
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_to_dict_always_has_selector_and_behaviors(
+        self, tree: CohortDefinition
+    ) -> None:
+        """to_dict() always returns dict with selector and behaviors."""
+        result = tree.to_dict()
+        assert "selector" in result
+        assert "behaviors" in result
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_to_dict_behavior_keys_unique(self, tree: CohortDefinition) -> None:
+        """to_dict() never produces duplicate behavior keys."""
+        result = tree.to_dict()
+        keys = list(result["behaviors"].keys())
+        assert len(keys) == len(set(keys))
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_to_dict_behavior_keys_sequential(self, tree: CohortDefinition) -> None:
+        """to_dict() produces sequential bhvr_N keys starting from 0."""
+        result = tree.to_dict()
+        keys = list(result["behaviors"].keys())
+        for i, key in enumerate(keys):
+            assert key == f"bhvr_{i}"
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_to_dict_json_serializable(self, tree: CohortDefinition) -> None:
+        """to_dict() output is always JSON-serializable."""
+        result = tree.to_dict()
+        serialized = json.dumps(result)
+        assert isinstance(serialized, str)
+        deserialized = json.loads(serialized)
+        assert deserialized == result
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_selector_tree_valid_structure(self, tree: CohortDefinition) -> None:
+        """Selector tree nodes are all valid (combinator or leaf)."""
+        result = tree.to_dict()
+
+        def _check_node(node: dict[str, Any]) -> None:
+            """Validate a selector tree node recursively.
+
+            Args:
+                node: Selector node to validate.
+            """
+            if "children" in node:
+                # Combinator node
+                assert "operator" in node
+                assert node["operator"] in ("and", "or")
+                for child in node["children"]:
+                    _check_node(child)
+            else:
+                # Leaf node
+                assert "property" in node
+                assert node["property"] in ("behaviors", "user", "cohort")
+
+        _check_node(result["selector"])
+
+    @given(tree=definition_trees())
+    @settings(max_examples=50)
+    def test_selector_behavior_refs_match_behaviors_dict(
+        self, tree: CohortDefinition
+    ) -> None:
+        """All behavior references in selector match keys in behaviors dict."""
+        result = tree.to_dict()
+        behavior_keys = set(result["behaviors"].keys())
+
+        def _collect_refs(node: dict[str, Any]) -> set[str]:
+            """Collect all behavior key references from selector tree.
+
+            Args:
+                node: Selector node to scan.
+
+            Returns:
+                Set of behavior key references found.
+            """
+            refs: set[str] = set()
+            if "children" in node:
+                for child in node["children"]:
+                    refs |= _collect_refs(child)
+            elif node.get("property") == "behaviors":
+                refs.add(node["value"])
+            return refs
+
+        selector_refs = _collect_refs(result["selector"])
+        assert selector_refs == behavior_keys
+
+
+# =============================================================================
+# PBT Tests for Validation Rules (T055)
+# =============================================================================
+
+
+class TestValidationPBT:
+    """Property-based tests for validation rules."""
+
+    @given(
+        at_least=st.integers(min_value=0, max_value=100),
+        at_most=st.integers(min_value=0, max_value=100),
+    )
+    def test_conflicting_frequency_always_raises(
+        self, at_least: int, at_most: int
+    ) -> None:
+        """Multiple frequency params always raise ValueError (CD1)."""
+        with pytest.raises(ValueError, match="exactly one of"):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=at_least,
+                at_most=at_most,
+                within_days=30,
+            )
+
+    @given(freq=st.integers(max_value=-1))
+    def test_negative_frequency_always_raises(self, freq: int) -> None:
+        """Negative frequency always raises ValueError (CD2)."""
+        with pytest.raises(ValueError, match="frequency value must be >= 0"):
+            CohortCriteria.did_event("Login", at_least=freq, within_days=30)
+
+    @given(event_name=st.text(max_size=10).filter(lambda s: not s or not s.strip()))
+    def test_empty_event_name_always_raises(self, event_name: str) -> None:
+        """Empty/whitespace event names always raise ValueError (CD4)."""
+        with pytest.raises(ValueError, match="event name must be non-empty"):
+            CohortCriteria.did_event(event_name, at_least=1, within_days=30)
+
+    @given(prop_name=st.text(max_size=10).filter(lambda s: not s or not s.strip()))
+    def test_empty_property_name_always_raises(self, prop_name: str) -> None:
+        """Empty/whitespace property names always raise ValueError (CD7)."""
+        with pytest.raises(ValueError, match="property name must be non-empty"):
+            CohortCriteria.has_property(prop_name, "value")
+
+    @given(cid=st.integers(max_value=0))
+    def test_nonpositive_cohort_id_always_raises(self, cid: int) -> None:
+        """Non-positive cohort IDs always raise ValueError (CD8)."""
+        with pytest.raises(ValueError, match="cohort_id must be a positive integer"):
+            CohortCriteria.in_cohort(cid)

--- a/tests/unit/test_cohort_definition.py
+++ b/tests/unit/test_cohort_definition.py
@@ -1,4 +1,4 @@
-"""Tests for Cohort Definition Builder types (Phase 035).
+"""Tests for Cohort Definition Builder types.
 
 Tests CohortCriteria and CohortDefinition frozen dataclasses including
 behavioral criteria (did_event), property criteria (has_property),
@@ -9,6 +9,7 @@ serialization (to_dict), validation, and CRUD integration.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -22,7 +23,7 @@ from mixpanel_data.types import (
 )
 
 # =============================================================================
-# Phase 2: Foundational Tests
+# Operator Mapping Tests
 # =============================================================================
 
 
@@ -60,7 +61,7 @@ class TestOperatorMaps:
 
 
 # =============================================================================
-# Phase 3: US1 — Behavioral Cohort Criteria (did_event)
+# Behavioral Criteria (did_event)
 # =============================================================================
 
 
@@ -248,6 +249,26 @@ class TestCohortCriteriaDidEventValidation:
                 "Login", at_least=1, within_days=30, within_weeks=4
             )
 
+    def test_unsupported_filter_operator_raises(self) -> None:
+        """ValueError when Filter uses an operator not in _FILTER_TO_SELECTOR_MAP."""
+        with pytest.raises(ValueError, match="unsupported filter operator"):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=1,
+                within_days=30,
+                where=Filter.is_true("flag"),
+            )
+
+    def test_cd6_invalid_calendar_date(self) -> None:
+        """ValueError for syntactically valid but calendrically invalid date."""
+        with pytest.raises(ValueError, match="not a valid calendar date"):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=1,
+                from_date="2024-02-30",
+                to_date="2024-03-01",
+            )
+
 
 class TestCohortCriteriaImmutability:
     """Immutability tests for CohortCriteria (T013)."""
@@ -264,7 +285,7 @@ class TestCohortCriteriaImmutability:
 
 
 # =============================================================================
-# Phase 4: US2 — CohortDefinition Composition
+# Definition Composition (all_of / any_of)
 # =============================================================================
 
 
@@ -453,7 +474,7 @@ class TestCohortDefinitionImmutability:
 
 
 # =============================================================================
-# Phase 5: US3 — Property-Based Criteria
+# Property-Based Criteria
 # =============================================================================
 
 
@@ -545,7 +566,7 @@ class TestCohortCriteriaHasProperty:
 
 
 # =============================================================================
-# Phase 6: US4 — Cohort Reference Criteria
+# Cohort Reference Criteria
 # =============================================================================
 
 
@@ -598,7 +619,7 @@ class TestCohortCriteriaCohortRef:
 
 
 # =============================================================================
-# Phase 7: US5 — CRUD Integration
+# CRUD Integration
 # =============================================================================
 
 
@@ -664,44 +685,26 @@ class TestCohortDefinitionCRUDIntegration:
 
 
 # =============================================================================
-# Phase 8: US6 — did_not_do_event Shorthand
+# did_not_do_event Shorthand
 # =============================================================================
 
 
 class TestCohortCriteriaDidNotDoEvent:
-    """Tests for CohortCriteria.did_not_do_event() (T049-T050)."""
+    """Tests for CohortCriteria.did_not_do_event()."""
 
-    def test_equivalent_to_did_event_exactly_zero(self) -> None:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"within_days": 30},
+            {"within_weeks": 4},
+            {"within_months": 3},
+            {"from_date": "2024-01-01", "to_date": "2024-03-31"},
+        ],
+    )
+    def test_equivalent_to_did_event_exactly_zero(self, kwargs: dict[str, Any]) -> None:
         """did_not_do_event is equivalent to did_event(exactly=0)."""
-        a = CohortCriteria.did_not_do_event("Login", within_days=30)
-        b = CohortCriteria.did_event("Login", exactly=0, within_days=30)
-
-        assert a._selector_node == b._selector_node
-        assert a._behavior_key == b._behavior_key
-        assert a._behavior == b._behavior
-
-    def test_within_weeks(self) -> None:
-        """did_not_do_event with within_weeks works correctly."""
-        a = CohortCriteria.did_not_do_event("Login", within_weeks=4)
-        b = CohortCriteria.did_event("Login", exactly=0, within_weeks=4)
-        assert a._selector_node == b._selector_node
-        assert a._behavior == b._behavior
-
-    def test_within_months(self) -> None:
-        """did_not_do_event with within_months works correctly."""
-        a = CohortCriteria.did_not_do_event("Login", within_months=3)
-        b = CohortCriteria.did_event("Login", exactly=0, within_months=3)
-        assert a._selector_node == b._selector_node
-        assert a._behavior == b._behavior
-
-    def test_with_date_range(self) -> None:
-        """did_not_do_event with from_date+to_date works correctly."""
-        a = CohortCriteria.did_not_do_event(
-            "Login", from_date="2024-01-01", to_date="2024-03-31"
-        )
-        b = CohortCriteria.did_event(
-            "Login", exactly=0, from_date="2024-01-01", to_date="2024-03-31"
-        )
+        a = CohortCriteria.did_not_do_event("Login", **kwargs)
+        b = CohortCriteria.did_event("Login", exactly=0, **kwargs)
         assert a._selector_node == b._selector_node
         assert a._behavior == b._behavior
 
@@ -807,25 +810,19 @@ class TestEmptyWhereList:
 class TestTimeWindowValidation:
     """Tests for rolling window value validation."""
 
-    def test_within_days_zero_raises(self) -> None:
-        """within_days=0 should raise ValueError."""
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"within_days": 0},
+            {"within_days": -5},
+            {"within_weeks": 0},
+            {"within_months": -1},
+        ],
+    )
+    def test_nonpositive_time_window_raises(self, kwargs: dict[str, Any]) -> None:
+        """Non-positive time window values raise ValueError."""
         with pytest.raises(ValueError, match="time window value must be positive"):
-            CohortCriteria.did_event("Login", at_least=1, within_days=0)
-
-    def test_within_days_negative_raises(self) -> None:
-        """within_days=-5 should raise ValueError."""
-        with pytest.raises(ValueError, match="time window value must be positive"):
-            CohortCriteria.did_event("Login", at_least=1, within_days=-5)
-
-    def test_within_weeks_zero_raises(self) -> None:
-        """within_weeks=0 should raise ValueError."""
-        with pytest.raises(ValueError, match="time window value must be positive"):
-            CohortCriteria.did_event("Login", at_least=1, within_weeks=0)
-
-    def test_within_months_negative_raises(self) -> None:
-        """within_months=-1 should raise ValueError."""
-        with pytest.raises(ValueError, match="time window value must be positive"):
-            CohortCriteria.did_event("Login", at_least=1, within_months=-1)
+            CohortCriteria.did_event("Login", at_least=1, **kwargs)
 
 
 class TestDateRangeOrdering:

--- a/tests/unit/test_cohort_definition.py
+++ b/tests/unit/test_cohort_definition.py
@@ -1,0 +1,847 @@
+"""Tests for Cohort Definition Builder types (Phase 035).
+
+Tests CohortCriteria and CohortDefinition frozen dataclasses including
+behavioral criteria (did_event), property criteria (has_property),
+cohort references (in_cohort), boolean composition (all_of/any_of),
+serialization (to_dict), validation, and CRUD integration.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mixpanel_data.types import (
+    _FILTER_TO_SELECTOR_MAP,
+    _PROPERTY_OPERATOR_MAP,
+    CohortCriteria,
+    CohortDefinition,
+    CreateCohortParams,
+    Filter,
+)
+
+# =============================================================================
+# Phase 2: Foundational Tests
+# =============================================================================
+
+
+class TestOperatorMaps:
+    """Tests for operator mapping dicts (T005, T006)."""
+
+    def test_property_operator_map_has_all_operators(self) -> None:
+        """_PROPERTY_OPERATOR_MAP maps all expected CohortCriteria operators."""
+        expected = {
+            "equals": "==",
+            "not_equals": "!=",
+            "contains": "in",
+            "not_contains": "not in",
+            "greater_than": ">",
+            "less_than": "<",
+            "is_set": "defined",
+            "is_not_set": "not defined",
+        }
+        assert expected == _PROPERTY_OPERATOR_MAP
+
+    def test_filter_to_selector_map_has_all_operators(self) -> None:
+        """_FILTER_TO_SELECTOR_MAP maps all expected Filter._operator strings."""
+        expected = {
+            "equals": "==",
+            "does not equal": "!=",
+            "contains": "in",
+            "does not contain": "not in",
+            "is greater than": ">",
+            "is less than": "<",
+            "is set": "defined",
+            "is not set": "not defined",
+            "is between": "between",
+        }
+        assert expected == _FILTER_TO_SELECTOR_MAP
+
+
+# =============================================================================
+# Phase 3: US1 — Behavioral Cohort Criteria (did_event)
+# =============================================================================
+
+
+class TestCohortCriteriaDidEvent:
+    """Tests for CohortCriteria.did_event() (T007-T013)."""
+
+    def test_at_least_within_days(self) -> None:
+        """did_event with at_least + within_days produces correct selector and behavior."""
+        c = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+
+        # Selector node
+        assert c._selector_node["property"] == "behaviors"
+        assert c._selector_node["operator"] == ">="
+        assert c._selector_node["operand"] == 3
+
+        # Behavior key
+        assert c._behavior_key is not None
+
+        # Behavior entry
+        assert c._behavior is not None
+        assert c._behavior["count"]["event_selector"]["event"] == "Purchase"
+        assert c._behavior["count"]["event_selector"]["selector"] is None
+        assert c._behavior["count"]["type"] == "absolute"
+        assert c._behavior["window"] == {"unit": "day", "value": 30}
+
+    def test_at_most_frequency(self) -> None:
+        """did_event with at_most maps to <= operator."""
+        c = CohortCriteria.did_event("Login", at_most=5, within_days=7)
+        assert c._selector_node["operator"] == "<="
+        assert c._selector_node["operand"] == 5
+
+    def test_exactly_frequency(self) -> None:
+        """did_event with exactly maps to == operator."""
+        c = CohortCriteria.did_event("Signup", exactly=1, within_days=14)
+        assert c._selector_node["operator"] == "=="
+        assert c._selector_node["operand"] == 1
+
+    def test_within_weeks(self) -> None:
+        """did_event with within_weeks uses week unit."""
+        c = CohortCriteria.did_event("Purchase", at_least=1, within_weeks=4)
+        assert c._behavior is not None
+        assert c._behavior["window"] == {"unit": "week", "value": 4}
+
+    def test_within_months(self) -> None:
+        """did_event with within_months uses month unit."""
+        c = CohortCriteria.did_event("Purchase", at_least=1, within_months=3)
+        assert c._behavior is not None
+        assert c._behavior["window"] == {"unit": "month", "value": 3}
+
+    def test_from_date_to_date(self) -> None:
+        """did_event with absolute date range stores from_date/to_date."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            from_date="2024-01-01",
+            to_date="2024-03-31",
+        )
+        assert c._behavior is not None
+        assert "window" not in c._behavior
+        assert c._behavior["from_date"] == "2024-01-01"
+        assert c._behavior["to_date"] == "2024-03-31"
+
+    def test_where_single_filter(self) -> None:
+        """did_event with single where filter builds event selector expression."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+            where=Filter.equals("plan", "premium"),
+        )
+        assert c._behavior is not None
+        selector = c._behavior["count"]["event_selector"]["selector"]
+        assert selector is not None
+        assert selector["operator"] == "and"
+        assert len(selector["children"]) == 1
+        child = selector["children"][0]
+        assert child["property"] == "event"
+        assert child["value"] == "plan"
+        assert child["operator"] == "=="
+        assert child["operand"] == ["premium"]
+        assert child["type"] == "string"
+
+    def test_where_multiple_filters(self) -> None:
+        """did_event with multiple where filters produces AND-combined children."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+            where=[
+                Filter.equals("plan", "premium"),
+                Filter.greater_than("amount", 100),
+            ],
+        )
+        assert c._behavior is not None
+        selector = c._behavior["count"]["event_selector"]["selector"]
+        assert selector is not None
+        assert selector["operator"] == "and"
+        assert len(selector["children"]) == 2
+
+        # First child: plan == premium
+        assert selector["children"][0]["value"] == "plan"
+        assert selector["children"][0]["operator"] == "=="
+
+        # Second child: amount > 100
+        assert selector["children"][1]["value"] == "amount"
+        assert selector["children"][1]["operator"] == ">"
+        assert selector["children"][1]["operand"] == 100
+        assert selector["children"][1]["type"] == "number"
+
+    def test_exactly_zero_is_valid(self) -> None:
+        """did_event with exactly=0 is valid (used by did_not_do_event)."""
+        c = CohortCriteria.did_event("Login", exactly=0, within_days=30)
+        assert c._selector_node["operator"] == "=="
+        assert c._selector_node["operand"] == 0
+
+
+class TestCohortCriteriaDidEventValidation:
+    """Validation error tests for did_event (T012)."""
+
+    def test_cd1_conflicting_frequency_params(self) -> None:
+        """ValueError when multiple frequency params are set (CD1)."""
+        with pytest.raises(ValueError, match="exactly one of"):
+            CohortCriteria.did_event("Login", at_least=1, at_most=5, within_days=30)
+
+    def test_cd1_no_frequency_params(self) -> None:
+        """ValueError when no frequency params are set (CD1)."""
+        with pytest.raises(ValueError, match="exactly one of"):
+            CohortCriteria.did_event("Login", within_days=30)
+
+    def test_cd2_negative_frequency(self) -> None:
+        """ValueError when frequency is negative (CD2)."""
+        with pytest.raises(ValueError, match="frequency value must be >= 0"):
+            CohortCriteria.did_event("Login", at_least=-1, within_days=30)
+
+    def test_cd3_no_time_constraint(self) -> None:
+        """ValueError when no time constraint is provided (CD3)."""
+        with pytest.raises(ValueError, match="exactly one time constraint"):
+            CohortCriteria.did_event("Login", at_least=1)
+
+    def test_cd3_both_rolling_and_date_range(self) -> None:
+        """ValueError when both rolling window and date range are set (CD3)."""
+        with pytest.raises(ValueError, match="exactly one time constraint"):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=1,
+                within_days=30,
+                from_date="2024-01-01",
+                to_date="2024-03-31",
+            )
+
+    def test_cd4_empty_event_name(self) -> None:
+        """ValueError when event name is empty (CD4)."""
+        with pytest.raises(ValueError, match="event name must be non-empty"):
+            CohortCriteria.did_event("", at_least=1, within_days=30)
+
+    def test_cd4_whitespace_event_name(self) -> None:
+        """ValueError when event name is whitespace only (CD4)."""
+        with pytest.raises(ValueError, match="event name must be non-empty"):
+            CohortCriteria.did_event("   ", at_least=1, within_days=30)
+
+    def test_cd5_from_date_without_to_date(self) -> None:
+        """ValueError when from_date is set without to_date (CD5)."""
+        with pytest.raises(ValueError, match="from_date requires to_date"):
+            CohortCriteria.did_event("Login", at_least=1, from_date="2024-01-01")
+
+    def test_cd5_to_date_without_from_date(self) -> None:
+        """ValueError when to_date is set without from_date."""
+        with pytest.raises(ValueError, match="to_date requires from_date"):
+            CohortCriteria.did_event("Login", at_least=1, to_date="2024-03-31")
+
+    def test_cd6_invalid_date_format(self) -> None:
+        """ValueError when dates are not YYYY-MM-DD format (CD6)."""
+        with pytest.raises(ValueError, match="dates must be YYYY-MM-DD"):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=1,
+                from_date="01-01-2024",
+                to_date="03-31-2024",
+            )
+
+    def test_cd3_multiple_rolling_windows(self) -> None:
+        """ValueError when multiple rolling windows are set."""
+        with pytest.raises(ValueError, match="exactly one time constraint"):
+            CohortCriteria.did_event(
+                "Login", at_least=1, within_days=30, within_weeks=4
+            )
+
+
+class TestCohortCriteriaImmutability:
+    """Immutability tests for CohortCriteria (T013)."""
+
+    def test_frozen_rejects_attribute_assignment(self) -> None:
+        """Frozen dataclass rejects attribute assignment after construction."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        with pytest.raises(AttributeError):
+            c._selector_node = {}  # type: ignore[misc]
+        with pytest.raises(AttributeError):
+            c._behavior_key = "other"  # type: ignore[misc]
+        with pytest.raises(AttributeError):
+            c._behavior = {}  # type: ignore[misc]
+
+
+# =============================================================================
+# Phase 4: US2 — CohortDefinition Composition
+# =============================================================================
+
+
+class TestCohortDefinitionInit:
+    """Tests for CohortDefinition.__init__() (T017)."""
+
+    def test_single_criterion(self) -> None:
+        """CohortDefinition with single criterion stores it and defaults to AND."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        assert d._criteria == (c,)
+        assert d._operator == "and"
+
+    def test_to_dict_produces_selector_and_behaviors(self) -> None:
+        """to_dict() produces dict with selector and behaviors keys."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        assert "selector" in result
+        assert "behaviors" in result
+
+    def test_to_dict_selector_is_combinator(self) -> None:
+        """to_dict() selector is always a combinator node at top level."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        selector = result["selector"]
+        assert selector["operator"] == "and"
+        assert "children" in selector
+
+
+class TestCohortDefinitionAllOf:
+    """Tests for CohortDefinition.all_of() (T018)."""
+
+    def test_two_behavioral_criteria(self) -> None:
+        """all_of with two behavioral criteria produces AND with two children."""
+        a = CohortCriteria.did_event("Login", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+        d = CohortDefinition.all_of(a, b)
+        result = d.to_dict()
+
+        selector = result["selector"]
+        assert selector["operator"] == "and"
+        assert len(selector["children"]) == 2
+
+        behaviors = result["behaviors"]
+        assert len(behaviors) == 2
+        assert "bhvr_0" in behaviors
+        assert "bhvr_1" in behaviors
+
+    def test_behavior_keys_are_unique(self) -> None:
+        """all_of produces globally unique behavior keys."""
+        a = CohortCriteria.did_event("Login", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+        d = CohortDefinition.all_of(a, b)
+        result = d.to_dict()
+        keys = list(result["behaviors"].keys())
+        assert len(keys) == len(set(keys))
+
+    def test_selector_references_match_behavior_keys(self) -> None:
+        """Selector node values reference the correct behavior keys."""
+        a = CohortCriteria.did_event("Login", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+        d = CohortDefinition.all_of(a, b)
+        result = d.to_dict()
+
+        children = result["selector"]["children"]
+        behavior_keys = set(result["behaviors"].keys())
+        selector_refs = {c["value"] for c in children}
+        assert selector_refs == behavior_keys
+
+
+class TestCohortDefinitionAnyOf:
+    """Tests for CohortDefinition.any_of() (T019)."""
+
+    def test_any_of_uses_or_operator(self) -> None:
+        """any_of produces selector with OR operator."""
+        a = CohortCriteria.did_event("Login", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("Purchase", at_least=1, within_days=30)
+        d = CohortDefinition.any_of(a, b)
+        result = d.to_dict()
+        assert result["selector"]["operator"] == "or"
+
+
+class TestCohortDefinitionNesting:
+    """Tests for nested definitions (T020, T021)."""
+
+    def test_nested_any_of_all_of(self) -> None:
+        """any_of(all_of(A, B), C) produces correct nested selector tree."""
+        a = CohortCriteria.did_event("Login", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+        c = CohortCriteria.did_event("Signup", at_least=1, within_days=14)
+
+        nested = CohortDefinition.any_of(
+            CohortDefinition.all_of(a, b),
+            c,
+        )
+        result = nested.to_dict()
+
+        # Top level is OR
+        selector = result["selector"]
+        assert selector["operator"] == "or"
+        assert len(selector["children"]) == 2
+
+        # First child is AND (nested)
+        inner = selector["children"][0]
+        assert inner["operator"] == "and"
+        assert len(inner["children"]) == 2
+
+        # Second child is a leaf (criterion C)
+        leaf = selector["children"][1]
+        assert leaf["property"] == "behaviors"
+
+        # All three behaviors collected with unique keys
+        assert len(result["behaviors"]) == 3
+        keys = list(result["behaviors"].keys())
+        assert keys == ["bhvr_0", "bhvr_1", "bhvr_2"]
+
+    def test_deeply_nested_three_levels(self) -> None:
+        """3+ levels of nesting produces correct tree and unique behavior keys."""
+        a = CohortCriteria.did_event("A", at_least=1, within_days=7)
+        b = CohortCriteria.did_event("B", at_least=1, within_days=7)
+        c = CohortCriteria.did_event("C", at_least=1, within_days=7)
+        d = CohortCriteria.did_event("D", at_least=1, within_days=7)
+
+        deep = CohortDefinition.any_of(
+            CohortDefinition.all_of(
+                CohortDefinition.any_of(a, b),
+                c,
+            ),
+            d,
+        )
+        result = deep.to_dict()
+
+        # 4 behaviors, all unique
+        assert len(result["behaviors"]) == 4
+        keys = sorted(result["behaviors"].keys())
+        assert keys == ["bhvr_0", "bhvr_1", "bhvr_2", "bhvr_3"]
+
+    def test_behavior_key_uniqueness_across_nesting(self) -> None:
+        """No duplicate behavior keys across arbitrary nesting."""
+        criteria = [
+            CohortCriteria.did_event(f"Event{i}", at_least=1, within_days=7)
+            for i in range(5)
+        ]
+        nested = CohortDefinition.any_of(
+            CohortDefinition.all_of(*criteria[:3]),
+            CohortDefinition.all_of(*criteria[3:]),
+        )
+        result = nested.to_dict()
+        keys = list(result["behaviors"].keys())
+        assert len(keys) == 5
+        assert len(set(keys)) == 5
+
+
+class TestCohortDefinitionValidation:
+    """Validation tests for CohortDefinition (T022)."""
+
+    def test_cd9_zero_criteria_init(self) -> None:
+        """ValueError when CohortDefinition() called with zero criteria (CD9)."""
+        with pytest.raises(ValueError, match="requires at least one criterion"):
+            CohortDefinition()
+
+    def test_cd9_zero_criteria_all_of(self) -> None:
+        """ValueError when all_of() called with zero criteria."""
+        with pytest.raises(ValueError, match="requires at least one criterion"):
+            CohortDefinition.all_of()
+
+    def test_cd9_zero_criteria_any_of(self) -> None:
+        """ValueError when any_of() called with zero criteria."""
+        with pytest.raises(ValueError, match="requires at least one criterion"):
+            CohortDefinition.any_of()
+
+
+class TestCohortDefinitionImmutability:
+    """Immutability tests for CohortDefinition (T023)."""
+
+    def test_frozen_rejects_attribute_assignment(self) -> None:
+        """Frozen dataclass rejects attribute assignment after construction."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        with pytest.raises(AttributeError):
+            d._criteria = ()  # type: ignore[misc]
+        with pytest.raises(AttributeError):
+            d._operator = "or"  # type: ignore[misc]
+
+
+# =============================================================================
+# Phase 5: US3 — Property-Based Criteria
+# =============================================================================
+
+
+class TestCohortCriteriaHasProperty:
+    """Tests for CohortCriteria.has_property() (T030-T035b)."""
+
+    def test_has_property_default_operator(self) -> None:
+        """has_property with default operator produces equals selector node."""
+        c = CohortCriteria.has_property("plan", "premium")
+        assert c._selector_node["property"] == "user"
+        assert c._selector_node["value"] == "plan"
+        assert c._selector_node["operator"] == "=="
+        assert c._selector_node["operand"] == "premium"
+        assert c._selector_node["type"] == "string"
+        assert c._behavior_key is None
+        assert c._behavior is None
+
+    @pytest.mark.parametrize(
+        ("operator", "expected_selector_op"),
+        [
+            ("equals", "=="),
+            ("not_equals", "!="),
+            ("contains", "in"),
+            ("not_contains", "not in"),
+            ("greater_than", ">"),
+            ("less_than", "<"),
+        ],
+    )
+    def test_has_property_all_operators(
+        self, operator: str, expected_selector_op: str
+    ) -> None:
+        """has_property maps all operators correctly via _PROPERTY_OPERATOR_MAP."""
+        c = CohortCriteria.has_property("age", 25, operator=operator)  # type: ignore[arg-type]
+        assert c._selector_node["operator"] == expected_selector_op
+
+    def test_has_property_number_type(self) -> None:
+        """has_property with property_type='number' sets type field."""
+        c = CohortCriteria.has_property(
+            "age", 25, operator="greater_than", property_type="number"
+        )
+        assert c._selector_node["type"] == "number"
+
+    def test_property_is_set(self) -> None:
+        """property_is_set produces 'defined' operator."""
+        c = CohortCriteria.property_is_set("email")
+        assert c._selector_node["property"] == "user"
+        assert c._selector_node["value"] == "email"
+        assert c._selector_node["operator"] == "defined"
+        assert c._behavior_key is None
+        assert c._behavior is None
+
+    def test_property_is_not_set(self) -> None:
+        """property_is_not_set produces 'not defined' operator."""
+        c = CohortCriteria.property_is_not_set("phone")
+        assert c._selector_node["operator"] == "not defined"
+
+    def test_cd7_empty_property_name(self) -> None:
+        """ValueError when property name is empty (CD7)."""
+        with pytest.raises(ValueError, match="property name must be non-empty"):
+            CohortCriteria.has_property("", "value")
+
+    def test_cd7_whitespace_property_name(self) -> None:
+        """ValueError when property name is whitespace only (CD7)."""
+        with pytest.raises(ValueError, match="property name must be non-empty"):
+            CohortCriteria.has_property("   ", "value")
+
+    def test_cd7_property_is_set_empty_name(self) -> None:
+        """ValueError when property_is_set receives empty name."""
+        with pytest.raises(ValueError, match="property name must be non-empty"):
+            CohortCriteria.property_is_set("")
+
+    def test_property_in_to_dict_empty_behaviors(self) -> None:
+        """Property-only definition produces empty behaviors dict."""
+        c = CohortCriteria.has_property("plan", "premium")
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        assert result["behaviors"] == {}
+
+    def test_definition_with_only_property_criteria(self) -> None:
+        """Definition with only property criteria has empty behaviors dict."""
+        d = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.property_is_set("email"),
+        )
+        result = d.to_dict()
+        assert result["behaviors"] == {}
+        assert result["selector"]["operator"] == "and"
+        assert len(result["selector"]["children"]) == 2
+
+
+# =============================================================================
+# Phase 6: US4 — Cohort Reference Criteria
+# =============================================================================
+
+
+class TestCohortCriteriaCohortRef:
+    """Tests for CohortCriteria.in_cohort() and not_in_cohort() (T039-T042)."""
+
+    def test_in_cohort(self) -> None:
+        """in_cohort produces correct cohort reference selector node."""
+        c = CohortCriteria.in_cohort(456)
+        assert c._selector_node["property"] == "cohort"
+        assert c._selector_node["value"] == 456
+        assert c._selector_node["operator"] == "in"
+        assert c._behavior_key is None
+        assert c._behavior is None
+
+    def test_not_in_cohort(self) -> None:
+        """not_in_cohort produces 'not in' operator."""
+        c = CohortCriteria.not_in_cohort(456)
+        assert c._selector_node["property"] == "cohort"
+        assert c._selector_node["value"] == 456
+        assert c._selector_node["operator"] == "not in"
+        assert c._behavior_key is None
+        assert c._behavior is None
+
+    def test_cd8_zero_cohort_id(self) -> None:
+        """ValueError when cohort_id is 0 (CD8)."""
+        with pytest.raises(ValueError, match="cohort_id must be a positive integer"):
+            CohortCriteria.in_cohort(0)
+
+    def test_cd8_negative_cohort_id(self) -> None:
+        """ValueError when cohort_id is negative (CD8)."""
+        with pytest.raises(ValueError, match="cohort_id must be a positive integer"):
+            CohortCriteria.in_cohort(-1)
+
+    def test_cd8_not_in_cohort_validation(self) -> None:
+        """not_in_cohort also validates cohort_id (CD8)."""
+        with pytest.raises(ValueError, match="cohort_id must be a positive integer"):
+            CohortCriteria.not_in_cohort(0)
+
+    def test_cohort_in_to_dict(self) -> None:
+        """Cohort-only definition produces correct selector and empty behaviors."""
+        c = CohortCriteria.in_cohort(456)
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        assert result["behaviors"] == {}
+        leaf = result["selector"]["children"][0]
+        assert leaf["property"] == "cohort"
+        assert leaf["value"] == 456
+        assert leaf["operator"] == "in"
+
+
+# =============================================================================
+# Phase 7: US5 — CRUD Integration
+# =============================================================================
+
+
+class TestCohortDefinitionCRUDIntegration:
+    """Integration tests with CreateCohortParams (T045-T047)."""
+
+    def test_definition_with_create_cohort_params(self) -> None:
+        """CohortDefinition.to_dict() integrates with CreateCohortParams."""
+        cohort_def = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+        )
+        params = CreateCohortParams(
+            name="Premium Purchasers",
+            definition=cohort_def.to_dict(),
+        )
+        data = params.model_dump(exclude_none=True)
+
+        # Top-level keys: name, selector, behaviors (definition flattened)
+        assert "name" in data
+        assert data["name"] == "Premium Purchasers"
+        assert "selector" in data
+        assert "behaviors" in data
+        assert "definition" not in data
+
+    def test_nested_definition_with_crud(self) -> None:
+        """Complex nested definition flattens correctly via CreateCohortParams."""
+        cohort_def = CohortDefinition.any_of(
+            CohortDefinition.all_of(
+                CohortCriteria.has_property("plan", "premium"),
+                CohortCriteria.did_event("Login", at_least=5, within_days=30),
+            ),
+            CohortCriteria.in_cohort(789),
+        )
+        params = CreateCohortParams(
+            name="Test",
+            definition=cohort_def.to_dict(),
+        )
+        data = params.model_dump(exclude_none=True)
+
+        assert "selector" in data
+        assert data["selector"]["operator"] == "or"
+        assert "behaviors" in data
+        assert len(data["behaviors"]) == 1  # Only Login is behavioral
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        """to_dict() output is fully JSON-serializable."""
+        cohort_def = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event(
+                "Purchase",
+                at_least=3,
+                within_days=30,
+                where=Filter.greater_than("amount", 100),
+            ),
+            CohortCriteria.in_cohort(456),
+        )
+        result = cohort_def.to_dict()
+        serialized = json.dumps(result)
+        assert isinstance(serialized, str)
+        deserialized = json.loads(serialized)
+        assert deserialized == result
+
+
+# =============================================================================
+# Phase 8: US6 — did_not_do_event Shorthand
+# =============================================================================
+
+
+class TestCohortCriteriaDidNotDoEvent:
+    """Tests for CohortCriteria.did_not_do_event() (T049-T050)."""
+
+    def test_equivalent_to_did_event_exactly_zero(self) -> None:
+        """did_not_do_event is equivalent to did_event(exactly=0)."""
+        a = CohortCriteria.did_not_do_event("Login", within_days=30)
+        b = CohortCriteria.did_event("Login", exactly=0, within_days=30)
+
+        assert a._selector_node == b._selector_node
+        assert a._behavior_key == b._behavior_key
+        assert a._behavior == b._behavior
+
+    def test_within_weeks(self) -> None:
+        """did_not_do_event with within_weeks works correctly."""
+        a = CohortCriteria.did_not_do_event("Login", within_weeks=4)
+        b = CohortCriteria.did_event("Login", exactly=0, within_weeks=4)
+        assert a._selector_node == b._selector_node
+        assert a._behavior == b._behavior
+
+    def test_within_months(self) -> None:
+        """did_not_do_event with within_months works correctly."""
+        a = CohortCriteria.did_not_do_event("Login", within_months=3)
+        b = CohortCriteria.did_event("Login", exactly=0, within_months=3)
+        assert a._selector_node == b._selector_node
+        assert a._behavior == b._behavior
+
+    def test_with_date_range(self) -> None:
+        """did_not_do_event with from_date+to_date works correctly."""
+        a = CohortCriteria.did_not_do_event(
+            "Login", from_date="2024-01-01", to_date="2024-03-31"
+        )
+        b = CohortCriteria.did_event(
+            "Login", exactly=0, from_date="2024-01-01", to_date="2024-03-31"
+        )
+        assert a._selector_node == b._selector_node
+        assert a._behavior == b._behavior
+
+
+# =============================================================================
+# Mixed Criteria Tests
+# =============================================================================
+
+
+class TestMixedCriteria:
+    """Tests for definitions mixing behavioral, property, and cohort criteria."""
+
+    def test_mixed_behavioral_and_property(self) -> None:
+        """Definition with behavioral + property criteria serializes correctly."""
+        d = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
+        )
+        result = d.to_dict()
+        assert len(result["behaviors"]) == 1
+        assert len(result["selector"]["children"]) == 2
+
+        # Property child has no behavior reference
+        prop_child = result["selector"]["children"][0]
+        assert prop_child["property"] == "user"
+
+        # Behavioral child references behavior
+        behav_child = result["selector"]["children"][1]
+        assert behav_child["property"] == "behaviors"
+        assert behav_child["value"] == "bhvr_0"
+
+    def test_all_criteria_types(self) -> None:
+        """Definition with all three criteria types serializes correctly."""
+        d = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Purchase", at_least=1, within_days=30),
+            CohortCriteria.in_cohort(456),
+        )
+        result = d.to_dict()
+        assert len(result["behaviors"]) == 1  # Only behavioral has a behavior
+        assert len(result["selector"]["children"]) == 3
+
+
+# =============================================================================
+# Edge Cases & Regression Tests
+# =============================================================================
+
+
+class TestToDictIsolation:
+    """Tests that to_dict() does not leak internal mutable state."""
+
+    def test_modifying_output_does_not_corrupt_criteria(self) -> None:
+        """Mutating to_dict() output must not affect the frozen criterion."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        result["behaviors"]["bhvr_0"]["window"]["value"] = 999
+        # The original criterion must be untouched
+        assert c._behavior is not None
+        assert c._behavior["window"]["value"] == 30
+
+    def test_multiple_to_dict_calls_are_independent(self) -> None:
+        """Successive to_dict() calls produce independent dicts."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition(c)
+        r1 = d.to_dict()
+        r2 = d.to_dict()
+        r1["behaviors"]["bhvr_0"]["window"]["value"] = 888
+        assert r2["behaviors"]["bhvr_0"]["window"]["value"] == 30
+
+    def test_reused_criterion_behaviors_are_independent(self) -> None:
+        """Same criterion used twice produces independent behavior copies."""
+        c = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        d = CohortDefinition.all_of(c, c)
+        result = d.to_dict()
+        result["behaviors"]["bhvr_0"]["window"]["value"] = 777
+        assert result["behaviors"]["bhvr_1"]["window"]["value"] == 30
+
+
+class TestEmptyWhereList:
+    """Tests for where=[] edge case."""
+
+    def test_empty_where_list_treated_as_no_filter(self) -> None:
+        """where=[] should produce None selector (same as no filter)."""
+        c_no_filter = CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        c_empty = CohortCriteria.did_event(
+            "Login", at_least=1, within_days=30, where=[]
+        )
+        assert c_no_filter._behavior is not None
+        assert c_empty._behavior is not None
+        assert c_no_filter._behavior["count"]["event_selector"]["selector"] is None
+        assert c_empty._behavior["count"]["event_selector"]["selector"] is None
+
+
+class TestTimeWindowValidation:
+    """Tests for rolling window value validation."""
+
+    def test_within_days_zero_raises(self) -> None:
+        """within_days=0 should raise ValueError."""
+        with pytest.raises(ValueError, match="time window value must be positive"):
+            CohortCriteria.did_event("Login", at_least=1, within_days=0)
+
+    def test_within_days_negative_raises(self) -> None:
+        """within_days=-5 should raise ValueError."""
+        with pytest.raises(ValueError, match="time window value must be positive"):
+            CohortCriteria.did_event("Login", at_least=1, within_days=-5)
+
+    def test_within_weeks_zero_raises(self) -> None:
+        """within_weeks=0 should raise ValueError."""
+        with pytest.raises(ValueError, match="time window value must be positive"):
+            CohortCriteria.did_event("Login", at_least=1, within_weeks=0)
+
+    def test_within_months_negative_raises(self) -> None:
+        """within_months=-1 should raise ValueError."""
+        with pytest.raises(ValueError, match="time window value must be positive"):
+            CohortCriteria.did_event("Login", at_least=1, within_months=-1)
+
+
+class TestDateRangeOrdering:
+    """Tests for from_date <= to_date validation."""
+
+    def test_from_date_after_to_date_raises(self) -> None:
+        """from_date > to_date should raise ValueError."""
+        with pytest.raises(
+            ValueError, match="from_date must be before or equal to to_date"
+        ):
+            CohortCriteria.did_event(
+                "Login",
+                at_least=1,
+                from_date="2025-12-31",
+                to_date="2024-01-01",
+            )
+
+    def test_from_date_equals_to_date_is_valid(self) -> None:
+        """from_date == to_date should be accepted (single day)."""
+        c = CohortCriteria.did_event(
+            "Login",
+            at_least=1,
+            from_date="2024-06-15",
+            to_date="2024-06-15",
+        )
+        assert c._behavior is not None
+        assert c._behavior["from_date"] == "2024-06-15"

--- a/tests/unit/test_cohort_definition.py
+++ b/tests/unit/test_cohort_definition.py
@@ -780,6 +780,14 @@ class TestToDictIsolation:
         result["behaviors"]["bhvr_0"]["window"]["value"] = 777
         assert result["behaviors"]["bhvr_1"]["window"]["value"] == 30
 
+    def test_mutable_operand_list_not_leaked(self) -> None:
+        """Mutating list operand in to_dict() output must not corrupt criterion."""
+        c = CohortCriteria.has_property("tags", ["premium", "active"])
+        d = CohortDefinition(c)
+        result = d.to_dict()
+        result["selector"]["children"][0]["operand"].append("CORRUPTED")
+        assert c._selector_node["operand"] == ["premium", "active"]
+
 
 class TestEmptyWhereList:
     """Tests for where=[] edge case."""


### PR DESCRIPTION
## Summary

- Add `CohortCriteria` and `CohortDefinition` frozen dataclasses to `types.py` for programmatic cohort definition construction
- `CohortCriteria` provides 7 class methods: `did_event()`, `did_not_do_event()`, `has_property()`, `property_is_set()`, `property_is_not_set()`, `in_cohort()`, `not_in_cohort()`
- `CohortDefinition` composes criteria with AND/OR logic (`__init__`, `all_of()`, `any_of()`) and serializes to valid Mixpanel legacy `selector` + `behaviors` JSON via `to_dict()`
- 10 validation rules (CD1-CD10) with fail-fast `ValueError` at construction time
- Deep-copy isolation in `to_dict()` output prevents mutation of frozen internal state
- Full compatibility with existing `CreateCohortParams` — `to_dict()` output passes directly to `definition=` parameter

## Test plan

- [x] 76 unit tests covering all 7 CohortCriteria methods, CohortDefinition composition/nesting, CRUD integration, validation rules, immutability, and edge cases
- [x] 17 property-based tests (Hypothesis) verifying invariants across random inputs: no crashes, unique behavior keys, valid selector trees, JSON serializability, validation always fires
- [x] 10 regression tests for QA-discovered bugs: mutable state leakage, empty where list, zero/negative window values, date range ordering
- [x] All 4216 tests pass, mypy --strict clean, ruff clean
- [x] All quickstart examples validated end-to-end