### PR TITLE
fix(workspace): create_bookmark requires dashboard_id and auto-adds to layout

### DIFF
--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -3114,7 +3114,9 @@ class CreateBookmarkParams(BaseModel):
         params: Query parameters (required).
         description: Bookmark description.
         icon: Bookmark icon.
-        dashboard_id: Dashboard to associate with.
+        dashboard_id: Dashboard to associate with.  Required by
+            ``Workspace.create_bookmark()`` — the Mixpanel v2 API
+            requires every bookmark to belong to a dashboard.
         is_visibility_restricted: Visibility restriction flag.
         is_modification_restricted: Modification restriction flag.
 
@@ -3124,6 +3126,7 @@ class CreateBookmarkParams(BaseModel):
             name="Signup Funnel",
             bookmark_type="funnels",
             params={"events": [{"event": "Signup"}]},
+            dashboard_id=12345,
         )
         data = params.model_dump(by_alias=True, exclude_none=True)
         ```

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -2812,6 +2812,31 @@ class Workspace:
             "displayOptions": {
                 "chartType": chart_type_map.get(mode, "retention-curve"),
             },
+            "sorting": {
+                "bar": {"colSortAttrs": [], "sortBy": "column"},
+                "line": {
+                    "sortBy": "column",
+                    "colSortAttrs": [
+                        {
+                            "sortBy": "value",
+                            "sortOrder": "desc",
+                            "valueField": "averageValue",
+                        }
+                    ],
+                },
+                "table": {
+                    "sortBy": "column",
+                    "colSortAttrs": [
+                        {
+                            "sortBy": "value",
+                            "sortOrder": "desc",
+                            "valueField": "size",
+                            "viewNLimit": 12,
+                        }
+                    ],
+                },
+            },
+            "columnWidths": {"bar": {}},
         }
 
     # =========================================================================
@@ -4295,6 +4320,14 @@ class Workspace:
             ))
             ```
         """
+        if params.dashboard_id is None:
+            raise MixpanelDataError(
+                "dashboard_id is required when creating a bookmark. "
+                "The Mixpanel v2 API requires every bookmark to be "
+                "associated with a dashboard. Create a dashboard first "
+                "with create_dashboard(), then pass its ID here.",
+            )
+
         client = self._require_api_client()
         raw = client.create_bookmark(
             params.model_dump(by_alias=True, exclude_none=True)
@@ -4303,7 +4336,18 @@ class Workspace:
             raise MixpanelDataError(
                 "API returned empty response for create_bookmark",
             )
-        return Bookmark.model_validate(raw)
+        bookmark = Bookmark.model_validate(raw)
+
+        # The v2 create endpoint associates the bookmark with the
+        # dashboard in the database, but does NOT add it to the
+        # dashboard's visual layout — that requires a separate
+        # PATCH call.
+        if bookmark.id is not None:
+            client.add_report_to_dashboard(
+                params.dashboard_id, bookmark.id
+            )
+
+        return bookmark
 
     def get_bookmark(self, bookmark_id: int) -> Bookmark:
         """Get a single bookmark by ID.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -2007,11 +2007,12 @@ class Workspace:
             params = ws.build_params("Login", math="unique", last=7)
             print(json.dumps(params, indent=2))
 
-            # Save as a bookmark
+            # Save as a bookmark (dashboard_id required)
             ws.create_bookmark(CreateBookmarkParams(
                 name="Daily Unique Logins",
                 bookmark_type="insights",
                 params=params,
+                dashboard_id=12345,
             ))
             ```
         """
@@ -2674,11 +2675,12 @@ class Workspace:
             params = ws.build_funnel_params(["Signup", "Purchase"])
             print(json.dumps(params, indent=2))
 
-            # Save as a report
+            # Save as a report (dashboard_id required)
             ws.create_bookmark(CreateBookmarkParams(
                 name="Signup → Purchase Funnel",
                 bookmark_type="funnels",
                 params=params,
+                dashboard_id=12345,
             ))
             ```
         """
@@ -3290,11 +3292,12 @@ class Workspace:
             params = ws.build_flow_params("Login")
             print(json.dumps(params, indent=2))
 
-            # Save as a report
+            # Save as a report (dashboard_id required)
             ws.create_bookmark(CreateBookmarkParams(
                 name="Login Flow",
                 bookmark_type="flows",
                 params=params,
+                dashboard_id=12345,
             ))
             ```
         """
@@ -3578,11 +3581,12 @@ class Workspace:
             params = ws.build_retention_params("Signup", "Login")
             print(json.dumps(params, indent=2))
 
-            # Save as a report
+            # Save as a report (dashboard_id required)
             ws.create_bookmark(CreateBookmarkParams(
                 name="Signup → Login Retention",
                 bookmark_type="retention",
                 params=params,
+                dashboard_id=12345,
             ))
             ```
         """
@@ -4299,12 +4303,15 @@ class Workspace:
         """Create a new bookmark (saved report).
 
         Args:
-            params: Bookmark creation parameters.
+            params: Bookmark creation parameters.  ``dashboard_id``
+                is required by the Mixpanel v2 API.
 
         Returns:
             The newly created ``Bookmark``.
 
         Raises:
+            MixpanelDataError: If ``params.dashboard_id`` is ``None``
+                (required by the Mixpanel v2 API).
             ConfigError: If credentials are not available.
             AuthenticationError: Invalid credentials (401).
             QueryError: Invalid parameters (400, 422).
@@ -4313,10 +4320,14 @@ class Workspace:
         Example:
             ```python
             ws = Workspace()
+            dashboard = ws.create_dashboard(
+                CreateDashboardParams(title="My Dashboard")
+            )
             report = ws.create_bookmark(CreateBookmarkParams(
                 name="Signup Funnel",
                 bookmark_type="funnels",
                 params={"events": [{"event": "Signup"}]},
+                dashboard_id=dashboard.id,
             ))
             ```
         """
@@ -4342,10 +4353,7 @@ class Workspace:
         # dashboard in the database, but does NOT add it to the
         # dashboard's visual layout — that requires a separate
         # PATCH call.
-        if bookmark.id is not None:
-            client.add_report_to_dashboard(
-                params.dashboard_id, bookmark.id
-            )
+        self.add_report_to_dashboard(params.dashboard_id, bookmark.id)
 
         return bookmark
 

--- a/tests/test_build_retention_params.py
+++ b/tests/test_build_retention_params.py
@@ -117,6 +117,27 @@ class TestBuildRetentionParamsDefaults:
         result = ws.build_retention_params("Signup", "Login")
         assert result["displayOptions"]["chartType"] == "retention-curve"
 
+    def test_sorting_object_present(self, ws: Workspace) -> None:
+        """Verify sorting object is included with expected chart-type keys.
+
+        The Mixpanel UI requires a sorting object to render retention
+        reports on dashboards without crashing.
+        """
+        result = ws.build_retention_params("Signup", "Login")
+        sorting = result["sorting"]
+        assert "bar" in sorting
+        assert "line" in sorting
+        assert "table" in sorting
+        assert sorting["bar"]["sortBy"] == "column"
+
+    def test_column_widths_present(self, ws: Workspace) -> None:
+        """Verify columnWidths object is included.
+
+        Required by the Mixpanel UI for dashboard rendering.
+        """
+        result = ws.build_retention_params("Signup", "Login")
+        assert result["columnWidths"] == {"bar": {}}
+
     def test_custom_bucket_sizes_defaults_to_empty_list(self, ws: Workspace) -> None:
         """Verify retentionCustomBucketSizes defaults to empty list."""
         result = ws.build_retention_params("Signup", "Login")

--- a/tests/unit/test_workspace_crud.py
+++ b/tests/unit/test_workspace_crud.py
@@ -618,7 +618,11 @@ class TestWorkspaceBookmarkCRUD:
         """create_bookmark() returns the created Bookmark."""
 
         def handler(request: httpx.Request) -> httpx.Response:
-            """Return created bookmark."""
+            """Return created bookmark or handle add-to-dashboard PATCH."""
+            if request.method == "PATCH":
+                return httpx.Response(
+                    200, json={"status": "ok", "results": {"id": 99}}
+                )
             return httpx.Response(
                 200,
                 json={
@@ -632,6 +636,7 @@ class TestWorkspaceBookmarkCRUD:
             name="New Bookmark",
             bookmark_type="insights",
             params={"events": [{"event": "Signup"}]},
+            dashboard_id=99,
         )
         bookmark = ws.create_bookmark(params)
 
@@ -644,6 +649,10 @@ class TestWorkspaceBookmarkCRUD:
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Return created bookmark with description."""
+            if request.method == "PATCH":
+                return httpx.Response(
+                    200, json={"status": "ok", "results": {"id": 99}}
+                )
             data = _bookmark_json(11, "Described BM", "funnels")
             data["description"] = "A test bookmark"
             return httpx.Response(200, json={"status": "ok", "results": data})
@@ -654,6 +663,7 @@ class TestWorkspaceBookmarkCRUD:
             bookmark_type="funnels",
             params={"events": []},
             description="A test bookmark",
+            dashboard_id=99,
         )
         bookmark = ws.create_bookmark(params)
 
@@ -663,7 +673,11 @@ class TestWorkspaceBookmarkCRUD:
         """create_bookmark() can associate with a dashboard."""
 
         def handler(request: httpx.Request) -> httpx.Response:
-            """Return created bookmark with dashboard_id."""
+            """Return created bookmark with dashboard_id or handle PATCH."""
+            if request.method == "PATCH":
+                return httpx.Response(
+                    200, json={"status": "ok", "results": {"id": 99}}
+                )
             data = _bookmark_json(12, "On Dashboard", "insights")
             data["dashboard_id"] = 99
             return httpx.Response(200, json={"status": "ok", "results": data})
@@ -678,6 +692,22 @@ class TestWorkspaceBookmarkCRUD:
         bookmark = ws.create_bookmark(params)
 
         assert bookmark.dashboard_id == 99
+
+    def test_create_bookmark_requires_dashboard_id(self, temp_dir: Path) -> None:
+        """create_bookmark() raises MixpanelDataError when dashboard_id is missing."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Should not be called."""
+            return httpx.Response(200, json={"status": "ok", "results": {}})
+
+        ws = _make_workspace(temp_dir, handler)
+        params = CreateBookmarkParams(
+            name="No Dashboard",
+            bookmark_type="insights",
+            params={"events": []},
+        )
+        with pytest.raises(MixpanelDataError, match="dashboard_id is required"):
+            ws.create_bookmark(params)
 
     def test_get_bookmark(self, temp_dir: Path) -> None:
         """get_bookmark() returns a single Bookmark by ID."""
@@ -1001,7 +1031,11 @@ class TestWorkspaceBookmarkCRUD:
         """create_bookmark() works with funnel bookmark type."""
 
         def handler(request: httpx.Request) -> httpx.Response:
-            """Return created funnel bookmark."""
+            """Return created funnel bookmark or handle PATCH."""
+            if request.method == "PATCH":
+                return httpx.Response(
+                    200, json={"status": "ok", "results": {"id": 99}}
+                )
             return httpx.Response(
                 200,
                 json={
@@ -1015,6 +1049,7 @@ class TestWorkspaceBookmarkCRUD:
             name="Funnel BM",
             bookmark_type="funnels",
             params={"steps": []},
+            dashboard_id=99,
         )
         bookmark = ws.create_bookmark(params)
 

--- a/tests/unit/test_workspace_crud.py
+++ b/tests/unit/test_workspace_crud.py
@@ -621,7 +621,7 @@ class TestWorkspaceBookmarkCRUD:
             """Return created bookmark or handle add-to-dashboard PATCH."""
             if request.method == "PATCH":
                 return httpx.Response(
-                    200, json={"status": "ok", "results": {"id": 99}}
+                    200, json={"status": "ok", "results": _dashboard_json(id=99)}
                 )
             return httpx.Response(
                 200,
@@ -651,7 +651,7 @@ class TestWorkspaceBookmarkCRUD:
             """Return created bookmark with description."""
             if request.method == "PATCH":
                 return httpx.Response(
-                    200, json={"status": "ok", "results": {"id": 99}}
+                    200, json={"status": "ok", "results": _dashboard_json(id=99)}
                 )
             data = _bookmark_json(11, "Described BM", "funnels")
             data["description"] = "A test bookmark"
@@ -676,7 +676,7 @@ class TestWorkspaceBookmarkCRUD:
             """Return created bookmark with dashboard_id or handle PATCH."""
             if request.method == "PATCH":
                 return httpx.Response(
-                    200, json={"status": "ok", "results": {"id": 99}}
+                    200, json={"status": "ok", "results": _dashboard_json(id=99)}
                 )
             data = _bookmark_json(12, "On Dashboard", "insights")
             data["dashboard_id"] = 99
@@ -692,6 +692,46 @@ class TestWorkspaceBookmarkCRUD:
         bookmark = ws.create_bookmark(params)
 
         assert bookmark.dashboard_id == 99
+
+    def test_create_bookmark_auto_adds_to_dashboard(self, temp_dir: Path) -> None:
+        """create_bookmark() issues a PATCH to add the report to dashboard layout."""
+        requests_made: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture requests and return appropriate responses."""
+            requests_made.append(request)
+            if request.method == "POST" and "bookmarks" in str(request.url):
+                data = _bookmark_json(42, "Auto Add", "insights")
+                data["dashboard_id"] = 99
+                return httpx.Response(
+                    200, json={"status": "ok", "results": data}
+                )
+            if request.method == "PATCH" and "dashboards" in str(request.url):
+                return httpx.Response(
+                    200,
+                    json={"status": "ok", "results": _dashboard_json(id=99)},
+                )
+            return httpx.Response(200, json={"status": "ok", "results": {}})
+
+        ws = _make_workspace(temp_dir, handler)
+        ws.create_bookmark(CreateBookmarkParams(
+            name="Auto Add",
+            bookmark_type="insights",
+            params={"events": []},
+            dashboard_id=99,
+        ))
+
+        patch_requests = [
+            r for r in requests_made
+            if r.method == "PATCH" and "dashboards" in str(r.url)
+        ]
+        assert len(patch_requests) == 1, (
+            f"Expected 1 PATCH to dashboards, got {len(patch_requests)}"
+        )
+        import json
+
+        patch_body = json.loads(patch_requests[0].content)
+        assert patch_body["content"]["content_params"]["source_bookmark_id"] == 42
 
     def test_create_bookmark_requires_dashboard_id(self, temp_dir: Path) -> None:
         """create_bookmark() raises MixpanelDataError when dashboard_id is missing."""
@@ -1034,7 +1074,7 @@ class TestWorkspaceBookmarkCRUD:
             """Return created funnel bookmark or handle PATCH."""
             if request.method == "PATCH":
                 return httpx.Response(
-                    200, json={"status": "ok", "results": {"id": 99}}
+                    200, json={"status": "ok", "results": _dashboard_json(id=99)}
                 )
             return httpx.Response(
                 200,

--- a/tests/unit/test_workspace_crud_edge.py
+++ b/tests/unit/test_workspace_crud_edge.py
@@ -115,11 +115,18 @@ class TestRequestBodySerialization:
                         },
                     },
                 )
+            # Handle PATCH for add_report_to_dashboard
+            if request.method == "PATCH":
+                return httpx.Response(
+                    200, json={"status": "ok", "results": {"id": 99}}
+                )
             return httpx.Response(200, json={"status": "ok", "results": []})
 
         ws = _make_workspace(temp_dir, handler)
         ws.create_bookmark(
-            CreateBookmarkParams(name="X", bookmark_type="funnels", params={})
+            CreateBookmarkParams(
+                name="X", bookmark_type="funnels", params={}, dashboard_id=99
+            )
         )
 
         body = captured["body"]

--- a/tests/unit/test_workspace_crud_edge.py
+++ b/tests/unit/test_workspace_crud_edge.py
@@ -118,7 +118,7 @@ class TestRequestBodySerialization:
             # Handle PATCH for add_report_to_dashboard
             if request.method == "PATCH":
                 return httpx.Response(
-                    200, json={"status": "ok", "results": {"id": 99}}
+                    200, json={"status": "ok", "results": {"id": 99, "title": "T"}}
                 )
             return httpx.Response(200, json={"status": "ok", "results": []})
 


### PR DESCRIPTION
## Summary

- **Bug 1**: `create_bookmark()` without `dashboard_id` produced a misleading "Dashboard doesn't exist" error from the Mixpanel v2 API. Now raises a clear `MixpanelDataError` explaining `dashboard_id` is required.
- **Bug 2**: `create_bookmark()` with `dashboard_id` created the bookmark in the database but did NOT add it to the dashboard's visual layout. Now automatically calls `add_report_to_dashboard()` after creation.
- **Bug 3**: Retention bookmark params were missing `sorting` and `columnWidths` objects, causing the Mixpanel UI to crash with `TypeError: Cannot read properties of undefined (reading 'retention-curve')` when rendering retention reports on dashboards.

## Test plan

- [x] `create_bookmark()` without `dashboard_id` raises `MixpanelDataError` with clear message
- [x] `create_bookmark()` with `dashboard_id` creates bookmark AND adds it to dashboard layout
- [x] Retention reports render correctly on dashboards (verified on project 8, dashboard 11083602)
- [x] All 576 bookmark and retention tests pass
- [x] Full test suite passes (4,220 tests)