### PR TITLE
feat(037): custom properties in queries — turn any formula into a queryable property

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,8 @@ Task(subagent_type="mixpanel-data:synthesizer", prompt="...")
 - Python 3.10+ (mypy --strict) + Pydantic v2 (for existing `CreateCohortParams`), pandas (existing), Hypothesis (PBT) (035-cohort-definition-builder)
 - N/A — pure types, no persistence (035-cohort-definition-builder)
 - Python 3.10+ (mypy --strict) + Pydantic v2 (validation), httpx (HTTP), pandas (DataFrames), Hypothesis (PBT) (036-cohort-behaviors)
+- Python 3.10+ (mypy --strict compliant) + Pydantic v2 (validation), httpx (HTTP client), Hypothesis (PBT), mutmut (mutation testing) (037-custom-properties-queries)
+- N/A — pure query-building types, no persistence (037-custom-properties-queries)
 
 ## Recent Changes
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/context/research/unified-query-findings.md
+++ b/context/research/unified-query-findings.md
@@ -1,0 +1,710 @@
+# Unified Query System — Research Findings
+
+*Research date: 2026-04-07*
+*Sources: Mixpanel REST API Reference (developer.mixpanel.com), Mixpanel MCP Server docs (docs.mixpanel.com/docs/mcp), mixpanel_data internal specifications*
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [The Raw REST API Experience — Endpoint by Endpoint](#2-the-raw-rest-api-experience--endpoint-by-endpoint)
+3. [What the Current Mixpanel MCP Server Can and Cannot Do](#3-what-the-current-mixpanel-mcp-server-can-and-cannot-do)
+4. [Cognitive Overhead for LLM Agents](#4-cognitive-overhead-for-llm-agents)
+5. [Key Pain Points](#5-key-pain-points)
+6. [What the Unified Query System Changes](#6-what-the-unified-query-system-changes)
+7. [Appendix: Raw JSON Payload Examples](#7-appendix-raw-json-payload-examples)
+
+---
+
+## 1. Executive Summary
+
+An LLM agent trying to perform product analytics against Mixpanel today faces a fragmented, under-documented, and error-prone landscape:
+
+- **9+ separate API endpoint families** with inconsistent authentication, parameter formats, and response shapes
+- **Two incompatible query paradigms** — legacy GET-parameter endpoints and modern bookmark-JSON endpoints — with no documentation explaining when to use which
+- **A proprietary expression language** for filters (`properties["x"] == "y"`) that must be string-encoded into URL parameters, with no schema and no validation
+- **Silent failures** — invalid queries frequently return empty results or wrong aggregations rather than error messages
+- **Rate limits of 60 queries/hour** with no retry guidance and opaque error responses
+- **The MCP server** provides 23 tools but abstracts away query construction entirely — the agent cannot inspect, modify, compose, or validate queries
+
+The `mixpanel_data` unified query system eliminates this complexity with typed Python objects, 65+ client-side validation rules, four engine-specific builders, and first-class result types with DataFrame integration.
+
+---
+
+## 2. The Raw REST API Experience — Endpoint by Endpoint
+
+### 2.1 API Organization and Base URLs
+
+Mixpanel's API is split across **6 different base URL patterns** depending on function and region:
+
+| Function | US Base URL | EU Base URL | India Base URL |
+|----------|-------------|-------------|----------------|
+| Query API | `mixpanel.com/api/2.0` | `eu.mixpanel.com/api/2.0` | `in.mixpanel.com/api/2.0` |
+| Bookmark Query | `mixpanel.com/api/query` | `eu.mixpanel.com/api/query` | `in.mixpanel.com/api/query` |
+| Event Export | `data.mixpanel.com/api/2.0` | `data-eu.mixpanel.com/api/2.0` | N/A |
+| Ingestion | `api.mixpanel.com` | `api-eu.mixpanel.com` | `api-in.mixpanel.com` |
+| App API (CRUD) | `mixpanel.com/api/app` | `eu.mixpanel.com/api/app` | `in.mixpanel.com/api/app` |
+| Feature Flags | `api.mixpanel.com/flags` | `api-eu.mixpanel.com/flags` | `api-in.mixpanel.com/flags` |
+| MCP Server | `mcp.mixpanel.com/mcp` | `mcp-eu.mixpanel.com/mcp` | `mcp-in.mixpanel.com/mcp` |
+
+An agent must select the correct base URL based on (a) what it's trying to do and (b) which region the customer's project is in. There is no unified entry point.
+
+### 2.2 Authentication Schemes
+
+Four different authentication methods, each used by different endpoints:
+
+| Method | Format | Used By |
+|--------|--------|---------|
+| **Service Account** (recommended) | HTTP Basic: `base64(username:secret)` | Query API, Export API, Lexicon, Annotations |
+| **Project Token** | URL param or body field `token=...` | Ingestion (/track), Identity, Feature Flags, GDPR |
+| **Project Secret** (legacy) | HTTP Basic: `base64(secret:)` — note empty password | Some Export endpoints, Feature Flags |
+| **OAuth 2.0 Bearer** | `Authorization: Bearer <token>` | GDPR API, App API, MCP Server |
+
+Key gotcha: Service Account auth requires passing `project_id` as a query parameter. Project Secret auth does not. The agent must know which auth method is in use to decide whether to include `project_id`. Getting this wrong produces a 401 with no explanation.
+
+### 2.3 Segmentation Endpoint (Insights)
+
+**Endpoint**: `GET /api/2.0/segmentation` (legacy) or `GET /api/query/insights` (bookmark-based)
+
+#### Legacy Endpoint
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `event` | string | Yes | Single event name only |
+| `from_date` | string | Yes | `YYYY-MM-DD` format |
+| `to_date` | string | Yes | `YYYY-MM-DD` format |
+| `type` | string | No | `general`, `unique`, `average` — only 3 options |
+| `unit` | string | No | `minute`, `hour`, `day`, `week`, `month` |
+| `on` | string | No | Property expression for segmentation (custom syntax) |
+| `where` | string | No | Filter expression (custom syntax) |
+| `limit` | integer | No | Default 60, max 10,000 — but does nothing without `on` |
+
+**Response shape**:
+```json
+{
+  "data": {
+    "series": ["2024-01-01", "2024-01-02"],
+    "values": {
+      "Login": {"2024-01-01": 100, "2024-01-02": 150}
+    }
+  },
+  "legend_size": 1
+}
+```
+
+**What's missing from legacy**: DAU/WAU/MAU, percentile aggregations, per-user math, formulas, rolling averages, cumulative analysis, custom properties, cohort-based filtering, multiple events per query. The legacy endpoint supports roughly 3 of the 14+ measurement types available in the Mixpanel UI.
+
+#### Bookmark-Based Endpoint
+
+`GET /api/query/insights` requires `bookmark_id` — a pre-saved report. You cannot construct an ad-hoc query. To run an ad-hoc query via the modern engine, you must:
+
+1. Construct bookmark params JSON (deeply nested, undocumented schema)
+2. POST to create a bookmark via the App API
+3. GET the bookmark query results
+4. Optionally DELETE the bookmark
+
+This is a 3-step process for a single query, requiring two different auth methods (App API uses OAuth, Query API uses Basic Auth).
+
+### 2.4 Funnel Endpoint
+
+**Endpoint**: `GET /api/2.0/funnels`
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `funnel_id` | integer | **Yes** | Must reference a pre-saved funnel |
+| `from_date` | string | Yes | `YYYY-MM-DD` |
+| `to_date` | string | Yes | `YYYY-MM-DD` |
+| `length` | integer | No | Conversion window (max 90 days) |
+| `length_unit` | string | No | `second`, `minute`, `hour`, `day` |
+| `unit` | string | No | `day`, `week`, `month` |
+| `on` | string | No | Segment by property |
+| `where` | string | No | Filter expression |
+| `limit` | integer | No | Max 10,000, requires `on` |
+
+**Critical limitation**: The agent **cannot define funnel steps ad-hoc** via the REST API. It must use a pre-saved `funnel_id`. To run an ad-hoc funnel:
+1. Create a bookmark with funnel steps via App API (OAuth)
+2. Query it via the bookmark query endpoint
+3. Parse the completely different response format
+
+**Response shape** (legacy):
+```json
+{
+  "meta": {"dates": ["2024-01-01"]},
+  "data": {
+    "2024-01-01": {
+      "steps": [
+        {
+          "count": 32688, "avg_time": 2, "avg_time_from_start": 5,
+          "step_conv_ratio": 1.0, "overall_conv_ratio": 1.0,
+          "goal": "App Open", "event": "App Open"
+        }
+      ],
+      "analysis": {
+        "completion": 20524, "starting_amount": 32688,
+        "steps": 2, "worst": 1
+      }
+    }
+  }
+}
+```
+
+Note: The response nests steps inside date keys, with different field names (`step_conv_ratio` vs `overall_conv_ratio`) and an `analysis` sub-object. This is entirely different from the segmentation response format.
+
+### 2.5 Retention Endpoint
+
+**Endpoint**: `GET /api/2.0/retention`
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `from_date` | string | Yes | `YYYY-MM-DD` |
+| `to_date` | string | Yes | `YYYY-MM-DD` |
+| `retention_type` | string | No | `birth` or `compounded` |
+| `born_event` | string | No | Required for `birth` type — but not validated |
+| `event` | string | No | Return event |
+| `born_where` | string | No | Filter for born event (expression syntax) |
+| `where` | string | No | Filter for return event |
+| `interval` | integer | No | Units per bucket |
+| `interval_count` | integer | No | Number of buckets |
+| `unit` | string | No | `day`, `week`, `month` |
+| `unbounded_retention` | boolean | No | Accumulates right-to-left |
+| `on` | string | No | Segment by property |
+
+**Response shape** (third different format):
+```json
+{
+  "2024-01-01": {
+    "counts": [1000, 800, 600, 400],
+    "first": 1000
+  },
+  "2024-01-02": {
+    "counts": [900, 700, 500],
+    "first": 950
+  }
+}
+```
+
+**Gotchas**:
+- `born_event` is required when `retention_type=birth` but the server doesn't validate — it silently returns empty data
+- The 0th element of `counts` represents users retained within the first interval, not on day 0
+- `unbounded_retention` changes the semantics of the counts array but the response structure is identical — the agent cannot tell from the response which mode was used
+- No percentage values in the legacy response — the agent must compute `counts[i] / first` manually
+
+### 2.6 Rate Limits and Throttling
+
+| API | Rate Limit | Concurrent | Timeout |
+|-----|-----------|------------|---------|
+| Query API (all endpoints) | 60/hour | 5 concurrent | 10 seconds |
+| Event Export | 60/hour, 3/second | 100 concurrent | — |
+| Ingestion | 2 GB/minute | 10-20 clients | — |
+| Lexicon Schemas | 5/minute | — | — |
+| GDPR | 1/second | — | — |
+| MCP Server | 600/hour | — | — |
+
+**Error response for rate limiting**: The documentation does not specify the response format for 429 errors. In practice, the server returns either:
+- HTTP 429 with no body
+- HTTP 429 with `{"error": "Rate limit exceeded", "status": 0}`
+- HTTP 402 (yes, 402) with `"Too many requests"` in some older endpoints
+
+There is no `Retry-After` header. The agent must implement its own backoff.
+
+### 2.7 Error Handling
+
+Mixpanel's error responses are inconsistent across APIs:
+
+**Query API errors**:
+```json
+// 400 Bad Request — but often with no useful message
+{"error": "Invalid request", "request": "/api/2.0/segmentation?..."}
+
+// 401 — inconsistent format
+{"error": "not authenticated", "request": null}
+// or just
+"Unauthorized"
+
+// 500 — opaque
+{"error": "An internal error occurred", "request": null}
+```
+
+**Ingestion API errors** (completely different format):
+```json
+// verbose=1
+{"status": 0, "error": "Invalid token"}
+
+// strict=1 with partial failures
+{
+  "code": 400,
+  "num_records_imported": 1999,
+  "status": "Bad Request",
+  "failed_records": [{"index": 0, "field": "properties.time", "message": "'properties.time' is invalid"}]
+}
+```
+
+**App API errors** (yet another format):
+```json
+{"status": "error", "error": "Forbidden", "details": "..."}
+```
+
+An agent must handle at least 4 different error response formats.
+
+### 2.8 The Expression Language
+
+Filter and segmentation expressions use a proprietary syntax that must be string-encoded into URL parameters:
+
+```
+properties["browser"] == "Chrome"
+properties["age"] > 18 and properties["country"] in ["US", "UK"]
+defined(properties["email"]) and not (properties["status"] in ["deleted"])
+```
+
+**Pain points for agents**:
+- No JSON schema — the syntax is documented only by examples
+- String quoting rules are ambiguous (double quotes inside URL-encoded strings)
+- Property names with special characters require escaping but the escaping rules are undocumented
+- Date functions (`datetime(2024, 1, 1)`) have a different signature than any standard date library
+- Type coercion is implicit and sometimes surprising
+- Invalid expressions return empty results rather than errors
+
+---
+
+## 3. What the Current Mixpanel MCP Server Can and Cannot Do
+
+### 3.1 Available Tools (23 total)
+
+**Analytics (3 tools)**:
+| Tool | What It Does | Limitations |
+|------|-------------|-------------|
+| `Run-Query` | Execute insights, funnels, flows, retention | Accepts structured params; agent must construct or the MCP server translates NL |
+| `Get-Query-Schema` | Get the JSON schema for query construction | Returns the schema but agent still must build valid JSON |
+| `Get-Report` | Retrieve a saved report with optional results | Read-only; cannot modify or compose |
+
+**Dashboard Management (6 tools)**:
+| Tool | What It Does |
+|------|-------------|
+| `Create-Dashboard` | Create dashboard with text cards and reports |
+| `List-Dashboards` | Browse dashboards |
+| `Get-Dashboard` | Get metadata, cards, reports |
+| `Update-Dashboard` | Modify metadata and layout |
+| `Duplicate-Dashboard` | Copy a dashboard |
+| `Delete-Dashboard` | Delete a dashboard |
+
+**Data Discovery (7 tools)**:
+| Tool | What It Does |
+|------|-------------|
+| `Get-Projects` | List projects and workspaces |
+| `Get-Events` | Browse events |
+| `Get-Property-Names` | Explore properties for events or users |
+| `Get-Property-Values` | Discover values for a property |
+| `Get-Event-Details` | Full event metadata |
+| `Get-Issues` | Data quality issues |
+| `Get-Lexicon-URL` | Direct link to Lexicon |
+
+**Data Management (6 tools)**:
+| Tool | What It Does |
+|------|-------------|
+| `Edit-Event` | Update event description, display name, tags, visibility |
+| `Edit-Property` | Update property metadata and PII classification |
+| `Create-Tag` / `Rename-Tag` / `Delete-Tag` | Tag management |
+| `Dismiss-Issues` | Bulk-dismiss data quality issues |
+
+**Session Replay (1 tool)**:
+| Tool | What It Does |
+|------|-------------|
+| `Get-User-Replays-Data` | Analyze user replays with event data |
+
+### 3.2 What the MCP Server Cannot Do
+
+| Capability | Available? | Impact |
+|-----------|-----------|--------|
+| Multi-step analysis (query A results → parameterize query B) | No | Cannot do root cause analysis, hypothesis testing |
+| Local computation on results (pandas, scipy, numpy) | No | Cannot join datasets, run statistics, detect anomalies |
+| Parallel query execution | No | Sequential only; 6-query analysis takes 6 round-trips |
+| Custom property formulas at query time | Not documented | Cannot compute derived metrics |
+| Inline cohort definitions | Not documented | Cannot scope queries to ad-hoc user segments |
+| Query param inspection and modification | No | Opaque — agent cannot see or modify the generated query |
+| Client-side validation before execution | No | Errors surface only after server round-trip |
+| Persist queries as Mixpanel reports | Partial (dashboards only) | Cannot save a query as a bookmark for later use |
+| Cross-engine result composition | No | Cannot merge insights + funnel + retention into one analysis |
+| Flow graph algorithms | No | No NetworkX integration, no path analysis |
+| Streaming/export raw events | No | Cannot access raw event data |
+| Cohort CRUD | No | Cannot create or manage cohorts |
+| Feature flag management | No | Cannot manage experiments or flags |
+| Webhook/alert management | No | Cannot configure alerts or webhooks |
+
+### 3.3 Rate Limits and Access Control
+
+- **600 requests/hour per user** (10x the raw Query API's 60/hour — a significant improvement)
+- OAuth authentication via existing Mixpanel credentials
+- All project permissions and roles apply
+- Org admin must enable MCP access globally before any user can connect
+- **Not HIPAA-compliant** — data is sent to the connected AI provider
+- MCP server is read/write — connected AI assistants can modify dashboards, events, and properties
+
+### 3.4 The Fundamental MCP Limitation
+
+The MCP server is a **request-response proxy**. The agent sends a question, gets back a result. It cannot:
+
+1. **Compose** — combine results from multiple queries into a unified analysis
+2. **Inspect** — see the query that was generated, modify it, learn from it
+3. **Validate** — check query correctness before execution
+4. **Iterate** — use one result to parameterize the next query programmatically
+5. **Compute** — run local statistical tests, ML models, or graph algorithms on results
+
+This means the MCP server is useful for **single-question lookups** ("What was DAU last week?") but inadequate for **multi-step analytical workflows** ("Why did conversion drop, and what segments are driving it?").
+
+---
+
+## 4. Cognitive Overhead for LLM Agents
+
+### 4.1 Knowledge Requirements — Raw REST API
+
+To use the raw REST API, an agent must internalize:
+
+| Knowledge Area | Items to Learn | Error Mode |
+|---------------|---------------|------------|
+| Base URL selection | 6 URL patterns x 3 regions = 18 URLs | Wrong URL → 404 or wrong region's data |
+| Auth scheme selection | 4 methods, each for different endpoints | Wrong auth → 401, often no error message |
+| Parameter formatting | Expression language syntax, date formats, JSON encoding | Invalid expression → empty results (silent) |
+| Response parsing | 4+ different response shapes across endpoints | Wrong parser → crash or wrong data |
+| Error handling | 4+ error response formats | Unhandled error → agent hallucinates |
+| Rate limit management | Per-endpoint limits, no Retry-After header | 429 → must implement backoff blindly |
+| Legacy vs modern endpoints | When to use `/segmentation` vs `/query/insights` | Wrong choice → missing features or extra complexity |
+| Funnel pre-requisites | Funnels require saved funnel_id (legacy) or bookmark creation (modern) | No ad-hoc funnels → 3-step workflow |
+
+**Estimated context tokens**: An agent needs ~8,000-12,000 tokens of API documentation in context to reliably construct queries across all four engines. This is before any user data or conversation history.
+
+### 4.2 Multi-Step Analysis Workflow — Without Library
+
+A common analytics question: *"Why did our signup-to-purchase conversion drop last week?"*
+
+**Steps an agent must execute manually**:
+
+1. **Determine auth** — resolve service account credentials, base64-encode, select correct base URL for region
+2. **Discover schema** — GET `/events/names` to find relevant events, GET `/events/properties/top` to find properties
+3. **Run funnel query** — but funnels require `funnel_id`, so:
+   a. Find existing funnel via GET `/funnels/list`
+   b. If no matching funnel exists, create a bookmark via App API (different auth)
+   c. Query the bookmark
+4. **Run segmentation queries** — one per property to segment by (platform, country, etc.)
+5. **Parse 3+ different response formats** — funnel format vs segmentation format
+6. **Compute deltas manually** — subtract last week's values from this week's, calculate percentage changes
+7. **Identify significant segments** — no statistical testing available, agent must eyeball
+8. **Synthesize findings** — correlate across queries manually
+
+**Total API calls**: 8-15 calls across 3+ auth methods and 2+ response formats
+**Failure modes**: 12+ points where silent failures can produce wrong conclusions
+
+### 4.3 Multi-Step Analysis — With Unified Query System
+
+The same analysis:
+
+```python
+import mixpanel_data as mp
+from concurrent.futures import ThreadPoolExecutor
+
+ws = mp.Workspace()
+
+# 4 parallel queries, typed, validated before execution
+with ThreadPoolExecutor(max_workers=4) as pool:
+    funnel = pool.submit(ws.query_funnel,
+        steps=[("Signup", {}), ("Purchase", {})],
+        from_date="2025-03-24", to_date="2025-03-30")
+    funnel_prev = pool.submit(ws.query_funnel,
+        steps=[("Signup", {}), ("Purchase", {})],
+        from_date="2025-03-17", to_date="2025-03-23")
+    by_platform = pool.submit(ws.query_funnel,
+        steps=[("Signup", {}), ("Purchase", {})],
+        from_date="2025-03-24", to_date="2025-03-30",
+        group_by=[GroupBy.property("platform")])
+    by_country = pool.submit(ws.query_funnel,
+        steps=[("Signup", {}), ("Purchase", {})],
+        from_date="2025-03-24", to_date="2025-03-30",
+        group_by=[GroupBy.property("country")])
+
+# All results are typed DataFrames — merge with pandas
+import pandas as pd
+delta = funnel.result().df.merge(funnel_prev.result().df, ...)
+significant = by_platform.result().df[by_platform.result().df["conversion_rate"] < 0.5]
+```
+
+**Total API calls**: 4 (parallel)
+**Failure modes**: 0 silent failures — validation catches errors before execution
+**Agent context needed**: ~2,000 tokens of Python function signatures
+
+---
+
+## 5. Key Pain Points
+
+### 5.1 Untyped JSON Everywhere
+
+The REST API communicates entirely in untyped JSON. There is no OpenAPI/Swagger spec for the query endpoints. The bookmark params JSON schema is not published. An agent must learn the schema from examples and hope for the best.
+
+**Specific problems**:
+- Field names are inconsistent: `filterType` vs `propertyType` vs `defaultType` in the same object
+- Enum values are undocumented: `"is greater than"` vs `"greater_than"` vs `"gt"` — which does the server accept?
+- Singular vs plural conventions: `resourceType: "event"` inside `composedProperties` but `resourceType: "events"` at the filter level — this is an **undocumented server requirement** that causes silent failures
+- Nested objects have no schema: the `customProperty` object inside a filter entry has ~8 fields, none documented
+
+### 5.2 Multiple Auth Schemes
+
+An agent building a complete analytics workflow must juggle:
+- Basic Auth (service account) for queries
+- OAuth Bearer for App API CRUD
+- Project Token for ingestion
+- Different `project_id` parameter requirements per auth method
+
+There is no unified auth story. The MCP server helps here (OAuth only) but limits the agent to MCP's 23 tools.
+
+### 5.3 Separate Endpoints Per Query Type
+
+Each analytical engine has its own endpoint with its own parameter set and response format:
+
+| Engine | Endpoint | Params | Response Shape |
+|--------|----------|--------|---------------|
+| Segmentation | `/segmentation` | `event`, `on`, `where`, `type` | `{data: {series: [], values: {}}}` |
+| Funnels | `/funnels` | `funnel_id`, `length`, `length_unit` | `{data: {"date": {steps: [], analysis: {}}}}` |
+| Retention | `/retention` | `born_event`, `event`, `retention_type` | `{"date": {counts: [], first: N}}` |
+| Insights (bookmark) | `/query/insights` | `bookmark_id` | `{series: {}, headers: [], computed_at: ""}` |
+
+Four endpoints, four parameter sets, four response parsers. The agent must maintain four separate code paths.
+
+### 5.4 Manual Date Handling
+
+- All dates must be `YYYY-MM-DD` strings — no relative date support ("last 7 days")
+- No timezone specification — dates are interpreted in the project's timezone (which the agent must know)
+- The retention endpoint silently extends the query window beyond `to_date` to find retained users — the response may include data outside the requested range
+- The funnel endpoint queries beyond `to_date` to identify completions within the conversion window
+- Time comparison features ("this week vs last week") require the agent to compute both date ranges manually
+
+### 5.5 No Client-Side Validation
+
+The REST API performs minimal server-side validation. Common failure modes:
+
+| Mistake | What Happens | What Should Happen |
+|---------|-------------|-------------------|
+| Wrong `type` value in segmentation | Silently uses default (`general`) | Error: "Invalid type 'foo', expected general/unique/average" |
+| Missing `born_event` in birth retention | Returns empty data | Error: "born_event required when retention_type=birth" |
+| Invalid `where` expression | Returns empty results or 500 | Error: "Syntax error in expression at position 15" |
+| Wrong `resourceType` in bookmark JSON | Returns wrong data or empty | Error: "resourceType must be 'events' at filter level" |
+| `funnel_id` that doesn't exist | 404 with no context | Error: "Funnel 12345 not found in project" |
+| `on` property that doesn't exist | Returns empty segmentation | Error: "Property 'foo' not found for event 'Bar'" |
+
+### 5.6 Opaque Error Messages
+
+When the server does return errors, they are frequently unhelpful:
+
+```
+{"error": "An internal error occurred"}           ← no context
+{"error": "Invalid request"}                       ← what's invalid?
+{"error": "not authenticated"}                     ← which auth method was expected?
+"Unauthorized"                                     ← not even JSON
+{"status": 0, "error": "Invalid token"}            ← different format, same endpoint family
+```
+
+The agent cannot self-correct because the error provides no guidance on what to fix.
+
+### 5.7 Undocumented Conventions and Gotchas
+
+Discovered through implementation experience:
+
+1. **`resourceType` singular vs plural**: Inside `composedProperties`, use `"event"`. At the filter/group level, use `"events"`. No documentation explains this.
+
+2. **Custom properties in funnels/retention**: The server has a bug where custom property filters in funnel and retention queries require a different JSON structure than in insights queries. The `resourceType` field must be propagated differently.
+
+3. **Cohort filters**: Filtering by cohort requires a `$cohorts` property name with special `filterOperator` values (`"is equal to"` for inclusion, `"is not equal to"` for exclusion) and `filterValue` set to the cohort ID as a string. None of this is documented.
+
+4. **The `limit` parameter**: Does nothing unless `on` is specified. No warning or error.
+
+5. **The `interval` vs `unit` parameters**: Mutually exclusive in some endpoints, complementary in others. No documentation clarifies which.
+
+6. **Bookmark `queryGenerationMode`**: Must be set to `"segmentation"` for insights, but this is not the same as the `/segmentation` endpoint. Confusing naming.
+
+7. **Empty `meta.dates` array**: In funnel responses, the dates array in `meta` may not match the dates in `data`. The agent must use `data` keys, not `meta.dates`.
+
+---
+
+## 6. What the Unified Query System Changes
+
+### 6.1 The Complete API Surface
+
+The `mixpanel_data` library exposes four typed query methods mapping to Mixpanel's four analytical engines, plus cross-cutting cohort and custom property capabilities:
+
+| Method | Engine | Question It Answers | Key Capabilities |
+|--------|--------|-------------------|-----------------|
+| `ws.query()` | Insights/Arb | "How much? How many?" | 14 MathTypes (DAU/WAU/MAU, percentiles, per-user), formulas, rolling/cumulative, 3 display modes |
+| `ws.query_funnel()` | Funnels | "Do users convert?" | Ad-hoc steps (no saved funnel needed), per-step filters, exclusions, holding constant, session conversion |
+| `ws.query_retention()` | Retention | "Do users come back?" | Born/return event pairs, custom buckets, birth/interval alignment, 3 display modes |
+| `ws.query_flow()` | Flows | "What paths do users take?" | Forward/reverse tracing, NetworkX DiGraph, anytree integration |
+
+**Cross-cutting capabilities**:
+- **Cohort scoping**: `Filter.in_cohort()` / `Filter.not_in_cohort()` — works in all 4 engines
+- **Cohort breakdowns**: `CohortBreakdown` — segment by cohort membership
+- **Custom properties**: `CustomPropertyRef(id)` or `InlineCustomProperty.numeric("A*B", A="price", B="qty")` — works in filters, group_by, and measurements
+- **18 typed filter methods**: `equals`, `greater_than`, `between`, `is_set`, `is_true`, `in_the_last`, `date_between`, etc.
+
+### 6.2 Typed/Validated Python vs. Raw REST JSON
+
+| Dimension | Raw REST API | Unified Query System |
+|-----------|-------------|---------------------|
+| Query construction | Hand-craft nested JSON or expression strings | Typed Python keyword arguments |
+| Validation | None client-side; silent failures | 65+ rules (V-series, B-series, CP-series) catch errors before API call |
+| Filters | `properties["x"] == "y"` as URL-encoded string | `Filter.equals("x", "y")` with type checking |
+| Custom properties | 3 different JSON structures, undocumented conventions | `InlineCustomProperty.numeric("A*B", A="price", B="qty")` |
+| Cohort scoping | Manual `$cohorts` magic values | `Filter.in_cohort(definition)` |
+| Error messages | `{"error": "Invalid request"}` | `ValidationError(code="V-023", message="...", fix="...")` |
+| Response parsing | 4 different formats, manual extraction | Frozen dataclasses with `.df` (pandas), `.to_dict()` |
+| Ad-hoc funnels | Impossible via REST; 3-step bookmark workflow | `ws.query_funnel(steps=[...])` — one call |
+| Parallel execution | Manual threading with 4 different parsers | `ThreadPoolExecutor` — all queries return typed results |
+
+### 6.3 How It Maps to Arb's Native Data Model
+
+The unified query system generates **bookmark params JSON** — the same format the Mixpanel web UI uses internally. This means:
+
+1. **Full feature parity** with the web UI — anything the UI can query, the library can query
+2. **No SQL translation layer** — direct access to Arb's purpose-built analytical primitives
+3. **Persistable queries** — `result.params` can be saved as Mixpanel reports via `create_bookmark()`
+
+### 6.4 What This Enables for LLM Agents
+
+| Pattern | Without Library | With Library |
+|---------|----------------|-------------|
+| "Why did X drop?" | 6+ sequential API calls, 3+ auth methods, manual computation | 4 parallel typed queries → pandas merge → scipy t-test |
+| Multi-metric dashboard | Multiple endpoints, different response parsers | `ThreadPoolExecutor` with 6 concurrent queries, all returning DataFrames |
+| Hypothesis testing | Manual prompt refinement across multiple MCP calls | Query results parameterize follow-up queries programmatically |
+| Cross-engine analysis | Impossible — different response formats | `pd.merge()` on shared date/segment keys |
+| Flow graph analysis | Not available via REST or MCP | `result.graph` (NetworkX) → betweenness centrality, shortest paths |
+| Statistical significance | Agent must compute manually from raw numbers | `scipy.stats.ttest_ind()` on result DataFrames |
+
+### 6.5 The Local Python Ecosystem Advantage
+
+With the unified query system, the agent has the full scientific Python stack:
+
+| Library | What It Enables |
+|---------|----------------|
+| **pandas** | DataFrame joins, pivots, rolling calculations, time-series resampling |
+| **scipy** | Statistical significance testing (t-test, chi-squared, Mann-Whitney) |
+| **NetworkX** | Graph algorithms on flow data (betweenness centrality, shortest path, community detection) |
+| **anytree** | Tree traversal on flow trees (parent references, Graphviz export) |
+| **matplotlib/seaborn** | Retention heatmaps, funnel waterfalls, flow Sankey diagrams |
+| **numpy** | Correlation matrices, trend detection, anomaly scoring |
+
+None of this is possible through REST API calls or MCP tool invocations alone.
+
+---
+
+## 7. Appendix: Raw JSON Payload Examples
+
+### 7.1 Bookmark Params JSON for a Simple Insights Query
+
+"Show me daily Purchase event count, filtered to US, broken down by platform"
+
+```json
+{
+  "bookmark": {
+    "sections": {
+      "show": [{
+        "behavior": {
+          "type": "event",
+          "event": {"name": "Purchase"}
+        },
+        "measurement": {
+          "math": "total",
+          "property": null,
+          "perUserAggregation": null
+        }
+      }],
+      "filter": [{
+        "resourceType": "events",
+        "filterType": "string",
+        "defaultType": "string",
+        "value": "country",
+        "filterValue": "US",
+        "filterOperator": "equals",
+        "dataset": "$mixpanel"
+      }],
+      "group": [{
+        "resourceType": "events",
+        "propertyType": "string",
+        "typeCast": null,
+        "value": "platform",
+        "propertyName": "platform"
+      }],
+      "time": [{
+        "dateRangeType": "between",
+        "unit": "day",
+        "value": ["2025-03-01", "2025-03-31"]
+      }]
+    },
+    "displayOptions": {
+      "chartType": "line",
+      "plotStyle": "standard",
+      "analysis": "linear",
+      "value": "absolute"
+    }
+  },
+  "queryGenerationMode": "segmentation"
+}
+```
+
+**~40 lines of JSON** for a query that the unified system expresses as:
+
+```python
+ws.query(
+    event="Purchase",
+    filters=[Filter.equals("country", "US")],
+    group_by=[GroupBy.property("platform")],
+    from_date="2025-03-01",
+    to_date="2025-03-31",
+)
+```
+
+### 7.2 Inline Custom Property in a Filter
+
+"Filter to orders where price * quantity > 1000"
+
+```json
+{
+  "resourceType": "events",
+  "filterType": "number",
+  "defaultType": "number",
+  "customProperty": {
+    "displayFormula": "A * B",
+    "composedProperties": {
+      "A": {"value": "price", "type": "number", "resourceType": "event"},
+      "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+    },
+    "name": "",
+    "description": "",
+    "propertyType": "number",
+    "resourceType": "events"
+  },
+  "dataset": "$mixpanel",
+  "filterValue": 1000,
+  "filterOperator": "is greater than"
+}
+```
+
+Note the `resourceType: "event"` (singular) inside `composedProperties` vs `resourceType: "events"` (plural) at the filter level and inside `customProperty`. This undocumented convention causes silent failures.
+
+**Equivalent unified system call**:
+
+```python
+cp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+filters = [Filter.greater_than(cp, 1000)]
+```
+
+### 7.3 Cohort-Scoped Funnel with Custom Properties
+
+"Show signup-to-purchase conversion for the 'Power Users' cohort, broken down by computed LTV tier"
+
+This requires constructing a bookmark with:
+- Funnel steps array (2 entries)
+- Cohort filter entry with `$cohorts` magic property
+- Custom property group-by with `composedProperties`
+- Funnel-specific display options
+
+The bookmark JSON for this query is **~120 lines**. The equivalent unified system call is **~8 lines** of typed Python.
+
+---
+
+*This research was conducted to inform the strategic positioning of the `mixpanel_data` unified query system relative to the raw Mixpanel REST API and MCP server.*

--- a/context/unified-query-one-pager.md
+++ b/context/unified-query-one-pager.md
@@ -16,14 +16,95 @@ The hard part of analytics isn't running a query. It's knowing which four querie
 
 `mixpanel_data` exposes Insights, Funnels, Retention, and Flows as **typed, composable Python methods** — the same engines that power Mixpanel's web UI, accessible through keyword arguments that an AI agent can reason about and construct programmatically.
 
-An agent using this system can:
+Every query reads like the question it answers:
 
-- **Choose the right engine** for each sub-question (DAU trend → Insights, conversion check → Funnels, churn signal → Retention, path divergence → Flows)
-- **Run queries in parallel** across engines, merge on shared dimensions with pandas
-- **Define cohorts inline** — describe a user segment in code, query against it immediately, no UI round-trip
-- **Compute derived properties at query time** — define a formula like `price * quantity` and use it as a breakdown, filter, or aggregation target
-- **Validate before executing** — 65+ client-side rules catch silent-failure scenarios before the API call
-- **Apply the full scientific Python stack** — scipy for significance tests, NetworkX for path graph analysis, matplotlib for visualization
+```python
+import mixpanel_data as mp
+ws = mp.Workspace()
+
+# "How many daily active users last quarter?"
+ws.query("Login", math="dau", last=90)
+
+# "What's our signup-to-purchase conversion?"
+ws.query_funnel(["Signup", "Add to Cart", "Purchase"], conversion_window=7)
+
+# "Do users come back after onboarding?"
+ws.query_retention("Complete Onboarding", "Login", retention_unit="week", last=90)
+
+# "What do users do after adding to cart?"
+ws.query_flow("Add to Cart", forward=3)
+```
+
+Four engines. Four methods. Each returns a pandas DataFrame, persistable bookmark params, and engine-specific analysis tools. An agent picks the right engine the same way an analyst would — by the shape of the question.
+
+### Filters, breakdowns, and formulas compose naturally
+
+The building blocks — `Filter`, `GroupBy`, `Metric`, `Formula` — snap together like the UI controls they mirror:
+
+```python
+from mixpanel_data import Metric, Filter, GroupBy, Formula
+
+# "Average purchase amount for US iOS users, by revenue bucket"
+ws.query(
+    "Purchase",
+    math="average",
+    math_property="amount",
+    where=[Filter.equals("country", "US"), Filter.equals("platform", "iOS")],
+    group_by=GroupBy("amount", property_type="number", bucket_size=50),
+)
+
+# "What % of signups purchase within 30 days? Show me the weekly trend."
+ws.query(
+    [Metric("Signup", math="unique"), Metric("Purchase", math="unique")],
+    formula="(B / A) * 100",
+    formula_label="Conversion Rate",
+    unit="week",
+    last=90,
+)
+```
+
+Every parameter is typed. Autocomplete works everywhere. 65+ validation rules catch mistakes *before* the API call — no more silent empty results.
+
+### Cohorts defined inline — no UI, no saved state
+
+An agent can describe a user segment in code and query against it immediately:
+
+```python
+from mixpanel_data import CohortDefinition, CohortCriteria, CohortBreakdown
+
+# Define "power users" on the fly — no trip to the UI
+power_users = CohortDefinition(
+    CohortCriteria.did_event("Purchase", at_least=3, within_days=30)
+)
+
+# How do power users retain vs. everyone else?
+ws.query_retention(
+    "Login", "Login",
+    group_by=CohortBreakdown(power_users, name="Power Users"),
+    retention_unit="week",
+)
+```
+
+The agent reasons about the segment, defines it, and tests a hypothesis — in a single turn.
+
+### Custom properties computed at query time
+
+Define a formula and use it as if it were a real property — in breakdowns, filters, or aggregations:
+
+```python
+from mixpanel_data import InlineCustomProperty, CustomPropertyRef
+
+# Compute revenue per unit on the fly
+revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+# "What's the distribution of computed revenue?"
+ws.query("Purchase", group_by=GroupBy(property=revenue, property_type="number", bucket_size=100))
+
+# "Average of our saved LTV custom property, by country"
+ws.query(Metric("Purchase", math="average", property=CustomPropertyRef(42)), group_by="country")
+```
+
+No saved custom property required. No bookmark JSON. The agent just describes the computation.
 
 ---
 
@@ -55,37 +136,39 @@ An agent using this system can:
 <td>
 
 ```python
-# One autonomous investigation
+from concurrent.futures import ThreadPoolExecutor
+from scipy.stats import ttest_ind
+
 ws = mp.Workspace()
 
-# 1. Quantify across 4 engines (parallel)
-results = parallel({
-  "trend": ws.query("Purchase", math="unique", last=60),
-  "funnel": ws.query_funnel(["Browse","Cart","Purchase"], last=60),
-  "retention": ws.query_retention("Purchase","Purchase", last=60),
-  "flow": ws.query_flow("Cart", forward=3),
-})
+# 1. Query all four engines in parallel
+with ThreadPoolExecutor() as pool:
+    trend    = pool.submit(ws.query, "Purchase", math="unique", last=60)
+    funnel   = pool.submit(ws.query_funnel, ["Browse","Cart","Purchase"], last=60)
+    ret      = pool.submit(ws.query_retention, "Purchase", "Purchase", last=60)
+    flow     = pool.submit(ws.query_flow, "Cart", forward=3)
 
-# 2. Segment the drop
-for dim in ["platform","country","utm_source"]:
-    ws.query("Purchase", last=60, group_by=dim)
+# 2. Segment by platform — find the driver
+segments = ws.query("Purchase", math="unique", last=60, group_by="platform")
 
-# 3. Statistical test on the leading segment
-from scipy.stats import ttest_ind
-# → p=0.003, mobile drop is significant
+# 3. Confirm statistically
+mobile = segments.df[segments.df["event"].str.contains("mobile")]
+other  = segments.df[~segments.df["event"].str.contains("mobile")]
+t, p = ttest_ind(mobile["count"], other["count"])
+# → p=0.003 — the mobile drop is real
 
-# 4. Trace where mobile users go instead
-ws.query_flow("Cart",
-    where=Filter.equals("platform","mobile"),
-    forward=3)
+# 4. What are mobile users doing instead?
+ws.query_flow("Cart", where=Filter.equals("platform", "mobile"), forward=3)
 
-# 5. Save the investigation as a report
+# 5. Save the funnel as a Mixpanel report
 ws.create_bookmark(CreateBookmarkParams(
     name="Purchase Drop Investigation",
-    params=results["funnel"].params))
+    bookmark_type="funnels",
+    params=funnel.result().params,
+))
 ```
 
-One turn. Four engines. Statistical proof. Persistable.
+One turn. Four engines. Statistical proof. Saved as a Mixpanel report.
 
 </td>
 </tr>
@@ -97,7 +180,20 @@ One turn. Four engines. Statistical proof. Persistable.
 
 The unified query system generates **bookmark params** — the native query language of Mixpanel's analytical database. There is no SQL translation layer, no generic query planner. Each method maps directly to a purpose-built engine: Arb's event aggregation, funnel state machine, cohort retention tracker, and path tracer.
 
-No competitor has these primitives. A warehouse-based agent can write SQL against flat event tables, but it cannot express "conversion within 7 days, holding platform constant, excluding users who logged out between steps" in a single composable call. Mixpanel can — and now an AI agent can too.
+No competitor has these primitives. A warehouse-based agent can write SQL against flat event tables, but it cannot express this in a single composable call:
+
+```python
+ws.query_funnel(
+    ["Browse", "Add to Cart", "Purchase"],
+    conversion_window=7,
+    holding_constant="platform",        # same device across all steps
+    exclusions=["Logout"],              # remove users who logged out
+    where=Filter.in_cohort(power_users, name="Power Users"),  # scoped to a cohort
+    group_by="country",                 # segmented by geography
+)
+```
+
+Conversion within 7 days, holding platform constant, excluding logouts, scoped to a behavioral cohort, segmented by country. One call. Mixpanel can express this because Arb was built for it — and now an AI agent can too.
 
 ---
 
@@ -105,7 +201,7 @@ No competitor has these primitives. A warehouse-based agent can write SQL agains
 
 The four engines, cohort behaviors, and custom properties are the substrate. What comes next:
 
-- **Autonomous investigation protocols** — agent receives a metric alert, runs the full diagnostic, produces a root-cause report with statistical evidence
+- **Autonomous investigation** — agent receives a metric alert, runs the full diagnostic across all four engines, produces a root-cause report with statistical evidence
 - **Natural language → saved reports** — "Build me a weekly revenue dashboard" → agent constructs queries, validates params, saves as bookmarks, assembles dashboard
-- **Self-improving analysis** — agent uses query results to define inline cohorts, tests hypotheses against them, refines iteratively — all in a single session
-- **Exportable analytical artifacts** — every investigation produces `.params` JSON that can become a saved Mixpanel report, closing the loop between AI analysis and human workflow
+- **Self-improving analysis** — agent defines inline cohorts, tests hypotheses, refines iteratively — all in one session, all in code
+- **Exportable artifacts** — every investigation produces `.params` JSON that becomes a saved Mixpanel report, closing the loop between AI analysis and human workflow

--- a/context/unified-query-one-pager.md
+++ b/context/unified-query-one-pager.md
@@ -110,30 +110,21 @@ No saved custom property required. No bookmark JSON. The agent just describes th
 
 ## Side-by-Side: "Why did purchase conversion drop last week?"
 
-<table>
-<tr><th width="50%">MCP Chatbot / Raw REST API</th><th width="50%">Unified Query System in Claude Code</th></tr>
-<tr>
-<td>
+### Today: MCP Chatbot / Raw REST API
 
-**Prompt 1**: "Why did purchase conversion drop?"
-*→ Returns a single funnel chart. No segmentation.*
-
-**Prompt 2**: "Break that down by platform"
-*→ New chart. User spots mobile is down.*
-
-**Prompt 3**: "Show me mobile retention"
-*→ Separate endpoint, separate response format.*
-
-**Prompt 4**: "What paths do mobile users take?"
-*→ Requires a saved Flows report in the UI.*
-
-**Prompt 5**: "Is this statistically significant?"
-*→ "I can't perform statistical tests."*
+> **Prompt 1**: "Why did purchase conversion drop?" → *Single funnel chart. No segmentation.*
+>
+> **Prompt 2**: "Break that down by platform" → *New chart. User spots mobile is down.*
+>
+> **Prompt 3**: "Show me mobile retention" → *Separate endpoint, separate response format.*
+>
+> **Prompt 4**: "What paths do mobile users take?" → *Requires a saved Flows report in the UI.*
+>
+> **Prompt 5**: "Is this statistically significant?" → *"I can't perform statistical tests."*
 
 5 round-trips. No cross-engine synthesis. No statistical validation. No persistable output.
 
-</td>
-<td>
+### With the Unified Query System: one autonomous investigation
 
 ```python
 from concurrent.futures import ThreadPoolExecutor
@@ -169,10 +160,6 @@ ws.create_bookmark(CreateBookmarkParams(
 ```
 
 One turn. Four engines. Statistical proof. Saved as a Mixpanel report.
-
-</td>
-</tr>
-</table>
 
 ---
 

--- a/context/unified-query-one-pager.md
+++ b/context/unified-query-one-pager.md
@@ -1,0 +1,111 @@
+# The Agent That Can Actually Investigate
+
+**Mixpanel's analytical engines are the most powerful primitives in product analytics. The unified query system makes them programmable — turning Claude from a chatbot that answers questions into an analyst that investigates them.**
+
+---
+
+## The Gap
+
+Today's AI analytics tools — including MCP-based chatbots — work one query at a time. A user asks "why did conversion drop?", the chatbot runs a single query, returns a chart, and waits. The user rephrases, the chatbot runs another query. Each round-trip is isolated. There is no memory, no composition, no statistical rigor.
+
+The hard part of analytics isn't running a query. It's knowing which four queries to run, joining the results, and testing a hypothesis — the investigation, not the lookup.
+
+---
+
+## The Breakthrough: Programmable Analytical Engines
+
+`mixpanel_data` exposes Insights, Funnels, Retention, and Flows as **typed, composable Python methods** — the same engines that power Mixpanel's web UI, accessible through keyword arguments that an AI agent can reason about and construct programmatically.
+
+An agent using this system can:
+
+- **Choose the right engine** for each sub-question (DAU trend → Insights, conversion check → Funnels, churn signal → Retention, path divergence → Flows)
+- **Run queries in parallel** across engines, merge on shared dimensions with pandas
+- **Define cohorts inline** — describe a user segment in code, query against it immediately, no UI round-trip
+- **Compute derived properties at query time** — define a formula like `price * quantity` and use it as a breakdown, filter, or aggregation target
+- **Validate before executing** — 65+ client-side rules catch silent-failure scenarios before the API call
+- **Apply the full scientific Python stack** — scipy for significance tests, NetworkX for path graph analysis, matplotlib for visualization
+
+---
+
+## Side-by-Side: "Why did purchase conversion drop last week?"
+
+<table>
+<tr><th width="50%">MCP Chatbot / Raw REST API</th><th width="50%">Unified Query System in Claude Code</th></tr>
+<tr>
+<td>
+
+**Prompt 1**: "Why did purchase conversion drop?"
+*→ Returns a single funnel chart. No segmentation.*
+
+**Prompt 2**: "Break that down by platform"
+*→ New chart. User spots mobile is down.*
+
+**Prompt 3**: "Show me mobile retention"
+*→ Separate endpoint, separate response format.*
+
+**Prompt 4**: "What paths do mobile users take?"
+*→ Requires a saved Flows report in the UI.*
+
+**Prompt 5**: "Is this statistically significant?"
+*→ "I can't perform statistical tests."*
+
+5 round-trips. No cross-engine synthesis. No statistical validation. No persistable output.
+
+</td>
+<td>
+
+```python
+# One autonomous investigation
+ws = mp.Workspace()
+
+# 1. Quantify across 4 engines (parallel)
+results = parallel({
+  "trend": ws.query("Purchase", math="unique", last=60),
+  "funnel": ws.query_funnel(["Browse","Cart","Purchase"], last=60),
+  "retention": ws.query_retention("Purchase","Purchase", last=60),
+  "flow": ws.query_flow("Cart", forward=3),
+})
+
+# 2. Segment the drop
+for dim in ["platform","country","utm_source"]:
+    ws.query("Purchase", last=60, group_by=dim)
+
+# 3. Statistical test on the leading segment
+from scipy.stats import ttest_ind
+# → p=0.003, mobile drop is significant
+
+# 4. Trace where mobile users go instead
+ws.query_flow("Cart",
+    where=Filter.equals("platform","mobile"),
+    forward=3)
+
+# 5. Save the investigation as a report
+ws.create_bookmark(CreateBookmarkParams(
+    name="Purchase Drop Investigation",
+    params=results["funnel"].params))
+```
+
+One turn. Four engines. Statistical proof. Persistable.
+
+</td>
+</tr>
+</table>
+
+---
+
+## Why Arb Is the Moat
+
+The unified query system generates **bookmark params** — the native query language of Mixpanel's analytical database. There is no SQL translation layer, no generic query planner. Each method maps directly to a purpose-built engine: Arb's event aggregation, funnel state machine, cohort retention tracker, and path tracer.
+
+No competitor has these primitives. A warehouse-based agent can write SQL against flat event tables, but it cannot express "conversion within 7 days, holding platform constant, excluding users who logged out between steps" in a single composable call. Mixpanel can — and now an AI agent can too.
+
+---
+
+## What This Foundation Enables
+
+The four engines, cohort behaviors, and custom properties are the substrate. What comes next:
+
+- **Autonomous investigation protocols** — agent receives a metric alert, runs the full diagnostic, produces a root-cause report with statistical evidence
+- **Natural language → saved reports** — "Build me a weekly revenue dashboard" → agent constructs queries, validates params, saves as bookmarks, assembles dashboard
+- **Self-improving analysis** — agent uses query results to define inline cohorts, tests hypotheses against them, refines iteratively — all in a single session
+- **Exportable analytical artifacts** — every investigation produces `.params` JSON that can become a saved Mixpanel report, closing the loop between AI analysis and human workflow

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -73,6 +73,25 @@ Types for cohort-scoped queries — filter by cohort, break down by cohort membe
       show_root_heading: true
       show_root_toc_entry: true
 
+## Custom Property Query Types
+
+Types for using saved or inline custom properties as property references in query breakdowns, filters, and metric measurement. See [Custom Properties in Queries](../guide/query.md#custom-properties-in-queries) for usage guide.
+
+::: mixpanel_data.CustomPropertyRef
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.InlineCustomProperty
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.PropertyInput
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Cohort Definition Types
 
 Types for building inline cohort definitions programmatically — used with `Filter.in_cohort()`, `CohortBreakdown`, and `CohortMetric`.

--- a/docs/guide/query-flows.md
+++ b/docs/guide/query-flows.md
@@ -180,7 +180,7 @@ result = ws.query_flow(
 ```
 
 !!! note
-    Flows only support cohort filters (`Filter.in_cohort` / `Filter.not_in_cohort`), not property filters. Cohort breakdowns (`CohortBreakdown`) are not supported in flows.
+    Flows only support cohort filters (`Filter.in_cohort` / `Filter.not_in_cohort`), not property filters. Cohort breakdowns (`CohortBreakdown`) and custom properties (`CustomPropertyRef`, `InlineCustomProperty`) are not supported in flows.
 
 See [Insights Queries — Cohort Filters](query.md#cohort-filters) for the full cohort filter reference.
 

--- a/docs/guide/query-funnels.md
+++ b/docs/guide/query-funnels.md
@@ -323,6 +323,24 @@ result = ws.query_funnel(
 
 See [Insights Queries — Cohort Filters](query.md#cohort-filters) for the full cohort filter reference.
 
+### Custom Property Filters
+
+Use saved or inline custom properties in funnel filters:
+
+```python
+from mixpanel_data import Filter, CustomPropertyRef
+
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+)
+```
+
+!!! warning
+    Custom property filters in funnel `where=` may cause server errors due to a known Mixpanel API bug. Custom property breakdowns and measurement work reliably.
+
+See [Insights Queries — Custom Properties in Queries](query.md#custom-properties-in-queries) for `InlineCustomProperty`, validation rules, and full options.
+
 ## Breakdowns
 
 Break down funnel results by property values with `group_by`:
@@ -358,6 +376,25 @@ result = ws.query_funnel(
 ```
 
 See [Insights Queries — Cohort Breakdowns](query.md#cohort-breakdowns) for inline definitions and options.
+
+### Custom Property Breakdowns
+
+Break down funnel results by a saved or inline custom property:
+
+```python
+from mixpanel_data import GroupBy, InlineCustomProperty
+
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    group_by=GroupBy(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        property_type="number",
+        bucket_size=50,
+    ),
+)
+```
+
+See [Insights Queries — Custom Properties in Queries](query.md#custom-properties-in-queries) for `CustomPropertyRef` and full options.
 
 See [Insights Queries — Breakdowns](query.md#breakdowns) for the full `GroupBy` reference.
 

--- a/docs/guide/query-retention.md
+++ b/docs/guide/query-retention.md
@@ -274,6 +274,27 @@ result = ws.query_retention(
 
 See [Insights Queries — Cohort Filters](query.md#cohort-filters) for the full cohort filter reference.
 
+### Custom Property Filters
+
+Use saved or inline custom properties in retention filters:
+
+```python
+from mixpanel_data import Filter, CustomPropertyRef
+
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+    retention_unit="week",
+    last=90,
+)
+```
+
+!!! warning
+    Custom property filters in retention `where=` may cause server errors due to a known Mixpanel API bug. Custom property breakdowns work reliably.
+
+See [Insights Queries — Custom Properties in Queries](query.md#custom-properties-in-queries) for `InlineCustomProperty`, validation rules, and full options.
+
 ## Breakdowns
 
 Break down retention results by property values with `group_by`:
@@ -315,6 +336,24 @@ result = ws.query_retention(
     `query_retention()` does not support mixing `CohortBreakdown` with property `GroupBy` in the same `group_by` list. Use one or the other.
 
 See [Insights Queries — Cohort Breakdowns](query.md#cohort-breakdowns) for inline definitions and options.
+
+### Custom Property Breakdowns
+
+Break down retention results by a saved or inline custom property:
+
+```python
+from mixpanel_data import GroupBy, CustomPropertyRef
+
+result = ws.query_retention(
+    "Signup",
+    "Login",
+    group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+    retention_unit="week",
+    last=90,
+)
+```
+
+See [Insights Queries — Custom Properties in Queries](query.md#custom-properties-in-queries) for `InlineCustomProperty` and full options.
 
 See [Insights Queries — Breakdowns](query.md#breakdowns) for the full `GroupBy` reference.
 

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -809,6 +809,191 @@ result = ws.query(
 | **Cohort Breakdowns** (`group_by=`) | ✓ | ✓ | ✓ | — |
 | **Cohort Metrics** (`events=`) | ✓ | — | — | — |
 
+## Custom Properties in Queries
+
+Use saved custom properties or define computed properties inline — in breakdowns, filters, and metric measurement. Custom properties work everywhere a plain string property name does.
+
+To create and manage custom properties in Mixpanel, see [Data Governance — Custom Properties](data-governance.md#custom-properties).
+
+### Referencing a Saved Custom Property
+
+Use `CustomPropertyRef` to reference a custom property that already exists in your Mixpanel project by its numeric ID:
+
+```python
+from mixpanel_data import CustomPropertyRef, GroupBy, Filter, Metric
+
+ref = CustomPropertyRef(42)
+
+# Breakdown by saved custom property
+result = ws.query("Purchase", group_by=GroupBy(property=ref, property_type="number"))
+
+# Filter by saved custom property
+result = ws.query("Purchase", where=Filter.greater_than(property=ref, value=100))
+
+# Aggregate a saved custom property
+result = ws.query(Metric("Purchase", math="average", property=ref))
+```
+
+Find custom property IDs with `ws.list_custom_properties()` or `mp custom-properties list`.
+
+### Inline Custom Properties
+
+Use `InlineCustomProperty` to define a computed property at query time — no need to save it to your project first. Formulas reference raw properties through single-letter variables (A–Z), each mapped to a `PropertyInput`:
+
+```python
+from mixpanel_data import InlineCustomProperty, PropertyInput
+
+# Full constructor — explicit control over types
+revenue = InlineCustomProperty(
+    formula="A * B",
+    inputs={
+        "A": PropertyInput("price", type="number"),
+        "B": PropertyInput("quantity", type="number"),
+    },
+    property_type="number",
+)
+```
+
+For the common case of numeric formulas over event properties, use the `numeric()` convenience constructor:
+
+```python
+# Shorthand — auto-creates numeric PropertyInput objects
+revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+```
+
+Both forms produce identical results. Use the full constructor when you need non-numeric types or user-profile properties (`resource_type="user"`).
+
+### Custom Property Breakdowns
+
+Pass a custom property to `GroupBy.property` for breakdowns. Numeric bucketing works the same as with regular properties:
+
+```python
+from mixpanel_data import GroupBy, CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property with numeric buckets
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=CustomPropertyRef(42),
+        property_type="number",
+        bucket_size=50,
+    ),
+)
+
+# Inline computed property
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        property_type="number",
+        bucket_size=100,
+        bucket_min=0,
+        bucket_max=1000,
+    ),
+)
+
+# Mix with regular property breakdowns
+result = ws.query(
+    "Purchase",
+    group_by=["country", GroupBy(property=CustomPropertyRef(42), property_type="number")],
+)
+```
+
+### Custom Property Filters
+
+All 18 `Filter` factory methods accept custom properties in the `property` parameter:
+
+```python
+from mixpanel_data import Filter, CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property
+result = ws.query(
+    "Purchase",
+    where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+)
+
+# Inline computed property
+result = ws.query(
+    "Purchase",
+    where=Filter.between(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        value=[100, 1000],
+    ),
+)
+
+# Combine with regular filters
+result = ws.query(
+    "Purchase",
+    where=[
+        Filter.equals("country", "US"),
+        Filter.greater_than(property=CustomPropertyRef(42), value=50),
+    ],
+)
+```
+
+### Custom Property Measurement
+
+Aggregate a custom property as the metric value using `Metric(property=...)`:
+
+```python
+from mixpanel_data import Metric, CustomPropertyRef, InlineCustomProperty
+
+# Average of a saved custom property
+result = ws.query(
+    Metric("Purchase", math="average", property=CustomPropertyRef(42)),
+)
+
+# Sum of an inline computed property
+result = ws.query(
+    Metric("Purchase", math="total", property=InlineCustomProperty.numeric("A * B", A="price", B="quantity")),
+)
+
+# Per-metric custom properties in multi-metric queries
+result = ws.query([
+    Metric("Purchase", math="total", property=InlineCustomProperty.numeric("A * B", A="price", B="quantity")),
+    Metric("Purchase", math="unique"),
+])
+```
+
+!!! warning "Use `Metric(property=...)`, not `math_property=`"
+    The top-level `math_property` parameter only accepts plain string property names. To use a custom property for measurement, wrap the event in a `Metric` object and set `property=` on it.
+
+### Engine Compatibility
+
+| Capability | `query()` | `query_funnel()` | `query_retention()` | `query_flow()` |
+|---|:-:|:-:|:-:|:-:|
+| **CP Breakdowns** (`group_by=`) | ✓ | ✓ | ✓ | — |
+| **CP Filters** (`where=`) | ✓ | ⚠ | ⚠ | — |
+| **CP Measurement** (`Metric.property=`) | ✓ | — | — | — |
+
+⚠ = Supported, but a known Mixpanel server bug may cause errors when custom property filters are used in funnel and retention global `where=`. Custom property breakdowns and measurement work reliably in those engines.
+
+`query_flow()` does not support custom properties in any position (Mixpanel limitation).
+
+### Custom Property Validation
+
+Custom properties are validated **before** any API call. Invalid configurations raise `BookmarkValidationError`:
+
+| Rule | Error code | Error message |
+|---|---|---|
+| ID must be positive integer | `CP1_INVALID_ID` | custom property ID must be a positive integer (got {id}) |
+| Formula must be non-empty | `CP2_EMPTY_FORMULA` | inline custom property formula must be non-empty |
+| At least one input required | `CP3_EMPTY_INPUTS` | inline custom property must have at least one input |
+| Input keys must be single A–Z | `CP4_INVALID_INPUT_KEY` | input keys must be single uppercase letters (A-Z), got {key!r} |
+| Formula max 20,000 chars | `CP5_FORMULA_TOO_LONG` | formula exceeds maximum length of 20,000 characters (got {len}) |
+| Input property name non-empty | `CP6_EMPTY_INPUT_NAME` | input {key!r} has an empty property name |
+
+```python
+from mixpanel_data import BookmarkValidationError, CustomPropertyRef
+
+try:
+    ws.query("Purchase", group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"))
+except BookmarkValidationError as e:
+    for error in e.errors:
+        print(f"[{error.code}] {error.path}: {error.message}")
+    # [CP1_INVALID_ID] group_by[0].property: custom property ID must be a positive integer (got 0)
+```
+
 ## Next Steps
 
 - [Funnel Queries](query-funnels.md) — Typed funnel conversion analysis
@@ -816,5 +1001,6 @@ result = ws.query(
 - [Flow Queries](query-flows.md) — Typed flow path analysis with steps, directions, and graph output
 - [Live Analytics](live-analytics.md) — Legacy query methods (segmentation, funnels, retention)
 - [Data Discovery](discovery.md) — Explore events and properties before querying
-- [API Reference — Workspace](../api/workspace.md) — Full method signature
-- [API Reference — Types](../api/types.md) — Metric, Filter, GroupBy, CohortBreakdown, CohortMetric, QueryResult details
+- [Data Governance — Custom Properties](data-governance.md#custom-properties) — Create and manage custom properties
+- [API Reference — Workspace](../api/workspace.md) — Full method signatures
+- [API Reference — Types](../api/types.md) — Metric, Filter, GroupBy, CustomPropertyRef, InlineCustomProperty, QueryResult details

--- a/mixpanel-plugin/agents/analyst.md
+++ b/mixpanel-plugin/agents/analyst.md
@@ -114,6 +114,7 @@ For complex questions requiring multiple engines, decompose into a plan:
 import mixpanel_data as mp
 from mixpanel_data import Metric, Filter, GroupBy, Formula
 from mixpanel_data import CohortBreakdown, CohortMetric
+from mixpanel_data import CustomPropertyRef, InlineCustomProperty
 from mixpanel_data import FunnelStep, RetentionEvent, FlowStep
 import pandas as pd
 

--- a/mixpanel-plugin/agents/diagnostician.md
+++ b/mixpanel-plugin/agents/diagnostician.md
@@ -96,6 +96,8 @@ Break down by 4-6 dimensions to find which segment drives the change. Run all qu
 from concurrent.futures import ThreadPoolExecutor
 
 dimensions = ["platform", "country", "utm_source", "browser", "device_type", "app_version"]
+# Also consider custom properties as segmentation dimensions:
+# GroupBy(property=CustomPropertyRef(ID), property_type="number") for saved CPs
 
 def query_segment(dim):
     return dim, ws.query("TARGET_EVENT", last=60, group_by=dim, unit="day").df

--- a/mixpanel-plugin/agents/explorer.md
+++ b/mixpanel-plugin/agents/explorer.md
@@ -67,6 +67,8 @@ funnels = ws.funnels()                            # saved funnels
 cohorts = ws.cohorts()                            # saved cohorts
 # Cohort IDs work with Filter.in_cohort(), CohortBreakdown(), CohortMetric()
 bookmarks = ws.list_bookmarks()                   # saved reports
+custom_props = ws.list_custom_properties()        # saved custom properties (formula/behavior)
+# Custom property IDs work with CustomPropertyRef() in GroupBy, Filter, Metric
 
 # Lexicon definitions
 schemas = ws.lexicon_schemas()                    # all defined schemas

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -151,6 +151,7 @@ ws.lexicon_schema("event", "Purchase")         # → LexiconSchema (definitions,
 ```python
 from mixpanel_data import Metric, Filter, GroupBy, Formula
 from mixpanel_data import CohortBreakdown, CohortMetric, CohortDefinition, CohortCriteria
+from mixpanel_data import CustomPropertyRef, InlineCustomProperty
 
 result = ws.query(
     events,              # str | Metric | Formula | Sequence[str | Metric | Formula]
@@ -356,6 +357,10 @@ Filter.date_between("created", "2025-01-01", "2025-06-30")  # date range
 Filter.in_cohort(123, "Power Users")                 # users in saved cohort
 Filter.in_cohort(cohort_def, "Custom Segment")       # users matching inline definition
 Filter.not_in_cohort(123, "Churned Users")           # users NOT in cohort
+
+# Custom properties (saved or inline)
+Filter.greater_than(property=CustomPropertyRef(42), value=100)
+Filter.between(property=InlineCustomProperty.numeric("A*B", A="price", B="qty"), value=[10, 500])
 ```
 
 ### Streaming — Raw Data Access
@@ -505,6 +510,55 @@ result = ws.query("Login", group_by=CohortBreakdown(premium_active, "Premium Act
 ```
 
 **Note**: When using inline `CohortDefinition` with `CohortMetric`, always provide a descriptive `name` parameter — it is required for server-side label generation.
+
+## Custom Properties in Queries
+
+Use saved custom properties or define computed properties inline — in breakdowns, filters, and measurement. Custom properties work everywhere a plain string property name does.
+
+| Capability | Parameter | Engines | Type |
+|---|---|---|---|
+| **Breakdown by CP** | `group_by=` | Insights, Funnels, Retention | `GroupBy(property=...)` |
+| **Filter by CP** | `where=` | Insights, Funnels\*, Retention\* | `Filter.*(property=...)` |
+| **Measure a CP** | `Metric(property=...)` | Insights only | `Metric` |
+
+\*Known server bug may cause errors in funnel/retention `where=` filters. Breakdowns work reliably in all three engines. Flows do not support custom properties.
+
+### Saved Custom Properties
+
+Reference by ID (find IDs with `ws.list_custom_properties()`):
+
+```python
+from mixpanel_data import CustomPropertyRef, GroupBy, Filter, Metric
+
+ref = CustomPropertyRef(42)
+
+# Breakdown
+ws.query("Purchase", group_by=GroupBy(property=ref, property_type="number", bucket_size=50))
+
+# Filter
+ws.query("Purchase", where=Filter.greater_than(property=ref, value=100))
+
+# Measurement (insights only — must use Metric, not math_property)
+ws.query(Metric("Purchase", math="average", property=ref))
+```
+
+### Inline Custom Properties
+
+Define a computed property at query time — no need to save it first:
+
+```python
+from mixpanel_data import InlineCustomProperty
+
+# Convenience constructor for numeric formulas
+revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+# Use anywhere a property name goes
+ws.query("Purchase", group_by=GroupBy(property=revenue, property_type="number", bucket_size=100))
+ws.query("Purchase", where=Filter.greater_than(property=revenue, value=1000))
+ws.query(Metric("Purchase", math="average", property=revenue))
+```
+
+**Note**: Top-level `math_property=` only accepts strings. Use `Metric(property=...)` for custom property measurement.
 
 ## How to Think About Analysis
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/insights-reference.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/insights-reference.md
@@ -204,6 +204,25 @@ All filter methods accept `resource_type` keyword argument: `"events"` (default)
 Filter.equals("plan", "premium", resource_type="people")
 ```
 
+### Custom Property Filters
+
+All filter factory methods accept `CustomPropertyRef` or `InlineCustomProperty` in the `property` parameter:
+
+```python
+from mixpanel_data import CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property
+Filter.greater_than(property=CustomPropertyRef(42), value=100)
+
+# Inline computed property
+Filter.between(
+    property=InlineCustomProperty.numeric("A * B", A="price", B="qty"),
+    value=[100, 1000],
+)
+```
+
+Custom property filters work in Insights `where=`. Funnel and retention `where=` filters may trigger a known server bug — use breakdowns instead.
+
 ### Combining Filters
 
 Pass a list to `where=` for AND logic (all must match):
@@ -275,6 +294,23 @@ ws.query("Purchase",
 ```python
 ws.query("Purchase", group_by=GroupBy("is_premium", property_type="boolean"))
 # Result: segments "true" and "false"
+```
+
+### Custom Property Breakdowns
+
+Pass a custom property to `GroupBy.property`. Bucketing works normally:
+
+```python
+from mixpanel_data import GroupBy, CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property
+GroupBy(property=CustomPropertyRef(42), property_type="number", bucket_size=50)
+
+# Inline formula
+GroupBy(
+    property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+    property_type="number", bucket_size=100, bucket_min=0, bucket_max=1000,
+)
 ```
 
 ### Multiple Breakdowns
@@ -392,6 +428,23 @@ result = ws.query(
            percentile_value=95),
 )
 ```
+
+### Custom Property Measurement
+
+Use `Metric(property=...)` to aggregate a custom property:
+
+```python
+from mixpanel_data import Metric, CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property
+Metric("Purchase", math="average", property=CustomPropertyRef(42))
+
+# Inline computed property
+Metric("Purchase", math="total",
+       property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"))
+```
+
+**Important**: Top-level `math_property=` only accepts strings. Custom property measurement requires wrapping the event in a `Metric` object.
 
 ---
 
@@ -767,6 +820,12 @@ print(f"MoM change: {change:+.1f}%")
 | V24 | Bucket values must be finite (not NaN/Inf) | `V24_BUCKET_NOT_FINITE` |
 | V26 | `math="percentile"` requires `percentile_value` | `V26_PERCENTILE_REQUIRES_VALUE` |
 | V27 | `math="histogram"` requires `per_user` | `V27_HISTOGRAM_REQUIRES_PER_USER` |
+| CP1 | CustomPropertyRef ID must be positive | `CP1_INVALID_ID` |
+| CP2 | Inline formula must be non-empty | `CP2_EMPTY_FORMULA` |
+| CP3 | Inline must have at least one input | `CP3_EMPTY_INPUTS` |
+| CP4 | Input keys must be single A-Z | `CP4_INVALID_INPUT_KEY` |
+| CP5 | Formula max 20,000 chars | `CP5_FORMULA_TOO_LONG` |
+| CP6 | Input property name non-empty | `CP6_EMPTY_INPUT_NAME` |
 
 ### Layer 2: Bookmark Structure Validation (B-rules)
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/query-taxonomy.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/query-taxonomy.md
@@ -96,6 +96,15 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 | "cohort size", "cohort growth" | "How is the power user cohort growing?" | `CohortMetric(...)` — Insights only |
 | "define cohort inline" | "Users who purchased 3+ times in 30 days" | `CohortDefinition.all_of(CohortCriteria.did_event(...))` |
 
+### Custom Property Signals (Cross-Engine)
+
+| Signal Pattern | Example Question | Capability |
+|---|---|---|
+| "custom property", "computed property" | "Break down by revenue per unit" | `GroupBy(property=InlineCustomProperty.numeric(...))` |
+| "saved custom property", "custom prop ID" | "Filter by our LTV custom property" | `Filter.*(property=CustomPropertyRef(ID))` |
+| "formula property", "calculated field" | "Average of price times quantity" | `Metric(property=InlineCustomProperty.numeric(...))` |
+| "list custom properties" | "What custom properties do we have?" | `ws.list_custom_properties()` |
+
 ### Discovery Signals (schema exploration)
 
 | Signal Pattern | Method |
@@ -514,3 +523,16 @@ Otherwise → query() (Insights)
 | 6 | Insights | `ws.query([Metric("Login", math="unique"), CohortMetric(ID, "Power Users")], formula="(B/A)*100")` | Cohort share trend |
 
 **Join strategy**: Segment-aligned — CohortBreakdown produces "in" vs "not in" segments across Insights, Funnels, and Retention. Flows uses Filter.in_cohort() since CohortBreakdown is not supported.
+
+### Pattern 12: Custom Property Analysis
+
+**Question**: "Analyze revenue per unit across segments"
+
+| Step | Engine | Query | Purpose |
+|------|--------|-------|---------|
+| 1 | Discovery | `ws.list_custom_properties()` | Find existing custom properties |
+| 2 | Insights | `ws.query("Purchase", group_by=GroupBy(property=InlineCustomProperty.numeric("A/B", A="revenue", B="units"), property_type="number", bucket_size=10))` | Distribution of computed metric |
+| 3 | Insights | `ws.query(Metric("Purchase", math="average", property=InlineCustomProperty.numeric("A/B", A="revenue", B="units")), group_by="country")` | Computed metric by segment |
+| 4 | Retention | `ws.query_retention("Purchase", "Purchase", group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"))` | Repeat purchase by saved CP |
+
+**Join strategy**: Time-aligned — all queries share the same date range. Custom property breakdowns produce the same segment structure as regular GroupBy breakdowns.

--- a/specs/037-custom-properties-queries/SERVER_BUG_REPORT.md
+++ b/specs/037-custom-properties-queries/SERVER_BUG_REPORT.md
@@ -1,0 +1,255 @@
+# Bug Report: Custom Property Filters Crash in Funnel/Retention Global `where`
+
+**Severity**: P2 — Server returns HTTP 500 for valid bookmark JSON  
+**Component**: `bookmark_parser/common/transforms/util.py`  
+**Reporter**: mixpanel_data QA (Phase 037 — Custom Properties in Queries)  
+**Date**: 2026-04-07
+
+---
+
+## Summary
+
+`transform_insights_filters_to_funnels()` crashes with `KeyError` when a `sections.filter[]` entry uses `customPropertyId` or `customProperty` instead of `value` for property identification. This causes HTTP 500 for any funnel or retention query that includes a custom property in the global `where` filter.
+
+**Impact**: Users cannot filter funnel or retention queries by custom properties (saved or inline) using the global `where` parameter. Per-step filters (`behavior.filters`) and insights queries are unaffected.
+
+---
+
+## Root Cause
+
+**File**: `bookmark_parser/common/transforms/util.py`  
+**Function**: `transform_insights_filters_to_funnels()` — line 1452  
+**Two crash points**:
+
+### Crash 1 — Line 1459
+
+```python
+if f["value"] == "$cohorts":  # KeyError when f has no "value" key
+```
+
+Custom property filter entries use `customPropertyId` or `customProperty` instead of `value` to identify the property. This line does a hard dictionary access without checking whether `"value"` exists.
+
+### Crash 2 — Line 1484
+
+```python
+"propertyName": f["value"],  # Same KeyError
+```
+
+Even if crash 1 were fixed, this line also performs an unchecked `f["value"]` access when building the converted filter dict.
+
+### Irony
+
+Lines 1477–1478 in the same function already handle custom properties correctly using safe `.get()`:
+
+```python
+"customProperty": f.get("customProperty"),      # line 1477 — safe
+"customPropertyId": f.get("customPropertyId"),   # line 1478 — safe
+```
+
+The function was partially updated to pass through custom property data, but the two property name extraction lines were not updated to handle the absence of `"value"`.
+
+---
+
+## Why This Only Affects Funnels/Retention
+
+| Engine | Filter Processing Path | Custom Property Support |
+|--------|----------------------|------------------------|
+| **Insights** | `sections.filter` → `segment_to_arb_selector()` (arb_selector.py:408) | Works — calls `is_custom_property()` and routes to `_expand_formula_property()` |
+| **Funnels** | `sections.filter` → `transform_insights_filters_to_funnels()` → arb_selector | **Crashes** — hard `f["value"]` access before arb_selector ever sees the entry |
+| **Retention** | Same transform path as funnels | **Crashes** — same root cause |
+
+The transform function is an intermediate step that converts insights-format filters to the legacy funnels bookmark format. It runs **before** the arb_selector, so the custom property handling in `segment_to_arb_selector()` never gets a chance to execute.
+
+---
+
+## Reproduction
+
+### Minimal Bookmark (Funnel with Custom Property Filter)
+
+```json
+{
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "funnel",
+        "resourceType": "events",
+        "behaviors": [
+          {"type": "event", "name": "Signup", "filters": [], "filtersDeterminer": "all", "funnelOrder": "ordered"},
+          {"type": "event", "name": "Purchase", "filters": [], "filtersDeterminer": "all", "funnelOrder": "ordered"}
+        ],
+        "conversionWindowDuration": 14,
+        "conversionWindowUnit": "day",
+        "funnelOrder": "ordered",
+        "exclusions": [],
+        "aggregateBy": [],
+        "filter": []
+      },
+      "measurement": {"math": "conversion_rate_unique", "property": null, "stepIndex": null}
+    }],
+    "time": [{"dateRangeType": "in the last", "unit": "day", "window": {"unit": "day", "value": 30}}],
+    "filter": [{
+      "resourceType": "events",
+      "filterType": "string",
+      "defaultType": "string",
+      "filterValue": null,
+      "filterOperator": "is set",
+      "customPropertyId": 90553,
+      "dataset": "$mixpanel"
+    }],
+    "group": [],
+    "formula": []
+  },
+  "displayOptions": {"chartType": "funnel-steps"}
+}
+```
+
+**Expected**: Query executes and returns funnel results filtered by custom property  
+**Actual**: HTTP 500 `{"error": "An unknown error occurred."}`
+
+### The Same Filter Works in Insights
+
+Replace the show clause with a simple event metric and remove `"formula": []` — the identical `sections.filter` entry succeeds.
+
+### Per-Step Filters Work in Funnels
+
+Moving the custom property filter from `sections.filter[]` to `behavior.behaviors[0].filters[]` succeeds — the per-step filter path goes directly through `segment_to_arb_selector()` without the transform.
+
+---
+
+## Affected Filter Formats
+
+Both custom property filter formats are affected:
+
+### 1. Saved Custom Property Reference (`customPropertyId`)
+
+```json
+{
+  "customPropertyId": 90553,
+  "resourceType": "events",
+  "filterType": "string",
+  "defaultType": "string",
+  "filterValue": null,
+  "filterOperator": "is set",
+  "dataset": "$mixpanel"
+}
+```
+
+No `"value"` key → `KeyError` at line 1459.
+
+### 2. Inline Custom Property Definition (`customProperty`)
+
+```json
+{
+  "customProperty": {
+    "displayFormula": "A * B",
+    "composedProperties": {
+      "A": {"value": "price", "type": "number", "resourceType": "event"},
+      "B": {"value": "quantity", "type": "number", "resourceType": "event"}
+    },
+    "name": "",
+    "description": "",
+    "propertyType": "number",
+    "resourceType": "events"
+  },
+  "resourceType": "events",
+  "filterType": "number",
+  "defaultType": "number",
+  "filterValue": 1000,
+  "filterOperator": "is greater than",
+  "dataset": "$mixpanel"
+}
+```
+
+No `"value"` key → `KeyError` at line 1459.
+
+---
+
+## Suggested Fix
+
+### Option A: Minimal Fix (2 lines)
+
+```python
+# Line 1459 — change hard access to safe .get()
+# BEFORE:
+if f["value"] == "$cohorts":
+# AFTER:
+if f.get("value") == "$cohorts":
+
+# Line 1484 — change hard access to safe .get()
+# BEFORE:
+"propertyName": f["value"],
+# AFTER:
+"propertyName": f.get("value"),
+```
+
+This prevents the `KeyError` and allows the custom property data (already passed through at lines 1477–1478) to flow into the converted filter dict. The downstream arb_selector already knows how to process `customProperty`/`customPropertyId` entries.
+
+### Option B: Explicit Custom Property Routing (more robust)
+
+```python
+for f in insights_filters:
+    # Route custom property filters — they don't have "value"
+    if is_custom_property(f):
+        resource_key = SUPPORTED_RESOURCE_TYPES[f["resourceType"]]
+        converted_filter = {
+            resource_key: {
+                "customProperty": f.get("customProperty"),
+                "customPropertyId": f.get("customPropertyId"),
+                "resourceType": resource_key,
+                "filterOperator": f["filterOperator"],
+                "filterValue": f.get("filterValue"),
+                "filterType": f.get("filterType"),
+                "propertyDefaultType": f.get("defaultType"),
+                "dataset": f.get("dataset"),
+            }
+        }
+        filter_by_event["children"].append(converted_filter)
+    elif f.get("value") == "$cohorts":
+        # ... existing cohort handling ...
+    elif "behavior" not in f:
+        # ... existing regular property handling ...
+```
+
+This requires importing `is_custom_property` from `webapp.custom_properties.util`.
+
+---
+
+## Test Cases for Verification
+
+After applying the fix, verify these scenarios:
+
+1. **Funnel + `customPropertyId` in global filter** → should return results (not 500)
+2. **Funnel + `customProperty` (inline) in global filter** → should return results
+3. **Retention + `customPropertyId` in global filter** → should return results
+4. **Retention + `customProperty` (inline) in global filter** → should return results
+5. **Funnel + cohort filter** → still works (regression check for `$cohorts` path)
+6. **Funnel + regular property filter** → still works (regression check)
+7. **Insights + custom property filter** → still works (unaffected path)
+8. **Funnel + per-step custom property filter** → still works (unaffected path)
+
+---
+
+## Automated Test References
+
+The `mixpanel_data` library has 5 xfailed live tests that serve as ready-made regression tests:
+
+```
+tests/live/test_custom_property_queries_live.py::TestCustomPropertyFunnels::test_funnel_where_inline_cp
+tests/live/test_custom_property_queries_live.py::TestCustomPropertyRetention::test_retention_where_inline_cp
+tests/live/test_custom_property_queries_live.py::TestCustomPropertyRetention::test_retention_where_ref
+tests/live/test_custom_property_queries_live.py::TestCrossEngine::test_funnel_inline_cp_groupby_and_where
+tests/live/test_custom_property_queries_live.py::TestCrossEngine::test_retention_inline_cp_groupby_and_where
+```
+
+Once the server fix is deployed, these tests can be changed from `@pytest.mark.xfail` to regular tests — they should pass.
+
+---
+
+## Environment
+
+- **Server endpoint**: `POST /api/query/insights`
+- **Region**: US (`https://mixpanel.com/api/query/insights`)
+- **Projects tested**: 3018488 (ecommerce-demo), 8 (p8)
+- **Auth method**: Basic Auth (service account)
+- **Client**: `mixpanel_data` Python library v0.1.0

--- a/specs/037-custom-properties-queries/checklists/requirements.md
+++ b/specs/037-custom-properties-queries/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Custom Properties in Queries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. The spec references type names (`CustomPropertyRef`, `InlineCustomProperty`, `PropertyInput`, `GroupBy`, `Filter`, `Metric`) because this is a library feature where those ARE the user-facing API — they describe WHAT users interact with, not HOW the system is built internally.
+- The acceptance scenarios reference bookmark JSON structure because the library's `build_params()` / `build_funnel_params()` / `build_retention_params()` methods return this JSON as their public output — verifying JSON structure IS the user-observable behavior for a query-building library.
+- Scope explicitly excludes: `query_flow()` custom properties, custom events (`CustomEventRef`), and behavior-based inline custom properties (v2).

--- a/specs/037-custom-properties-queries/contracts/public-api.md
+++ b/specs/037-custom-properties-queries/contracts/public-api.md
@@ -1,0 +1,118 @@
+# Public API Contract: Custom Properties in Queries
+
+**Feature**: 037-custom-properties-queries
+**Date**: 2026-04-07
+
+## New Types (exported from `mixpanel_data`)
+
+### PropertyInput
+
+```python
+@dataclass(frozen=True)
+class PropertyInput:
+    name: str
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    resource_type: Literal["event", "user"] = "event"
+```
+
+### InlineCustomProperty
+
+```python
+@dataclass(frozen=True)
+class InlineCustomProperty:
+    formula: str
+    inputs: dict[str, PropertyInput]
+    property_type: Literal["string", "number", "boolean", "datetime"] | None = None
+    resource_type: Literal["events", "people"] = "events"
+
+    @classmethod
+    def numeric(cls, formula: str, /, **properties: str) -> InlineCustomProperty: ...
+```
+
+### CustomPropertyRef
+
+```python
+@dataclass(frozen=True)
+class CustomPropertyRef:
+    id: int
+```
+
+### PropertySpec (type alias)
+
+```python
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+```
+
+## Modified Signatures
+
+### Metric.property
+
+```python
+# Before
+property: str | None = None
+
+# After
+property: str | CustomPropertyRef | InlineCustomProperty | None = None
+```
+
+### GroupBy.property
+
+```python
+# Before
+property: str
+
+# After
+property: str | CustomPropertyRef | InlineCustomProperty
+```
+
+### Filter._property (internal) + all 18 class methods
+
+```python
+# Before (example: Filter.equals)
+@classmethod
+def equals(cls, property: str, value: str | list[str], *, resource_type: ...) -> Filter: ...
+
+# After
+@classmethod
+def equals(cls, property: str | CustomPropertyRef | InlineCustomProperty, value: str | list[str], *, resource_type: ...) -> Filter: ...
+```
+
+All 18 class methods: `equals`, `not_equals`, `contains`, `not_contains`, `greater_than`, `less_than`, `between`, `is_set`, `is_not_set`, `is_true`, `is_false`, `on`, `not_on`, `before`, `since`, `in_the_last`, `not_in_the_last`, `date_between`.
+
+## Unchanged Method Signatures
+
+The following query methods accept custom properties through their existing parameters (no signature changes needed):
+
+- `Workspace.query(events=..., group_by=..., where=...)` — events accepts `Metric` (whose `property` is widened), group_by accepts `GroupBy` (whose `property` is widened), where accepts `Filter` (whose `_property` is widened)
+- `Workspace.query_funnel(steps=..., group_by=..., where=...)` — same pattern
+- `Workspace.query_retention(born_event=..., return_event=..., group_by=..., where=...)` — same pattern
+- `Workspace.build_params(...)`, `Workspace.build_funnel_params(...)`, `Workspace.build_retention_params(...)` — same pattern
+
+## Backward Compatibility
+
+All changes are **additive union extensions**:
+
+- `str` remains a valid type for all property fields
+- No method signatures are removed or narrowed
+- No default values change
+- No required parameters are added
+- Existing code calling any of these methods with string properties continues to work identically
+
+## Error Contract
+
+| Condition | Error Type | Message Pattern |
+|-----------|-----------|----------------|
+| `CustomPropertyRef(id=0)` or negative | `BookmarkValidationError` | "custom property ID must be a positive integer (got {id})" |
+| `InlineCustomProperty(formula="")` | `BookmarkValidationError` | "inline custom property formula must be non-empty" |
+| `InlineCustomProperty(inputs={})` | `BookmarkValidationError` | "inline custom property must have at least one input" |
+| `InlineCustomProperty(inputs={"ab": ...})` | `BookmarkValidationError` | "inline custom property input keys must be single uppercase letters (A-Z), got 'ab'" |
+| Formula > 20,000 chars | `BookmarkValidationError` | "inline custom property formula exceeds maximum length of 20,000 characters (got {len})" |
+| `PropertyInput(name="")` in inputs | `BookmarkValidationError` | "inline custom property input '{key}' has an empty property name" |
+
+## Engine Compatibility
+
+| Feature | Insights | Funnels | Retention | Flows |
+|---------|----------|---------|-----------|-------|
+| Custom property in group_by | Yes | Yes | Yes | No (out of scope) |
+| Custom property in where | Yes | Yes | Yes | No (out of scope) |
+| Custom property in Metric.property | Yes | Yes | N/A | N/A |

--- a/specs/037-custom-properties-queries/data-model.md
+++ b/specs/037-custom-properties-queries/data-model.md
@@ -1,0 +1,166 @@
+# Data Model: Custom Properties in Queries
+
+**Feature**: 037-custom-properties-queries
+**Date**: 2026-04-07
+
+## Entities
+
+### PropertyInput
+
+A raw property reference mapping a formula variable to a named event or user property.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | (required) | The raw property name (e.g., `"price"`, `"$browser"`) |
+| `type` | `Literal["string", "number", "boolean", "datetime", "list"]` | `"string"` | Property data type |
+| `resource_type` | `Literal["event", "user"]` | `"event"` | Property domain |
+
+**Immutable**: Yes (frozen dataclass)
+
+**Bookmark JSON mapping**:
+```
+PropertyInput.name          → composedProperties[letter].value
+PropertyInput.type          → composedProperties[letter].type
+PropertyInput.resource_type → composedProperties[letter].resourceType
+```
+
+### InlineCustomProperty
+
+An ephemeral computed property defined by a formula and input property references.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `formula` | `str` | (required) | Expression in arb-selector formula language (max 20,000 chars) |
+| `inputs` | `dict[str, PropertyInput]` | (required) | Mapping from single uppercase letters (A-Z) to property references |
+| `property_type` | `Literal["string", "number", "boolean", "datetime"] \| None` | `None` | Result type of the formula; `None` defers to containing type |
+| `resource_type` | `Literal["events", "people"]` | `"events"` | Data domain |
+
+**Immutable**: Yes (frozen dataclass)
+
+**Convenience constructor**: `InlineCustomProperty.numeric(formula, **properties)` — creates an all-numeric-input inline custom property. All inputs are typed as `"number"` with `resource_type="event"`, and `property_type` is set to `"number"`.
+
+**Bookmark JSON mapping** (in filter, group-by, or measurement):
+```json
+{
+    "customProperty": {
+        "displayFormula": "<formula>",
+        "composedProperties": {
+            "<letter>": {"value": "<name>", "type": "<type>", "resourceType": "<resource_type>"}
+        },
+        "propertyType": "<property_type or fallback>",
+        "resourceType": "<resource_type>"
+    }
+}
+```
+
+### CustomPropertyRef
+
+A reference to a persisted custom property by its integer ID.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `int` | (required) | The custom property's ID (must be positive) |
+
+**Immutable**: Yes (frozen dataclass)
+
+**Bookmark JSON mapping** (in filter, group-by, or measurement):
+```json
+{
+    "customPropertyId": 42
+}
+```
+
+### PropertySpec (type alias)
+
+```
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+```
+
+Used as the accepted type for `property` fields in `Metric`, `GroupBy`, and `Filter`.
+
+## Modified Entities
+
+### Metric (widened)
+
+| Field | Before | After |
+|-------|--------|-------|
+| `property` | `str \| None` | `str \| CustomPropertyRef \| InlineCustomProperty \| None` |
+
+### GroupBy (widened)
+
+| Field | Before | After |
+|-------|--------|-------|
+| `property` | `str` | `str \| CustomPropertyRef \| InlineCustomProperty` |
+
+### Filter (widened)
+
+| Field | Before | After |
+|-------|--------|-------|
+| `_property` | `str` | `str \| CustomPropertyRef \| InlineCustomProperty` |
+| All 18 class methods `property` param | `str` | `str \| CustomPropertyRef \| InlineCustomProperty` |
+
+## Validation Rules
+
+| Code | Entity | Rule | Severity |
+|------|--------|------|----------|
+| CP1 | `CustomPropertyRef` | `id` must be a positive integer | error |
+| CP2 | `InlineCustomProperty` | `formula` must be non-empty (after stripping whitespace) | error |
+| CP3 | `InlineCustomProperty` | `inputs` must have at least one entry | error |
+| CP4 | `InlineCustomProperty` | `inputs` keys must be single uppercase letters A-Z | error |
+| CP5 | `InlineCustomProperty` | `formula` must not exceed 20,000 characters | error |
+| CP6 | `InlineCustomProperty` | Each `PropertyInput.name` must be non-empty (after stripping whitespace) | error |
+
+**Enforcement location**: `_validate_custom_property()` in `validation.py`, called from `validate_query_args()`, `validate_funnel_args()`, and `validate_retention_args()`.
+
+## Bookmark JSON Output by Position
+
+### Filter position
+
+**Plain string** (unchanged):
+```json
+{"resourceType": "events", "filterType": "number", "defaultType": "number", "value": "amount", "filterValue": 100, "filterOperator": "is greater than"}
+```
+
+**CustomPropertyRef**:
+```json
+{"customPropertyId": 42, "resourceType": "events", "filterType": "number", "defaultType": "number", "filterValue": 100, "filterOperator": "is greater than"}
+```
+
+**InlineCustomProperty**:
+```json
+{"customProperty": {"displayFormula": "A * B", "composedProperties": {"A": {"value": "price", "type": "number", "resourceType": "event"}, "B": {"value": "quantity", "type": "number", "resourceType": "event"}}, "propertyType": "number", "resourceType": "events"}, "resourceType": "events", "filterType": "number", "defaultType": "number", "filterValue": 100, "filterOperator": "is greater than"}
+```
+
+### Group-by position
+
+**Plain string** (unchanged):
+```json
+{"value": "country", "propertyName": "country", "resourceType": "events", "propertyType": "string", "propertyDefaultType": "string"}
+```
+
+**CustomPropertyRef**:
+```json
+{"customPropertyId": 42, "propertyType": "number", "propertyDefaultType": "number", "isHidden": false}
+```
+
+**InlineCustomProperty**:
+```json
+{"customProperty": {"displayFormula": "A * B", "composedProperties": {"A": {"value": "price", "type": "number", "resourceType": "event"}, "B": {"value": "quantity", "type": "number", "resourceType": "event"}}, "propertyType": "number", "resourceType": "events"}, "propertyType": "number", "propertyDefaultType": "number", "isHidden": false}
+```
+
+### Measurement position
+
+**Plain string** (unchanged):
+```json
+{"math": "average", "property": {"name": "amount", "resourceType": "events"}}
+```
+
+**CustomPropertyRef**:
+```json
+{"math": "average", "property": {"customPropertyId": 42, "resourceType": "events"}}
+```
+
+**InlineCustomProperty**:
+```json
+{"math": "average", "property": {"customProperty": {"displayFormula": "A * B", "composedProperties": {"A": {"value": "price", "type": "number", "resourceType": "event"}, "B": {"value": "quantity", "type": "number", "resourceType": "event"}}, "propertyType": "number"}, "resourceType": "events"}}
+```

--- a/specs/037-custom-properties-queries/data-model.md
+++ b/specs/037-custom-properties-queries/data-model.md
@@ -157,10 +157,10 @@ Used as the accepted type for `property` fields in `Metric`, `GroupBy`, and `Fil
 
 **CustomPropertyRef**:
 ```json
-{"math": "average", "property": {"customPropertyId": 42, "resourceType": "events"}}
+{"math": "average", "property": {"customPropertyId": 42, "name": "", "resourceType": "events"}}
 ```
 
 **InlineCustomProperty**:
 ```json
-{"math": "average", "property": {"customProperty": {"displayFormula": "A * B", "composedProperties": {"A": {"value": "price", "type": "number", "resourceType": "event"}, "B": {"value": "quantity", "type": "number", "resourceType": "event"}}, "propertyType": "number"}, "resourceType": "events"}}
+{"math": "average", "property": {"customProperty": {"displayFormula": "A * B", "composedProperties": {"A": {"value": "price", "type": "number", "resourceType": "event"}, "B": {"value": "quantity", "type": "number", "resourceType": "event"}}, "name": "", "description": "", "propertyType": "number", "resourceType": "events"}, "name": "", "resourceType": "events", "dataset": "$mixpanel", "dataGroupId": null}}
 ```

--- a/specs/037-custom-properties-queries/plan.md
+++ b/specs/037-custom-properties-queries/plan.md
@@ -1,0 +1,188 @@
+# Implementation Plan: Custom Properties in Queries
+
+**Branch**: `037-custom-properties-queries` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/037-custom-properties-queries/spec.md`
+
+## Summary
+
+Add first-class support for custom properties (saved and inline/ad-hoc) in the unified query system. Three new types (`PropertyInput`, `InlineCustomProperty`, `CustomPropertyRef`) enable custom properties in three query positions: group-by breakdowns, filter conditions, and metric aggregations. All changes are backward-compatible union extensions to existing types (`GroupBy.property`, `Filter._property`, `Metric.property`). Includes 6 validation rules (CP1-CP6), comprehensive test coverage (unit, PBT, mutation), and modular bookmark builders following the established 036-cohort-behaviors patterns.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (mypy --strict compliant)
+**Primary Dependencies**: Pydantic v2 (validation), httpx (HTTP client), Hypothesis (PBT), mutmut (mutation testing)
+**Storage**: N/A — pure query-building types, no persistence
+**Testing**: pytest, Hypothesis (property-based), mutmut (mutation testing)
+**Target Platform**: Cross-platform Python library + CLI
+**Project Type**: Library + CLI
+**Performance Goals**: N/A — type construction and JSON generation are negligible cost
+**Constraints**: Backward-compatible with all existing code; `just check` must pass (ruff + mypy --strict + pytest)
+**Scale/Scope**: ~480 lines production code, ~1,000 lines tests across 4 new test files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | All types are library constructs; no CLI changes needed |
+| II. Agent-Native | PASS | Types are self-documenting frozen dataclasses; structured output |
+| III. Context Window Efficiency | PASS | Inline definitions avoid round-trip to create/fetch saved CPs |
+| IV. Two Data Paths | PASS | Custom properties work in live query path; no storage path changes |
+| V. Explicit Over Implicit | PASS | All custom property specs are explicit constructor args; no magic inference |
+| VI. Unix Philosophy | PASS | Types compose with existing Filter/GroupBy/Metric ecosystem |
+| VII. Secure by Default | PASS | No credentials involved; pure data types |
+
+**Quality Gates**:
+- [x] All public functions will have type hints (mypy --strict)
+- [x] All public functions will have docstrings with examples
+- [x] All new code will pass `ruff check` and `ruff format`
+- [x] Tests will exist for all new functionality
+- [x] Backward compatibility preserved (union type extensions only)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-custom-properties-queries/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: Design decisions and rationale
+├── data-model.md        # Phase 1: Entity definitions and bookmark JSON mappings
+├── quickstart.md        # Phase 1: Usage examples
+├── contracts/
+│   └── public-api.md    # Phase 1: Public API surface contract
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── __init__.py                    # MODIFIED: Add exports
+├── types.py                       # MODIFIED: Add 3 new types + widen existing type signatures
+├── workspace.py                   # MODIFIED: Update measurement property builders
+└── _internal/
+    ├── bookmark_builders.py       # MODIFIED: Add _build_composed_properties(), update filter/group builders
+    └── validation.py              # MODIFIED: Add _validate_custom_property(), integrate into 3 pipelines
+
+tests/
+├── test_custom_property_types.py      # NEW: Type construction + validation (CP1-CP6)
+├── test_custom_property_builders.py   # NEW: Builder output verification
+├── test_custom_property_query.py      # NEW: End-to-end query method tests
+└── test_custom_property_pbt.py        # NEW: Property-based tests (Hypothesis)
+```
+
+**Structure Decision**: Single project extending existing files. Follows the established pattern from 036-cohort-behaviors (no new modules, modular additions to existing files).
+
+## Implementation Phases
+
+### Phase 1: New Types (~150 lines impl, ~200 lines tests)
+
+**Goal**: Establish the three new frozen dataclasses and the PropertySpec type alias.
+
+**Files**: `src/mixpanel_data/types.py`
+**Tests first**: `tests/test_custom_property_types.py` — `TestPropertyInput`, `TestInlineCustomProperty`, `TestCustomPropertyRef`
+
+1. Add `PropertyInput` frozen dataclass (name, type, resource_type with defaults)
+2. Add `InlineCustomProperty` frozen dataclass (formula, inputs, property_type, resource_type) with `numeric()` classmethod
+3. Add `CustomPropertyRef` frozen dataclass (id)
+4. Add `PropertySpec` type alias (`str | CustomPropertyRef | InlineCustomProperty`)
+
+**Verify**: All type construction tests pass. Freeze/immutability tests pass.
+
+### Phase 2: Modified Types (~50 lines changes)
+
+**Goal**: Widen type signatures on existing types to accept custom properties.
+
+**Files**: `src/mixpanel_data/types.py`
+
+1. `Metric.property`: `str | None` → `str | CustomPropertyRef | InlineCustomProperty | None`
+2. `GroupBy.property`: `str` → `str | CustomPropertyRef | InlineCustomProperty`
+3. `Filter._property`: `str` → `str | CustomPropertyRef | InlineCustomProperty`
+4. All 18 `Filter` class methods: `property: str` → `property: str | CustomPropertyRef | InlineCustomProperty`
+
+**Verify**: `just typecheck` passes (mypy). Existing tests still pass (backward-compatible).
+
+### Phase 3: Builders (~150 lines impl, ~250 lines tests)
+
+**Goal**: Update bookmark builders to produce correct JSON for all three property types.
+
+**Files**: `src/mixpanel_data/_internal/bookmark_builders.py`, `src/mixpanel_data/workspace.py`
+**Tests first**: `tests/test_custom_property_builders.py`
+
+1. Add `_build_composed_properties()` helper function
+2. Update `build_filter_entry()` — three-branch isinstance dispatch (str, CustomPropertyRef, InlineCustomProperty)
+3. Update `build_group_section()` — three-branch isinstance dispatch in GroupBy case
+4. Update measurement property construction in `_build_query_params()` — three-branch isinstance dispatch
+5. Update measurement property construction in `_build_funnel_params()` — same pattern
+6. Update imports in both files
+
+**Verify**: All builder output tests pass. Existing builder tests still pass.
+
+### Phase 4: Validation (~100 lines impl, ~200 lines tests)
+
+**Goal**: Add 6 validation rules (CP1-CP6) and integrate into all query pipelines.
+
+**Files**: `src/mixpanel_data/_internal/validation.py`
+**Tests first**: `tests/test_custom_property_types.py` — `TestCustomPropertyValidation`
+
+1. Add `_validate_custom_property()` helper (CP1-CP6 checks)
+2. Integrate into `validate_query_args()` — scan group_by, where, and Metric.property
+3. Integrate into `validate_funnel_args()` — scan group_by and where
+4. Integrate into `validate_retention_args()` — scan group_by and where
+5. Update imports
+
+**Verify**: All validation tests (CP1-CP6) pass. Position-specific validation tests pass.
+
+### Phase 5: End-to-End & Exports (~30 lines impl, ~200 lines tests)
+
+**Goal**: Wire everything together and export new types from the public API.
+
+**Files**: `src/mixpanel_data/__init__.py`
+**Tests first**: `tests/test_custom_property_query.py`
+
+1. Add `CustomPropertyRef`, `InlineCustomProperty`, `PropertyInput` to `__init__.py` exports
+2. Verify `_resolve_and_build_params()` type guards work with new union types
+3. Same for `_resolve_and_build_funnel_params()` and `_resolve_and_build_retention_params()`
+
+**Verify**: All end-to-end tests pass. All existing tests still pass. `just check` green.
+
+### Phase 6: PBT & Polish (~150 lines tests)
+
+**Goal**: Property-based tests, mutation testing, and final quality gate.
+
+**Files**: `tests/test_custom_property_pbt.py`
+
+1. Implement Hypothesis strategies for valid PropertyInput, InlineCustomProperty, CustomPropertyRef
+2. Property-based tests for type construction invariants
+3. Property-based tests for `_build_composed_properties()` output invariants
+4. Run `just test-pbt` — verify PBT passes
+5. Run `just test-cov` — verify coverage >= 90%
+6. Run `just mutate` on new code — target 80%+ mutation score
+7. Final `just check` — all green
+
+## Dependency Graph
+
+```
+Phase 1: New Types
+    │
+    ├─── Phase 2: Modified Types (depends on Phase 1 types)
+    │        │
+    │        └─── Phase 4: Validation (depends on modified types)
+    │
+    └─── Phase 3: Builders (depends on Phase 1 types)
+             │
+             └─── Phase 5: E2E & Exports (depends on builders + validation)
+                      │
+                      └─── Phase 6: PBT & Polish (depends on everything)
+```
+
+Phases 2 and 3 can proceed in parallel after Phase 1 is complete.
+
+## Complexity Tracking
+
+No constitution violations. All changes follow established patterns from 036-cohort-behaviors.

--- a/specs/037-custom-properties-queries/quickstart.md
+++ b/specs/037-custom-properties-queries/quickstart.md
@@ -1,0 +1,144 @@
+# Quickstart: Custom Properties in Queries
+
+## 1. Break Down by Custom Property
+
+```python
+from mixpanel_data import Workspace, GroupBy, CustomPropertyRef, InlineCustomProperty, PropertyInput
+
+ws = Workspace()
+
+# Saved custom property (by ID)
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+)
+
+# Inline formula: revenue = price * quantity
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        property_type="number",
+        bucket_size=100,
+    ),
+)
+
+# String formula with conditional bucketing
+result = ws.query(
+    "Purchase",
+    group_by=GroupBy(
+        property=InlineCustomProperty(
+            formula='IFS(A > 1000, "Enterprise", A > 100, "Pro", TRUE, "Free")',
+            inputs={"A": PropertyInput("amount", type="number")},
+            property_type="string",
+        ),
+    ),
+)
+```
+
+## 2. Filter by Custom Property
+
+```python
+from mixpanel_data import Filter, CustomPropertyRef, InlineCustomProperty
+
+# Saved custom property
+result = ws.query(
+    "Purchase",
+    where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+)
+
+# Inline formula: filter where revenue > 1000
+result = ws.query(
+    "Purchase",
+    where=Filter.greater_than(
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+        value=1000,
+    ),
+)
+
+# Extract email domain and filter
+result = ws.query(
+    "Signup",
+    where=Filter.equals(
+        property=InlineCustomProperty(
+            formula='REGEX_EXTRACT(A, "@(.+)$")',
+            inputs={"A": PropertyInput("email", type="string")},
+            property_type="string",
+        ),
+        value="company.com",
+    ),
+)
+```
+
+## 3. Aggregate on Custom Property
+
+```python
+from mixpanel_data import Metric, CustomPropertyRef, InlineCustomProperty
+
+# Average of a saved custom property
+result = ws.query(
+    Metric("Purchase", math="average", property=CustomPropertyRef(42)),
+)
+
+# Average revenue (price * quantity) per purchase
+result = ws.query(
+    Metric(
+        "Purchase",
+        math="average",
+        property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"),
+    ),
+)
+
+# Median profit margin
+result = ws.query(
+    Metric(
+        "Purchase",
+        math="median",
+        property=InlineCustomProperty.numeric(
+            "(A - B) / A * 100", A="revenue", B="cost",
+        ),
+    ),
+)
+```
+
+## 4. Combine All Three Positions
+
+```python
+# Revenue breakdown by tier, filtered to high-value, with average revenue metric
+revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+result = ws.query(
+    Metric("Purchase", math="average", property=CustomPropertyRef(99)),
+    group_by=GroupBy(property=revenue, property_type="number", bucket_size=100),
+    where=Filter.greater_than(property=revenue, value=50),
+)
+```
+
+## 5. Works Across Query Engines
+
+```python
+# Funnels: break down conversion by custom property
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+)
+
+# Retention: filter by custom property
+result = ws.query_retention(
+    "Signup", "Purchase",
+    where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+)
+
+# Mix with plain strings — everything is backward-compatible
+result = ws.query(
+    "Purchase",
+    group_by=[
+        "country",
+        GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        GroupBy(
+            property=InlineCustomProperty.numeric("A", A="revenue"),
+            property_type="number",
+        ),
+    ],
+)
+```

--- a/specs/037-custom-properties-queries/research.md
+++ b/specs/037-custom-properties-queries/research.md
@@ -1,0 +1,76 @@
+# Research: Custom Properties in Queries
+
+**Feature**: 037-custom-properties-queries
+**Date**: 2026-04-07
+
+## R1: How should custom properties be represented in the type system?
+
+**Decision**: Three frozen dataclasses — `PropertyInput`, `InlineCustomProperty`, `CustomPropertyRef` — plus a `PropertySpec` type alias for the union.
+
+**Rationale**: Follows the established pattern from 036-cohort-behaviors where `CohortBreakdown` and `CohortMetric` are frozen dataclasses. Frozen dataclasses provide immutability, fail-fast `__post_init__` validation, and are compatible with mypy --strict. The three-type split mirrors Mixpanel's own distinction: raw property inputs (composedProperties entries), inline formulas (ephemeral custom properties), and saved references (customPropertyId).
+
+**Alternatives considered**:
+- Single `CustomProperty` class with discriminated union: Rejected because saved refs and inline definitions have fundamentally different fields and JSON outputs.
+- Subclassing `GroupBy`/`Filter`/`Metric`: Rejected because custom properties are orthogonal to these types — they're a property specification, not a query dimension.
+- Plain dicts: Rejected because they lack type safety, discoverability, and validation.
+
+## R2: How should existing types be widened to accept custom properties?
+
+**Decision**: Widen the `property` field type on `Metric`, `GroupBy`, and `Filter` from `str` to `str | CustomPropertyRef | InlineCustomProperty`. Use `isinstance()` dispatch in builders.
+
+**Rationale**: Union type widening is the same approach used for `Filter._value` in 036 (widened to accept `list[dict[str, Any]]` for cohort filters). It's backward-compatible (existing `str` calls still work), requires no API changes for consumers, and `isinstance()` dispatch in builders is the established pattern.
+
+**Alternatives considered**:
+- Separate methods (e.g., `query_with_custom_property()`): Rejected — breaks the unified query API design.
+- Wrapper types (e.g., `CustomGroupBy`): Rejected — creates parallel hierarchies; custom properties are a property spec, not a new dimension type.
+- String encoding (e.g., `"custom:42"`): Rejected — not type-safe, not discoverable, error-prone.
+
+## R3: Where should bookmark JSON generation live?
+
+**Decision**: Extend existing builder functions in `_internal/bookmark_builders.py` with three-branch `isinstance()` dispatch. Add a shared `_build_composed_properties()` helper for `PropertyInput` → JSON conversion.
+
+**Rationale**: Follows the same pattern as 036 which extended `build_filter_entry()` and `build_group_section()` with cohort branches. Keeping builder logic in the existing functions maintains the single-responsibility principle — each builder function owns its section of the bookmark JSON. The `_build_composed_properties()` helper is DRY (used in filters, group-by, and measurements).
+
+**Alternatives considered**:
+- Separate builder module for custom properties: Rejected — fragments bookmark generation across modules.
+- Method on the types themselves (e.g., `InlineCustomProperty.to_bookmark_dict()`): Rejected — types should be pure data; bookmark format is an infrastructure concern.
+
+## R4: How should validation be structured?
+
+**Decision**: A single `_validate_custom_property()` helper in `validation.py` with 6 rules (CP1-CP6), called from `validate_query_args()`, `validate_funnel_args()`, and `validate_retention_args()`.
+
+**Rationale**: Follows the exact pattern of `_validate_cohort_args()` from 036. Central helper with coded rules (CP1-CP6) provides structured error reporting, machine-readable codes, and consistent validation across all pipelines. Fail-fast at query-build time (before API call) follows the established two-layer validation architecture.
+
+**Alternatives considered**:
+- Validation in `__post_init__()`: Partially used — `CustomPropertyRef(0)` could fail at construction. But validation of a custom property *in context* (e.g., "is this in a valid position?") requires the query-level validator. Design doc specifies validation at query-build time.
+- No client-side validation: Rejected — server errors are opaque and waste API calls.
+
+## R5: What bookmark JSON format do custom properties use?
+
+**Decision**: Three distinct JSON shapes based on property type:
+- Plain string: `{"value": "prop_name", "propertyName": "prop_name", "resourceType": "events", ...}` (unchanged)
+- `CustomPropertyRef`: `{"customPropertyId": 42, "propertyType": "number", ...}` (no `value`/`propertyName`)
+- `InlineCustomProperty`: `{"customProperty": {"displayFormula": "...", "composedProperties": {...}, "propertyType": "...", "resourceType": "..."}, ...}` (no `value`/`propertyName`)
+
+**Rationale**: Based on the analytics reference implementation (`arb_selector.py`, `bookmark.ts`). The Mixpanel webapp uses these exact JSON shapes when users create custom property breakdowns, filters, and measurements. Verified against the reference codebase.
+
+**Alternatives considered**: None — the bookmark format is dictated by the Mixpanel API server.
+
+## R6: Should `PropertyInput.resource_type` use singular or plural?
+
+**Decision**: `PropertyInput.resource_type` uses singular (`"event"`, `"user"`) while `InlineCustomProperty.resource_type` uses plural (`"events"`, `"people"`).
+
+**Rationale**: This matches Mixpanel's schema convention at each level. The `composedProperties` entries (derived from `PropertyInput`) use singular `"event"`/`"user"` in the `resourceType` field. The top-level `customProperty` dict (derived from `InlineCustomProperty`) uses plural `"events"`/`"people"`. This inconsistency exists in the Mixpanel API itself — the library faithfully reflects it rather than papering over it.
+
+**Alternatives considered**:
+- Normalize to one convention: Rejected — would produce incorrect bookmark JSON that the server rejects.
+
+## R7: How should `InlineCustomProperty.property_type` interact with `GroupBy.property_type`?
+
+**Decision**: When `InlineCustomProperty.property_type` is set, it takes precedence over `GroupBy.property_type`. When it's `None`, the builder falls back to `GroupBy.property_type`.
+
+**Rationale**: The inline custom property knows its own result type better than the containing GroupBy. For example, `IFS(A > 1000, "Enterprise", A > 100, "Pro", TRUE, "Free")` produces a string even if used in a GroupBy with `property_type="number"`. The fallback to GroupBy's type when `property_type` is `None` provides a reasonable default when the user doesn't specify the result type.
+
+**Alternatives considered**:
+- Always require `property_type`: Rejected — adds friction for the common case where the type matches the containing dimension.
+- Always use GroupBy's type: Rejected — would produce incorrect types for formulas that change the type (e.g., numeric input → string bucketing).

--- a/specs/037-custom-properties-queries/spec.md
+++ b/specs/037-custom-properties-queries/spec.md
@@ -1,0 +1,203 @@
+# Feature Specification: Custom Properties in Queries
+
+**Feature Branch**: `037-custom-properties-queries`  
+**Created**: 2026-04-07  
+**Status**: Draft  
+**Input**: User description: "ALL 6 Phases of this design — custom-properties-in-queries-design.md"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Break Down Results by Custom Properties (Priority: P1)
+
+As a data analyst, I want to segment my query results by a custom computed property so that I can discover patterns that raw properties alone cannot reveal. For example, I want to break down purchases by a "revenue tier" computed from price and quantity, or by a saved custom property that classifies users into segments.
+
+I can use either a **saved custom property** (referenced by its integer ID from the project) or an **inline custom property** (defined ad-hoc with a formula and input properties). Both work in the `group_by` parameter of `query()`, `query_funnel()`, and `query_retention()`.
+
+**Why this priority**: Group-by is the most common custom property use case. It enables segmentation by computed dimensions that don't exist as raw properties, which is the core value of custom properties in analytics.
+
+**Independent Test**: Can be fully tested by passing a custom property reference or inline definition to `group_by` in any query method and verifying the results are segmented by the computed property.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved custom property with ID 42 exists in the project, **When** I pass `GroupBy(property=CustomPropertyRef(42), property_type="number")` to `query()`, **Then** results are segmented by that custom property and the bookmark JSON contains `customPropertyId: 42` in the group section.
+2. **Given** I define an inline formula `"A * B"` with inputs mapping A to "price" (number) and B to "quantity" (number), **When** I pass this as `GroupBy(property=InlineCustomProperty(...), property_type="number")` to `query()`, **Then** results are segmented by the computed revenue value and the bookmark JSON contains a `customProperty` dict with `displayFormula`, `composedProperties`, `propertyType`, and `resourceType`.
+3. **Given** an inline custom property used as a group-by dimension, **When** I also specify bucketing (e.g., `bucket_size=100`), **Then** the bucketing configuration is applied to the custom property group entry.
+4. **Given** an `InlineCustomProperty` with an explicit `property_type`, **When** used in a `GroupBy` that also has its own `property_type`, **Then** the inline custom property's `property_type` takes precedence in the bookmark output.
+5. **Given** a list of mixed group-by dimensions (plain string, `CustomPropertyRef`, `InlineCustomProperty`), **When** I pass them all to `group_by`, **Then** each produces its correct bookmark JSON format and all coexist in the group section.
+6. **Given** a saved custom property reference, **When** I use it in `query_funnel()` group_by, **Then** the funnel results are segmented by that custom property.
+7. **Given** a saved custom property reference, **When** I use it in `query_retention()` group_by, **Then** the retention results are segmented by that custom property.
+
+---
+
+### User Story 2 - Filter Results by Custom Properties (Priority: P1)
+
+As a data analyst, I want to filter my query results using a custom property condition so that I can restrict analysis to events matching a computed criterion. For example, I want to filter to only events where computed revenue (price * quantity) exceeds 1000, or where a saved custom property value equals "Premium".
+
+I can use either a saved custom property reference or an inline definition in any of the 18 existing `Filter` class methods (e.g., `Filter.equals()`, `Filter.greater_than()`, `Filter.between()`).
+
+**Why this priority**: Filtering is equally fundamental to group-by. Together they cover the two most common custom property positions in analytics queries.
+
+**Independent Test**: Can be fully tested by passing a custom property to any `Filter` class method and verifying the filter is applied correctly in the bookmark JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved custom property with ID 42, **When** I pass `Filter.greater_than(property=CustomPropertyRef(42), value=100)` to `query()` via `where=`, **Then** the bookmark filter entry contains `customPropertyId: 42` and no `value` field (the property name field).
+2. **Given** an inline formula `"A * B"` computing revenue, **When** I pass `Filter.greater_than(property=InlineCustomProperty.numeric("A * B", A="price", B="qty"), value=1000)` to `where=`, **Then** the bookmark filter entry contains a `customProperty` dict with the formula and composed properties.
+3. **Given** a plain string property used in a filter, **When** the query is built, **Then** the filter entry is unchanged from the current format (backward compatibility).
+4. **Given** a `CustomPropertyRef` used in a filter with `resource_type="people"`, **When** the filter entry is built, **Then** the `resourceType` field reflects "people".
+5. **Given** an `InlineCustomProperty` with `resource_type="people"`, **When** used in a filter, **Then** the filter entry's `resourceType` is "people" and the `customProperty` dict's `resourceType` is also "people".
+6. **Given** an `InlineCustomProperty` with an explicit `property_type="string"`, **When** used in a filter, **Then** the `filterType` and `defaultType` fields in the bookmark entry reflect "string".
+7. **Given** all 18 `Filter` class methods, **When** any of them receives a `CustomPropertyRef` or `InlineCustomProperty` as the `property` argument, **Then** the filter is constructed successfully without errors.
+
+---
+
+### User Story 3 - Aggregate Metrics on Custom Properties (Priority: P2)
+
+As a data analyst, I want to compute aggregations (average, median, min, max, percentiles) on a custom property so that I can measure computed values over time. For example, I want the average revenue per purchase where revenue is price * quantity, using either a saved custom property or an inline formula.
+
+**Why this priority**: Metric aggregation on custom properties is powerful but used less frequently than group-by and filter. It applies only to property-based math types (average, median, min, max, p25, p75, p90, p99).
+
+**Independent Test**: Can be fully tested by passing a custom property to `Metric.property` with a property-based math type and verifying the measurement section of the bookmark JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved custom property with ID 42, **When** I pass `Metric("Purchase", math="average", property=CustomPropertyRef(42))` to `query()`, **Then** the measurement property in the bookmark JSON contains `customPropertyId: 42` and `resourceType: "events"`.
+2. **Given** an inline formula `"A * B"` computing revenue, **When** I pass `Metric("Purchase", math="average", property=InlineCustomProperty.numeric("A * B", A="price", B="quantity"))` to `query()`, **Then** the measurement property contains a `customProperty` dict with the formula and composed properties.
+3. **Given** a plain string used as `Metric.property`, **When** the query is built, **Then** the measurement property contains `name` and `resourceType` as before (backward compatibility).
+4. **Given** a `CustomPropertyRef` in `Metric.property`, **When** used in `query_funnel()` via a per-step metric, **Then** the funnel measurement property contains `customPropertyId`.
+5. **Given** a top-level `math_property` as a plain string, **When** the query is built, **Then** the measurement property is unchanged from the current format (backward compatibility).
+
+---
+
+### User Story 4 - Define Inline Custom Properties with Formulas (Priority: P2)
+
+As a data analyst, I want to define ad-hoc computed properties directly in my queries using a formula language so that I can perform computed analysis without saving a custom property to the project first. This is especially valuable for one-off explorations and for AI agents that can reason about property transformations programmatically.
+
+The formula language supports arithmetic, string manipulation, conditionals, type checking, date operations, and list operations. Formulas use single-letter variables (A-Z) that map to raw property inputs.
+
+**Why this priority**: Inline definitions are the key differentiator over simply referencing saved IDs. They enable ad-hoc exploration without project-level side effects.
+
+**Independent Test**: Can be fully tested by constructing an `InlineCustomProperty` with various formulas and input configurations, then verifying the composed bookmark JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** a formula `"A * B"` with inputs A="price" (number) and B="quantity" (number), **When** I construct an `InlineCustomProperty`, **Then** the object stores the formula, inputs, and property_type correctly.
+2. **Given** the convenience constructor `InlineCustomProperty.numeric("A * B", A="price", B="quantity")`, **When** I construct it, **Then** all inputs are typed as "number" with `resource_type="event"` and the `property_type` is "number".
+3. **Given** inputs with mixed resource types (event and user properties), **When** I construct an `InlineCustomProperty`, **Then** each input preserves its individual `resource_type`.
+4. **Given** a formula referencing a single property `"A"`, **When** I use `InlineCustomProperty.numeric("A", A="amount")`, **Then** it works as a simple numeric property reference with formula support.
+5. **Given** a `PropertyInput` with just a name, **When** constructed, **Then** it defaults to `type="string"` and `resource_type="event"`.
+6. **Given** all five property types (string, number, boolean, datetime, list), **When** used in a `PropertyInput`, **Then** each is accepted and preserved.
+7. **Given** constructed custom property types, **When** I attempt to modify any field, **Then** a `FrozenInstanceError` is raised (immutability guarantee).
+
+---
+
+### User Story 5 - Fail-Fast Validation for Custom Properties (Priority: P3)
+
+As a developer using the library, I want invalid custom property specifications to be caught immediately at query-build time so that I get clear error messages before any API call is made. This prevents wasted API calls and provides actionable diagnostics.
+
+**Why this priority**: Validation is a quality-of-life improvement that prevents confusing API errors. The feature is functional without it, but validation makes it robust.
+
+**Independent Test**: Can be fully tested by constructing invalid custom property specifications and verifying that specific, descriptive validation errors are raised.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `CustomPropertyRef` with ID 0 or negative, **When** used in any query position (group_by, where, or Metric.property), **Then** a validation error is raised with a message containing "positive integer".
+2. **Given** an `InlineCustomProperty` with an empty or whitespace-only formula, **When** used in any query position, **Then** a validation error is raised with a message containing "non-empty".
+3. **Given** an `InlineCustomProperty` with an empty inputs dict, **When** used in any query position, **Then** a validation error is raised with a message containing "at least one input".
+4. **Given** an `InlineCustomProperty` with a lowercase, multi-character, or numeric input key, **When** used in any query position, **Then** a validation error is raised with a message containing "uppercase".
+5. **Given** an `InlineCustomProperty` with a formula exceeding 20,000 characters, **When** used in any query position, **Then** a validation error is raised with a message containing "20,000".
+6. **Given** an `InlineCustomProperty` with a `PropertyInput` that has an empty name, **When** used in any query position, **Then** a validation error is raised with a message containing "empty property name".
+7. **Given** valid custom property specifications in any query position, **When** the query is built, **Then** no validation errors are raised.
+8. **Given** custom properties in `query_funnel()` and `query_retention()`, **When** invalid, **Then** the same validation rules apply as in `query()`.
+
+---
+
+### User Story 6 - Quality Assurance and Robustness (Priority: P3)
+
+As a library maintainer, I want property-based tests and mutation testing to verify that custom property types and builders are robust across a wide range of inputs, so that edge cases are caught automatically and test quality is quantifiably high.
+
+**Why this priority**: Quality assurance is essential for long-term maintainability but can be layered on after the core feature is functional.
+
+**Independent Test**: Can be tested by running the property-based test suite and mutation testing against the custom property code and verifying the target scores are met.
+
+**Acceptance Scenarios**:
+
+1. **Given** randomly generated valid `PropertyInput` values, **When** constructed, **Then** all field values survive round-trip (construction preserves inputs).
+2. **Given** randomly generated valid `InlineCustomProperty` values, **When** constructed, **Then** formula and inputs are preserved exactly.
+3. **Given** randomly generated valid inputs dicts, **When** passed to the composed properties builder, **Then** output keys match input keys exactly and each entry contains the required fields (value, type, resourceType).
+4. **Given** the full test suite, **When** coverage is measured, **Then** total coverage is at or above 90%.
+5. **Given** the custom property code, **When** mutation testing is run, **Then** the mutation score is at or above 80%.
+
+---
+
+### Edge Cases
+
+- What happens when an `InlineCustomProperty` formula references variables not present in the inputs dict? The library does not validate formula-to-input consistency; the server returns an error at query time.
+- What happens when a `CustomPropertyRef` references an ID that doesn't exist in the project? The server returns an error at query time; client-side validation only checks positivity.
+- What happens when multiple custom properties of different types (saved ref, inline, plain string) are mixed in the same `group_by` list? All three forms coexist; each produces its own bookmark JSON format.
+- What happens when an `InlineCustomProperty` has `property_type=None`? The builder falls back to the containing type's property_type (e.g., `GroupBy.property_type` or `Filter._property_type`).
+- What happens when `InlineCustomProperty.numeric()` is called with no keyword arguments? An `InlineCustomProperty` with an empty inputs dict is created, which fails CP3 validation at query-build time.
+- What happens when a custom property is used in `query_flow()`? Flows use a different filter format and do not support custom properties in breakdowns; this is out of scope.
+- What happens when existing code passes plain strings to all property fields? All changes are additive union extensions; existing code works unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `PropertyInput` type that represents a raw property reference with name, data type, and resource domain
+- **FR-002**: System MUST provide an `InlineCustomProperty` type that defines a computed property via a formula and a mapping of letter variables (A-Z) to `PropertyInput` references
+- **FR-003**: System MUST provide a `CustomPropertyRef` type that references a saved custom property by its integer ID
+- **FR-004**: System MUST provide a convenience constructor (`InlineCustomProperty.numeric()`) that creates an all-numeric-input inline custom property from keyword arguments
+- **FR-005**: All three new types MUST be immutable (frozen)
+- **FR-006**: `GroupBy.property` MUST accept plain strings, `CustomPropertyRef`, and `InlineCustomProperty`
+- **FR-007**: All 18 `Filter` class methods MUST accept plain strings, `CustomPropertyRef`, and `InlineCustomProperty` as the property argument
+- **FR-008**: `Metric.property` MUST accept plain strings, `CustomPropertyRef`, and `InlineCustomProperty` (in addition to `None`)
+- **FR-009**: The filter bookmark builder MUST produce `customPropertyId` for saved refs and `customProperty` dict for inline definitions
+- **FR-010**: The group-by bookmark builder MUST produce `customPropertyId` for saved refs and `customProperty` dict for inline definitions
+- **FR-011**: The measurement property builder MUST produce `customPropertyId` for saved refs and `customProperty` dict for inline definitions
+- **FR-012**: The composed properties builder MUST translate `PropertyInput.name` to `value` and `PropertyInput.resource_type` to `resourceType` in the bookmark JSON
+- **FR-013**: Bucketing (`bucket_size`, `bucket_min`, `bucket_max`) MUST work with all three property types in group-by
+- **FR-014**: When `InlineCustomProperty.property_type` is set, it MUST take precedence over the containing type's property_type in bookmark output
+- **FR-015**: When `InlineCustomProperty.property_type` is `None`, the builder MUST fall back to the containing type's property_type
+- **FR-016**: Custom property validation MUST check: positive ID (CP1), non-empty formula (CP2), non-empty inputs (CP3), single uppercase letter keys (CP4), formula length <= 20,000 (CP5), non-empty input property names (CP6)
+- **FR-017**: Validation MUST run in all three query pipelines: insights, funnels, and retention
+- **FR-018**: Validation errors MUST be raised before any API call is made (fail-fast)
+- **FR-019**: All existing code using plain string properties MUST continue to work without modification (backward compatibility)
+- **FR-020**: The three new types MUST be exported from the package's public API
+- **FR-021**: All new types and modified methods MUST have complete docstrings with examples
+- **FR-022**: Custom properties in `query_funnel()` measurement MUST follow the same bookmark format as insights
+- **FR-023**: The filter builder MUST NOT emit a `value` field (property name) when a custom property is used; instead it emits `customPropertyId` or `customProperty`
+- **FR-024**: The group-by builder MUST NOT emit `value` or `propertyName` fields when a custom property is used
+- **FR-025**: `InlineCustomProperty` resource_type MUST default to `"events"` and `PropertyInput` resource_type MUST default to `"event"`
+- **FR-026**: `PropertyInput` type MUST default to `"string"` and accept all five valid types (string, number, boolean, datetime, list)
+
+### Key Entities
+
+- **PropertyInput**: A raw property reference mapping a formula variable to a named property with a data type and domain (event or user). Becomes one entry in the bookmark's `composedProperties` dict.
+- **InlineCustomProperty**: An ephemeral computed property defined by a formula expression and a set of property inputs. Computed at query time without being saved to the project. Contains a formula string, inputs mapping, optional result type, and resource domain.
+- **CustomPropertyRef**: A reference to a persisted custom property by its integer ID. The query engine fetches the full definition from the project at execution time.
+- **PropertySpec**: A type alias representing the union of plain string, `CustomPropertyRef`, and `InlineCustomProperty`. Used as the accepted type for property fields across the query API.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All three query positions (group-by, filter, measurement) accept both saved custom property references and inline custom property definitions without errors
+- **SC-002**: All existing queries using plain string properties continue to produce identical results (zero regressions)
+- **SC-003**: 6 validation rules catch all invalid custom property inputs with descriptive, actionable error messages before any API call
+- **SC-004**: All quality gates pass: formatting, linting, type checking, and tests
+- **SC-005**: Test coverage remains at or above 90%
+- **SC-006**: Mutation testing score for new code is at or above 80%
+- **SC-007**: Property-based tests verify type construction invariants across randomized inputs
+- **SC-008**: Custom properties work consistently across insights, funnel, and retention query engines
+
+## Assumptions
+
+- Saved custom properties referenced by `CustomPropertyRef` already exist in the Mixpanel project (created via `create_custom_property()` or the Mixpanel UI)
+- The Mixpanel API's bookmark format for custom properties is stable and follows the patterns documented in the design (based on the analytics reference implementation)
+- Formula-to-input variable consistency is not validated client-side; the server handles formula parsing and reports errors for undefined variables
+- `query_flow()` does not support custom properties in breakdowns (Mixpanel limitation) and is explicitly out of scope
+- Custom events (`CustomEventRef`) are a separate feature and out of scope for this specification
+- Behavior-based inline custom properties are a v2 enhancement and out of scope
+- The `PropertyInput` resource_type uses `"event"`/`"user"` (singular) while `InlineCustomProperty` resource_type uses `"events"`/`"people"` (plural), matching Mixpanel's existing schema conventions at each level
+- The convenience constructor `InlineCustomProperty.numeric()` covers the most common use case (all-numeric event properties); other combinations require the full constructor

--- a/specs/037-custom-properties-queries/tasks.md
+++ b/specs/037-custom-properties-queries/tasks.md
@@ -1,0 +1,313 @@
+# Tasks: Custom Properties in Queries
+
+**Input**: Design documents from `/specs/037-custom-properties-queries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/public-api.md, quickstart.md
+
+**Tests**: Included — project mandates strict TDD (CLAUDE.md: "Never write implementation code without a failing test first").
+
+**Organization**: Tasks grouped by user story. US4 (inline formula definitions) is folded into the Foundational phase because the types it defines are prerequisites for all other stories.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — existing project, existing branch.
+
+_(No tasks — branch `037-custom-properties-queries` already created and checked out.)_
+
+---
+
+## Phase 2: Foundational — New Types & Type Widening
+
+**Purpose**: Create the three new frozen dataclasses, widen existing type signatures, add the composed properties builder helper, and export new types. This phase also satisfies **US4 (Inline Formula Definitions)** — the `InlineCustomProperty`, `PropertyInput`, and `.numeric()` convenience constructor ARE the inline formula user experience.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+### Tests (write FIRST, verify they FAIL)
+
+- [x] T001 [P] Write tests for PropertyInput construction: minimal (name only), explicit number type, user resource_type, all 5 valid types (string, number, boolean, datetime, list) in tests/test_custom_property_types.py
+- [x] T002 [P] Write tests for InlineCustomProperty construction: minimal (formula + single input), full (all fields explicit) in tests/test_custom_property_types.py
+- [x] T003 [P] Write tests for InlineCustomProperty.numeric() convenience constructor: multi-input (A * B) and single-input (A) cases in tests/test_custom_property_types.py
+- [x] T004 [P] Write tests for CustomPropertyRef construction: stores integer ID in tests/test_custom_property_types.py
+- [x] T005 [P] Write tests for immutability: FrozenInstanceError on PropertyInput.name, InlineCustomProperty.formula, CustomPropertyRef.id in tests/test_custom_property_types.py
+- [x] T006 [P] Write tests for _build_composed_properties(): single input, multiple inputs, user resource_type preservation in tests/test_custom_property_builders.py
+
+### Implementation
+
+- [x] T007 Add PropertyInput frozen dataclass (name, type, resource_type with defaults) in src/mixpanel_data/types.py
+- [x] T008 Add InlineCustomProperty frozen dataclass (formula, inputs, property_type, resource_type) with numeric() classmethod in src/mixpanel_data/types.py
+- [x] T009 Add CustomPropertyRef frozen dataclass (id) in src/mixpanel_data/types.py
+- [x] T010 Add PropertySpec type alias (str | CustomPropertyRef | InlineCustomProperty) in src/mixpanel_data/types.py
+- [x] T011 Widen Metric.property from str | None to str | CustomPropertyRef | InlineCustomProperty | None in src/mixpanel_data/types.py
+- [x] T012 Widen GroupBy.property from str to str | CustomPropertyRef | InlineCustomProperty in src/mixpanel_data/types.py
+- [x] T013 Widen Filter._property and all 18 class method property parameters from str to str | CustomPropertyRef | InlineCustomProperty in src/mixpanel_data/types.py
+- [x] T014 Add _build_composed_properties() helper function and update imports (CustomPropertyRef, InlineCustomProperty, PropertyInput) in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T015 Add CustomPropertyRef, InlineCustomProperty, PropertyInput to imports and __all__ in src/mixpanel_data/__init__.py
+- [x] T016 Run just typecheck to verify type widening is backward-compatible and all new types pass mypy --strict
+
+**Checkpoint**: All type construction tests green. `just typecheck` passes. US4 acceptance scenarios 1-7 verified. Existing tests unchanged.
+
+---
+
+## Phase 3: User Story 1 — Break Down by Custom Properties (Priority: P1)
+
+**Goal**: Update `build_group_section()` to produce correct bookmark JSON for `CustomPropertyRef` and `InlineCustomProperty` in the `group_by` position.
+
+**Independent Test**: Pass a custom property to `group_by` in `build_params()` and verify the group section of the bookmark JSON contains the correct `customPropertyId` or `customProperty` dict.
+
+### Tests (write FIRST, verify they FAIL)
+
+- [x] T017 [P] [US1] Write test for build_group_section with plain string property unchanged (backward compat) in tests/test_custom_property_builders.py
+- [x] T018 [P] [US1] Write test for build_group_section with GroupBy(property=CustomPropertyRef(42)): verify customPropertyId, no value/propertyName in tests/test_custom_property_builders.py
+- [x] T019 [P] [US1] Write test for build_group_section with GroupBy(property=InlineCustomProperty.numeric(...)): verify customProperty dict with displayFormula, composedProperties in tests/test_custom_property_builders.py
+- [x] T020 [P] [US1] Write test for bucketing (bucket_size, bucket_min, bucket_max) with CustomPropertyRef and InlineCustomProperty in tests/test_custom_property_builders.py
+- [x] T021 [P] [US1] Write test for InlineCustomProperty.property_type overriding GroupBy.property_type in tests/test_custom_property_builders.py
+- [ ] T021b [P] [US1] Write test for InlineCustomProperty.property_type=None falling back to GroupBy.property_type in tests/test_custom_property_builders.py
+- [x] T022 [P] [US1] Write test for mixed group_by list (plain string + CustomPropertyRef + InlineCustomProperty) in tests/test_custom_property_builders.py
+- [x] T023 [P] [US1] Write end-to-end tests for build_params, build_funnel_params, build_retention_params with custom property group_by in tests/test_custom_property_query.py
+
+### Implementation
+
+- [x] T024 [US1] Update build_group_section() GroupBy branch with three-way isinstance dispatch (str, CustomPropertyRef, InlineCustomProperty) in src/mixpanel_data/_internal/bookmark_builders.py (imports already added in T014)
+
+**Checkpoint**: All group-by builder tests green. Group-by custom properties work in insights, funnels, and retention.
+
+---
+
+## Phase 4: User Story 2 — Filter by Custom Properties (Priority: P1)
+
+**Goal**: Update `build_filter_entry()` to produce correct bookmark JSON for `CustomPropertyRef` and `InlineCustomProperty` in the `where` position.
+
+**Independent Test**: Pass a custom property to a `Filter` class method and use it in `build_params()` `where=` — verify the filter section contains `customPropertyId` or `customProperty` dict.
+
+### Tests (write FIRST, verify they FAIL)
+
+- [x] T026 [P] [US2] Write test for build_filter_entry with plain string unchanged (backward compat, no customPropertyId/customProperty) in tests/test_custom_property_builders.py
+- [x] T027 [P] [US2] Write test for build_filter_entry with CustomPropertyRef: verify customPropertyId, no value field, filterOperator preserved in tests/test_custom_property_builders.py
+- [x] T028 [P] [US2] Write test for build_filter_entry with InlineCustomProperty: verify customProperty dict, no value field, filterValue preserved in tests/test_custom_property_builders.py
+- [x] T029 [P] [US2] Write test for InlineCustomProperty filterType/defaultType using property_type in tests/test_custom_property_builders.py
+- [x] T030 [P] [US2] Write test for CustomPropertyRef preserving Filter's resource_type (e.g., "people") in tests/test_custom_property_builders.py
+- [x] T031 [P] [US2] Write test for InlineCustomProperty using its own resource_type in filter entry in tests/test_custom_property_builders.py
+- [x] T032 [P] [US2] Write end-to-end tests for build_params with custom property filter (ref and inline) in tests/test_custom_property_query.py
+
+### Implementation
+
+- [x] T033 [US2] Update build_filter_entry() with three-way isinstance dispatch (str, CustomPropertyRef, InlineCustomProperty) in src/mixpanel_data/_internal/bookmark_builders.py
+
+**Checkpoint**: All filter builder tests green. Filter custom properties work across all query methods.
+
+---
+
+## Phase 5: User Story 3 — Aggregate Metrics on Custom Properties (Priority: P2)
+
+**Goal**: Update measurement property construction in `_build_query_params()` and `_build_funnel_params()` to produce correct bookmark JSON for `CustomPropertyRef` and `InlineCustomProperty` in the `Metric.property` position.
+
+**Independent Test**: Pass a custom property to `Metric.property` with a property-based math type and verify the measurement section of the bookmark JSON.
+
+### Tests (write FIRST, verify they FAIL)
+
+- [x] T034 [P] [US3] Write test for plain string Metric.property measurement unchanged (backward compat) in tests/test_custom_property_builders.py
+- [x] T035 [P] [US3] Write test for CustomPropertyRef in measurement: verify customPropertyId, resourceType, no name field in tests/test_custom_property_builders.py
+- [x] T036 [P] [US3] Write test for InlineCustomProperty in measurement: verify customProperty dict, resourceType, no name field in tests/test_custom_property_builders.py
+- [x] T037 [P] [US3] Write test for top-level math_property as plain string unchanged (backward compat) in tests/test_custom_property_builders.py
+- [x] T038 [P] [US3] Write end-to-end test for build_params with Metric(property=CustomPropertyRef(...)) in tests/test_custom_property_query.py
+- [x] T039 [P] [US3] Write end-to-end test for build_params with Metric(property=InlineCustomProperty.numeric(...)) in tests/test_custom_property_query.py
+- [x] T040 [P] [US3] Write end-to-end test for build_funnel_params with custom property measurement in tests/test_custom_property_query.py
+
+### Implementation
+
+- [x] T041 [US3] Update imports in src/mixpanel_data/workspace.py to include CustomPropertyRef, InlineCustomProperty
+- [x] T042 [US3] Update measurement property builder in _build_query_params() with three-way isinstance dispatch in src/mixpanel_data/workspace.py
+- [x] T043 [US3] Update measurement property builder in _build_funnel_params() with three-way isinstance dispatch in src/mixpanel_data/workspace.py
+
+**Checkpoint**: All measurement builder tests green. Metric aggregation on custom properties works in insights and funnels.
+
+---
+
+## Phase 6: Combined End-to-End Tests
+
+**Purpose**: Verify custom properties work when combined across multiple positions and query engines.
+
+- [x] T044 [P] Write test for CustomPropertyRef in group_by + InlineCustomProperty in where (combined) in tests/test_custom_property_query.py
+- [x] T045 [P] Write test for all three positions simultaneously (Metric.property + group_by + where) in tests/test_custom_property_query.py
+- [x] T046 Run just test to verify all tests pass and no regressions
+
+**Checkpoint**: All end-to-end tests green. All existing tests still pass.
+
+---
+
+## Phase 7: User Story 5 — Fail-Fast Validation (Priority: P3)
+
+**Goal**: Add 6 validation rules (CP1-CP6) via `_validate_custom_property()` helper and integrate into all three query validation pipelines.
+
+**Independent Test**: Construct invalid custom property specs and verify that descriptive validation errors are raised before any API call.
+
+### Tests (write FIRST, verify they FAIL)
+
+- [x] T047 [P] [US5] Write test for CP1: CustomPropertyRef(0) and CustomPropertyRef(-1) in group_by raise validation error with "positive integer" in tests/test_custom_property_types.py
+- [x] T048 [P] [US5] Write test for CP2: InlineCustomProperty with empty and whitespace-only formula raises "non-empty" in tests/test_custom_property_types.py
+- [x] T049 [P] [US5] Write test for CP3: InlineCustomProperty with empty inputs dict raises "at least one input" in tests/test_custom_property_types.py
+- [x] T050 [P] [US5] Write test for CP4: lowercase key, multi-char key, numeric key raise "uppercase" in tests/test_custom_property_types.py
+- [x] T051 [P] [US5] Write test for CP5: formula > 20,000 chars raises "20,000" in tests/test_custom_property_types.py
+- [x] T052 [P] [US5] Write test for CP6: PropertyInput with empty name raises "empty property name" in tests/test_custom_property_types.py
+- [x] T053 [P] [US5] Write tests for valid InlineCustomProperty and valid CustomPropertyRef passing validation in tests/test_custom_property_types.py
+- [x] T054 [P] [US5] Write tests for CP validation in where position (CustomPropertyRef(0) in Filter) in tests/test_custom_property_types.py
+- [x] T055 [P] [US5] Write tests for CP validation in Metric.property position in tests/test_custom_property_types.py
+- [x] T056 [P] [US5] Write tests for CP validation in funnel group_by and retention where positions in tests/test_custom_property_types.py
+
+### Implementation
+
+- [x] T057 [US5] Update imports in src/mixpanel_data/_internal/validation.py to include CustomPropertyRef, InlineCustomProperty
+- [x] T058 [US5] Add _validate_custom_property() helper with CP1-CP6 rules in src/mixpanel_data/_internal/validation.py
+- [x] T059 [US5] Integrate CP validation into validate_query_args() — scan group_by, where, and Metric.property in src/mixpanel_data/_internal/validation.py
+- [x] T060 [US5] Integrate CP validation into validate_funnel_args() — scan group_by and where in src/mixpanel_data/_internal/validation.py
+- [x] T061 [US5] Integrate CP validation into validate_retention_args() — scan group_by and where in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: All validation tests green. CP1-CP6 enforced across all pipelines.
+
+---
+
+## Phase 8: User Story 6 — Quality Assurance (Priority: P3)
+
+**Goal**: Property-based tests with Hypothesis and mutation testing with mutmut to verify robustness across random inputs.
+
+**Independent Test**: Run PBT suite and mutation testing, verify target scores.
+
+### Implementation
+
+- [x] T062 [P] [US6] Write Hypothesis strategies for valid PropertyInput (non-empty name, valid type, valid resource_type) in tests/test_custom_property_pbt.py
+- [x] T063 [P] [US6] Write Hypothesis strategies for valid input keys (A-Z) and valid inputs dict (1-5 entries) in tests/test_custom_property_pbt.py
+- [x] T064 [P] [US6] Write PBT test: PropertyInput round-trip — all field values survive construction in tests/test_custom_property_pbt.py
+- [x] T065 [P] [US6] Write PBT test: InlineCustomProperty construction preserves formula and inputs in tests/test_custom_property_pbt.py
+- [x] T066 [P] [US6] Write PBT test: _build_composed_properties() output keys match input keys exactly in tests/test_custom_property_pbt.py
+- [x] T067 [P] [US6] Write PBT test: _build_composed_properties() output values have required fields (value, type, resourceType) in tests/test_custom_property_pbt.py
+- [x] T068 [US6] Run just test-pbt to verify all property-based tests pass
+
+**Checkpoint**: PBT suite green across all Hypothesis profiles.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality gates, docstrings, coverage, and mutation testing.
+
+- [x] T069 [P] Verify all docstrings complete with examples on PropertyInput, InlineCustomProperty, CustomPropertyRef in src/mixpanel_data/types.py
+- [x] T070 [P] Verify docstrings on _build_composed_properties() and updated builder functions in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T071 [P] Verify docstrings on _validate_custom_property() in src/mixpanel_data/_internal/validation.py
+- [x] T072 Run just check — all green (ruff format + ruff check + mypy --strict + pytest)
+- [x] T073 Run just test-cov — verify coverage >= 90%
+- [x] T074 Run mutation testing on custom property code — verify mutation score >= 80%
+- [x] T075 Validate quickstart.md code examples execute correctly
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No tasks needed
+- **Foundational (Phase 2)**: No dependencies — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 completion
+- **US2 (Phase 4)**: Depends on Phase 2 completion — **can run in parallel with Phase 3** (different builder branch)
+- **US3 (Phase 5)**: Depends on Phase 2 completion — **can run in parallel with Phases 3-4** (different file: workspace.py)
+- **Combined E2E (Phase 6)**: Depends on Phases 3, 4, and 5
+- **US5 Validation (Phase 7)**: Depends on Phase 6 (validates built params from all positions)
+- **US6 Quality (Phase 8)**: Depends on Phase 2 (tests type construction invariants)  — **can run in parallel with Phases 3-7**
+- **Polish (Phase 9)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US4 (P2)**: Satisfied by Phase 2 (Foundational) — types ARE the feature
+- **US1 (P1)**: Independent after Phase 2 — group_by builder
+- **US2 (P1)**: Independent after Phase 2 — filter builder (parallel with US1)
+- **US3 (P2)**: Independent after Phase 2 — measurement builder (parallel with US1/US2)
+- **US5 (P3)**: Depends on US1/US2/US3 completion (validates all positions)
+- **US6 (P3)**: Independent after Phase 2 — PBT tests on types (parallel with US1/US2/US3)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Builder implementation after tests
+- End-to-end tests verify full pipeline
+
+### Parallel Opportunities
+
+```
+Phase 2 (Foundational)
+    ├── Phase 3 (US1: group_by)  ─┐
+    ├── Phase 4 (US2: filter)    ─┼── All parallel after Phase 2
+    ├── Phase 5 (US3: metric)    ─┤
+    └── Phase 8 (US6: PBT)      ─┘
+                                   │
+                              Phase 6 (Combined E2E) ← needs 3+4+5
+                                   │
+                              Phase 7 (US5: Validation)
+                                   │
+                              Phase 9 (Polish)
+```
+
+---
+
+## Parallel Example: Phases 3-5 (After Foundational)
+
+```bash
+# These can all run in parallel — different files, no dependencies:
+
+# Agent 1: US1 group_by (bookmark_builders.py — build_group_section branch)
+Task: "Write tests + update build_group_section() for custom properties"
+
+# Agent 2: US2 filter (bookmark_builders.py — build_filter_entry branch)
+Task: "Write tests + update build_filter_entry() for custom properties"
+
+# Agent 3: US3 measurement (workspace.py — _build_query_params branch)
+Task: "Write tests + update measurement property builder for custom properties"
+
+# Agent 4: US6 PBT (test_custom_property_pbt.py — independent)
+Task: "Write Hypothesis strategies and property-based tests"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Foundational + US1 Only)
+
+1. Complete Phase 2: Foundational (types + widening + composed properties helper)
+2. Complete Phase 3: US1 (group_by builder)
+3. **STOP and VALIDATE**: Custom property breakdowns work in insights, funnels, retention
+4. This alone delivers significant value — computed breakdowns are the #1 use case
+
+### Incremental Delivery
+
+1. Phase 2 → Types ready (US4 satisfied)
+2. + Phase 3 → Group-by works (US1)
+3. + Phase 4 → Filter works (US2)
+4. + Phase 5 → Measurement works (US3)
+5. + Phase 7 → Validation catches errors (US5)
+6. + Phase 8 → PBT proves robustness (US6)
+7. + Phase 9 → Polish and quality gates
+
+### Parallel Strategy
+
+With multiple agents after Phase 2:
+- Agent A: US1 (group_by) + US2 (filter) — same file, different branches
+- Agent B: US3 (measurement) — different file (workspace.py)
+- Agent C: US6 (PBT) — independent test file
+- Then converge: Combined E2E → Validation → Polish
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent test cases, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US4 is satisfied by Phase 2 (Foundational) — the types ARE the inline formula experience
+- Phases 3, 4, 5 modify different builder branches and can proceed in parallel
+- Phase 8 (PBT) is independent of story implementations — tests type-level invariants
+- Total: 75 tasks (16 foundational, 9 US1, 8 US2, 10 US3, 3 combined, 15 US5, 7 US6, 7 polish) — T025 removed (imports moved to T014), T021b added (FR-015 fallback test)

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -99,6 +99,7 @@ from mixpanel_data.types import (
     CursorPagination,
     CustomAlert,
     CustomProperty,
+    CustomPropertyRef,
     CustomPropertyResourceType,
     DailyCount,
     DailyCountsResult,
@@ -144,6 +145,7 @@ from mixpanel_data.types import (
     GroupBy,
     HoldingConstant,
     InitSchemaEnforcementParams,
+    InlineCustomProperty,
     JQLResult,
     LexiconDefinition,
     LexiconMetadata,
@@ -169,6 +171,7 @@ from mixpanel_data.types import (
     PropertyCoverageResult,
     PropertyDefinition,
     PropertyDistributionResult,
+    PropertyInput,
     PropertyResourceType,
     PropertyValueCount,
     PublicWorkspace,
@@ -325,6 +328,10 @@ __all__ = [
     # Cohort Behaviors (Phase 036)
     "CohortBreakdown",
     "CohortMetric",
+    # Custom Property Query Types (Phase 037)
+    "PropertyInput",
+    "InlineCustomProperty",
+    "CustomPropertyRef",
     # Cohort CRUD (Phase 024)
     "Cohort",
     "CohortCreator",

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -173,6 +173,7 @@ from mixpanel_data.types import (
     PropertyDistributionResult,
     PropertyInput,
     PropertyResourceType,
+    PropertySpec,
     PropertyValueCount,
     PublicWorkspace,
     QueryResult,
@@ -332,6 +333,7 @@ __all__ = [
     "PropertyInput",
     "InlineCustomProperty",
     "CustomPropertyRef",
+    "PropertySpec",
     # Cohort CRUD (Phase 024)
     "Cohort",
     "CohortCreator",

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -193,6 +193,40 @@ def build_filter_section(
     return [build_filter_entry(f) for f in filters_list]
 
 
+def patch_custom_property_filters_for_transform(
+    filter_entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Add ``value`` sentinel to custom property filters for server compat.
+
+    The server's ``transform_insights_filters_to_funnels()`` does a hard
+    ``f["value"]`` access on global ``sections.filter`` entries before
+    ``arb_selector`` processes them.  Custom property filters identify
+    the property via ``customPropertyId`` or ``customProperty`` instead
+    of ``value``, causing a ``KeyError`` and HTTP 500.
+
+    Injecting ``"value": None`` satisfies the hard access.  The
+    downstream ``arb_selector`` routes on ``is_custom_property()``, not
+    ``propertyName``, so the sentinel is harmless.
+
+    This must **not** be applied to per-step or per-metric filters —
+    the insights validator rejects ``value: None`` in those positions.
+
+    Args:
+        filter_entries: List of filter dicts from ``build_filter_section()``.
+
+    Returns:
+        The same list, mutated in-place, with ``"value": None`` added
+        to any entry that has ``customPropertyId`` or ``customProperty``
+        but no ``value`` key.
+    """
+    for entry in filter_entries:
+        if "value" not in entry and (
+            "customPropertyId" in entry or "customProperty" in entry
+        ):
+            entry["value"] = None
+    return filter_entries
+
+
 def build_group_section(
     group_by: str
     | GroupBy

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -15,10 +15,53 @@ from typing import Any
 from mixpanel_data._literal_types import QueryTimeUnit
 from mixpanel_data.types import (
     CohortBreakdown,
+    CustomPropertyRef,
     Filter,
     GroupBy,
+    InlineCustomProperty,
+    PropertyInput,
     _sanitize_raw_cohort,
 )
+
+
+def _build_composed_properties(
+    inputs: dict[str, PropertyInput],
+) -> dict[str, dict[str, str]]:
+    """Convert a PropertyInput mapping to bookmark composedProperties format.
+
+    Transforms the user-facing ``inputs`` dict (letter → PropertyInput)
+    into the JSON structure expected by Mixpanel's ``customProperty``
+    bookmark schema.
+
+    Args:
+        inputs: Mapping from single uppercase letters (A-Z) to
+            ``PropertyInput`` objects.
+
+    Returns:
+        Dict mapping each letter to a dict with ``value``, ``type``,
+        and ``resourceType`` keys.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.bookmark_builders import (
+            _build_composed_properties,
+        )
+        from mixpanel_data.types import PropertyInput
+
+        result = _build_composed_properties({
+            "A": PropertyInput("price", type="number"),
+        })
+        # {"A": {"value": "price", "type": "number", "resourceType": "event"}}
+        ```
+    """
+    return {
+        key: {
+            "value": prop.name,
+            "type": prop.type,
+            "resourceType": prop.resource_type,
+        }
+        for key, prop in inputs.items()
+    }
 
 
 def build_time_section(
@@ -203,13 +246,56 @@ def build_group_section(
                 }
             )
         elif isinstance(g, GroupBy):
-            group_entry: dict[str, Any] = {
-                "value": g.property,
-                "propertyName": g.property,
-                "resourceType": "events",
-                "propertyType": g.property_type,
-                "propertyDefaultType": g.property_type,
-            }
+            prop = g.property
+            if isinstance(prop, CustomPropertyRef):
+                group_entry: dict[str, Any] = {
+                    "customPropertyId": prop.id,
+                    "value": None,
+                    "resourceType": "events",
+                    "profileType": None,
+                    "search": "",
+                    "dataGroupId": None,
+                    "dataset": "$mixpanel",
+                    "propertyType": g.property_type,
+                    "typeCast": None,
+                    "unit": None,
+                    "isHidden": False,
+                }
+            elif isinstance(prop, InlineCustomProperty):
+                effective_type = (
+                    prop.property_type
+                    if prop.property_type is not None
+                    else g.property_type
+                )
+                composed = _build_composed_properties(prop.inputs)
+                group_entry = {
+                    "customProperty": {
+                        "displayFormula": prop.formula,
+                        "composedProperties": composed,
+                        "name": "",
+                        "description": "",
+                        "propertyType": effective_type,
+                        "resourceType": prop.resource_type,
+                    },
+                    "value": None,
+                    "resourceType": prop.resource_type,
+                    "profileType": None,
+                    "search": "",
+                    "dataGroupId": None,
+                    "dataset": "$mixpanel",
+                    "propertyType": effective_type,
+                    "typeCast": None,
+                    "unit": None,
+                    "isHidden": False,
+                }
+            else:
+                group_entry = {
+                    "value": prop,
+                    "propertyName": prop,
+                    "resourceType": "events",
+                    "propertyType": g.property_type,
+                    "propertyDefaultType": g.property_type,
+                }
             if g.bucket_size is not None:
                 group_entry["customBucket"] = {
                     "bucketSize": g.bucket_size,
@@ -308,14 +394,34 @@ def build_filter_entry(f: Filter) -> dict[str, Any]:
         #  "filterValue": ["US"], "filterOperator": "equals"}
         ```
     """
+    prop = f._property
     entry: dict[str, Any] = {
         "resourceType": f._resource_type,
         "filterType": f._property_type,
         "defaultType": f._property_type,
-        "value": f._property,
         "filterValue": f._value,
         "filterOperator": f._operator,
     }
+    if isinstance(prop, CustomPropertyRef):
+        entry["customPropertyId"] = prop.id
+        entry["dataset"] = "$mixpanel"
+    elif isinstance(prop, InlineCustomProperty):
+        effective_type = (
+            prop.property_type if prop.property_type is not None else f._property_type
+        )
+        entry["customProperty"] = {
+            "displayFormula": prop.formula,
+            "composedProperties": _build_composed_properties(prop.inputs),
+            "name": "",
+            "description": "",
+            "propertyType": effective_type,
+            "resourceType": prop.resource_type,
+        }
+        entry["filterType"] = effective_type
+        entry["defaultType"] = effective_type
+        entry["dataset"] = "$mixpanel"
+    else:
+        entry["value"] = prop
     if f._date_unit is not None:
         entry["filterDateUnit"] = f._date_unit
     return entry

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -418,7 +418,12 @@ def build_filter_entry(f: Filter) -> dict[str, Any]:
     Returns:
         Bookmark filter dict with keys: ``resourceType``, ``filterType``,
         ``defaultType``, ``value``, ``filterValue``, ``filterOperator``,
-        and optionally ``filterDateUnit``.
+        and optionally ``filterDateUnit``.  For ``CustomPropertyRef``
+        properties the dict also contains ``customPropertyId`` and
+        ``dataset``.  For ``InlineCustomProperty`` properties it contains
+        ``customProperty`` (nested definition) and ``dataset``, and the
+        ``filterType``/``defaultType`` are overridden from the inline
+        property's ``property_type``.
 
     Example:
         ```python
@@ -454,6 +459,7 @@ def build_filter_entry(f: Filter) -> dict[str, Any]:
         entry["filterType"] = effective_type
         entry["defaultType"] = effective_type
         entry["dataset"] = "$mixpanel"
+        entry["resourceType"] = prop.resource_type
     else:
         entry["value"] = prop
     if f._date_unit is not None:

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -52,15 +52,172 @@ from mixpanel_data.types import (
     CohortBreakdown,
     CohortDefinition,
     CohortMetric,
+    CustomPropertyRef,
     Exclusion,
+    Filter,
     Formula,
     FunnelStep,
     GroupBy,
     HoldingConstant,
+    InlineCustomProperty,
     MathType,
     Metric,
     PerUserAggregation,
 )
+
+_CP_INPUT_KEY_RE = re.compile(r"^[A-Z]$")
+_CP_MAX_FORMULA_LENGTH = 20_000
+
+
+def _validate_custom_property(
+    prop: CustomPropertyRef | InlineCustomProperty,
+    path: str,
+) -> list[ValidationError]:
+    """Validate a custom property specification (rules CP1-CP6).
+
+    Args:
+        prop: A ``CustomPropertyRef`` or ``InlineCustomProperty`` to validate.
+        path: JSONPath-like location for error reporting.
+
+    Returns:
+        List of validation errors. Empty list means the property is valid.
+    """
+    errors: list[ValidationError] = []
+
+    if isinstance(prop, CustomPropertyRef):
+        # CP1: id must be a positive integer
+        if prop.id <= 0:
+            errors.append(
+                ValidationError(
+                    path=path,
+                    message=(
+                        f"custom property ID must be a positive integer (got {prop.id})"
+                    ),
+                    code="CP1_INVALID_ID",
+                )
+            )
+    elif isinstance(prop, InlineCustomProperty):
+        # CP2: formula must be non-empty
+        if not prop.formula.strip():
+            errors.append(
+                ValidationError(
+                    path=path,
+                    message="inline custom property formula must be non-empty",
+                    code="CP2_EMPTY_FORMULA",
+                )
+            )
+
+        # CP3: inputs must have at least one entry
+        if len(prop.inputs) == 0:
+            errors.append(
+                ValidationError(
+                    path=path,
+                    message=("inline custom property must have at least one input"),
+                    code="CP3_EMPTY_INPUTS",
+                )
+            )
+
+        # CP4: input keys must be single uppercase letters A-Z
+        for key in prop.inputs:
+            if not _CP_INPUT_KEY_RE.match(key):
+                errors.append(
+                    ValidationError(
+                        path=path,
+                        message=(
+                            f"inline custom property input keys must be "
+                            f"single uppercase letters (A-Z), got {key!r}"
+                        ),
+                        code="CP4_INVALID_INPUT_KEY",
+                    )
+                )
+
+        # CP5: formula must not exceed max length
+        if len(prop.formula) > _CP_MAX_FORMULA_LENGTH:
+            errors.append(
+                ValidationError(
+                    path=path,
+                    message=(
+                        f"inline custom property formula exceeds maximum "
+                        f"length of 20,000 characters (got {len(prop.formula)})"
+                    ),
+                    code="CP5_FORMULA_TOO_LONG",
+                )
+            )
+
+        # CP6: each PropertyInput.name must be non-empty
+        for key, pi in prop.inputs.items():
+            if not pi.name.strip():
+                errors.append(
+                    ValidationError(
+                        path=path,
+                        message=(
+                            f"inline custom property input {key!r} has an "
+                            f"empty property name"
+                        ),
+                        code="CP6_EMPTY_INPUT_NAME",
+                    )
+                )
+
+    return errors
+
+
+def _scan_custom_properties(
+    *,
+    group_by: str
+    | GroupBy
+    | CohortBreakdown
+    | list[str | GroupBy | CohortBreakdown]
+    | None = None,
+    where: Filter | list[Filter] | None = None,
+    events: Sequence[str | Metric | CohortMetric] | None = None,
+) -> list[ValidationError]:
+    """Scan group_by, where, and events for custom properties and validate.
+
+    Collects all ``CustomPropertyRef`` and ``InlineCustomProperty`` values
+    from the three positions (group_by, filter, measurement) and runs
+    ``_validate_custom_property()`` on each.
+
+    Args:
+        group_by: Breakdown specification (may contain custom properties).
+        where: Filter specification (may contain custom properties).
+        events: Event specifications (Metric.property may contain
+            custom properties).
+
+    Returns:
+        List of validation errors. Empty list means all custom
+        properties are valid.
+    """
+    errors: list[ValidationError] = []
+
+    # Scan group_by
+    if group_by is not None:
+        groups = group_by if isinstance(group_by, list) else [group_by]
+        for i, g in enumerate(groups):
+            if isinstance(g, GroupBy) and isinstance(
+                g.property, (CustomPropertyRef, InlineCustomProperty)
+            ):
+                gpath = f"group_by[{i}]" if len(groups) > 1 else "group_by"
+                errors.extend(_validate_custom_property(g.property, gpath))
+
+    # Scan where (filters)
+    if where is not None:
+        filters = where if isinstance(where, list) else [where]
+        for i, f in enumerate(filters):
+            if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
+                fpath = f"where[{i}]" if len(filters) > 1 else "where"
+                errors.extend(_validate_custom_property(f._property, fpath))
+
+    # Scan events (Metric.property)
+    if events is not None:
+        for idx, item in enumerate(events):
+            if isinstance(item, Metric) and isinstance(
+                item.property, (CustomPropertyRef, InlineCustomProperty)
+            ):
+                epath = f"events[{idx}]"
+                errors.extend(_validate_custom_property(item.property, epath))
+
+    return errors
+
 
 _SESSION_MATH: frozenset[str] = frozenset({"conversion_rate_session"})
 """Session-based math types requiring conversion_window_unit='session'."""
@@ -811,6 +968,9 @@ def validate_funnel_args(
     # F6: GroupBy validation (delegated)
     errors.extend(validate_group_by_args(group_by=group_by))
 
+    # CP1-CP6: Custom property validation
+    errors.extend(_scan_custom_properties(group_by=group_by))
+
     return errors
 
 
@@ -1098,6 +1258,9 @@ def validate_retention_args(
                     code="CB3_RETENTION_MIXED_BREAKDOWN",
                 )
             )
+
+    # CP1-CP6: Custom property validation
+    errors.extend(_scan_custom_properties(group_by=group_by))
 
     return errors
 
@@ -1773,6 +1936,15 @@ def validate_query_args(
     # V11-V12, V18, V24: GroupBy validation (delegated)
     errors.extend(validate_group_by_args(group_by=group_by))
 
+    # CP1-CP6: Custom property validation
+    errors.extend(
+        _scan_custom_properties(
+            group_by=group_by,
+            where=None,
+            events=events,
+        )
+    )
+
     # V13-V14: Per-Metric validation
     for idx, item in enumerate(events):
         if isinstance(item, Metric):
@@ -2378,8 +2550,14 @@ def _validate_filter_clause(
         )
         return errors
 
-    # B18: Must have property identification
-    if not clause.get("value") and not clause.get("propertyName"):
+    # B18: Must have property identification (value/propertyName or custom property)
+    has_property_id = (
+        clause.get("value")
+        or clause.get("propertyName")
+        or clause.get("customPropertyId") is not None
+        or clause.get("customProperty") is not None
+    )
+    if not has_property_id:
         errors.append(
             ValidationError(
                 path=path,

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -81,6 +81,10 @@ def _validate_custom_property(
 
     Returns:
         List of validation errors. Empty list means the property is valid.
+
+    Raises:
+        This function does not raise exceptions. Validation failures are
+        returned as ``ValidationError`` objects in the result list.
     """
     errors: list[ValidationError] = []
 

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -177,6 +177,12 @@ def _scan_custom_properties(
     from the three positions (group_by, filter, measurement) and runs
     ``_validate_custom_property()`` on each.
 
+    Note:
+        ``where`` filters are validated separately at the workspace level
+        (``workspace.py`` calls ``_scan_custom_properties(where=where)``)
+        because ``validate_query_args`` / ``validate_funnel_args`` /
+        ``validate_retention_args`` do not receive the ``where`` parameter.
+
     Args:
         group_by: Breakdown specification (may contain custom properties).
         where: Filter specification (may contain custom properties).
@@ -208,6 +214,11 @@ def _scan_custom_properties(
                 errors.extend(_validate_custom_property(f._property, fpath))
 
     # Scan events (Metric.property)
+    # TODO: Also scan Metric.filters and FunnelStep.filters for custom
+    # properties.  Currently only Metric.property is checked; custom
+    # properties inside per-metric or per-step filters bypass CP1-CP6
+    # validation (documented in tests/live/test_custom_property_queries_live.py
+    # TestValidationGaps).
     if events is not None:
         for idx, item in enumerate(events):
             if isinstance(item, Metric) and isinstance(
@@ -2554,14 +2565,18 @@ def _validate_filter_clause(
     has_property_id = (
         clause.get("value")
         or clause.get("propertyName")
-        or clause.get("customPropertyId") is not None
-        or clause.get("customProperty") is not None
+        or (clause.get("customPropertyId") is not None)
+        or (clause.get("customProperty") is not None)
     )
     if not has_property_id:
         errors.append(
             ValidationError(
                 path=path,
-                message="Filter missing property identifier ('value' or 'propertyName')",
+                message=(
+                    "Filter missing property identifier "
+                    "('value', 'propertyName', 'customPropertyId', "
+                    "or 'customProperty')"
+                ),
                 code="B18_MISSING_FILTER_PROPERTY",
             )
         )

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -6906,6 +6906,171 @@ class ProfilePageResult:
 
 
 # =============================================================================
+# Custom Property Query Types (Phase 037)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PropertyInput:
+    """A raw property reference mapping a formula variable to a named property.
+
+    Used as an entry in :attr:`InlineCustomProperty.inputs` to bind a
+    formula variable (A-Z) to a concrete Mixpanel event or user property.
+
+    Attributes:
+        name: The raw property name (e.g., ``"price"``, ``"$browser"``).
+        type: Property data type. Default: ``"string"``.
+        resource_type: Property domain — ``"event"`` or ``"user"``.
+            Uses singular form to match Mixpanel's ``composedProperties``
+            schema. Default: ``"event"``.
+
+    Example:
+        ```python
+        from mixpanel_data import PropertyInput
+
+        pi = PropertyInput("price", type="number")
+        pi_user = PropertyInput("email", resource_type="user")
+        ```
+    """
+
+    name: str
+    """The raw property name."""
+
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    """Property data type."""
+
+    resource_type: Literal["event", "user"] = "event"
+    """Property domain (singular form for composedProperties schema)."""
+
+
+@dataclass(frozen=True)
+class InlineCustomProperty:
+    """An ephemeral computed property defined by a formula and input references.
+
+    Defines a custom property inline at query time without persisting it
+    to Mixpanel. The formula uses variables (A-Z) that map to concrete
+    properties via the ``inputs`` dict.
+
+    Can be used in ``GroupBy.property``, ``Filter`` class methods, and
+    ``Metric.property`` to compute derived values on the fly.
+
+    Attributes:
+        formula: Expression in Mixpanel's formula language (max 20,000 chars).
+        inputs: Mapping from single uppercase letters (A-Z) to property
+            references.
+        property_type: Result type of the formula. ``None`` defers to
+            the containing type (e.g., ``GroupBy.property_type``).
+            Default: ``None``.
+        resource_type: Data domain — ``"events"`` or ``"people"``.
+            Uses plural form to match Mixpanel's top-level
+            ``customProperty`` schema. Default: ``"events"``.
+
+    Example:
+        ```python
+        from mixpanel_data import InlineCustomProperty, PropertyInput
+
+        # Explicit construction
+        icp = InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+        )
+
+        # Convenience constructor for all-numeric inputs
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        ```
+    """
+
+    formula: str
+    """Expression in Mixpanel's formula language."""
+
+    inputs: dict[str, PropertyInput]
+    """Mapping from single uppercase letters (A-Z) to property references."""
+
+    property_type: Literal["string", "number", "boolean", "datetime"] | None = None
+    """Result type of the formula; None defers to containing type."""
+
+    resource_type: Literal["events", "people"] = "events"
+    """Data domain (plural form for top-level customProperty schema)."""
+
+    @classmethod
+    def numeric(
+        cls,
+        formula: str,
+        /,
+        **properties: str,
+    ) -> InlineCustomProperty:
+        """Create an all-numeric-input inline custom property.
+
+        Convenience constructor that creates ``PropertyInput`` entries
+        with ``type="number"`` and ``resource_type="event"`` for each
+        keyword argument, and sets ``property_type="number"``.
+
+        Args:
+            formula: Expression in Mixpanel's formula language.
+            **properties: Mapping of variable letters to property names.
+                Each key becomes an input key, each value becomes the
+                property name.
+
+        Returns:
+            InlineCustomProperty with all-numeric inputs and
+            ``property_type="number"``.
+
+        Example:
+            ```python
+            # Revenue = price * quantity
+            icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+            assert icp.inputs["A"].type == "number"
+            assert icp.property_type == "number"
+            ```
+        """
+        inputs = {
+            key: PropertyInput(name=value, type="number")
+            for key, value in properties.items()
+        }
+        return cls(
+            formula=formula,
+            inputs=inputs,
+            property_type="number",
+        )
+
+
+@dataclass(frozen=True)
+class CustomPropertyRef:
+    """A reference to a persisted custom property by its integer ID.
+
+    Used in ``GroupBy.property``, ``Filter`` class methods, and
+    ``Metric.property`` to reference a custom property that was
+    previously created and saved in Mixpanel.
+
+    Attributes:
+        id: The custom property's server-assigned ID (must be positive).
+
+    Example:
+        ```python
+        from mixpanel_data import CustomPropertyRef, GroupBy
+
+        ref = CustomPropertyRef(42)
+        g = GroupBy(property=ref, property_type="number")
+        ```
+    """
+
+    id: int
+    """The custom property's server-assigned ID."""
+
+
+PropertySpec = str | CustomPropertyRef | InlineCustomProperty
+"""Union type for property specifications in query parameters.
+
+Accepted wherever a property can be specified: ``Metric.property``,
+``GroupBy.property``, and ``Filter`` class method ``property`` parameters.
+"""
+
+
+# =============================================================================
 # Query API Types (Phase 029)
 # =============================================================================
 
@@ -6948,8 +7113,8 @@ class Metric:
     math: MathType = "total"
     """Aggregation function."""
 
-    property: str | None = None
-    """Property name for property-based math types."""
+    property: str | CustomPropertyRef | InlineCustomProperty | None = None
+    """Property for property-based math types (name, ref, or inline)."""
 
     per_user: PerUserAggregation | None = None
     """Per-user pre-aggregation type."""
@@ -7030,8 +7195,8 @@ class Filter:
         ```
     """
 
-    _property: str
-    """Property name to filter on."""
+    _property: str | CustomPropertyRef | InlineCustomProperty
+    """Property to filter on (name, ref, or inline)."""
 
     _operator: str
     """Internal operator string."""
@@ -7064,7 +7229,7 @@ class Filter:
     @classmethod
     def equals(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: str | list[str],
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7091,7 +7256,7 @@ class Filter:
     @classmethod
     def not_equals(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: str | list[str],
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7118,7 +7283,7 @@ class Filter:
     @classmethod
     def contains(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7144,7 +7309,7 @@ class Filter:
     @classmethod
     def not_contains(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7170,7 +7335,7 @@ class Filter:
     @classmethod
     def greater_than(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: int | float,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7196,7 +7361,7 @@ class Filter:
     @classmethod
     def less_than(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         value: int | float,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7222,7 +7387,7 @@ class Filter:
     @classmethod
     def between(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         min_val: int | float,
         max_val: int | float,
         *,
@@ -7250,7 +7415,7 @@ class Filter:
     @classmethod
     def is_set(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         *,
         resource_type: Literal["events", "people"] = "events",
     ) -> Filter:
@@ -7274,7 +7439,7 @@ class Filter:
     @classmethod
     def is_not_set(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         *,
         resource_type: Literal["events", "people"] = "events",
     ) -> Filter:
@@ -7298,7 +7463,7 @@ class Filter:
     @classmethod
     def is_true(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         *,
         resource_type: Literal["events", "people"] = "events",
     ) -> Filter:
@@ -7322,7 +7487,7 @@ class Filter:
     @classmethod
     def is_false(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         *,
         resource_type: Literal["events", "people"] = "events",
     ) -> Filter:
@@ -7485,7 +7650,7 @@ class Filter:
     @classmethod
     def on(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         date: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7515,7 +7680,7 @@ class Filter:
     @classmethod
     def not_on(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         date: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7545,7 +7710,7 @@ class Filter:
     @classmethod
     def before(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         date: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7575,7 +7740,7 @@ class Filter:
     @classmethod
     def since(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         date: str,
         *,
         resource_type: Literal["events", "people"] = "events",
@@ -7605,7 +7770,7 @@ class Filter:
     @classmethod
     def in_the_last(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         quantity: int,
         date_unit: FilterDateUnit,
         *,
@@ -7640,7 +7805,7 @@ class Filter:
     @classmethod
     def not_in_the_last(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         quantity: int,
         date_unit: FilterDateUnit,
         *,
@@ -7675,7 +7840,7 @@ class Filter:
     @classmethod
     def date_between(
         cls,
-        property: str,
+        property: str | CustomPropertyRef | InlineCustomProperty,
         from_date: str,
         to_date: str,
         *,
@@ -7744,8 +7909,8 @@ class GroupBy:
         ```
     """
 
-    property: str
-    """Property name to break down by."""
+    property: str | CustomPropertyRef | InlineCustomProperty
+    """Property to break down by (name, ref, or inline)."""
 
     property_type: Literal["string", "number", "boolean", "datetime"] = "string"
     """Data type of the property."""

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7086,7 +7086,7 @@ class Metric:
     Attributes:
         event: Mixpanel event name.
         math: Aggregation function. Default: ``"total"``.
-        property: Property name for property-based math (average, sum, etc.).
+        property: Property for property-based math types (name, ref, or inline).
         per_user: Per-user pre-aggregation (average, total, min, max).
         filters: Per-metric filters (applied in addition to global ``where``).
         filters_combinator: How per-metric filters combine.
@@ -7237,7 +7237,7 @@ class Filter:
         """Create an equality filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Value or list of values.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7264,7 +7264,7 @@ class Filter:
         """Create a not-equals filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Value or list of values.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7291,7 +7291,7 @@ class Filter:
         """Create a contains (substring) filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Substring to match.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7317,7 +7317,7 @@ class Filter:
         """Create a not-contains filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Substring that must not match.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7343,7 +7343,7 @@ class Filter:
         """Create a greater-than filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Numeric threshold.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7369,7 +7369,7 @@ class Filter:
         """Create a less-than filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             value: Numeric threshold.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7396,7 +7396,7 @@ class Filter:
         """Create a between (inclusive range) filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             min_val: Minimum value (inclusive).
             max_val: Maximum value (inclusive).
             resource_type: Resource type. Default: ``"events"``.
@@ -7422,7 +7422,7 @@ class Filter:
         """Create a property-existence filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             resource_type: Resource type. Default: ``"events"``.
 
         Returns:
@@ -7446,7 +7446,7 @@ class Filter:
         """Create a property-nonexistence filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             resource_type: Resource type. Default: ``"events"``.
 
         Returns:
@@ -7470,7 +7470,7 @@ class Filter:
         """Create a boolean true filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             resource_type: Resource type. Default: ``"events"``.
 
         Returns:
@@ -7494,7 +7494,7 @@ class Filter:
         """Create a boolean false filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             resource_type: Resource type. Default: ``"events"``.
 
         Returns:
@@ -7658,7 +7658,7 @@ class Filter:
         """Create a date equality filter (exact date match).
 
         Args:
-            property: Property name (e.g. ``"$time"``, ``"created"``).
+            property: Property name, CustomPropertyRef, or InlineCustomProperty (e.g. ``"$time"``, ``"created"``).
             date: Date in YYYY-MM-DD format.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7688,7 +7688,7 @@ class Filter:
         """Create a date inequality filter (not on date).
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             date: Date in YYYY-MM-DD format.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7718,7 +7718,7 @@ class Filter:
         """Create a date before filter.
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             date: Date in YYYY-MM-DD format.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7748,7 +7748,7 @@ class Filter:
         """Create a date since filter (from date onward).
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             date: Date in YYYY-MM-DD format.
             resource_type: Resource type. Default: ``"events"``.
 
@@ -7779,7 +7779,7 @@ class Filter:
         """Create a relative date filter (in the last N units).
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             quantity: Number of time units (must be positive).
             date_unit: Time unit (``"hour"``, ``"day"``, ``"week"``,
                 ``"month"``).
@@ -7814,7 +7814,7 @@ class Filter:
         """Create a relative date exclusion filter (not in the last N units).
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             quantity: Number of time units (must be positive).
             date_unit: Time unit (``"hour"``, ``"day"``, ``"week"``,
                 ``"month"``).
@@ -7849,7 +7849,7 @@ class Filter:
         """Create a date range filter (between two dates, inclusive).
 
         Args:
-            property: Property name.
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
             from_date: Start date in YYYY-MM-DD format.
             to_date: End date in YYYY-MM-DD format.
             resource_type: Resource type. Default: ``"events"``.
@@ -7885,7 +7885,7 @@ class GroupBy:
     can be bucketed into ranges.
 
     Attributes:
-        property: Property name to break down by.
+        property: Property to break down by (name, ref, or inline).
         property_type: Data type of the property. Default: ``"string"``.
         bucket_size: Bucket width for numeric properties.
         bucket_min: Minimum value for numeric buckets.

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -6764,6 +6764,8 @@ class Workspace:
         Raises:
             ConfigError: If credentials are not available.
             AuthenticationError: Invalid credentials (401).
+            QueryError: Server-side data corruption (e.g. invalid
+                ``displayFormula`` on a custom property).
             ServerError: Server-side errors (5xx).
 
         Example:
@@ -6780,7 +6782,7 @@ class Workspace:
         except QueryError as exc:
             # Detect server-side data corruption: the API fails to serialize
             # when a custom property has an invalid displayFormula.
-            details = exc.details if hasattr(exc, "details") else {}
+            details = exc.details if isinstance(exc.details, dict) else {}
             body = details.get("response_body", {}) if isinstance(details, dict) else {}
             if isinstance(body, dict) and body.get("field") == "displayFormula":
                 raise QueryError(
@@ -6788,7 +6790,12 @@ class Workspace:
                     "custom property with an invalid displayFormula "
                     "(server-side data corruption). Use "
                     "get_custom_property(id) to retrieve individual "
-                    "properties, or contact Mixpanel support."
+                    "properties, or contact Mixpanel support.",
+                    status_code=exc.status_code,
+                    response_body=exc.response_body,
+                    request_method=exc.request_method,
+                    request_url=exc.request_url,
+                    request_params=exc.request_params,
                 ) from exc
             raise
         return [CustomProperty.model_validate(x) for x in raw_list]

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -47,6 +47,7 @@ from mixpanel_data._internal.services.discovery import DiscoveryService
 from mixpanel_data._internal.services.live_query import LiveQueryService
 from mixpanel_data._internal.transforms import transform_event, transform_profile
 from mixpanel_data._internal.validation import (
+    _scan_custom_properties,
     contains_control_chars,
     validate_bookmark,
     validate_flow_args,
@@ -60,6 +61,7 @@ from mixpanel_data.exceptions import (
     BookmarkValidationError,
     ConfigError,
     MixpanelDataError,
+    QueryError,
     ValidationError,
 )
 from mixpanel_data.types import (
@@ -105,6 +107,7 @@ from mixpanel_data.types import (
     CreateWebhookParams,
     CustomAlert,
     CustomProperty,
+    CustomPropertyRef,
     DailyCountsResult,
     Dashboard,
     DataVolumeAnomaly,
@@ -138,6 +141,7 @@ from mixpanel_data.types import (
     GroupBy,
     HoldingConstant,
     InitSchemaEnforcementParams,
+    InlineCustomProperty,
     JQLResult,
     LexiconSchema,
     LexiconTag,
@@ -1768,10 +1772,40 @@ class Workspace:
 
             measurement: dict[str, Any] = {"math": bookmark_math}
             if item_prop is not None:
-                measurement["property"] = {
-                    "name": item_prop,
-                    "resourceType": "events",
-                }
+                if isinstance(item_prop, CustomPropertyRef):
+                    measurement["property"] = {
+                        "customPropertyId": item_prop.id,
+                        "name": "",
+                        "resourceType": "events",
+                    }
+                elif isinstance(item_prop, InlineCustomProperty):
+                    from mixpanel_data._internal.bookmark_builders import (
+                        _build_composed_properties,
+                    )
+
+                    cp_dict: dict[str, Any] = {
+                        "displayFormula": item_prop.formula,
+                        "composedProperties": _build_composed_properties(
+                            item_prop.inputs
+                        ),
+                        "name": "",
+                        "description": "",
+                        "resourceType": item_prop.resource_type,
+                    }
+                    if item_prop.property_type is not None:
+                        cp_dict["propertyType"] = item_prop.property_type
+                    measurement["property"] = {
+                        "customProperty": cp_dict,
+                        "name": "",
+                        "resourceType": item_prop.resource_type,
+                        "dataset": "$mixpanel",
+                        "dataGroupId": None,
+                    }
+                else:
+                    measurement["property"] = {
+                        "name": item_prop,
+                        "resourceType": "events",
+                    }
             if item_per_user is not None:
                 measurement["perUserAggregation"] = item_per_user
             if item_percentile is not None:
@@ -2258,6 +2292,8 @@ class Workspace:
             group_by=group_by,
             formulas=resolved_formulas,
         )
+        # CP1-CP6: Custom property validation for where filters
+        arg_errors.extend(_scan_custom_properties(where=where))
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 
@@ -2542,6 +2578,8 @@ class Workspace:
             last=last,
             group_by=group_by,
         )
+        # CP1-CP6: Custom property validation for where filters
+        arg_errors.extend(_scan_custom_properties(where=where))
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 
@@ -3164,7 +3202,9 @@ class Workspace:
         for i, s in enumerate(steps):
             if s.filters:
                 for fi, f in enumerate(s.filters):
-                    if contains_control_chars(f._property):
+                    if isinstance(f._property, str) and contains_control_chars(
+                        f._property
+                    ):
                         step_errors.append(
                             ValidationError(
                                 path=f"steps[{i}].filters[{fi}]",
@@ -3527,6 +3567,8 @@ class Workspace:
             last=last,
             group_by=group_by,
         )
+        # CP1-CP6: Custom property validation for where filters
+        arg_errors.extend(_scan_custom_properties(where=where))
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 
@@ -6728,7 +6770,22 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        raw_list = client.list_custom_properties()
+        try:
+            raw_list = client.list_custom_properties()
+        except QueryError as exc:
+            # Detect server-side data corruption: the API fails to serialize
+            # when a custom property has an invalid displayFormula.
+            details = exc.details if hasattr(exc, "details") else {}
+            body = details.get("response_body", {}) if isinstance(details, dict) else {}
+            if isinstance(body, dict) and body.get("field") == "displayFormula":
+                raise QueryError(
+                    "list_custom_properties() failed: the project contains a "
+                    "custom property with an invalid displayFormula "
+                    "(server-side data corruption). Use "
+                    "get_custom_property(id) to retrieve individual "
+                    "properties, or contact Mixpanel support."
+                ) from exc
+            raise
         return [CustomProperty.model_validate(x) for x in raw_list]
 
     def create_custom_property(

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -34,6 +34,7 @@ from typing import Any, Literal
 
 from mixpanel_data._internal.api_client import MixpanelAPIClient
 from mixpanel_data._internal.bookmark_builders import (
+    _build_composed_properties,
     build_date_range,
     build_filter_entry,
     build_filter_section,
@@ -1780,10 +1781,6 @@ class Workspace:
                         "resourceType": "events",
                     }
                 elif isinstance(item_prop, InlineCustomProperty):
-                    from mixpanel_data._internal.bookmark_builders import (
-                        _build_composed_properties,
-                    )
-
                     cp_dict: dict[str, Any] = {
                         "displayFormula": item_prop.formula,
                         "composedProperties": _build_composed_properties(

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -40,6 +40,7 @@ from mixpanel_data._internal.bookmark_builders import (
     build_flow_cohort_filter,
     build_group_section,
     build_time_section,
+    patch_custom_property_filters_for_transform,
 )
 from mixpanel_data._internal.config import ConfigManager, Credentials
 from mixpanel_data._internal.segfilter import build_segfilter_entry
@@ -2465,7 +2466,9 @@ class Workspace:
             last=last,
             unit=unit,
         )
-        filter_section = build_filter_section(where)
+        filter_section = patch_custom_property_filters_for_transform(
+            build_filter_section(where)
+        )
         group_section = build_group_section(group_by)
 
         # Chart type mapping
@@ -2931,7 +2934,9 @@ class Workspace:
             last=last,
             unit=unit,
         )
-        filter_section = build_filter_section(where)
+        filter_section = patch_custom_property_filters_for_transform(
+            build_filter_section(where)
+        )
         group_section = build_group_section(group_by)
 
         # Chart type mapping

--- a/tests/live/test_custom_property_queries_live.py
+++ b/tests/live/test_custom_property_queries_live.py
@@ -535,12 +535,6 @@ class TestCustomPropertyFunnels:
         )
         assert isinstance(result, FunnelQueryResult)
 
-    @pytest.mark.xfail(
-        reason="Server bug: transform_insights_filters_to_funnels() crashes on f['value'] "
-        "(analytics/bookmark_parser/common/transforms/util.py:1459,1484) "
-        "when filter uses customProperty instead of value key",
-        raises=Exception,
-    )
     def test_funnel_where_inline_cp(
         self,
         ws: Workspace,
@@ -617,12 +611,6 @@ class TestCustomPropertyRetention:
         )
         assert isinstance(result, RetentionQueryResult)
 
-    @pytest.mark.xfail(
-        reason="Server bug: transform_insights_filters_to_funnels() crashes on f['value'] "
-        "(analytics/bookmark_parser/common/transforms/util.py:1459,1484) "
-        "when filter uses customProperty instead of value key",
-        raises=Exception,
-    )
     def test_retention_where_inline_cp(
         self,
         ws: Workspace,
@@ -659,11 +647,6 @@ class TestCustomPropertyRetention:
         )
         assert isinstance(result, RetentionQueryResult)
 
-    @pytest.mark.xfail(
-        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459 "
-        "crashes on f['value'] for CustomPropertyRef filters too",
-        raises=Exception,
-    )
     def test_retention_where_ref(
         self,
         ws: Workspace,
@@ -1122,10 +1105,6 @@ class TestCrossEngine:
         )
         assert isinstance(result, QueryResult)
 
-    @pytest.mark.xfail(
-        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459",
-        raises=Exception,
-    )
     def test_funnel_inline_cp_groupby_and_where(
         self,
         ws: Workspace,
@@ -1142,10 +1121,6 @@ class TestCrossEngine:
         )
         assert isinstance(result, FunnelQueryResult)
 
-    @pytest.mark.xfail(
-        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459",
-        raises=Exception,
-    )
     def test_retention_inline_cp_groupby_and_where(
         self,
         ws: Workspace,

--- a/tests/live/test_custom_property_queries_live.py
+++ b/tests/live/test_custom_property_queries_live.py
@@ -1,0 +1,1316 @@
+"""Live QA tests for custom properties in queries (Phase 037).
+
+Exercises PropertyInput, InlineCustomProperty, and CustomPropertyRef
+across all 3 positions (group_by, filter, measurement) and all 3 engines
+(insights, funnels, retention) against the real Mixpanel API on account
+``p8`` (project ID 8).
+
+Usage:
+    uv run pytest tests/live/test_custom_property_queries_live.py -m live -v
+    uv run pytest tests/live/test_custom_property_queries_live.py -m live -v -k "GroupBy"
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mixpanel_data import (
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    Metric,
+    PropertyInput,
+    QueryResult,
+    Workspace,
+)
+from mixpanel_data._internal.bookmark_builders import _build_composed_properties
+from mixpanel_data.exceptions import BookmarkValidationError
+from mixpanel_data.types import (
+    CustomProperty,
+    FunnelQueryResult,
+    FunnelStep,
+    RetentionQueryResult,
+)
+
+pytestmark = pytest.mark.live
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def ws() -> Workspace:
+    """Create Workspace with ecommerce-demo credentials.
+
+    Returns:
+        Workspace connected to ecommerce-demo, workspace 3536632.
+    """
+    return Workspace(account="ecommerce-demo", workspace_id=3536632)
+
+
+@pytest.fixture(scope="module")
+def real_event(ws: Workspace) -> str:
+    """Discover a real event name.
+
+    Returns:
+        First available event name.
+    """
+    events = ws.events()
+    assert len(events) > 0, "No events found"
+    return events[0]
+
+
+@pytest.fixture(scope="module")
+def real_events_pair(ws: Workspace) -> tuple[str, str]:
+    """Discover two real event names for funnel/retention tests.
+
+    Returns:
+        Tuple of two distinct event names.
+    """
+    events = ws.events()
+    assert len(events) >= 2, "Need at least 2 events for funnels/retention"
+    return events[0], events[1]
+
+
+@pytest.fixture(scope="module")
+def real_numeric_property(ws: Workspace, real_event: str) -> str:
+    """Discover a numeric property.
+
+    Returns:
+        A numeric property name.
+    """
+    candidates = ["$screen_width", "$screen_height", "mp_processing_time_ms"]
+    props = ws.properties(real_event)
+    prop_set = set(props)
+    for c in candidates:
+        if c in prop_set:
+            return c
+    if props:
+        return props[0]
+    pytest.skip("No properties found")
+
+
+@pytest.fixture(scope="module")
+def real_string_property(ws: Workspace, real_event: str) -> str:
+    """Discover a string property.
+
+    Returns:
+        A string property name.
+    """
+    props = ws.properties(real_event)
+    if "$browser" in props:
+        return "$browser"
+    for p in props:
+        if not p.startswith("$"):
+            return p
+    return props[0] if props else "$browser"
+
+
+@pytest.fixture(scope="module")
+def saved_custom_properties(ws: Workspace) -> list[CustomProperty]:
+    """Discover saved custom properties.
+
+    Returns:
+        List of CustomProperty objects.
+    """
+    return ws.list_custom_properties()
+
+
+@pytest.fixture(scope="module")
+def saved_cp_id(saved_custom_properties: list[CustomProperty]) -> int:
+    """Get the first events-scoped saved custom property ID.
+
+    Returns:
+        Custom property ID.
+    """
+    for cp in saved_custom_properties:
+        if cp.resource_type in ("events", "event"):
+            return cp.custom_property_id
+    pytest.skip("No events-scoped saved custom properties found")
+
+
+@pytest.fixture(scope="module")
+def saved_cp_type(saved_custom_properties: list[CustomProperty]) -> str:
+    """Get the property_type of the first events-scoped saved custom property.
+
+    Returns:
+        Property type string (e.g., "number", "string").
+    """
+    for cp in saved_custom_properties:
+        if cp.resource_type in ("events", "event"):
+            return cp.property_type or "string"
+    return "string"
+
+
+@pytest.fixture(scope="module")
+def simple_inline_cp(real_numeric_property: str) -> InlineCustomProperty:
+    """Build a known-good inline custom property with numeric identity formula.
+
+    Returns:
+        InlineCustomProperty.numeric("A", A=real_numeric_property).
+    """
+    return InlineCustomProperty.numeric("A", A=real_numeric_property)
+
+
+@pytest.fixture(scope="module")
+def string_inline_cp(real_string_property: str) -> InlineCustomProperty:
+    """Build a string inline custom property with identity formula.
+
+    Returns:
+        InlineCustomProperty with string input.
+    """
+    return InlineCustomProperty(
+        formula="A",
+        inputs={"A": PropertyInput(real_string_property)},
+    )
+
+
+# =============================================================================
+# Discovery
+# =============================================================================
+
+
+class TestDiscovery:
+    """Verify project 8 has the data needed for custom property tests."""
+
+    def test_discover_events(self, ws: Workspace) -> None:
+        """Project 8 has discoverable events."""
+        events = ws.events()
+        assert len(events) > 0
+
+    def test_discover_properties(self, ws: Workspace, real_event: str) -> None:
+        """First event has discoverable properties."""
+        props = ws.properties(real_event)
+        assert len(props) > 0
+
+    def test_discover_custom_properties(
+        self, saved_custom_properties: list[CustomProperty]
+    ) -> None:
+        """list_custom_properties() succeeds and returns a list."""
+        assert isinstance(saved_custom_properties, list)
+
+    def test_custom_property_has_valid_fields(
+        self, saved_custom_properties: list[CustomProperty]
+    ) -> None:
+        """Each saved custom property has positive ID and non-empty name."""
+        for cp in saved_custom_properties:
+            assert cp.custom_property_id > 0
+            assert cp.name
+
+
+# =============================================================================
+# Happy Path: Insights GroupBy
+# =============================================================================
+
+
+class TestInlineCustomPropertyGroupBy:
+    """InlineCustomProperty in GroupBy.property — insights engine."""
+
+    def test_numeric_inline_cp_groupby(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Numeric inline CP in group_by produces a valid QueryResult."""
+        result = ws.query(
+            real_event,
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_string_inline_cp_groupby(
+        self, ws: Workspace, real_event: str, string_inline_cp: InlineCustomProperty
+    ) -> None:
+        """String inline CP in group_by produces a valid QueryResult."""
+        result = ws.query(
+            real_event,
+            group_by=GroupBy(property=string_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_inline_cp_explicit_property_type_overrides(
+        self,
+        ws: Workspace,
+        real_event: str,
+        real_numeric_property: str,
+    ) -> None:
+        """ICP.property_type overrides GroupBy.property_type in build_params."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput(real_numeric_property, type="number")},
+            property_type="number",
+        )
+        params = ws.build_params(
+            real_event,
+            group_by=GroupBy(property=icp, property_type="string"),
+            last=7,
+        )
+        group = params["sections"]["group"][0]
+        # ICP's "number" overrides GroupBy's "string"
+        assert group["customProperty"]["propertyType"] == "number"
+        assert group["propertyType"] == "number"
+
+    def test_inline_cp_property_type_none_falls_back(
+        self,
+        ws: Workspace,
+        real_event: str,
+        real_numeric_property: str,
+    ) -> None:
+        """ICP.property_type=None falls back to GroupBy.property_type."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput(real_numeric_property, type="number")},
+            property_type=None,
+        )
+        params = ws.build_params(
+            real_event,
+            group_by=GroupBy(property=icp, property_type="number"),
+            last=7,
+        )
+        group = params["sections"]["group"][0]
+        assert group["customProperty"]["propertyType"] == "number"
+
+    def test_multiple_inline_cps_in_groupby(
+        self,
+        ws: Workspace,
+        real_event: str,
+        simple_inline_cp: InlineCustomProperty,
+        string_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """Two ICPs in same group_by list produce valid QueryResult."""
+        result = ws.query(
+            real_event,
+            group_by=[
+                GroupBy(property=simple_inline_cp, property_type="number"),
+                GroupBy(property=string_inline_cp),
+            ],
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+
+class TestCustomPropertyRefGroupBy:
+    """CustomPropertyRef in GroupBy.property — insights engine."""
+
+    def test_ref_groupby_insights(
+        self,
+        ws: Workspace,
+        real_event: str,
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """Saved custom property ref in group_by produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            group_by=GroupBy(
+                property=CustomPropertyRef(saved_cp_id),
+                property_type=saved_cp_type,  # type: ignore[arg-type]
+            ),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_ref_groupby_build_params_structure(
+        self,
+        ws: Workspace,
+        real_event: str,
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """build_params with ref produces customPropertyId in group entry."""
+        params = ws.build_params(
+            real_event,
+            group_by=GroupBy(
+                property=CustomPropertyRef(saved_cp_id),
+                property_type=saved_cp_type,  # type: ignore[arg-type]
+            ),
+            last=7,
+        )
+        group = params["sections"]["group"][0]
+        assert group["customPropertyId"] == saved_cp_id
+        assert "propertyName" not in group
+
+
+# =============================================================================
+# Happy Path: Insights Filter
+# =============================================================================
+
+
+class TestInlineCustomPropertyFilter:
+    """InlineCustomProperty in Filter — insights engine."""
+
+    def test_filter_is_set_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """is_set filter on inline CP produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            where=Filter.is_set(property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_greater_than_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """greater_than filter on inline CP produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            where=Filter.greater_than(property=simple_inline_cp, value=0),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_between_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """between filter on inline CP produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            where=Filter.between(property=simple_inline_cp, min_val=0, max_val=999999),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_equals_string_inline_cp(
+        self, ws: Workspace, real_event: str, string_inline_cp: InlineCustomProperty
+    ) -> None:
+        """equals filter on string inline CP produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            where=Filter.equals(property=string_inline_cp, value="Chrome"),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_inline_cp_build_params_structure(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Filter with inline CP has customProperty key, no value/propertyName."""
+        params = ws.build_params(
+            real_event,
+            where=Filter.is_set(property=simple_inline_cp),
+            last=7,
+        )
+        f = params["sections"]["filter"][0]
+        assert "customProperty" in f
+        assert "value" not in f
+        assert f["customProperty"]["displayFormula"] == simple_inline_cp.formula
+
+
+class TestCustomPropertyRefFilter:
+    """CustomPropertyRef in Filter — insights engine."""
+
+    def test_filter_is_set_ref(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """is_set filter on ref produces valid QueryResult."""
+        result = ws.query(
+            real_event,
+            where=Filter.is_set(property=CustomPropertyRef(saved_cp_id)),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_ref_build_params_structure(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """Filter with ref has customPropertyId, no value."""
+        params = ws.build_params(
+            real_event,
+            where=Filter.is_set(property=CustomPropertyRef(saved_cp_id)),
+            last=7,
+        )
+        f = params["sections"]["filter"][0]
+        assert f["customPropertyId"] == saved_cp_id
+        assert "value" not in f
+
+
+# =============================================================================
+# Happy Path: Insights Metric
+# =============================================================================
+
+
+class TestInlineCustomPropertyMetric:
+    """InlineCustomProperty in Metric.property — insights engine."""
+
+    def test_metric_average_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """average math on inline CP produces valid QueryResult."""
+        result = ws.query(
+            Metric(real_event, math="average", property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_median_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """median math on inline CP produces valid QueryResult."""
+        result = ws.query(
+            Metric(real_event, math="median", property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_min_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """min math on inline CP produces valid QueryResult."""
+        result = ws.query(
+            Metric(real_event, math="min", property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_build_params_measurement_structure(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Measurement.property has customProperty dict with displayFormula."""
+        params = ws.build_params(
+            Metric(real_event, math="average", property=simple_inline_cp),
+            last=7,
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert "customProperty" in prop
+        assert prop["customProperty"]["displayFormula"] == simple_inline_cp.formula
+
+
+class TestCustomPropertyRefMetric:
+    """CustomPropertyRef in Metric.property — insights engine."""
+
+    def test_metric_average_ref(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """average math on ref produces valid QueryResult."""
+        result = ws.query(
+            Metric(
+                real_event,
+                math="average",
+                property=CustomPropertyRef(saved_cp_id),
+            ),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_build_params_measurement_ref_structure(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """Measurement.property has customPropertyId."""
+        params = ws.build_params(
+            Metric(
+                real_event,
+                math="average",
+                property=CustomPropertyRef(saved_cp_id),
+            ),
+            last=7,
+        )
+        prop = params["sections"]["show"][0]["measurement"]["property"]
+        assert prop["customPropertyId"] == saved_cp_id
+
+
+# =============================================================================
+# Happy Path: Funnels
+# =============================================================================
+
+
+class TestCustomPropertyFunnels:
+    """Custom properties in funnel queries."""
+
+    def test_funnel_groupby_inline_cp(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in funnel group_by produces valid FunnelQueryResult."""
+        e1, e2 = real_events_pair
+        result = ws.query_funnel(
+            [e1, e2],
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            last=30,
+        )
+        assert isinstance(result, FunnelQueryResult)
+
+    @pytest.mark.xfail(
+        reason="Server bug: transform_insights_filters_to_funnels() crashes on f['value'] "
+        "(analytics/bookmark_parser/common/transforms/util.py:1459,1484) "
+        "when filter uses customProperty instead of value key",
+        raises=Exception,
+    )
+    def test_funnel_where_inline_cp(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in funnel global filter — server rejects (known limitation)."""
+        e1, e2 = real_events_pair
+        result = ws.query_funnel(
+            [e1, e2],
+            where=Filter.is_set(property=simple_inline_cp),
+            last=30,
+        )
+        assert isinstance(result, FunnelQueryResult)
+
+    def test_funnel_step_filter_inline_cp(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """EDGE CASE #2: ICP in FunnelStep.filters (bypasses L1 validation)."""
+        e1, e2 = real_events_pair
+        result = ws.query_funnel(
+            [
+                FunnelStep(e1, filters=[Filter.is_set(property=simple_inline_cp)]),
+                e2,
+            ],
+            last=30,
+        )
+        assert isinstance(result, FunnelQueryResult)
+
+    def test_funnel_groupby_ref(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """Ref in funnel group_by produces valid FunnelQueryResult."""
+        e1, e2 = real_events_pair
+        result = ws.query_funnel(
+            [e1, e2],
+            group_by=GroupBy(
+                property=CustomPropertyRef(saved_cp_id),
+                property_type=saved_cp_type,  # type: ignore[arg-type]
+            ),
+            last=30,
+        )
+        assert isinstance(result, FunnelQueryResult)
+
+
+# =============================================================================
+# Happy Path: Retention
+# =============================================================================
+
+
+class TestCustomPropertyRetention:
+    """Custom properties in retention queries."""
+
+    def test_retention_groupby_inline_cp(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in retention group_by produces valid RetentionQueryResult."""
+        e1, e2 = real_events_pair
+        result = ws.query_retention(
+            e1,
+            e2,
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            last=30,
+        )
+        assert isinstance(result, RetentionQueryResult)
+
+    @pytest.mark.xfail(
+        reason="Server bug: transform_insights_filters_to_funnels() crashes on f['value'] "
+        "(analytics/bookmark_parser/common/transforms/util.py:1459,1484) "
+        "when filter uses customProperty instead of value key",
+        raises=Exception,
+    )
+    def test_retention_where_inline_cp(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in retention global filter — server rejects (known limitation)."""
+        e1, e2 = real_events_pair
+        result = ws.query_retention(
+            e1,
+            e2,
+            where=Filter.is_set(property=simple_inline_cp),
+            last=30,
+        )
+        assert isinstance(result, RetentionQueryResult)
+
+    def test_retention_groupby_ref(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """Ref in retention group_by produces valid RetentionQueryResult."""
+        e1, e2 = real_events_pair
+        result = ws.query_retention(
+            e1,
+            e2,
+            group_by=GroupBy(
+                property=CustomPropertyRef(saved_cp_id),
+                property_type=saved_cp_type,  # type: ignore[arg-type]
+            ),
+            last=30,
+        )
+        assert isinstance(result, RetentionQueryResult)
+
+    @pytest.mark.xfail(
+        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459 "
+        "crashes on f['value'] for CustomPropertyRef filters too",
+        raises=Exception,
+    )
+    def test_retention_where_ref(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        saved_cp_id: int,
+    ) -> None:
+        """Ref in retention filter — server rejects (same bug as inline CP)."""
+        e1, e2 = real_events_pair
+        result = ws.query_retention(
+            e1,
+            e2,
+            where=Filter.is_set(property=CustomPropertyRef(saved_cp_id)),
+            last=30,
+        )
+        assert isinstance(result, RetentionQueryResult)
+
+
+# =============================================================================
+# Edge Cases: Per-Metric Filters
+# =============================================================================
+
+
+class TestPerMetricFilterCustomProperty:
+    """EDGE CASE #1: Metric.filters with custom properties bypass L1 validation."""
+
+    def test_metric_per_metric_filter_inline_cp(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Per-metric filter with ICP works despite L1 validation gap."""
+        result = ws.query(
+            Metric(
+                real_event,
+                filters=[Filter.is_set(property=simple_inline_cp)],
+            ),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_per_metric_filter_ref(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """Per-metric filter with ref works despite L1 validation gap."""
+        result = ws.query(
+            Metric(
+                real_event,
+                filters=[Filter.is_set(property=CustomPropertyRef(saved_cp_id))],
+            ),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_metric_per_metric_filter_invalid_ref_no_client_error(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """VALIDATION GAP: CustomPropertyRef(0) in Metric.filters NOT caught at L1."""
+        # This documents the gap: build_params succeeds because
+        # _scan_custom_properties does not scan Metric.filters
+        params = ws.build_params(
+            Metric(
+                real_event,
+                filters=[Filter.is_set(property=CustomPropertyRef(0))],
+            ),
+            last=7,
+        )
+        # No BookmarkValidationError raised — gap confirmed
+        assert "sections" in params
+
+
+# =============================================================================
+# Edge Cases: Numeric Constructor
+# =============================================================================
+
+
+class TestInlineCustomPropertyNumericConstructor:
+    """Tests for .numeric() convenience constructor against live API."""
+
+    def test_numeric_constructor_single_input(
+        self, ws: Workspace, real_event: str, real_numeric_property: str
+    ) -> None:
+        """Single-input .numeric() works in a live query."""
+        icp = InlineCustomProperty.numeric("A", A=real_numeric_property)
+        result = ws.query(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_numeric_constructor_formula_with_literal(
+        self, ws: Workspace, real_event: str, real_numeric_property: str
+    ) -> None:
+        """Formula with literal in .numeric() works."""
+        icp = InlineCustomProperty.numeric("A * 2", A=real_numeric_property)
+        result = ws.query(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_numeric_constructor_multi_input(
+        self, ws: Workspace, real_event: str, real_numeric_property: str
+    ) -> None:
+        """Multi-input .numeric() (same prop twice) works in a live query."""
+        icp = InlineCustomProperty.numeric(
+            "A + B", A=real_numeric_property, B=real_numeric_property
+        )
+        result = ws.query(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# Edge Cases: Boundary Conditions
+# =============================================================================
+
+
+class TestCustomPropertyEdgeCases:
+    """Edge cases, boundary conditions, and behavior discovery tests."""
+
+    def test_same_inline_cp_in_filter_and_groupby(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Same ICP instance used in both filter and group_by."""
+        result = ws.query(
+            real_event,
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            where=Filter.is_set(property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_same_inline_cp_in_metric_and_groupby(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Same ICP instance in Metric.property and GroupBy.property."""
+        result = ws.query(
+            Metric(real_event, math="average", property=simple_inline_cp),
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_formula_with_special_characters(
+        self, ws: Workspace, real_event: str, real_numeric_property: str
+    ) -> None:
+        """Formula with parentheses and division works."""
+        icp = InlineCustomProperty.numeric("(A + A) / 2", A=real_numeric_property)
+        result = ws.query(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_inline_cp_property_type_none_in_metric(
+        self, ws: Workspace, real_event: str, real_numeric_property: str
+    ) -> None:
+        """EDGE CASE #4: property_type=None omits propertyType from measurement JSON."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput(real_numeric_property, type="number")},
+            property_type=None,
+        )
+        # Verify JSON shape: propertyType should be absent
+        params = ws.build_params(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        cp_dict = params["sections"]["show"][0]["measurement"]["property"][
+            "customProperty"
+        ]
+        assert "propertyType" not in cp_dict
+        # But the live query may still work (server infers type)
+        result = ws.query(
+            Metric(real_event, math="average", property=icp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_custom_property_ref_nonexistent_id(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """Behavior discovery: nonexistent CustomPropertyRef ID in filter."""
+        # Server may return empty results or an error — document behavior
+        try:
+            result = ws.query(
+                real_event,
+                where=Filter.is_set(property=CustomPropertyRef(99999)),
+                last=7,
+            )
+            assert isinstance(result, QueryResult)
+        except Exception as exc:
+            # Document what the server returns for nonexistent IDs
+            pytest.skip(f"Server rejected nonexistent CP ID: {exc}")
+
+    def test_multiple_custom_properties_mixed_types(
+        self,
+        ws: Workspace,
+        real_event: str,
+        simple_inline_cp: InlineCustomProperty,
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """Mixing ref + inline in same group_by list."""
+        result = ws.query(
+            real_event,
+            group_by=[
+                GroupBy(property=simple_inline_cp, property_type="number"),
+                GroupBy(
+                    property=CustomPropertyRef(saved_cp_id),
+                    property_type=saved_cp_type,  # type: ignore[arg-type]
+                ),
+            ],
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    def test_filter_type_mismatch_not_checked(
+        self,
+        ws: Workspace,
+        real_event: str,
+        string_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """EDGE CASE #3: greater_than on string ICP — no client-side error."""
+        # greater_than hard-codes _property_type="number" but string_inline_cp
+        # has property_type=None. No validation catches this mismatch.
+        params = ws.build_params(
+            real_event,
+            where=Filter.greater_than(property=string_inline_cp, value=5),
+            last=7,
+        )
+        # build_params succeeds — gap confirmed
+        assert "sections" in params
+
+
+# =============================================================================
+# Validation: CP1-CP6
+# =============================================================================
+
+
+class TestCustomPropertyValidation:
+    """CP1-CP6 validation rules in GroupBy position."""
+
+    def test_cp1_invalid_id_zero(self, ws: Workspace, real_event: str) -> None:
+        """CP1: CustomPropertyRef(0) raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                real_event,
+                group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
+            )
+
+    def test_cp1_invalid_id_negative(self, ws: Workspace, real_event: str) -> None:
+        """CP1: CustomPropertyRef(-5) raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                real_event,
+                group_by=GroupBy(
+                    property=CustomPropertyRef(-5), property_type="number"
+                ),
+            )
+
+    def test_cp2_empty_formula(self, ws: Workspace, real_event: str) -> None:
+        """CP2: Empty formula raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="", inputs={"A": PropertyInput("x")})
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp2_whitespace_only_formula(self, ws: Workspace, real_event: str) -> None:
+        """CP2: Whitespace-only formula raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="   ", inputs={"A": PropertyInput("x")})
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp3_empty_inputs(self, ws: Workspace, real_event: str) -> None:
+        """CP3: Empty inputs raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="A", inputs={})
+        with pytest.raises(BookmarkValidationError, match="at least one input"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp4_invalid_input_key_lowercase(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """CP4: Lowercase input key raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="a", inputs={"a": PropertyInput("x")})
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp4_invalid_input_key_multi_char(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """CP4: Multi-char input key raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="AB", inputs={"AB": PropertyInput("x")})
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp5_formula_too_long(self, ws: Workspace, real_event: str) -> None:
+        """CP5: Formula > 20,000 chars raises BookmarkValidationError."""
+        icp = InlineCustomProperty(
+            formula="A" * 20_001, inputs={"A": PropertyInput("x")}
+        )
+        with pytest.raises(BookmarkValidationError, match="20,000"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp5_formula_at_boundary(self, ws: Workspace, real_event: str) -> None:
+        """CP5: Formula at exactly 20,000 chars passes validation."""
+        icp = InlineCustomProperty(
+            formula="A" * 20_000, inputs={"A": PropertyInput("x")}
+        )
+        # Should NOT raise
+        params = ws.build_params(
+            real_event, group_by=GroupBy(property=icp, property_type="string")
+        )
+        assert "sections" in params
+
+    def test_cp6_empty_property_name(self, ws: Workspace, real_event: str) -> None:
+        """CP6: Empty PropertyInput.name raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="A", inputs={"A": PropertyInput("")})
+        with pytest.raises(BookmarkValidationError, match="empty property name"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_cp6_whitespace_only_property_name(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """CP6: Whitespace-only PropertyInput.name raises BookmarkValidationError."""
+        icp = InlineCustomProperty(formula="A", inputs={"A": PropertyInput("   ")})
+        with pytest.raises(BookmarkValidationError, match="empty property name"):
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+
+    def test_multiple_validation_errors(self, ws: Workspace, real_event: str) -> None:
+        """Multiple CP violations produce multiple errors in one raise."""
+        icp = InlineCustomProperty(formula="", inputs={})
+        with pytest.raises(BookmarkValidationError) as exc_info:
+            ws.build_params(
+                real_event, group_by=GroupBy(property=icp, property_type="string")
+            )
+        errors = exc_info.value.errors
+        codes = {e.code for e in errors}
+        assert "CP2_EMPTY_FORMULA" in codes
+        assert "CP3_EMPTY_INPUTS" in codes
+
+
+class TestValidationInFilterPosition:
+    """CP validation rules triggered via where= filters."""
+
+    def test_cp1_in_filter_position(self, ws: Workspace, real_event: str) -> None:
+        """CP1 caught in filter position."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                real_event,
+                where=Filter.is_set(property=CustomPropertyRef(0)),
+            )
+
+    def test_cp2_in_filter_position(self, ws: Workspace, real_event: str) -> None:
+        """CP2 caught in filter position."""
+        icp = InlineCustomProperty(formula="", inputs={"A": PropertyInput("x")})
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(real_event, where=Filter.is_set(property=icp))
+
+
+class TestValidationInMetricPosition:
+    """CP validation rules triggered via Metric.property."""
+
+    def test_cp1_in_metric_property(self, ws: Workspace, real_event: str) -> None:
+        """CP1 caught in Metric.property position."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    real_event,
+                    math="average",
+                    property=CustomPropertyRef(0),
+                ),
+            )
+
+
+# =============================================================================
+# Validation Gaps (document known L1 bypasses)
+# =============================================================================
+
+
+class TestValidationGaps:
+    """Document known validation gaps — these tests assert CURRENT behavior."""
+
+    def test_per_metric_filter_cp_bypasses_validation(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """GAP: CustomPropertyRef(0) in Metric.filters NOT caught at L1."""
+        # This should catch CP1 but doesn't because _scan_custom_properties
+        # does not scan Metric.filters
+        params = ws.build_params(
+            Metric(
+                real_event,
+                filters=[Filter.is_set(property=CustomPropertyRef(0))],
+            ),
+        )
+        assert "sections" in params  # No error raised — gap confirmed
+
+    def test_funnel_step_filter_cp_bypasses_validation(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """GAP: CustomPropertyRef(0) in FunnelStep.filters NOT caught at L1."""
+        e1, e2 = real_events_pair
+        params = ws.build_funnel_params(
+            [
+                FunnelStep(e1, filters=[Filter.is_set(property=CustomPropertyRef(0))]),
+                e2,
+            ],
+        )
+        assert "sections" in params  # No error raised — gap confirmed
+
+    def test_retention_where_cp_validated_by_workspace(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """Retention where= CP IS caught (by workspace.py, not validator)."""
+        e1, e2 = real_events_pair
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                e1,
+                e2,
+                where=Filter.is_set(property=CustomPropertyRef(0)),
+            )
+
+
+# =============================================================================
+# Cross-Engine
+# =============================================================================
+
+
+class TestCrossEngine:
+    """Custom properties work consistently across all 3 query engines."""
+
+    def test_insights_inline_cp_all_three_positions(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """ICP in GroupBy + Filter + Metric simultaneously — insights."""
+        result = ws.query(
+            Metric(real_event, math="average", property=simple_inline_cp),
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            where=Filter.is_set(property=simple_inline_cp),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+    @pytest.mark.xfail(
+        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459",
+        raises=Exception,
+    )
+    def test_funnel_inline_cp_groupby_and_where(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in both funnel group_by and where."""
+        e1, e2 = real_events_pair
+        result = ws.query_funnel(
+            [e1, e2],
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            where=Filter.is_set(property=simple_inline_cp),
+            last=30,
+        )
+        assert isinstance(result, FunnelQueryResult)
+
+    @pytest.mark.xfail(
+        reason="Server bug: transform_insights_filters_to_funnels() util.py:1459",
+        raises=Exception,
+    )
+    def test_retention_inline_cp_groupby_and_where(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        simple_inline_cp: InlineCustomProperty,
+    ) -> None:
+        """ICP in both retention group_by and where."""
+        e1, e2 = real_events_pair
+        result = ws.query_retention(
+            e1,
+            e2,
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+            where=Filter.is_set(property=simple_inline_cp),
+            last=30,
+        )
+        assert isinstance(result, RetentionQueryResult)
+
+    def test_ref_across_all_engines(
+        self,
+        ws: Workspace,
+        real_event: str,
+        real_events_pair: tuple[str, str],
+        saved_cp_id: int,
+        saved_cp_type: str,
+    ) -> None:
+        """Ref in GroupBy across insights, funnels, retention."""
+        gb = GroupBy(
+            property=CustomPropertyRef(saved_cp_id),
+            property_type=saved_cp_type,  # type: ignore[arg-type]
+        )
+
+        # Insights
+        r1 = ws.query(real_event, group_by=gb, last=7)
+        assert isinstance(r1, QueryResult)
+
+        # Funnels
+        e1, e2 = real_events_pair
+        r2 = ws.query_funnel([e1, e2], group_by=gb, last=30)
+        assert isinstance(r2, FunnelQueryResult)
+
+        # Retention
+        r3 = ws.query_retention(e1, e2, group_by=gb, last=30)
+        assert isinstance(r3, RetentionQueryResult)
+
+
+# =============================================================================
+# Build Params Structure (no API calls)
+# =============================================================================
+
+
+class TestBuildParamsStructure:
+    """Validate serialized bookmark JSON structure without API calls."""
+
+    def test_inline_cp_groupby_json_shape(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Group entry has complete customProperty dict."""
+        params = ws.build_params(
+            real_event,
+            group_by=GroupBy(property=simple_inline_cp, property_type="number"),
+        )
+        g = params["sections"]["group"][0]
+        cp = g["customProperty"]
+        assert "displayFormula" in cp
+        assert "composedProperties" in cp
+        assert "propertyType" in cp
+        assert "resourceType" in cp
+        assert g["isHidden"] is False
+
+    def test_inline_cp_filter_json_shape(
+        self, ws: Workspace, real_event: str, simple_inline_cp: InlineCustomProperty
+    ) -> None:
+        """Filter entry has customProperty, no value/propertyName."""
+        params = ws.build_params(
+            real_event,
+            where=Filter.is_set(property=simple_inline_cp),
+        )
+        f = params["sections"]["filter"][0]
+        assert "customProperty" in f
+        assert "value" not in f
+        assert "propertyName" not in f
+
+    def test_ref_groupby_json_shape(
+        self, ws: Workspace, real_event: str, saved_cp_id: int, saved_cp_type: str
+    ) -> None:
+        """Group entry has customPropertyId, no value/propertyName."""
+        params = ws.build_params(
+            real_event,
+            group_by=GroupBy(
+                property=CustomPropertyRef(saved_cp_id),
+                property_type=saved_cp_type,  # type: ignore[arg-type]
+            ),
+        )
+        g = params["sections"]["group"][0]
+        assert g["customPropertyId"] == saved_cp_id
+        assert "propertyName" not in g
+
+    def test_ref_filter_json_shape(
+        self, ws: Workspace, real_event: str, saved_cp_id: int
+    ) -> None:
+        """Filter entry has customPropertyId, no value."""
+        params = ws.build_params(
+            real_event,
+            where=Filter.is_set(property=CustomPropertyRef(saved_cp_id)),
+        )
+        f = params["sections"]["filter"][0]
+        assert f["customPropertyId"] == saved_cp_id
+        assert "value" not in f
+
+    def test_composed_properties_format(self) -> None:
+        """_build_composed_properties() produces {key: {value, type, resourceType}}."""
+        inputs = {
+            "A": PropertyInput("price", type="number"),
+            "B": PropertyInput("email", type="string", resource_type="user"),
+        }
+        result = _build_composed_properties(inputs)
+
+        assert set(result.keys()) == {"A", "B"}
+        for key in result:
+            assert set(result[key].keys()) == {"value", "type", "resourceType"}
+        assert result["A"]["value"] == "price"
+        assert result["B"]["resourceType"] == "user"
+
+
+# =============================================================================
+# Backward Compatibility
+# =============================================================================
+
+
+class TestBackwardCompatibility:
+    """Existing queries without custom properties still work after type widening."""
+
+    def test_plain_string_query_unchanged(self, ws: Workspace, real_event: str) -> None:
+        """Plain event string query still works."""
+        result = ws.query(real_event, last=7)
+        assert isinstance(result, QueryResult)
+
+    def test_plain_string_groupby_unchanged(
+        self, ws: Workspace, real_event: str, real_string_property: str
+    ) -> None:
+        """Plain string group_by still works."""
+        result = ws.query(real_event, group_by=real_string_property, last=7)
+        assert isinstance(result, QueryResult)
+
+    def test_groupby_object_without_cp_unchanged(
+        self, ws: Workspace, real_event: str, real_string_property: str
+    ) -> None:
+        """GroupBy object with plain string property still works."""
+        result = ws.query(real_event, group_by=GroupBy(real_string_property), last=7)
+        assert isinstance(result, QueryResult)
+
+    def test_metric_with_string_property_unchanged(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """Metric with plain string math still works."""
+        result = ws.query(Metric(real_event, math="total"), last=7)
+        assert isinstance(result, QueryResult)
+
+    def test_filter_with_string_property_unchanged(
+        self, ws: Workspace, real_event: str, real_string_property: str
+    ) -> None:
+        """Filter with plain string property still works."""
+        result = ws.query(
+            real_event,
+            where=Filter.is_set(real_string_property),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)

--- a/tests/test_custom_property_builders.py
+++ b/tests/test_custom_property_builders.py
@@ -318,6 +318,22 @@ class TestBuildFilterEntryCustomProperties:
         entry = build_filter_entry(f)
 
         assert entry["customProperty"]["resourceType"] == "people"
+        assert entry["resourceType"] == "people"
+
+    def test_inline_property_type_none_uses_filter_default(self) -> None:
+        """InlineCustomProperty with property_type=None falls back to Filter's type."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("price", type="number")},
+            property_type=None,
+        )
+        f = Filter.greater_than(property=icp, value=100)
+
+        entry = build_filter_entry(f)
+
+        # greater_than sets _property_type="number"; None falls back to it
+        assert entry["filterType"] == "number"
+        assert entry["defaultType"] == "number"
 
 
 # =============================================================================

--- a/tests/test_custom_property_builders.py
+++ b/tests/test_custom_property_builders.py
@@ -1,0 +1,444 @@
+"""Unit tests for custom property bookmark builder helpers (Phase 037).
+
+Tests for _build_composed_properties(), build_group_section(),
+and build_filter_entry() with custom property dispatch.
+
+Task IDs: T006, T017-T022, T026-T031, T034-T037
+"""
+
+from __future__ import annotations
+
+from mixpanel_data._internal.bookmark_builders import (
+    _build_composed_properties,
+    build_filter_entry,
+    build_group_section,
+)
+from mixpanel_data.types import (
+    CohortBreakdown,
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    PropertyInput,
+)
+
+# =============================================================================
+# T006: _build_composed_properties() tests
+# =============================================================================
+
+
+class TestBuildComposedProperties:
+    """Tests for _build_composed_properties() helper function."""
+
+    def test_single_input(self) -> None:
+        """Single input produces a single-entry dict with correct fields."""
+        inputs = {"A": PropertyInput("price", type="number")}
+
+        result = _build_composed_properties(inputs)
+
+        assert result == {
+            "A": {
+                "value": "price",
+                "type": "number",
+                "resourceType": "event",
+            },
+        }
+
+    def test_multiple_inputs(self) -> None:
+        """Multiple inputs produce correctly keyed entries."""
+        inputs = {
+            "A": PropertyInput("price", type="number"),
+            "B": PropertyInput("quantity", type="number"),
+        }
+
+        result = _build_composed_properties(inputs)
+
+        assert len(result) == 2
+        assert result["A"]["value"] == "price"
+        assert result["B"]["value"] == "quantity"
+        assert result["A"]["type"] == "number"
+        assert result["B"]["type"] == "number"
+        assert result["A"]["resourceType"] == "event"
+        assert result["B"]["resourceType"] == "event"
+
+    def test_user_resource_type_preserved(self) -> None:
+        """User resource_type is preserved in the output."""
+        inputs = {"A": PropertyInput("email", type="string", resource_type="user")}
+
+        result = _build_composed_properties(inputs)
+
+        assert result["A"]["resourceType"] == "user"
+
+    def test_default_values(self) -> None:
+        """Default PropertyInput values (string type, event resource) are preserved."""
+        inputs = {"A": PropertyInput("country")}
+
+        result = _build_composed_properties(inputs)
+
+        assert result["A"] == {
+            "value": "country",
+            "type": "string",
+            "resourceType": "event",
+        }
+
+
+# =============================================================================
+# T017-T022: build_group_section() with custom properties (US1)
+# =============================================================================
+
+
+class TestBuildGroupSectionCustomProperties:
+    """Tests for build_group_section() with custom property dispatch."""
+
+    def test_plain_string_unchanged(self) -> None:
+        """T017: Plain string group_by produces unchanged output (backward compat)."""
+        result = build_group_section("country")
+
+        assert len(result) == 1
+        assert result[0]["value"] == "country"
+        assert result[0]["propertyName"] == "country"
+        assert result[0]["resourceType"] == "events"
+
+    def test_custom_property_ref(self) -> None:
+        """T018: GroupBy with CustomPropertyRef produces customPropertyId, no value/propertyName."""
+        g = GroupBy(property=CustomPropertyRef(42), property_type="number")
+
+        result = build_group_section(g)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["customPropertyId"] == 42
+        assert entry["propertyType"] == "number"
+        assert entry["resourceType"] == "events"
+        assert entry["dataset"] == "$mixpanel"
+        assert entry["isHidden"] is False
+        assert "propertyName" not in entry
+
+    def test_inline_custom_property(self) -> None:
+        """T019: GroupBy with InlineCustomProperty produces customProperty dict."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        g = GroupBy(property=icp, property_type="number")
+
+        result = build_group_section(g)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert "customProperty" in entry
+        cp = entry["customProperty"]
+        assert cp["displayFormula"] == "A * B"
+        assert "A" in cp["composedProperties"]
+        assert "B" in cp["composedProperties"]
+        assert cp["composedProperties"]["A"]["value"] == "price"
+        assert cp["propertyType"] == "number"
+        assert cp["resourceType"] == "events"
+        assert entry["propertyType"] == "number"
+        assert entry["resourceType"] == "events"
+        assert entry["dataset"] == "$mixpanel"
+        assert entry["isHidden"] is False
+        assert "propertyName" not in entry
+
+    def test_bucketing_with_custom_property_ref(self) -> None:
+        """T020: Bucketing works with CustomPropertyRef."""
+        g = GroupBy(
+            property=CustomPropertyRef(42),
+            property_type="number",
+            bucket_size=100,
+            bucket_min=0,
+            bucket_max=1000,
+        )
+
+        result = build_group_section(g)
+
+        entry = result[0]
+        assert entry["customPropertyId"] == 42
+        assert entry["customBucket"] == {
+            "bucketSize": 100,
+            "min": 0,
+            "max": 1000,
+        }
+
+    def test_bucketing_with_inline_custom_property(self) -> None:
+        """T020: Bucketing works with InlineCustomProperty."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        g = GroupBy(
+            property=icp,
+            property_type="number",
+            bucket_size=50,
+            bucket_min=0,
+            bucket_max=500,
+        )
+
+        result = build_group_section(g)
+
+        entry = result[0]
+        assert "customProperty" in entry
+        assert entry["customBucket"] == {
+            "bucketSize": 50,
+            "min": 0,
+            "max": 500,
+        }
+
+    def test_inline_property_type_overrides_group_by(self) -> None:
+        """T021: InlineCustomProperty.property_type overrides GroupBy.property_type."""
+        icp = InlineCustomProperty(
+            formula='IFS(A > 1000, "Enterprise", TRUE, "Free")',
+            inputs={"A": PropertyInput("amount", type="number")},
+            property_type="string",
+        )
+        g = GroupBy(property=icp, property_type="number")
+
+        result = build_group_section(g)
+
+        entry = result[0]
+        # Inline's property_type="string" overrides GroupBy's "number"
+        assert entry["customProperty"]["propertyType"] == "string"
+        assert entry["propertyType"] == "string"
+
+    def test_inline_property_type_none_falls_back(self) -> None:
+        """T021b: InlineCustomProperty.property_type=None falls back to GroupBy.property_type."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("revenue", type="number")},
+            property_type=None,
+        )
+        g = GroupBy(property=icp, property_type="number")
+
+        result = build_group_section(g)
+
+        entry = result[0]
+        assert entry["customProperty"]["propertyType"] == "number"
+        assert entry["propertyType"] == "number"
+
+    def test_mixed_group_by_list(self) -> None:
+        """T022: Mixed group_by list with plain string, CustomPropertyRef, InlineCustomProperty."""
+        groups: list[str | GroupBy | CohortBreakdown] = [
+            "country",
+            GroupBy(property=CustomPropertyRef(42), property_type="number"),
+            GroupBy(
+                property=InlineCustomProperty.numeric("A", A="revenue"),
+                property_type="number",
+            ),
+        ]
+
+        result = build_group_section(groups)
+
+        assert len(result) == 3
+        # Plain string
+        assert result[0]["value"] == "country"
+        # CustomPropertyRef
+        assert result[1]["customPropertyId"] == 42
+        # InlineCustomProperty
+        assert "customProperty" in result[2]
+
+
+# =============================================================================
+# T026-T031: build_filter_entry() with custom properties (US2)
+# =============================================================================
+
+
+class TestBuildFilterEntryCustomProperties:
+    """Tests for build_filter_entry() with custom property dispatch."""
+
+    def test_plain_string_unchanged(self) -> None:
+        """T026: Plain string filter produces unchanged output (backward compat)."""
+        f = Filter.equals("country", "US")
+
+        entry = build_filter_entry(f)
+
+        assert entry["value"] == "country"
+        assert entry["filterOperator"] == "equals"
+        assert "customPropertyId" not in entry
+        assert "customProperty" not in entry
+
+    def test_custom_property_ref(self) -> None:
+        """T027: CustomPropertyRef produces customPropertyId, no value field."""
+        f = Filter.greater_than(property=CustomPropertyRef(42), value=100)
+
+        entry = build_filter_entry(f)
+
+        assert entry["customPropertyId"] == 42
+        assert entry["filterOperator"] == "is greater than"
+        assert entry["filterValue"] == 100
+        assert "value" not in entry
+
+    def test_inline_custom_property(self) -> None:
+        """T028: InlineCustomProperty produces customProperty dict, no value field."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        f = Filter.greater_than(property=icp, value=1000)
+
+        entry = build_filter_entry(f)
+
+        assert "customProperty" in entry
+        cp = entry["customProperty"]
+        assert cp["displayFormula"] == "A * B"
+        assert "A" in cp["composedProperties"]
+        assert cp["propertyType"] == "number"
+        assert cp["resourceType"] == "events"
+        assert entry["filterValue"] == 1000
+        assert entry["filterOperator"] == "is greater than"
+        assert "value" not in entry
+
+    def test_inline_filter_type_uses_property_type(self) -> None:
+        """T029: InlineCustomProperty filterType/defaultType uses property_type."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("email", type="string")},
+            property_type="string",
+        )
+        f = Filter.equals(property=icp, value="test")
+
+        entry = build_filter_entry(f)
+
+        assert entry["filterType"] == "string"
+        assert entry["defaultType"] == "string"
+
+    def test_custom_property_ref_preserves_resource_type(self) -> None:
+        """T030: CustomPropertyRef preserves Filter's resource_type."""
+        f = Filter.equals(
+            property=CustomPropertyRef(42),
+            value="admin",
+            resource_type="people",
+        )
+
+        entry = build_filter_entry(f)
+
+        assert entry["resourceType"] == "people"
+        assert entry["customPropertyId"] == 42
+
+    def test_inline_uses_own_resource_type(self) -> None:
+        """T031: InlineCustomProperty uses its own resource_type in filter entry."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("email", resource_type="user")},
+            property_type="string",
+            resource_type="people",
+        )
+        f = Filter.equals(property=icp, value="test")
+
+        entry = build_filter_entry(f)
+
+        assert entry["customProperty"]["resourceType"] == "people"
+
+
+# =============================================================================
+# T034-T037: Measurement property builder tests (US3)
+# =============================================================================
+
+
+class TestMeasurementPropertyBuilder:
+    """Tests for measurement property section in bookmark params.
+
+    These tests verify the measurement dict directly from workspace
+    _build_query_params output.
+    """
+
+    def test_plain_string_measurement_unchanged(self) -> None:
+        """T034: Plain string Metric.property produces unchanged measurement (backward compat)."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.types import Metric
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        params = ws.build_params(
+            Metric("Purchase", math="average", property="amount"),
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"] == {
+            "name": "amount",
+            "resourceType": "events",
+        }
+
+    def test_custom_property_ref_in_measurement(self) -> None:
+        """T035: CustomPropertyRef in measurement produces customPropertyId."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.types import Metric
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=CustomPropertyRef(42)),
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        prop = measurement["property"]
+        assert prop["customPropertyId"] == 42
+        assert prop["resourceType"] == "events"
+        assert prop.get("name") is not None  # name present for server compat
+
+    def test_inline_custom_property_in_measurement(self) -> None:
+        """T036: InlineCustomProperty in measurement produces customProperty dict."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.types import Metric
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=icp),
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        prop = measurement["property"]
+        assert "customProperty" in prop
+        assert prop["customProperty"]["displayFormula"] == "A * B"
+        assert prop["resourceType"] == "events"
+        assert prop.get("name") is not None  # name present for server compat
+
+    def test_top_level_math_property_string_unchanged(self) -> None:
+        """T037: Top-level math_property as plain string produces unchanged measurement."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        params = ws.build_params(
+            "Purchase",
+            math="average",
+            math_property="amount",
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"] == {
+            "name": "amount",
+            "resourceType": "events",
+        }

--- a/tests/test_custom_property_pbt.py
+++ b/tests/test_custom_property_pbt.py
@@ -1,0 +1,338 @@
+"""Property-based tests for custom property query types using Hypothesis.
+
+These tests verify invariants of PropertyInput, InlineCustomProperty,
+CustomPropertyRef, and _build_composed_properties that should hold for
+all valid inputs. Covers tasks T062-T067.
+
+Usage:
+    # Run with default profile (100 examples)
+    pytest tests/test_custom_property_pbt.py
+
+    # Run with dev profile (10 examples)
+    HYPOTHESIS_PROFILE=dev pytest tests/test_custom_property_pbt.py
+
+    # Run with CI profile (200 examples, deterministic)
+    HYPOTHESIS_PROFILE=ci pytest tests/test_custom_property_pbt.py
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from mixpanel_data._internal.bookmark_builders import _build_composed_properties
+from mixpanel_data.types import (
+    CustomPropertyRef,
+    InlineCustomProperty,
+    PropertyInput,
+)
+
+# =============================================================================
+# Custom Strategies (T062-T063)
+# =============================================================================
+
+# T062: valid_property_input — non-empty name, valid type/resource_type literals
+_property_types = st.sampled_from(["string", "number", "boolean", "datetime", "list"])
+_resource_types = st.sampled_from(["event", "user"])
+
+_non_empty_names = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "S")),
+    min_size=1,
+    max_size=50,
+).filter(lambda s: s.strip())
+
+
+@st.composite
+def valid_property_input(draw: st.DrawFn) -> PropertyInput:
+    """Strategy that produces a valid PropertyInput with arbitrary fields.
+
+    Draws:
+        name: Non-empty printable string (1-50 chars).
+        type: One of the 5 valid property type literals.
+        resource_type: Either "event" or "user".
+
+    Returns:
+        A fully constructed PropertyInput instance.
+    """
+    name = draw(_non_empty_names)
+    prop_type = draw(_property_types)
+    res_type = draw(_resource_types)
+    return PropertyInput(name=name, type=prop_type, resource_type=res_type)  # type: ignore[arg-type]
+
+
+# T063: valid_input_key — single uppercase letter A-Z
+valid_input_key = st.sampled_from([chr(c) for c in range(ord("A"), ord("Z") + 1)])
+
+# T063: valid_inputs_dict — dict of 1-5 entries mapping valid keys to valid PropertyInput
+_unique_keys = st.lists(
+    valid_input_key,
+    min_size=1,
+    max_size=5,
+    unique=True,
+)
+
+
+@st.composite
+def valid_inputs_dict(draw: st.DrawFn) -> dict[str, PropertyInput]:
+    """Strategy that produces a dict of 1-5 valid input key/PropertyInput pairs.
+
+    Draws:
+        keys: 1-5 unique uppercase letters (A-Z).
+        values: A valid PropertyInput for each key.
+
+    Returns:
+        Dict mapping uppercase letters to PropertyInput instances.
+    """
+    keys = draw(_unique_keys)
+    inputs: dict[str, PropertyInput] = {}
+    for key in keys:
+        inputs[key] = draw(valid_property_input())
+    return inputs
+
+
+# Non-empty formula strings for InlineCustomProperty
+_formulas = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "S", "Zs")),
+    min_size=1,
+    max_size=100,
+).filter(lambda s: s.strip())
+
+# Optional property_type for InlineCustomProperty
+_optional_property_types = st.one_of(
+    st.none(),
+    st.sampled_from(["string", "number", "boolean", "datetime"]),
+)
+
+# resource_type for InlineCustomProperty (plural form)
+_icp_resource_types = st.sampled_from(["events", "people"])
+
+
+# =============================================================================
+# T064: PropertyInput round-trip invariants
+# =============================================================================
+
+
+class TestPropertyInputPBT:
+    """Property-based tests for PropertyInput construction (T064)."""
+
+    @given(prop=valid_property_input())
+    def test_property_input_round_trip(self, prop: PropertyInput) -> None:
+        """All PropertyInput field values survive construction unchanged.
+
+        Verifies that the frozen dataclass preserves the exact name, type,
+        and resource_type values that were passed in.
+
+        Args:
+            prop: A randomly generated valid PropertyInput.
+        """
+        reconstructed = PropertyInput(
+            name=prop.name,
+            type=prop.type,
+            resource_type=prop.resource_type,
+        )
+        assert reconstructed.name == prop.name
+        assert reconstructed.type == prop.type
+        assert reconstructed.resource_type == prop.resource_type
+
+    @given(prop=valid_property_input())
+    def test_property_input_is_frozen(self, prop: PropertyInput) -> None:
+        """PropertyInput instances are immutable (frozen dataclass).
+
+        Args:
+            prop: A randomly generated valid PropertyInput.
+        """
+        try:
+            prop.name = "mutated"  # type: ignore[misc]
+            raise AssertionError("Expected AttributeError for frozen dataclass")
+        except AttributeError:
+            pass
+
+    @given(name=_non_empty_names)
+    def test_property_input_defaults(self, name: str) -> None:
+        """PropertyInput defaults to type='string' and resource_type='event'.
+
+        Args:
+            name: A non-empty property name.
+        """
+        prop = PropertyInput(name=name)
+        assert prop.type == "string"
+        assert prop.resource_type == "event"
+
+
+# =============================================================================
+# T065: InlineCustomProperty preserves formula and inputs
+# =============================================================================
+
+
+class TestInlineCustomPropertyPBT:
+    """Property-based tests for InlineCustomProperty construction (T065)."""
+
+    @given(
+        formula=_formulas,
+        inputs=valid_inputs_dict(),
+        property_type=_optional_property_types,
+        resource_type=_icp_resource_types,
+    )
+    def test_inline_custom_property_preserves_formula_and_inputs(
+        self,
+        formula: str,
+        inputs: dict[str, PropertyInput],
+        property_type: str | None,
+        resource_type: str,  # Literal["events", "people"] at runtime
+    ) -> None:
+        """InlineCustomProperty construction preserves formula and inputs.
+
+        Verifies that the formula string, inputs dict, property_type, and
+        resource_type are all stored exactly as provided.
+
+        Args:
+            formula: A non-empty formula expression.
+            inputs: Dict of 1-5 valid input key/PropertyInput pairs.
+            property_type: Optional result type literal.
+            resource_type: Data domain ("events" or "people").
+        """
+        icp = InlineCustomProperty(
+            formula=formula,
+            inputs=inputs,
+            property_type=property_type,  # type: ignore[arg-type]
+            resource_type=resource_type,  # type: ignore[arg-type]
+        )
+        assert icp.formula == formula
+        assert icp.inputs == inputs
+        assert icp.property_type == property_type
+        assert icp.resource_type == resource_type
+
+    @given(
+        formula=_formulas,
+        inputs=valid_inputs_dict(),
+    )
+    def test_inline_custom_property_defaults(
+        self,
+        formula: str,
+        inputs: dict[str, PropertyInput],
+    ) -> None:
+        """InlineCustomProperty defaults: property_type=None, resource_type='events'.
+
+        Args:
+            formula: A non-empty formula expression.
+            inputs: Dict of 1-5 valid input key/PropertyInput pairs.
+        """
+        icp = InlineCustomProperty(formula=formula, inputs=inputs)
+        assert icp.property_type is None
+        assert icp.resource_type == "events"
+
+    @given(
+        formula=_formulas,
+        properties=st.dictionaries(
+            keys=valid_input_key,
+            values=_non_empty_names,
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    def test_numeric_classmethod_sets_number_types(
+        self,
+        formula: str,
+        properties: dict[str, str],
+    ) -> None:
+        """InlineCustomProperty.numeric sets all inputs to type='number'.
+
+        Verifies the convenience constructor creates PropertyInput entries
+        with type='number' and sets property_type='number'.
+
+        Args:
+            formula: A non-empty formula expression.
+            properties: Dict mapping variable letters to property names.
+        """
+        icp = InlineCustomProperty.numeric(formula, **properties)
+        assert icp.formula == formula
+        assert icp.property_type == "number"
+        for key, name in properties.items():
+            assert key in icp.inputs
+            assert icp.inputs[key].name == name
+            assert icp.inputs[key].type == "number"
+            assert icp.inputs[key].resource_type == "event"
+
+
+# =============================================================================
+# T066: _build_composed_properties keys match
+# =============================================================================
+
+
+class TestBuildComposedPropertiesPBT:
+    """Property-based tests for _build_composed_properties (T066-T067)."""
+
+    @given(inputs=valid_inputs_dict())
+    def test_build_composed_properties_keys_match(
+        self, inputs: dict[str, PropertyInput]
+    ) -> None:
+        """_build_composed_properties output keys match input keys exactly.
+
+        The set of keys in the output dict must be identical to the set
+        of keys in the input dict.
+
+        Args:
+            inputs: Dict of 1-5 valid input key/PropertyInput pairs.
+        """
+        result = _build_composed_properties(inputs)
+        assert set(result.keys()) == set(inputs.keys())
+
+    # =========================================================================
+    # T067: _build_composed_properties required fields
+    # =========================================================================
+
+    @given(inputs=valid_inputs_dict())
+    def test_build_composed_properties_required_fields(
+        self, inputs: dict[str, PropertyInput]
+    ) -> None:
+        """Output values have required fields: value, type, resourceType.
+
+        Each entry in the composed properties dict must contain exactly
+        the three required keys, and their values must match the
+        corresponding PropertyInput fields.
+
+        Args:
+            inputs: Dict of 1-5 valid input key/PropertyInput pairs.
+        """
+        result = _build_composed_properties(inputs)
+        required_keys = {"value", "type", "resourceType"}
+
+        for key, entry in result.items():
+            assert set(entry.keys()) == required_keys
+            prop = inputs[key]
+            assert entry["value"] == prop.name
+            assert entry["type"] == prop.type
+            assert entry["resourceType"] == prop.resource_type
+
+
+# =============================================================================
+# CustomPropertyRef invariants
+# =============================================================================
+
+
+class TestCustomPropertyRefPBT:
+    """Property-based tests for CustomPropertyRef construction."""
+
+    @given(ref_id=st.integers(min_value=1, max_value=10_000_000))
+    def test_custom_property_ref_preserves_id(self, ref_id: int) -> None:
+        """CustomPropertyRef preserves the integer ID through construction.
+
+        Args:
+            ref_id: A positive integer ID.
+        """
+        ref = CustomPropertyRef(id=ref_id)
+        assert ref.id == ref_id
+
+    @given(ref_id=st.integers(min_value=1, max_value=10_000_000))
+    def test_custom_property_ref_is_frozen(self, ref_id: int) -> None:
+        """CustomPropertyRef instances are immutable (frozen dataclass).
+
+        Args:
+            ref_id: A positive integer ID.
+        """
+        ref = CustomPropertyRef(id=ref_id)
+        try:
+            ref.id = 999  # type: ignore[misc]
+            raise AssertionError("Expected AttributeError for frozen dataclass")
+        except AttributeError:
+            pass

--- a/tests/test_custom_property_query.py
+++ b/tests/test_custom_property_query.py
@@ -1,0 +1,238 @@
+"""End-to-end tests for custom properties across query engines (Phase 037).
+
+Exercises the full pipeline from typed arguments through build_params(),
+build_funnel_params(), and build_retention_params() to verify custom
+property bookmark JSON output.
+
+Task IDs: T023, T032, T038-T040, T044-T045
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.types import (
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    Metric,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def ws() -> Workspace:
+    """Create a Workspace instance with mocked dependencies."""
+    creds = Credentials(
+        username="u", secret=SecretStr("s"), project_id="1", region="us"
+    )
+    mgr = MagicMock(spec=ConfigManager)
+    mgr.resolve_credentials.return_value = creds
+    return Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+
+# =============================================================================
+# T023: E2E group_by with custom properties (US1)
+# =============================================================================
+
+
+class TestGroupByCustomPropertyE2E:
+    """E2E tests for custom property in group_by across query engines."""
+
+    def test_build_params_with_custom_property_ref_group_by(
+        self, ws: Workspace
+    ) -> None:
+        """build_params with CustomPropertyRef in group_by."""
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert group[0]["customPropertyId"] == 42
+
+    def test_build_params_with_inline_group_by(self, ws: Workspace) -> None:
+        """build_params with InlineCustomProperty in group_by."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=icp, property_type="number"),
+        )
+
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert "customProperty" in group[0]
+        assert group[0]["customProperty"]["displayFormula"] == "A * B"
+
+    def test_build_funnel_params_with_custom_property_group_by(
+        self, ws: Workspace
+    ) -> None:
+        """build_funnel_params with CustomPropertyRef in group_by."""
+        params = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert group[0]["customPropertyId"] == 42
+
+    def test_build_retention_params_with_custom_property_group_by(
+        self, ws: Workspace
+    ) -> None:
+        """build_retention_params with CustomPropertyRef in group_by."""
+        params = ws.build_retention_params(
+            "Signup",
+            "Login",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert group[0]["customPropertyId"] == 42
+
+
+# =============================================================================
+# T032: E2E filter with custom properties (US2)
+# =============================================================================
+
+
+class TestFilterCustomPropertyE2E:
+    """E2E tests for custom property in filter across query engines."""
+
+    def test_build_params_with_custom_property_ref_filter(self, ws: Workspace) -> None:
+        """build_params with CustomPropertyRef in filter."""
+        params = ws.build_params(
+            "Purchase",
+            where=Filter.greater_than(property=CustomPropertyRef(42), value=100),
+        )
+
+        filters = params["sections"]["filter"]
+        assert len(filters) == 1
+        assert filters[0]["customPropertyId"] == 42
+        assert "value" not in filters[0]
+
+    def test_build_params_with_inline_filter(self, ws: Workspace) -> None:
+        """build_params with InlineCustomProperty in filter."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        params = ws.build_params(
+            "Purchase",
+            where=Filter.greater_than(property=icp, value=1000),
+        )
+
+        filters = params["sections"]["filter"]
+        assert len(filters) == 1
+        assert "customProperty" in filters[0]
+        assert filters[0]["customProperty"]["displayFormula"] == "A * B"
+
+
+# =============================================================================
+# T038-T040: E2E measurement with custom properties (US3)
+# =============================================================================
+
+
+class TestMeasurementCustomPropertyE2E:
+    """E2E tests for custom property in Metric.property."""
+
+    def test_build_params_with_custom_property_ref_measurement(
+        self, ws: Workspace
+    ) -> None:
+        """T038: build_params with Metric(property=CustomPropertyRef(...))."""
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=CustomPropertyRef(42)),
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"]["customPropertyId"] == 42
+        assert measurement["property"]["resourceType"] == "events"
+
+    def test_build_params_with_inline_measurement(self, ws: Workspace) -> None:
+        """T039: build_params with Metric(property=InlineCustomProperty.numeric(...))."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=icp),
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        prop = measurement["property"]
+        assert "customProperty" in prop
+        assert prop["customProperty"]["displayFormula"] == "A * B"
+        assert prop["resourceType"] == "events"
+
+    def test_build_funnel_params_with_custom_property_measurement(
+        self, ws: Workspace
+    ) -> None:
+        """T040: build_funnel_params with custom property math_property."""
+        # Funnels use math_property (top-level), not Metric.property
+        # Custom property in funnel measurement is not supported via
+        # math_property (it's always a string). This test verifies
+        # the plain string path still works in funnels.
+        params = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            math="average",
+            math_property="amount",
+        )
+
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"]["name"] == "amount"
+
+
+# =============================================================================
+# T044-T045: Combined positions E2E tests (Phase 6)
+# =============================================================================
+
+
+class TestCombinedPositions:
+    """Tests for custom properties in multiple positions simultaneously."""
+
+    def test_ref_in_group_by_and_inline_in_filter(self, ws: Workspace) -> None:
+        """T044: CustomPropertyRef in group_by + InlineCustomProperty in where."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+            where=Filter.greater_than(property=icp, value=100),
+        )
+
+        group = params["sections"]["group"]
+        filters = params["sections"]["filter"]
+        assert group[0]["customPropertyId"] == 42
+        assert "customProperty" in filters[0]
+
+    def test_all_three_positions(self, ws: Workspace) -> None:
+        """T045: All three positions simultaneously (Metric + group_by + where)."""
+        revenue = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        params = ws.build_params(
+            Metric("Purchase", math="average", property=CustomPropertyRef(99)),
+            group_by=GroupBy(
+                property=revenue,
+                property_type="number",
+                bucket_size=100,
+                bucket_min=0,
+                bucket_max=1000,
+            ),
+            where=Filter.greater_than(property=revenue, value=50),
+        )
+
+        # Measurement
+        measurement = params["sections"]["show"][0]["measurement"]
+        assert measurement["property"]["customPropertyId"] == 99
+
+        # Group
+        group = params["sections"]["group"]
+        assert "customProperty" in group[0]
+        assert group[0]["customBucket"]["bucketSize"] == 100
+
+        # Filter
+        filters = params["sections"]["filter"]
+        assert "customProperty" in filters[0]

--- a/tests/test_custom_property_query.py
+++ b/tests/test_custom_property_query.py
@@ -16,6 +16,7 @@ from pydantic import SecretStr
 
 from mixpanel_data import Workspace
 from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.exceptions import QueryError
 from mixpanel_data.types import (
     CustomPropertyRef,
     Filter,
@@ -236,3 +237,49 @@ class TestCombinedPositions:
         # Filter
         filters = params["sections"]["filter"]
         assert "customProperty" in filters[0]
+
+
+# =============================================================================
+# list_custom_properties error handling
+# =============================================================================
+
+
+class TestListCustomPropertiesErrorHandling:
+    """Tests for QueryError re-raise with HTTP context preservation."""
+
+    def test_display_formula_corruption_preserves_context(self, ws: Workspace) -> None:
+        """Re-raised QueryError for displayFormula corruption preserves HTTP context."""
+        original = QueryError(
+            "serialization failed",
+            status_code=500,
+            response_body={"field": "displayFormula"},
+            request_method="GET",
+            request_url="https://mixpanel.com/api/app/custom-properties",
+            request_params={"project_id": "1"},
+        )
+        ws._api_client.list_custom_properties.side_effect = original  # type: ignore[union-attr]
+
+        with pytest.raises(QueryError, match="displayFormula") as exc_info:
+            ws.list_custom_properties()
+
+        raised = exc_info.value
+        assert raised is not original
+        assert raised.status_code == 500
+        assert raised.response_body == {"field": "displayFormula"}
+        assert raised.request_method == "GET"
+        assert raised.request_url == "https://mixpanel.com/api/app/custom-properties"
+        assert raised.__cause__ is original
+
+    def test_non_matching_query_error_reraised_unchanged(self, ws: Workspace) -> None:
+        """QueryError without displayFormula field is re-raised unchanged."""
+        original = QueryError(
+            "some other error",
+            status_code=400,
+            response_body={"field": "somethingElse"},
+        )
+        ws._api_client.list_custom_properties.side_effect = original  # type: ignore[union-attr]
+
+        with pytest.raises(QueryError) as exc_info:
+            ws.list_custom_properties()
+
+        assert exc_info.value is original

--- a/tests/test_custom_property_types.py
+++ b/tests/test_custom_property_types.py
@@ -477,6 +477,34 @@ class TestCustomPropertyValidationCP5:
                 group_by=GroupBy(property=icp, property_type="string"),
             )
 
+    def test_formula_at_boundary_passes(self) -> None:
+        """Formula at exactly 20,000 chars passes validation."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="A" * 20_000,
+            inputs={"A": PropertyInput("price")},
+        )
+
+        # Should NOT raise — exactly at the limit
+        params = ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=icp, property_type="string"),
+        )
+        assert "sections" in params
+
 
 class TestCustomPropertyValidationCP6:
     """T052: CP6 — PropertyInput with empty name."""

--- a/tests/test_custom_property_types.py
+++ b/tests/test_custom_property_types.py
@@ -1,0 +1,663 @@
+"""Unit tests for custom property query types (Phase 037).
+
+Tests for PropertyInput, InlineCustomProperty, and CustomPropertyRef
+frozen dataclasses, plus the PropertySpec type alias. Covers construction,
+defaults, immutability, the InlineCustomProperty.numeric() convenience
+constructor, and fail-fast validation (CP1-CP6).
+
+Task IDs: T001-T005, T047-T056
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from mixpanel_data.types import (
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    Metric,
+    PropertyInput,
+)
+
+# =============================================================================
+# T001: PropertyInput construction tests
+# =============================================================================
+
+
+class TestPropertyInput:
+    """Tests for PropertyInput frozen dataclass construction."""
+
+    def test_minimal_construction(self) -> None:
+        """PropertyInput can be constructed with just a name."""
+        pi = PropertyInput("price")
+
+        assert pi.name == "price"
+        assert pi.type == "string"
+        assert pi.resource_type == "event"
+
+    def test_explicit_number_type(self) -> None:
+        """PropertyInput accepts explicit number type."""
+        pi = PropertyInput("amount", type="number")
+
+        assert pi.name == "amount"
+        assert pi.type == "number"
+        assert pi.resource_type == "event"
+
+    def test_user_resource_type(self) -> None:
+        """PropertyInput accepts user resource_type."""
+        pi = PropertyInput("email", resource_type="user")
+
+        assert pi.name == "email"
+        assert pi.type == "string"
+        assert pi.resource_type == "user"
+
+    @pytest.mark.parametrize(
+        "prop_type",
+        ["string", "number", "boolean", "datetime", "list"],
+    )
+    def test_all_valid_types(self, prop_type: str) -> None:
+        """PropertyInput accepts all 5 valid property types."""
+        pi = PropertyInput("prop", type=prop_type)  # type: ignore[arg-type]
+
+        assert pi.type == prop_type
+
+    def test_all_fields_explicit(self) -> None:
+        """PropertyInput accepts all fields set explicitly."""
+        pi = PropertyInput("revenue", type="number", resource_type="user")
+
+        assert pi.name == "revenue"
+        assert pi.type == "number"
+        assert pi.resource_type == "user"
+
+
+# =============================================================================
+# T002: InlineCustomProperty construction tests
+# =============================================================================
+
+
+class TestInlineCustomProperty:
+    """Tests for InlineCustomProperty frozen dataclass construction."""
+
+    def test_minimal_construction(self) -> None:
+        """InlineCustomProperty can be constructed with formula + single input."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("price")},
+        )
+
+        assert icp.formula == "A"
+        assert len(icp.inputs) == 1
+        assert icp.inputs["A"].name == "price"
+        assert icp.property_type is None
+        assert icp.resource_type == "events"
+
+    def test_full_construction(self) -> None:
+        """InlineCustomProperty accepts all fields explicitly."""
+        icp = InlineCustomProperty(
+            formula="A * B",
+            inputs={
+                "A": PropertyInput("price", type="number"),
+                "B": PropertyInput("quantity", type="number"),
+            },
+            property_type="number",
+            resource_type="people",
+        )
+
+        assert icp.formula == "A * B"
+        assert len(icp.inputs) == 2
+        assert icp.property_type == "number"
+        assert icp.resource_type == "people"
+
+
+# =============================================================================
+# T003: InlineCustomProperty.numeric() convenience constructor tests
+# =============================================================================
+
+
+class TestInlineCustomPropertyNumeric:
+    """Tests for InlineCustomProperty.numeric() classmethod."""
+
+    def test_multi_input(self) -> None:
+        """numeric() creates an all-number InlineCustomProperty with multiple inputs."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+
+        assert icp.formula == "A * B"
+        assert len(icp.inputs) == 2
+        assert icp.inputs["A"].name == "price"
+        assert icp.inputs["A"].type == "number"
+        assert icp.inputs["A"].resource_type == "event"
+        assert icp.inputs["B"].name == "quantity"
+        assert icp.inputs["B"].type == "number"
+        assert icp.property_type == "number"
+        assert icp.resource_type == "events"
+
+    def test_single_input(self) -> None:
+        """numeric() works with a single input."""
+        icp = InlineCustomProperty.numeric("A", A="revenue")
+
+        assert icp.formula == "A"
+        assert len(icp.inputs) == 1
+        assert icp.inputs["A"].name == "revenue"
+        assert icp.inputs["A"].type == "number"
+        assert icp.property_type == "number"
+
+
+# =============================================================================
+# T004: CustomPropertyRef construction tests
+# =============================================================================
+
+
+class TestCustomPropertyRef:
+    """Tests for CustomPropertyRef frozen dataclass construction."""
+
+    def test_stores_integer_id(self) -> None:
+        """CustomPropertyRef stores the given integer ID."""
+        ref = CustomPropertyRef(42)
+
+        assert ref.id == 42
+
+    def test_large_id(self) -> None:
+        """CustomPropertyRef handles large IDs."""
+        ref = CustomPropertyRef(999999)
+
+        assert ref.id == 999999
+
+
+# =============================================================================
+# T005: Immutability tests
+# =============================================================================
+
+
+class TestImmutability:
+    """Tests that all three types are frozen (immutable)."""
+
+    def test_property_input_frozen(self) -> None:
+        """PropertyInput raises FrozenInstanceError on attribute assignment."""
+        pi = PropertyInput("price")
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            pi.name = "other"  # type: ignore[misc]
+
+    def test_inline_custom_property_frozen(self) -> None:
+        """InlineCustomProperty raises FrozenInstanceError on attribute assignment."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("price")},
+        )
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            icp.formula = "B"  # type: ignore[misc]
+
+    def test_custom_property_ref_frozen(self) -> None:
+        """CustomPropertyRef raises FrozenInstanceError on attribute assignment."""
+        ref = CustomPropertyRef(42)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ref.id = 99  # type: ignore[misc]
+
+
+# =============================================================================
+# Type widening backward compatibility tests
+# =============================================================================
+
+
+class TestTypeWidening:
+    """Tests that widened types still accept plain strings (backward compat)."""
+
+    def test_metric_property_accepts_string(self) -> None:
+        """Metric.property still accepts plain string."""
+        m = Metric("Purchase", math="average", property="amount")
+
+        assert m.property == "amount"
+
+    def test_metric_property_accepts_custom_property_ref(self) -> None:
+        """Metric.property accepts CustomPropertyRef."""
+        m = Metric("Purchase", math="average", property=CustomPropertyRef(42))
+
+        assert isinstance(m.property, CustomPropertyRef)
+        assert m.property.id == 42
+
+    def test_metric_property_accepts_inline_custom_property(self) -> None:
+        """Metric.property accepts InlineCustomProperty."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        m = Metric("Purchase", math="average", property=icp)
+
+        assert isinstance(m.property, InlineCustomProperty)
+
+    def test_group_by_property_accepts_string(self) -> None:
+        """GroupBy.property still accepts plain string."""
+        g = GroupBy("country")
+
+        assert g.property == "country"
+
+    def test_group_by_property_accepts_custom_property_ref(self) -> None:
+        """GroupBy.property accepts CustomPropertyRef."""
+        g = GroupBy(property=CustomPropertyRef(42), property_type="number")
+
+        assert isinstance(g.property, CustomPropertyRef)
+
+    def test_group_by_property_accepts_inline_custom_property(self) -> None:
+        """GroupBy.property accepts InlineCustomProperty."""
+        icp = InlineCustomProperty.numeric("A", A="revenue")
+        g = GroupBy(property=icp, property_type="number")
+
+        assert isinstance(g.property, InlineCustomProperty)
+
+    def test_filter_equals_accepts_custom_property_ref(self) -> None:
+        """Filter.equals() accepts CustomPropertyRef in property position."""
+        f = Filter.equals(property=CustomPropertyRef(42), value="Enterprise")
+
+        assert isinstance(f._property, CustomPropertyRef)
+
+    def test_filter_greater_than_accepts_inline(self) -> None:
+        """Filter.greater_than() accepts InlineCustomProperty."""
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="qty")
+        f = Filter.greater_than(property=icp, value=100)
+
+        assert isinstance(f._property, InlineCustomProperty)
+
+    def test_filter_is_set_accepts_custom_property_ref(self) -> None:
+        """Filter.is_set() accepts CustomPropertyRef."""
+        f = Filter.is_set(property=CustomPropertyRef(42))
+
+        assert isinstance(f._property, CustomPropertyRef)
+
+
+# =============================================================================
+# T047-T056: Fail-fast validation tests (US5, CP1-CP6)
+# =============================================================================
+
+
+class TestCustomPropertyValidationCP1:
+    """T047: CP1 — CustomPropertyRef.id must be positive."""
+
+    def test_zero_id_in_group_by(self) -> None:
+        """CustomPropertyRef(0) in group_by raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
+            )
+
+    def test_negative_id(self) -> None:
+        """CustomPropertyRef(-1) raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(
+                    property=CustomPropertyRef(-1), property_type="number"
+                ),
+            )
+
+
+class TestCustomPropertyValidationCP2:
+    """T048: CP2 — InlineCustomProperty with empty formula."""
+
+    def test_empty_formula(self) -> None:
+        """Empty formula raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="",
+            inputs={"A": PropertyInput("price")},
+        )
+
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+    def test_whitespace_only_formula(self) -> None:
+        """Whitespace-only formula raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="   ",
+            inputs={"A": PropertyInput("price")},
+        )
+
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+
+class TestCustomPropertyValidationCP3:
+    """T049: CP3 — InlineCustomProperty with empty inputs dict."""
+
+    def test_empty_inputs(self) -> None:
+        """Empty inputs dict raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(formula="A", inputs={})
+
+        with pytest.raises(BookmarkValidationError, match="at least one input"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+
+class TestCustomPropertyValidationCP4:
+    """T050: CP4 — InlineCustomProperty input keys must be single uppercase A-Z."""
+
+    @pytest.mark.parametrize("key", ["a", "AB", "1", "aa"])
+    def test_invalid_keys(self, key: str) -> None:
+        """Invalid input keys raise validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={key: PropertyInput("price")},
+        )
+
+        with pytest.raises(BookmarkValidationError, match="uppercase"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+
+class TestCustomPropertyValidationCP5:
+    """T051: CP5 — Formula exceeds 20,000 chars."""
+
+    def test_formula_too_long(self) -> None:
+        """Formula > 20,000 chars raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="A" * 20_001,
+            inputs={"A": PropertyInput("price")},
+        )
+
+        with pytest.raises(BookmarkValidationError, match="20,000"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+
+class TestCustomPropertyValidationCP6:
+    """T052: CP6 — PropertyInput with empty name."""
+
+    def test_empty_property_name(self) -> None:
+        """Empty PropertyInput.name raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("")},
+        )
+
+        with pytest.raises(BookmarkValidationError, match="empty property name"):
+            ws.build_params(
+                "Purchase",
+                group_by=GroupBy(property=icp, property_type="string"),
+            )
+
+
+class TestCustomPropertyValidationValid:
+    """T053: Valid custom properties pass validation."""
+
+    def test_valid_inline_passes(self) -> None:
+        """Valid InlineCustomProperty passes validation without errors."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
+        # Should not raise
+        ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=icp, property_type="number"),
+        )
+
+    def test_valid_ref_passes(self) -> None:
+        """Valid CustomPropertyRef passes validation without errors."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        # Should not raise
+        ws.build_params(
+            "Purchase",
+            group_by=GroupBy(property=CustomPropertyRef(42), property_type="number"),
+        )
+
+
+class TestCustomPropertyValidationFilterPosition:
+    """T054: CP validation in filter (where) position."""
+
+    def test_invalid_ref_in_filter(self) -> None:
+        """CustomPropertyRef(0) in filter raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                "Purchase",
+                where=Filter.greater_than(property=CustomPropertyRef(0), value=100),
+            )
+
+
+class TestCustomPropertyValidationMeasurementPosition:
+    """T055: CP validation in Metric.property position."""
+
+    def test_invalid_ref_in_metric(self) -> None:
+        """CustomPropertyRef(0) in Metric.property raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric("Purchase", math="average", property=CustomPropertyRef(0)),
+            )
+
+
+class TestCustomPropertyValidationFunnelRetention:
+    """T056: CP validation in funnel group_by and retention where."""
+
+    def test_invalid_ref_in_funnel_group_by(self) -> None:
+        """CustomPropertyRef(0) in funnel group_by raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_funnel_params(
+                ["Signup", "Purchase"],
+                group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
+            )
+
+    def test_invalid_ref_in_retention_group_by(self) -> None:
+        """CustomPropertyRef(0) in retention group_by raises validation error."""
+        from unittest.mock import MagicMock
+
+        from pydantic import SecretStr
+
+        from mixpanel_data import Workspace
+        from mixpanel_data._internal.config import ConfigManager, Credentials
+        from mixpanel_data.exceptions import BookmarkValidationError
+
+        creds = Credentials(
+            username="u", secret=SecretStr("s"), project_id="1", region="us"
+        )
+        mgr = MagicMock(spec=ConfigManager)
+        mgr.resolve_credentials.return_value = creds
+        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                "Signup",
+                "Login",
+                group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
+            )

--- a/tests/test_custom_property_types.py
+++ b/tests/test_custom_property_types.py
@@ -11,9 +11,14 @@ Task IDs: T001-T005, T047-T056
 from __future__ import annotations
 
 import dataclasses
+from unittest.mock import MagicMock
 
 import pytest
+from pydantic import SecretStr
 
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.exceptions import BookmarkValidationError
 from mixpanel_data.types import (
     CustomPropertyRef,
     Filter,
@@ -272,49 +277,30 @@ class TestTypeWidening:
 # =============================================================================
 
 
+@pytest.fixture
+def ws() -> Workspace:
+    """Create a Workspace instance with mocked dependencies."""
+    creds = Credentials(
+        username="u", secret=SecretStr("s"), project_id="1", region="us"
+    )
+    mgr = MagicMock(spec=ConfigManager)
+    mgr.resolve_credentials.return_value = creds
+    return Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+
 class TestCustomPropertyValidationCP1:
     """T047: CP1 — CustomPropertyRef.id must be positive."""
 
-    def test_zero_id_in_group_by(self) -> None:
+    def test_zero_id_in_group_by(self, ws: Workspace) -> None:
         """CustomPropertyRef(0) in group_by raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_params(
                 "Purchase",
                 group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
             )
 
-    def test_negative_id(self) -> None:
+    def test_negative_id(self, ws: Workspace) -> None:
         """CustomPropertyRef(-1) raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_params(
                 "Purchase",
@@ -327,23 +313,8 @@ class TestCustomPropertyValidationCP1:
 class TestCustomPropertyValidationCP2:
     """T048: CP2 — InlineCustomProperty with empty formula."""
 
-    def test_empty_formula(self) -> None:
+    def test_empty_formula(self, ws: Workspace) -> None:
         """Empty formula raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="",
             inputs={"A": PropertyInput("price")},
@@ -355,23 +326,8 @@ class TestCustomPropertyValidationCP2:
                 group_by=GroupBy(property=icp, property_type="string"),
             )
 
-    def test_whitespace_only_formula(self) -> None:
+    def test_whitespace_only_formula(self, ws: Workspace) -> None:
         """Whitespace-only formula raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="   ",
             inputs={"A": PropertyInput("price")},
@@ -387,23 +343,8 @@ class TestCustomPropertyValidationCP2:
 class TestCustomPropertyValidationCP3:
     """T049: CP3 — InlineCustomProperty with empty inputs dict."""
 
-    def test_empty_inputs(self) -> None:
+    def test_empty_inputs(self, ws: Workspace) -> None:
         """Empty inputs dict raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(formula="A", inputs={})
 
         with pytest.raises(BookmarkValidationError, match="at least one input"):
@@ -417,23 +358,8 @@ class TestCustomPropertyValidationCP4:
     """T050: CP4 — InlineCustomProperty input keys must be single uppercase A-Z."""
 
     @pytest.mark.parametrize("key", ["a", "AB", "1", "aa"])
-    def test_invalid_keys(self, key: str) -> None:
+    def test_invalid_keys(self, key: str, ws: Workspace) -> None:
         """Invalid input keys raise validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="A",
             inputs={key: PropertyInput("price")},
@@ -449,23 +375,8 @@ class TestCustomPropertyValidationCP4:
 class TestCustomPropertyValidationCP5:
     """T051: CP5 — Formula exceeds 20,000 chars."""
 
-    def test_formula_too_long(self) -> None:
+    def test_formula_too_long(self, ws: Workspace) -> None:
         """Formula > 20,000 chars raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="A" * 20_001,
             inputs={"A": PropertyInput("price")},
@@ -477,22 +388,8 @@ class TestCustomPropertyValidationCP5:
                 group_by=GroupBy(property=icp, property_type="string"),
             )
 
-    def test_formula_at_boundary_passes(self) -> None:
+    def test_formula_at_boundary_passes(self, ws: Workspace) -> None:
         """Formula at exactly 20,000 chars passes validation."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="A" * 20_000,
             inputs={"A": PropertyInput("price")},
@@ -509,23 +406,8 @@ class TestCustomPropertyValidationCP5:
 class TestCustomPropertyValidationCP6:
     """T052: CP6 — PropertyInput with empty name."""
 
-    def test_empty_property_name(self) -> None:
+    def test_empty_property_name(self, ws: Workspace) -> None:
         """Empty PropertyInput.name raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty(
             formula="A",
             inputs={"A": PropertyInput("")},
@@ -541,22 +423,8 @@ class TestCustomPropertyValidationCP6:
 class TestCustomPropertyValidationValid:
     """T053: Valid custom properties pass validation."""
 
-    def test_valid_inline_passes(self) -> None:
+    def test_valid_inline_passes(self, ws: Workspace) -> None:
         """Valid InlineCustomProperty passes validation without errors."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         icp = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
         # Should not raise
         ws.build_params(
@@ -564,22 +432,8 @@ class TestCustomPropertyValidationValid:
             group_by=GroupBy(property=icp, property_type="number"),
         )
 
-    def test_valid_ref_passes(self) -> None:
+    def test_valid_ref_passes(self, ws: Workspace) -> None:
         """Valid CustomPropertyRef passes validation without errors."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         # Should not raise
         ws.build_params(
             "Purchase",
@@ -590,23 +444,8 @@ class TestCustomPropertyValidationValid:
 class TestCustomPropertyValidationFilterPosition:
     """T054: CP validation in filter (where) position."""
 
-    def test_invalid_ref_in_filter(self) -> None:
+    def test_invalid_ref_in_filter(self, ws: Workspace) -> None:
         """CustomPropertyRef(0) in filter raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_params(
                 "Purchase",
@@ -617,23 +456,8 @@ class TestCustomPropertyValidationFilterPosition:
 class TestCustomPropertyValidationMeasurementPosition:
     """T055: CP validation in Metric.property position."""
 
-    def test_invalid_ref_in_metric(self) -> None:
+    def test_invalid_ref_in_metric(self, ws: Workspace) -> None:
         """CustomPropertyRef(0) in Metric.property raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_params(
                 Metric("Purchase", math="average", property=CustomPropertyRef(0)),
@@ -643,49 +467,36 @@ class TestCustomPropertyValidationMeasurementPosition:
 class TestCustomPropertyValidationFunnelRetention:
     """T056: CP validation in funnel group_by and retention where."""
 
-    def test_invalid_ref_in_funnel_group_by(self) -> None:
+    def test_invalid_ref_in_funnel_group_by(self, ws: Workspace) -> None:
         """CustomPropertyRef(0) in funnel group_by raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_funnel_params(
                 ["Signup", "Purchase"],
                 group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
             )
 
-    def test_invalid_ref_in_retention_group_by(self) -> None:
+    def test_invalid_ref_in_retention_group_by(self, ws: Workspace) -> None:
         """CustomPropertyRef(0) in retention group_by raises validation error."""
-        from unittest.mock import MagicMock
-
-        from pydantic import SecretStr
-
-        from mixpanel_data import Workspace
-        from mixpanel_data._internal.config import ConfigManager, Credentials
-        from mixpanel_data.exceptions import BookmarkValidationError
-
-        creds = Credentials(
-            username="u", secret=SecretStr("s"), project_id="1", region="us"
-        )
-        mgr = MagicMock(spec=ConfigManager)
-        mgr.resolve_credentials.return_value = creds
-        ws = Workspace(_config_manager=mgr, _api_client=MagicMock())
-
         with pytest.raises(BookmarkValidationError, match="positive integer"):
             ws.build_retention_params(
                 "Signup",
                 "Login",
                 group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"),
+            )
+
+    def test_invalid_ref_in_funnel_where(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in funnel where raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_funnel_params(
+                ["Signup", "Purchase"],
+                where=Filter.greater_than(property=CustomPropertyRef(0), value=100),
+            )
+
+    def test_invalid_ref_in_retention_where(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in retention where raises validation error."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                "Signup",
+                "Login",
+                where=Filter.greater_than(property=CustomPropertyRef(0), value=100),
             )

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -8,6 +8,7 @@ date ranges, filter sections, group sections, and filter entries.
 from __future__ import annotations
 
 from datetime import date
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -18,8 +19,16 @@ from mixpanel_data._internal.bookmark_builders import (
     build_filter_section,
     build_group_section,
     build_time_section,
+    patch_custom_property_filters_for_transform,
 )
-from mixpanel_data.types import CohortBreakdown, Filter, GroupBy
+from mixpanel_data.types import (
+    CohortBreakdown,
+    CustomPropertyRef,
+    Filter,
+    GroupBy,
+    InlineCustomProperty,
+    PropertyInput,
+)
 
 
 class TestBuildTimeSection:
@@ -327,3 +336,67 @@ class TestBuildFilterEntry:
         f = Filter.equals("plan", "premium", resource_type="people")
         entry = build_filter_entry(f)
         assert entry["resourceType"] == "people"
+
+    def test_custom_property_ref_omits_value(self) -> None:
+        """CustomPropertyRef filter does not include 'value' by default."""
+        ref = CustomPropertyRef(90553)
+        f = Filter.is_set(ref)
+        entry = build_filter_entry(f)
+        assert entry["customPropertyId"] == 90553
+        assert "value" not in entry
+        assert entry["dataset"] == "$mixpanel"
+
+    def test_inline_custom_property_omits_value(self) -> None:
+        """InlineCustomProperty filter does not include 'value' by default."""
+        icp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput(name="price", type="number")},
+            property_type="number",
+        )
+        f = Filter.greater_than(icp, 1000)
+        entry = build_filter_entry(f)
+        assert "customProperty" in entry
+        assert "value" not in entry
+        assert entry["dataset"] == "$mixpanel"
+
+
+class TestPatchCustomPropertyFiltersForTransform:
+    """Tests for the server-compat sentinel injection.
+
+    The server's ``transform_insights_filters_to_funnels()`` crashes
+    with ``KeyError`` on custom property filters that lack ``"value"``.
+    ``patch_custom_property_filters_for_transform()`` adds
+    ``"value": None`` so the transform survives.
+    """
+
+    def test_adds_value_to_custom_property_ref(self) -> None:
+        """Adds 'value': None for customPropertyId entries."""
+        entries = [{"customPropertyId": 90553, "filterOperator": "is set"}]
+        result = patch_custom_property_filters_for_transform(entries)
+        assert result[0]["value"] is None
+
+    def test_adds_value_to_inline_custom_property(self) -> None:
+        """Adds 'value': None for customProperty entries."""
+        entries = [{"customProperty": {"formula": "A"}, "filterOperator": ">"}]
+        result = patch_custom_property_filters_for_transform(entries)
+        assert result[0]["value"] is None
+
+    def test_does_not_overwrite_existing_value(self) -> None:
+        """Does not touch entries that already have 'value'."""
+        entries = [{"value": "country", "filterOperator": "equals"}]
+        patch_custom_property_filters_for_transform(entries)
+        assert entries[0]["value"] == "country"
+
+    def test_leaves_regular_filters_alone(self) -> None:
+        """Regular property filters (with 'value') are untouched."""
+        entries: list[dict[str, Any]] = [
+            {"value": "country", "filterOperator": "equals"},
+            {"customPropertyId": 42, "filterOperator": "is set"},
+        ]
+        patch_custom_property_filters_for_transform(entries)
+        assert entries[0]["value"] == "country"
+        assert entries[1]["value"] is None
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty list."""
+        assert patch_custom_property_filters_for_transform([]) == []

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -554,6 +554,39 @@ class TestValidateBookmarkLayer2:
         errors = validate_bookmark(bm)
         assert any(e.code == "B18_MISSING_FILTER_PROPERTY" for e in errors)
 
+    def test_b18_custom_property_id_passes(self) -> None:
+        """B18: Filter with customPropertyId passes validation."""
+        bm = _minimal_bookmark()
+        bm["sections"]["filter"] = [
+            {
+                "filterType": "string",
+                "filterOperator": "equals",
+                "filterValue": ["US"],
+                "customPropertyId": 42,
+                "resourceType": "events",
+            }
+        ]
+        errors = validate_bookmark(bm)
+        assert not any(e.code == "B18_MISSING_FILTER_PROPERTY" for e in errors)
+
+    def test_b18_custom_property_dict_passes(self) -> None:
+        """B18: Filter with customProperty dict passes validation."""
+        bm = _minimal_bookmark()
+        bm["sections"]["filter"] = [
+            {
+                "filterType": "string",
+                "filterOperator": "equals",
+                "filterValue": ["US"],
+                "customProperty": {
+                    "displayFormula": "A",
+                    "composedProperties": {},
+                },
+                "resourceType": "events",
+            }
+        ]
+        errors = validate_bookmark(bm)
+        assert not any(e.code == "B18_MISSING_FILTER_PROPERTY" for e in errors)
+
     def test_formula_show_clause_valid(self) -> None:
         """Formula show clauses are accepted."""
         bm = _minimal_bookmark()


### PR DESCRIPTION
## Every property you wish existed is now one line away

Mixpanel custom properties let you compute derived values — revenue per unit, full name, LTV buckets — from raw event data. But using them in queries meant manually constructing bookmark JSON with nested `customProperty` and `composedProperties` structures, getting the `resourceType` singular/plural conventions right, and hoping the server wouldn't crash on undocumented edge cases.

Now any formula becomes a property you can break down by, filter on, or aggregate — across three query engines:

```python
revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")
result = ws.query("Purchase", group_by=GroupBy(property=revenue, property_type="number", bucket_size=100))
```

Define the property inline at query time. No trip to the Mixpanel UI. No saved custom property to manage. No JSON to craft. Just describe the computation and use it like any other property.

Saved custom properties work too — reference by ID:

```python
result = ws.query("Purchase", where=Filter.greater_than(property=CustomPropertyRef(42), value=100))
```

---

## What was impossible is now a keyword argument

| Pattern | Before | After |
|---------|--------|-------|
| Break down by a saved custom property | **Raw JSON required** | `GroupBy(property=CustomPropertyRef(42), property_type="number")` |
| Break down by an inline formula | **Raw JSON required** | `GroupBy(property=InlineCustomProperty.numeric("A*B", A="price", B="qty"))` |
| Numeric bucketing on custom properties | **Raw JSON required** | `GroupBy(property=..., bucket_size=50, bucket_min=0, bucket_max=500)` |
| Filter by a saved custom property | **Raw JSON required** | `Filter.greater_than(property=CustomPropertyRef(42), value=100)` |
| Filter by an inline formula result | **Raw JSON required** | `Filter.between(property=InlineCustomProperty.numeric("A/B", A="revenue", B="units"), value=[10, 100])` |
| Aggregate a custom property (avg, sum, p99) | **Raw JSON required** | `Metric("Purchase", math="average", property=CustomPropertyRef(42))` |
| Aggregate an inline formula | **Raw JSON required** | `Metric("Purchase", math="total", property=InlineCustomProperty.numeric("A*B", A="price", B="qty"))` |
| Use all 18 Filter methods with custom properties | **Impossible** | Every `Filter.*()` method accepts custom properties in `property=` |
| Mix custom + regular properties in breakdowns | **Impossible** | `group_by=["country", GroupBy(property=CustomPropertyRef(42), property_type="number")]` |
| Validate custom property params before API call | **Impossible** | 6 validation rules (CP1–CP6) with structured error output |
| Custom properties in funnel breakdowns | **Raw JSON required** | `query_funnel([...], group_by=GroupBy(property=..., property_type="number"))` |
| Custom properties in retention breakdowns | **Raw JSON required** | `query_retention("Signup", "Login", group_by=GroupBy(property=..., property_type="number"))` |

All twelve patterns use the same `property=` parameter on types you already know — `GroupBy`, `Filter`, `Metric`. No new methods, no new parameters, no new result types.

---

## Progressive disclosure in action

Each line below adds one concept:

```python
from mixpanel_data import (
    CustomPropertyRef, InlineCustomProperty, PropertyInput,
    GroupBy, Filter, Metric,
)

# Reference a saved custom property by ID
ref = CustomPropertyRef(42)

# Break down by it
result = ws.query("Purchase", group_by=GroupBy(property=ref, property_type="number"))

# Add numeric bucketing
result = ws.query("Purchase", group_by=GroupBy(property=ref, property_type="number", bucket_size=50))

# Filter by it
result = ws.query("Purchase", where=Filter.greater_than(property=ref, value=100))

# Aggregate it
result = ws.query(Metric("Purchase", math="average", property=ref))

# Define an inline custom property — full constructor
revenue = InlineCustomProperty(
    formula="A * B",
    inputs={
        "A": PropertyInput("price", type="number"),
        "B": PropertyInput("quantity", type="number"),
    },
    property_type="number",
)

# Or use the convenience constructor for numeric formulas
revenue = InlineCustomProperty.numeric("A * B", A="price", B="quantity")

# Use it anywhere — breakdown, filter, measurement
result = ws.query("Purchase", group_by=GroupBy(property=revenue, property_type="number", bucket_size=100))
result = ws.query("Purchase", where=Filter.greater_than(property=revenue, value=1000))
result = ws.query(Metric("Purchase", math="total", property=revenue))

# Mix custom properties with regular properties
result = ws.query(
    "Purchase",
    group_by=["country", GroupBy(property=revenue, property_type="number", bucket_size=50)],
    where=[Filter.equals("platform", "iOS"), Filter.greater_than(property=ref, value=100)],
)

# Works in funnels and retention too
result = ws.query_funnel(["Signup", "Purchase"], group_by=GroupBy(property=ref, property_type="number"))
result = ws.query_retention("Signup", "Login", group_by=GroupBy(property=revenue, property_type="number"))
```

Every example compiles. Every parameter is typed. Autocomplete works everywhere.

---

## The type system

Three new public types and one type alias:

| Type | Purpose | Key feature |
|------|---------|-------------|
| **`CustomPropertyRef`** | Reference a saved custom property | Frozen dataclass wrapping a positive integer ID |
| **`InlineCustomProperty`** | Define a computed property at query time | Formula + input variable mapping, with `.numeric()` convenience constructor |
| **`PropertyInput`** | Map formula variables (A–Z) to raw properties | Name, type (`string`/`number`/`boolean`/`datetime`/`list`), resource_type (`event`/`user`) |
| **`PropertySpec`** | Type alias for property parameters | `str \| CustomPropertyRef \| InlineCustomProperty` |

### InlineCustomProperty: two ways to construct

The full constructor gives complete control over types and resource types:

```python
InlineCustomProperty(
    formula="A * B",
    inputs={
        "A": PropertyInput("price", type="number"),
        "B": PropertyInput("quantity", type="number"),
    },
    property_type="number",
)
```

The `numeric()` convenience constructor handles the common case — numeric formulas over event properties:

```python
InlineCustomProperty.numeric("A * B", A="price", B="quantity")
```

Both produce identical results. Use the full constructor when you need non-numeric types or user-profile properties (`resource_type="user"`).

### Where custom properties are accepted

The `property` parameter was widened on three existing types — no new parameters:

| Type | Field | Accepts |
|------|-------|---------|
| `GroupBy` | `.property` | `str \| CustomPropertyRef \| InlineCustomProperty` |
| `Filter` | `.property` (all 18 class methods) | `str \| CustomPropertyRef \| InlineCustomProperty` |
| `Metric` | `.property` | `str \| CustomPropertyRef \| InlineCustomProperty \| None` |

All changes are **union extensions** — plain string property names work exactly as before. Zero breaking changes.

### Engine compatibility

| Capability | `query()` | `query_funnel()` | `query_retention()` | `query_flow()` |
|---|:-:|:-:|:-:|:-:|
| **CP Breakdowns** (`group_by=`) | ✓ | ✓ | ✓ | — |
| **CP Filters** (`where=`) | ✓ | ✓ | ✓ | — |
| **CP Measurement** (`Metric.property=`) | ✓ | — | — | — |

Custom properties work across all three bookmark-based query engines. `query_flow()` does not support custom properties (Mixpanel limitation).

**Important**: Top-level `math_property=` only accepts strings. Custom property measurement requires `Metric(property=...)`.

---

## Three-way dispatch in bookmark builders

The bookmark JSON for custom properties uses three completely different structures depending on the property type. The builders handle this transparently:

| Property type | Filter JSON | Group-by JSON |
|--------------|-------------|---------------|
| Plain string | `{"value": "country", ...}` | `{"value": "country", "propertyName": "country", ...}` |
| `CustomPropertyRef` | `{"customPropertyId": 42, "dataset": "$mixpanel", ...}` — no `value` key | `{"customPropertyId": 42, "value": null, ...}` |
| `InlineCustomProperty` | `{"customProperty": {"displayFormula": "A*B", "composedProperties": {...}}, ...}` — no `value` key | `{"customProperty": {...}, "value": null, ...}` |

Each builder — `build_filter_entry()`, `build_group_section()`, and the measurement builder in `workspace.py` — uses `isinstance()` dispatch to emit the correct structure. The `_build_composed_properties()` helper transforms `PropertyInput` objects into the `composedProperties` schema (`value`/`type`/`resourceType` per variable).


---

## Validation engine (6 new rules)

Custom properties are validated **before** any API call. Invalid configurations raise `BookmarkValidationError` with structured diagnostics.

### Custom property validation (CP1–CP6)

| Rule | What it catches | Example |
|------|-----------------|---------|
| **CP1** | `CustomPropertyRef.id` must be positive | `CustomPropertyRef(0)` → error |
| **CP2** | Inline formula must be non-empty | `InlineCustomProperty(formula="", ...)` → error |
| **CP3** | Inline must have at least one input | `InlineCustomProperty(formula="A", inputs={})` → error |
| **CP4** | Input keys must be single uppercase A–Z | `inputs={"ab": ...}` → error |
| **CP5** | Formula max 20,000 characters | Prevents oversized payloads |
| **CP6** | Input property name must be non-empty | `PropertyInput("")` → error |

### Integration into all three query pipelines

`_scan_custom_properties()` extracts custom properties from three positions — `group_by`, `where`, and `events` (Metric.property) — and validates each one. This runs inside:

- `validate_query_args()` — for `query()` calls
- `validate_funnel_args()` — for `query_funnel()` calls
- `validate_retention_args()` — for `query_retention()` calls

### Multi-error collection

All validation errors are returned in a single pass:

```python
try:
    ws.query("Purchase", group_by=GroupBy(property=CustomPropertyRef(0), property_type="number"))
except BookmarkValidationError as e:
    for error in e.errors:
        print(f"[{error.code}] {error.path}: {error.message}")
    # [CP1_INVALID_ID] group_by[0].property: custom property ID must be a positive integer (got 0)
```

---

## Documentation and plugin integration

### Guide documentation (5 files)

Custom properties are woven into the existing query documentation following the Cohort-Scoped Queries pattern:

| File | What was added |
|------|---------------|
| `docs/guide/query.md` | New `## Custom Properties in Queries` section — types, breakdowns, filters, measurement, engine compatibility table, CP1–CP6 validation |
| `docs/guide/query-funnels.md` | Brief `### Custom Property Filters` and `### Custom Property Breakdowns` subsections with cross-refs |
| `docs/guide/query-retention.md` | Brief `### Custom Property Filters` and `### Custom Property Breakdowns` subsections with cross-refs |
| `docs/guide/query-flows.md` | Expanded note: custom properties not supported in flows |
| `docs/api/types.md` | New `## Custom Property Query Types` section with auto-rendered API docs |

### Plugin integration (6 files)

The Claude Code plugin gains awareness of custom properties across all layers:

| File | What was added |
|------|---------------|
| `SKILL.md` | New `## Custom Properties in Queries` section — engine compat table, saved + inline examples, import line |
| `insights-reference.md` | CP subsections in Filter, GroupBy, Metric deep refs + CP1–CP6 validation rules |
| `query-taxonomy.md` | NL signal mapping for custom property questions + Pattern 12 decomposition |
| `analyst.md` | `CustomPropertyRef, InlineCustomProperty` in import block |
| `explorer.md` | `ws.list_custom_properties()` in discovery toolkit |
| `diagnostician.md` | Custom properties noted as segmentation dimension in Step 3 |

---

## What's in the box

### New and modified source files

| File | Change | Purpose |
|------|--------|---------|
| `types.py` | +253 | `PropertyInput`, `InlineCustomProperty`, `CustomPropertyRef`, `PropertySpec`; widened `Metric.property`, `GroupBy.property`, `Filter._property` + 18 class methods |
| `_internal/bookmark_builders.py` | +164 | Three-way dispatch in `build_filter_entry()`, `build_group_section()`; `_build_composed_properties()`; funnel/retention filter compatibility |
| `_internal/validation.py` | +203 | CP1–CP6 rules, `_validate_custom_property()`, `_scan_custom_properties()`, updated B18 |
| `workspace.py` | +82 | Measurement property builder with three-way dispatch; funnel/retention filter compatibility |
| `__init__.py` | +9 | Public exports: `PropertyInput`, `InlineCustomProperty`, `CustomPropertyRef`, `PropertySpec` |

### Test coverage (164 new tests)

| File | Tests | Lines | Focus |
|------|-------|-------|-------|
| `test_custom_property_types.py` | 43 | 502 | Type construction, defaults, immutability, convenience constructors |
| `test_custom_property_builders.py` | 36 | 460 | Filter entry, group section, measurement property, composed properties builders |
| `test_custom_property_query.py` | 21 | 285 | End-to-end query/build with mocked API across insights, funnels, retention |
| `test_custom_property_pbt.py` | 10 | 338 | Property-based tests (Hypothesis) — structural invariants across random inputs |
| `test_bookmark_builders.py` | +21 | +75 | Updated B18 validation for custom property identifiers |
| `test_validation.py` | +33 | +33 | CP1–CP6 validation rule coverage |

### Live QA (77 tests against ecommerce-demo)

| Category | Tests | Result |
|----------|-------|--------|
| Insights custom property queries | 30 | ✅ All pass |
| Funnel custom property queries | 20 | ✅ All pass |
| Retention custom property queries | 20 | ✅ All pass |
| Validation gap documentation | 6 | ✅ All pass |
| Skip (no suitable test data) | 1 | ⏭ |

