### PR TITLE
fix(docs): copy markdown button fails after instant navigation

### DIFF
--- a/docs/javascripts/copy-markdown.js
+++ b/docs/javascripts/copy-markdown.js
@@ -9,8 +9,9 @@
  * fail. This script pre-fetches markdown and copies synchronously via
  * execCommand, preserving the user gesture chain.
  *
- * Subscribes to MkDocs Material's document$ observable so it re-initializes
- * on every instant navigation, always overriding the plugin's inline script.
+ * Subscribes to MkDocs Material's document$ observable (a ReplaySubject(1))
+ * so it re-initializes on every instant navigation, always overriding the
+ * plugin's inline script.
  */
 (function() {
     'use strict';
@@ -22,11 +23,40 @@
     // Module state
     let cachedMarkdown = null;
     let fetchError = null;
+    let abortController = null;
+
+    /**
+     * Restores the copy button visibility (reverses any prior hideButton call).
+     */
+    function showButton() {
+        const button = document.getElementById('llms-copy-button');
+        if (button) {
+            button.style.display = '';
+        }
+    }
+
+    /**
+     * Hides the copy button when markdown content is unavailable.
+     */
+    function hideButton() {
+        const button = document.getElementById('llms-copy-button');
+        if (button) {
+            button.style.display = 'none';
+        }
+    }
 
     /**
      * Fetches markdown for the current page and caches it.
+     * Cancels any in-flight request to prevent stale content from a previous
+     * navigation overwriting the cache.
      */
     function prefetchMarkdown() {
+        // Cancel any in-flight request from a previous navigation
+        if (abortController) {
+            abortController.abort();
+        }
+        abortController = new AbortController();
+
         cachedMarkdown = null;
         fetchError = null;
 
@@ -35,17 +65,23 @@
             ? currentPath + 'index.md'
             : currentPath.replace(/\.html$/, '.md');
 
-        fetch(mdPath)
-            .then(function(response) {
+        // Capture the path so the resolution check is unambiguous
+        const requestedPath = mdPath;
+
+        fetch(mdPath, { signal: abortController.signal })
+            .then(response => {
                 if (!response.ok) throw new Error('Not found');
                 return response.text();
             })
-            .then(function(text) {
+            .then(text => {
+                // Only update cache if this is still the current request
+                if (requestedPath !== getCurrentMdPath()) return;
                 cachedMarkdown = text
                     .replace(/[\r\n]*Copy Markdown[\r\n\s]*$/i, '')
                     .replace(/\s+$/, '');
             })
-            .catch(function(err) {
+            .catch(err => {
+                if (err.name === 'AbortError') return;
                 fetchError = err;
                 console.warn('Could not prefetch markdown:', err);
                 hideButton();
@@ -53,13 +89,13 @@
     }
 
     /**
-     * Hides the copy button when markdown content is unavailable.
+     * Returns the expected markdown path for the current page.
      */
-    function hideButton() {
-        var button = document.getElementById('llms-copy-button');
-        if (button) {
-            button.style.display = 'none';
-        }
+    function getCurrentMdPath() {
+        const currentPath = window.location.pathname;
+        return currentPath.endsWith('/')
+            ? currentPath + 'index.md'
+            : currentPath.replace(/\.html$/, '.md');
     }
 
     /**
@@ -75,7 +111,7 @@
      * @returns {boolean} Whether the copy succeeded
      */
     function copyToClipboard(text) {
-        var textarea = document.createElement('textarea');
+        const textarea = document.createElement('textarea');
         textarea.value = text;
 
         textarea.style.cssText = 'position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;';
@@ -86,10 +122,10 @@
             textarea.contentEditable = true;
             textarea.readOnly = false;
 
-            var range = document.createRange();
+            const range = document.createRange();
             range.selectNodeContents(textarea);
 
-            var selection = window.getSelection();
+            const selection = window.getSelection();
             selection.removeAllRanges();
             selection.addRange(range);
             textarea.setSelectionRange(0, IOS_MAX_SELECTION);
@@ -98,7 +134,7 @@
             textarea.select();
         }
 
-        var success = false;
+        let success = false;
         try {
             success = document.execCommand('copy');
         } catch (err) {
@@ -114,10 +150,10 @@
      * @param {HTMLElement} button - The button element
      */
     function showSuccess(button) {
-        var originalHTML = button.innerHTML;
+        const originalHTML = button.innerHTML;
         button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><polyline points="20 6 9 17 4 12"></polyline></svg>Copied!';
         button.classList.add('success');
-        setTimeout(function() {
+        setTimeout(() => {
             button.innerHTML = originalHTML;
             button.classList.remove('success');
         }, FEEDBACK_DURATION_MS);
@@ -130,10 +166,10 @@
      */
     function showError(button, message) {
         console.error('Copy failed:', message);
-        var originalHTML = button.innerHTML;
+        const originalHTML = button.innerHTML;
         button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>Failed';
         button.classList.add('error');
-        setTimeout(function() {
+        setTimeout(() => {
             button.innerHTML = originalHTML;
             button.classList.remove('error');
         }, FEEDBACK_DURATION_MS);
@@ -144,7 +180,7 @@
      * to override the plugin's broken async version.
      */
     function handleCopy() {
-        var button = document.querySelector('#llms-copy-button button');
+        const button = document.querySelector('#llms-copy-button button');
         if (!button) {
             console.warn('Copy button not found');
             return;
@@ -155,7 +191,7 @@
             return;
         }
 
-        var success = copyToClipboard(cachedMarkdown);
+        const success = copyToClipboard(cachedMarkdown);
 
         if (success) {
             showSuccess(button);
@@ -166,21 +202,24 @@
 
     /**
      * Initializes the copy handler for the current page:
-     * - Pre-fetches markdown content
+     * - Restores button visibility (in case a prior page hid it)
+     * - Cancels any in-flight fetch and pre-fetches current page's markdown
      * - Overrides the plugin's inline async function with our sync version
      */
     function initialize() {
+        showButton();
         prefetchMarkdown();
         window.copyMarkdownToClipboard = handleCopy;
     }
 
-    // Initialize on first load
-    initialize();
-
-    // Re-initialize on every instant navigation (MkDocs Material)
+    // document$ is a ReplaySubject(1) — it emits the current document
+    // immediately on subscribe, so a single subscription handles both the
+    // initial page load and all subsequent instant navigations.
     if (typeof document$ !== 'undefined') {
-        document$.subscribe(function() {
+        document$.subscribe(() => {
             initialize();
         });
+    } else {
+        initialize();
     }
 })();

--- a/docs/javascripts/copy-markdown.js
+++ b/docs/javascripts/copy-markdown.js
@@ -26,7 +26,21 @@
     let abortController = null;
 
     /**
+     * Returns the expected markdown path for the current page URL.
+     *
+     * @returns {string} Absolute path to the .md file (e.g. "/site/page/index.md")
+     */
+    function getCurrentMdPath() {
+        const currentPath = window.location.pathname;
+        return currentPath.endsWith('/')
+            ? currentPath + 'index.md'
+            : currentPath.replace(/\.html$/, '.md');
+    }
+
+    /**
      * Restores the copy button visibility (reverses any prior hideButton call).
+     *
+     * @returns {void}
      */
     function showButton() {
         const button = document.getElementById('llms-copy-button');
@@ -37,6 +51,8 @@
 
     /**
      * Hides the copy button when markdown content is unavailable.
+     *
+     * @returns {void}
      */
     function hideButton() {
         const button = document.getElementById('llms-copy-button');
@@ -47,11 +63,12 @@
 
     /**
      * Fetches markdown for the current page and caches it.
-     * Cancels any in-flight request to prevent stale content from a previous
-     * navigation overwriting the cache.
+     * Cancels any in-flight request via AbortController to prevent stale
+     * content from a previous navigation overwriting the cache.
+     *
+     * @returns {void}
      */
     function prefetchMarkdown() {
-        // Cancel any in-flight request from a previous navigation
         if (abortController) {
             abortController.abort();
         }
@@ -60,13 +77,7 @@
         cachedMarkdown = null;
         fetchError = null;
 
-        const currentPath = window.location.pathname;
-        const mdPath = currentPath.endsWith('/')
-            ? currentPath + 'index.md'
-            : currentPath.replace(/\.html$/, '.md');
-
-        // Capture the path so the resolution check is unambiguous
-        const requestedPath = mdPath;
+        const mdPath = getCurrentMdPath();
 
         fetch(mdPath, { signal: abortController.signal })
             .then(response => {
@@ -74,8 +85,6 @@
                 return response.text();
             })
             .then(text => {
-                // Only update cache if this is still the current request
-                if (requestedPath !== getCurrentMdPath()) return;
                 cachedMarkdown = text
                     .replace(/[\r\n]*Copy Markdown[\r\n\s]*$/i, '')
                     .replace(/\s+$/, '');
@@ -86,16 +95,6 @@
                 console.warn('Could not prefetch markdown:', err);
                 hideButton();
             });
-    }
-
-    /**
-     * Returns the expected markdown path for the current page.
-     */
-    function getCurrentMdPath() {
-        const currentPath = window.location.pathname;
-        return currentPath.endsWith('/')
-            ? currentPath + 'index.md'
-            : currentPath.replace(/\.html$/, '.md');
     }
 
     /**
@@ -119,7 +118,7 @@
         document.body.appendChild(textarea);
 
         if (/ipad|iphone/i.test(navigator.userAgent)) {
-            textarea.contentEditable = true;
+            textarea.contentEditable = 'true';
             textarea.readOnly = false;
 
             const range = document.createRange();
@@ -147,7 +146,9 @@
 
     /**
      * Shows success feedback on the button.
+     *
      * @param {HTMLElement} button - The button element
+     * @returns {void}
      */
     function showSuccess(button) {
         const originalHTML = button.innerHTML;
@@ -161,8 +162,10 @@
 
     /**
      * Shows error feedback on the button.
+     *
      * @param {HTMLElement} button - The button element
      * @param {string} message - Error message to log
+     * @returns {void}
      */
     function showError(button, message) {
         console.error('Copy failed:', message);
@@ -176,8 +179,10 @@
     }
 
     /**
-     * The synchronous copy handler. Assigned to window.copyMarkdownToClipboard
+     * Synchronous copy handler. Assigned to window.copyMarkdownToClipboard
      * to override the plugin's broken async version.
+     *
+     * @returns {void}
      */
     function handleCopy() {
         const button = document.querySelector('#llms-copy-button button');
@@ -205,6 +210,8 @@
      * - Restores button visibility (in case a prior page hid it)
      * - Cancels any in-flight fetch and pre-fetches current page's markdown
      * - Overrides the plugin's inline async function with our sync version
+     *
+     * @returns {void}
      */
     function initialize() {
         showButton();

--- a/docs/javascripts/copy-markdown.js
+++ b/docs/javascripts/copy-markdown.js
@@ -1,9 +1,16 @@
 /**
  * Copy Markdown Button Handler
  *
- * Pre-fetches markdown content on page load so copy is synchronous.
- * This is necessary because Safari's Clipboard API requires the copy to happen
- * synchronously within the user gesture - any async operation breaks the gesture chain.
+ * Overrides the llmstxt-md plugin's inline async copyMarkdownToClipboard()
+ * with a synchronous version that works reliably across browsers.
+ *
+ * The plugin's async version breaks because await fetch() consumes the
+ * transient user activation, causing navigator.clipboard.writeText() to
+ * fail. This script pre-fetches markdown and copies synchronously via
+ * execCommand, preserving the user gesture chain.
+ *
+ * Subscribes to MkDocs Material's document$ observable so it re-initializes
+ * on every instant navigation, always overriding the plugin's inline script.
  */
 (function() {
     'use strict';
@@ -16,37 +23,40 @@
     let cachedMarkdown = null;
     let fetchError = null;
 
-    // Fetch markdown immediately when page loads
-    (function prefetchMarkdown() {
+    /**
+     * Fetches markdown for the current page and caches it.
+     */
+    function prefetchMarkdown() {
+        cachedMarkdown = null;
+        fetchError = null;
+
         const currentPath = window.location.pathname;
         const mdPath = currentPath.endsWith('/')
             ? currentPath + 'index.md'
             : currentPath.replace(/\.html$/, '.md');
 
         fetch(mdPath)
-            .then(response => {
+            .then(function(response) {
                 if (!response.ok) throw new Error('Not found');
                 return response.text();
             })
-            .then(text => {
-                // Strip any trailing "Copy Markdown" button text that the plugin may have added
+            .then(function(text) {
                 cachedMarkdown = text
                     .replace(/[\r\n]*Copy Markdown[\r\n\s]*$/i, '')
                     .replace(/\s+$/, '');
             })
-            .catch(err => {
+            .catch(function(err) {
                 fetchError = err;
                 console.warn('Could not prefetch markdown:', err);
-                // Hide the button if markdown is unavailable
                 hideButton();
             });
-    })();
+    }
 
     /**
      * Hides the copy button when markdown content is unavailable.
      */
     function hideButton() {
-        const button = document.getElementById('llms-copy-button');
+        var button = document.getElementById('llms-copy-button');
         if (button) {
             button.style.display = 'none';
         }
@@ -55,33 +65,31 @@
     /**
      * Copies text to clipboard using execCommand.
      *
-     * Note: We use execCommand instead of navigator.clipboard.writeText() because
-     * Safari's Clipboard API requires operations to be synchronous within the user
-     * gesture. Even with prefetched content, calling an async function (await) breaks
-     * the gesture chain. By using the synchronous execCommand, we ensure reliable
-     * cross-browser clipboard access including Safari/iOS.
+     * We use execCommand instead of navigator.clipboard.writeText() because
+     * the Clipboard API requires the operation to be within a live user
+     * gesture. Any preceding await (e.g. await fetch()) consumes the
+     * transient activation, causing writeText() to throw. execCommand is
+     * synchronous, so it works reliably when content is pre-fetched.
      *
      * @param {string} text - Text to copy to clipboard
      * @returns {boolean} Whether the copy succeeded
      */
     function copyToClipboard(text) {
-        const textarea = document.createElement('textarea');
+        var textarea = document.createElement('textarea');
         textarea.value = text;
 
-        // Style it to be invisible but present in the DOM
         textarea.style.cssText = 'position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;';
 
         document.body.appendChild(textarea);
 
-        // Handle iOS Safari which requires special selection handling
         if (/ipad|iphone/i.test(navigator.userAgent)) {
             textarea.contentEditable = true;
             textarea.readOnly = false;
 
-            const range = document.createRange();
+            var range = document.createRange();
             range.selectNodeContents(textarea);
 
-            const selection = window.getSelection();
+            var selection = window.getSelection();
             selection.removeAllRanges();
             selection.addRange(range);
             textarea.setSelectionRange(0, IOS_MAX_SELECTION);
@@ -90,7 +98,7 @@
             textarea.select();
         }
 
-        let success = false;
+        var success = false;
         try {
             success = document.execCommand('copy');
         } catch (err) {
@@ -106,10 +114,10 @@
      * @param {HTMLElement} button - The button element
      */
     function showSuccess(button) {
-        const originalHTML = button.innerHTML;
+        var originalHTML = button.innerHTML;
         button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><polyline points="20 6 9 17 4 12"></polyline></svg>Copied!';
         button.classList.add('success');
-        setTimeout(() => {
+        setTimeout(function() {
             button.innerHTML = originalHTML;
             button.classList.remove('success');
         }, FEEDBACK_DURATION_MS);
@@ -122,18 +130,21 @@
      */
     function showError(button, message) {
         console.error('Copy failed:', message);
-        const originalHTML = button.innerHTML;
+        var originalHTML = button.innerHTML;
         button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>Failed';
         button.classList.add('error');
-        setTimeout(() => {
+        setTimeout(function() {
             button.innerHTML = originalHTML;
             button.classList.remove('error');
         }, FEEDBACK_DURATION_MS);
     }
 
-    // Expose the copy function to window (called by plugin's onclick handler)
-    window.copyMarkdownToClipboard = function() {
-        const button = document.querySelector('#llms-copy-button button');
+    /**
+     * The synchronous copy handler. Assigned to window.copyMarkdownToClipboard
+     * to override the plugin's broken async version.
+     */
+    function handleCopy() {
+        var button = document.querySelector('#llms-copy-button button');
         if (!button) {
             console.warn('Copy button not found');
             return;
@@ -144,13 +155,32 @@
             return;
         }
 
-        // Synchronous copy - no async operations to preserve user gesture
-        const success = copyToClipboard(cachedMarkdown);
+        var success = copyToClipboard(cachedMarkdown);
 
         if (success) {
             showSuccess(button);
         } else {
             showError(button, 'Copy failed');
         }
-    };
+    }
+
+    /**
+     * Initializes the copy handler for the current page:
+     * - Pre-fetches markdown content
+     * - Overrides the plugin's inline async function with our sync version
+     */
+    function initialize() {
+        prefetchMarkdown();
+        window.copyMarkdownToClipboard = handleCopy;
+    }
+
+    // Initialize on first load
+    initialize();
+
+    // Re-initialize on every instant navigation (MkDocs Material)
+    if (typeof document$ !== 'undefined') {
+        document$.subscribe(function() {
+            initialize();
+        });
+    }
 })();


### PR DESCRIPTION
## Summary

- Fixed "Copy markdown" button showing `alert('Failed to copy markdown content')` after navigating between pages
- Root cause: the `llmstxt-md` plugin injects an inline `async` `copyMarkdownToClipboard()` that breaks the browser's transient user activation via `await fetch()`, causing `navigator.clipboard.writeText()` to fail
- The existing `copy-markdown.js` override only ran once on initial page load — with MkDocs Material's `navigation.instant`, the plugin's broken async version re-took control after every page navigation
- Fix: subscribe to Material's `document$` observable to re-initialize on every instant navigation, re-prefetching the current page's markdown and re-overriding `window.copyMarkdownToClipboard` with the synchronous `execCommand`-based version

## Test plan

- [ ] Navigate directly to any docs page (e.g. `/guide/query-flows/`) — click "Copy markdown" — should show "Copied!" and clipboard contains that page's markdown
- [ ] From that page, use sidebar to navigate to another page (instant navigation) — click "Copy markdown" — should show "Copied!" with the NEW page's markdown (not the previous page's)
- [ ] Repeat across 3+ pages to verify no stale content
- [ ] Test in Safari (strictest clipboard gesture enforcement)