### PR TITLE
fix: close 6 validation engine bypass vectors across all query paths

### DIFF
--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -174,8 +174,9 @@ def _scan_filters_for_custom_properties(
     """Scan a list of Filter objects for custom property references.
 
     Used by ``_scan_custom_properties()`` to validate custom properties
-    inside per-metric (``Metric.filters``) and per-step
-    (``FunnelStep.filters``) filter lists that were previously unscanned.
+    inside filter lists attached to metrics and steps, including
+    ``Metric.filters``, ``FunnelStep.filters``, ``FlowStep.filters``,
+    and ``RetentionEvent.filters``.
 
     Args:
         filters: Filter objects to scan.
@@ -258,16 +259,16 @@ def _scan_custom_properties(
     # Scan events (Metric.property AND Metric.filters)
     if events is not None:
         for idx, item in enumerate(events):
-            if isinstance(item, Metric):
-                if isinstance(item.property, (CustomPropertyRef, InlineCustomProperty)):
-                    epath = f"events[{idx}]"
-                    errors.extend(_validate_custom_property(item.property, epath))
-                if item.filters:
-                    errors.extend(
-                        _scan_filters_for_custom_properties(
-                            item.filters, f"events[{idx}]"
-                        )
-                    )
+            if isinstance(item, Metric) and isinstance(
+                item.property, (CustomPropertyRef, InlineCustomProperty)
+            ):
+                errors.extend(
+                    _validate_custom_property(item.property, f"events[{idx}]")
+                )
+            if isinstance(item, Metric) and item.filters:
+                errors.extend(
+                    _scan_filters_for_custom_properties(item.filters, f"events[{idx}]")
+                )
 
     # Scan funnel steps (FunnelStep.filters)
     if funnel_steps is not None:
@@ -2649,7 +2650,9 @@ def _validate_filter_clause(
 
     # B18b: customPropertyId must be a positive integer (defense-in-depth)
     cp_id = clause.get("customPropertyId")
-    if cp_id is not None and (not isinstance(cp_id, int) or cp_id <= 0):
+    if cp_id is not None and (
+        isinstance(cp_id, bool) or not isinstance(cp_id, int) or cp_id <= 0
+    ):
         errors.append(
             ValidationError(
                 path=f"{path}.customPropertyId",

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -215,10 +215,12 @@ def _scan_custom_properties(
     and runs ``_validate_custom_property()`` on each.
 
     Note:
-        ``where`` filters are validated separately at the workspace level
-        (``workspace.py`` calls ``_scan_custom_properties(where=where)``)
+        ``where`` filters and some step/event filters are scanned from
+        ``workspace.py`` rather than from the standalone validators
         because ``validate_query_args`` / ``validate_funnel_args`` /
-        ``validate_retention_args`` do not receive the ``where`` parameter.
+        ``validate_retention_args`` do not receive the ``where`` parameter
+        or the full step/event objects.  Flow step filters and retention
+        event filters are scanned from ``workspace.py`` for the same reason.
 
     Args:
         group_by: Breakdown specification (may contain custom properties).
@@ -259,16 +261,17 @@ def _scan_custom_properties(
     # Scan events (Metric.property AND Metric.filters)
     if events is not None:
         for idx, item in enumerate(events):
-            if isinstance(item, Metric) and isinstance(
-                item.property, (CustomPropertyRef, InlineCustomProperty)
-            ):
-                errors.extend(
-                    _validate_custom_property(item.property, f"events[{idx}]")
-                )
-            if isinstance(item, Metric) and item.filters:
-                errors.extend(
-                    _scan_filters_for_custom_properties(item.filters, f"events[{idx}]")
-                )
+            if isinstance(item, Metric):
+                if isinstance(item.property, (CustomPropertyRef, InlineCustomProperty)):
+                    errors.extend(
+                        _validate_custom_property(item.property, f"events[{idx}]")
+                    )
+                if item.filters:
+                    errors.extend(
+                        _scan_filters_for_custom_properties(
+                            item.filters, f"events[{idx}]"
+                        )
+                    )
 
     # Scan funnel steps (FunnelStep.filters)
     if funnel_steps is not None:
@@ -287,6 +290,7 @@ def _scan_custom_properties(
                 )
 
     # Scan retention events (RetentionEvent.filters)
+    # retention_events is always [born_event, return_event] — see workspace.py
     if retention_events is not None:
         for idx, rev in enumerate(retention_events):
             if rev.filters:
@@ -2648,7 +2652,7 @@ def _validate_filter_clause(
             )
         )
 
-    # B18b: customPropertyId must be a positive integer (defense-in-depth)
+    # B18B: customPropertyId must be a positive integer (defense-in-depth)
     cp_id = clause.get("customPropertyId")
     if cp_id is not None and (
         isinstance(cp_id, bool) or not isinstance(cp_id, int) or cp_id <= 0
@@ -2747,7 +2751,7 @@ def _validate_filter_clause(
             )
         )
 
-    # B20b: Numeric filter values must be finite (not NaN/Inf)
+    # B20B: Numeric filter values must be finite (not NaN/Inf)
     if isinstance(fv, float) and not _is_finite(fv):
         errors.append(
             ValidationError(

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -55,6 +55,7 @@ from mixpanel_data.types import (
     CustomPropertyRef,
     Exclusion,
     Filter,
+    FlowStep,
     Formula,
     FunnelStep,
     GroupBy,
@@ -63,6 +64,7 @@ from mixpanel_data.types import (
     MathType,
     Metric,
     PerUserAggregation,
+    RetentionEvent,
 )
 
 _CP_INPUT_KEY_RE = re.compile(r"^[A-Z]$")
@@ -165,6 +167,32 @@ def _validate_custom_property(
     return errors
 
 
+def _scan_filters_for_custom_properties(
+    filters: list[Filter],
+    base_path: str,
+) -> list[ValidationError]:
+    """Scan a list of Filter objects for custom property references.
+
+    Used by ``_scan_custom_properties()`` to validate custom properties
+    inside per-metric (``Metric.filters``) and per-step
+    (``FunnelStep.filters``) filter lists that were previously unscanned.
+
+    Args:
+        filters: Filter objects to scan.
+        base_path: JSONPath prefix for error reporting
+            (e.g. ``"events[0]"`` or ``"steps[1]"``).
+
+    Returns:
+        List of validation errors for any invalid custom properties.
+    """
+    errors: list[ValidationError] = []
+    for i, f in enumerate(filters):
+        if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
+            fpath = f"{base_path}.filters[{i}]"
+            errors.extend(_validate_custom_property(f._property, fpath))
+    return errors
+
+
 def _scan_custom_properties(
     *,
     group_by: str
@@ -174,12 +202,16 @@ def _scan_custom_properties(
     | None = None,
     where: Filter | list[Filter] | None = None,
     events: Sequence[str | Metric | CohortMetric] | None = None,
+    funnel_steps: Sequence[str | FunnelStep] | None = None,
+    flow_steps: Sequence[FlowStep] | None = None,
+    retention_events: Sequence[RetentionEvent] | None = None,
 ) -> list[ValidationError]:
-    """Scan group_by, where, and events for custom properties and validate.
+    """Scan all query positions for custom properties and validate.
 
     Collects all ``CustomPropertyRef`` and ``InlineCustomProperty`` values
-    from the three positions (group_by, filter, measurement) and runs
-    ``_validate_custom_property()`` on each.
+    from group_by, filter, measurement, per-metric filter, per-funnel-step
+    filter, per-flow-step filter, and per-retention-event filter positions
+    and runs ``_validate_custom_property()`` on each.
 
     Note:
         ``where`` filters are validated separately at the workspace level
@@ -190,8 +222,14 @@ def _scan_custom_properties(
     Args:
         group_by: Breakdown specification (may contain custom properties).
         where: Filter specification (may contain custom properties).
-        events: Event specifications (Metric.property may contain
-            custom properties).
+        events: Event specifications (Metric.property and Metric.filters
+            may contain custom properties).
+        funnel_steps: Funnel step specifications (FunnelStep.filters
+            may contain custom properties).
+        flow_steps: Flow step specifications (FlowStep.filters
+            may contain custom properties).
+        retention_events: Retention event specifications
+            (RetentionEvent.filters may contain custom properties).
 
     Returns:
         List of validation errors. Empty list means all custom
@@ -217,19 +255,42 @@ def _scan_custom_properties(
                 fpath = f"where[{i}]" if len(filters) > 1 else "where"
                 errors.extend(_validate_custom_property(f._property, fpath))
 
-    # Scan events (Metric.property)
-    # TODO: Also scan Metric.filters and FunnelStep.filters for custom
-    # properties.  Currently only Metric.property is checked; custom
-    # properties inside per-metric or per-step filters bypass CP1-CP6
-    # validation (documented in tests/live/test_custom_property_queries_live.py
-    # TestValidationGaps).
+    # Scan events (Metric.property AND Metric.filters)
     if events is not None:
         for idx, item in enumerate(events):
-            if isinstance(item, Metric) and isinstance(
-                item.property, (CustomPropertyRef, InlineCustomProperty)
-            ):
-                epath = f"events[{idx}]"
-                errors.extend(_validate_custom_property(item.property, epath))
+            if isinstance(item, Metric):
+                if isinstance(item.property, (CustomPropertyRef, InlineCustomProperty)):
+                    epath = f"events[{idx}]"
+                    errors.extend(_validate_custom_property(item.property, epath))
+                if item.filters:
+                    errors.extend(
+                        _scan_filters_for_custom_properties(
+                            item.filters, f"events[{idx}]"
+                        )
+                    )
+
+    # Scan funnel steps (FunnelStep.filters)
+    if funnel_steps is not None:
+        for idx, step in enumerate(funnel_steps):
+            if isinstance(step, FunnelStep) and step.filters:
+                errors.extend(
+                    _scan_filters_for_custom_properties(step.filters, f"steps[{idx}]")
+                )
+
+    # Scan flow steps (FlowStep.filters)
+    if flow_steps is not None:
+        for idx, fstep in enumerate(flow_steps):
+            if fstep.filters:
+                errors.extend(
+                    _scan_filters_for_custom_properties(fstep.filters, f"steps[{idx}]")
+                )
+
+    # Scan retention events (RetentionEvent.filters)
+    if retention_events is not None:
+        for idx, rev in enumerate(retention_events):
+            if rev.filters:
+                label = "born_event" if idx == 0 else "return_event"
+                errors.extend(_scan_filters_for_custom_properties(rev.filters, label))
 
     return errors
 
@@ -983,8 +1044,8 @@ def validate_funnel_args(
     # F6: GroupBy validation (delegated)
     errors.extend(validate_group_by_args(group_by=group_by))
 
-    # CP1-CP6: Custom property validation
-    errors.extend(_scan_custom_properties(group_by=group_by))
+    # CP1-CP6: Custom property validation (group_by and per-step filters)
+    errors.extend(_scan_custom_properties(group_by=group_by, funnel_steps=steps))
 
     return errors
 
@@ -2208,8 +2269,9 @@ def _validate_show_clause(
         )
         return errors
 
-    # Formula show clause — minimal validation
-    if "formula" in clause or clause.get("type") == "formula":
+    # Formula show clause — minimal validation (only for pure formula clauses)
+    is_formula = "formula" in clause or clause.get("type") == "formula"
+    if is_formula and "behavior" not in clause:
         return errors
 
     # Multi-metric show clause: requires behavior
@@ -2585,6 +2647,17 @@ def _validate_filter_clause(
             )
         )
 
+    # B18b: customPropertyId must be a positive integer (defense-in-depth)
+    cp_id = clause.get("customPropertyId")
+    if cp_id is not None and (not isinstance(cp_id, int) or cp_id <= 0):
+        errors.append(
+            ValidationError(
+                path=f"{path}.customPropertyId",
+                message=(f"customPropertyId must be a positive integer (got {cp_id})"),
+                code="B18B_INVALID_CP_ID",
+            )
+        )
+
     # B16: Validate resourceType
     rt = clause.get("resourceType")
     if rt is not None and rt not in VALID_RESOURCE_TYPES:
@@ -2670,6 +2743,26 @@ def _validate_filter_clause(
                 code="B21_FILTER_VALUE_TOO_MANY",
             )
         )
+
+    # B20b: Numeric filter values must be finite (not NaN/Inf)
+    if isinstance(fv, float) and not _is_finite(fv):
+        errors.append(
+            ValidationError(
+                path=f"{path}.filterValue",
+                message=f"filterValue must be a finite number (got {fv})",
+                code="B20B_FILTER_VALUE_NOT_FINITE",
+            )
+        )
+    elif isinstance(fv, list):
+        for vi, v in enumerate(fv):
+            if isinstance(v, float) and not _is_finite(v):
+                errors.append(
+                    ValidationError(
+                        path=f"{path}.filterValue[{vi}]",
+                        message=(f"filterValue must be a finite number (got {v})"),
+                        code="B20B_FILTER_VALUE_NOT_FINITE",
+                    )
+                )
 
     return errors
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -3259,6 +3259,8 @@ class Workspace:
             to_date=to_date,
             last=last,
         )
+        # CP1-CP6: Custom property validation for flow step filters
+        arg_errors.extend(_scan_custom_properties(flow_steps=steps))
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 
@@ -3569,8 +3571,13 @@ class Workspace:
             last=last,
             group_by=group_by,
         )
-        # CP1-CP6: Custom property validation for where filters
-        arg_errors.extend(_scan_custom_properties(where=where))
+        # CP1-CP6: Custom property validation for where and event filters
+        arg_errors.extend(
+            _scan_custom_properties(
+                where=where,
+                retention_events=[norm_born, norm_return],
+            )
+        )
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 

--- a/tests/test_validation_bypass.py
+++ b/tests/test_validation_bypass.py
@@ -1,0 +1,397 @@
+"""Validation bypass tests: verify the validation engine catches invalid inputs.
+
+Originally written as QA bypass probes (Vectors 1-7). After fixing Bug 1
+(``_scan_custom_properties()`` blind spot) and Bug 3b (formula show clause
+guard), Vectors 1/2/5/6 and V7b are now caught by validation.
+
+Vectors 3 and 4 remain as **design-documentation tests** — they demonstrate
+intentional design choices (construction-time validation for cohorts,
+forward-compatible warning severity for enum rules).
+
+Test layout:
+- **Fixed bugs**: Expect ``BookmarkValidationError`` (bypasses closed)
+- **Design choices**: Assert current behavior is intentional (no fix needed)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data._internal.validation import validate_bookmark
+from mixpanel_data.exceptions import BookmarkValidationError, ValidationError
+from mixpanel_data.types import (
+    CohortBreakdown,
+    CohortCriteria,
+    CohortDefinition,
+    CustomPropertyRef,
+    Filter,
+    FunnelStep,
+    InlineCustomProperty,
+    Metric,
+    PropertyInput,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def ws() -> Workspace:
+    """Create a Workspace with mocked dependencies (no network)."""
+    creds = Credentials(
+        username="u", secret=SecretStr("s"), project_id="1", region="us"
+    )
+    mgr = MagicMock(spec=ConfigManager)
+    mgr.resolve_credentials.return_value = creds
+    return Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+
+def _has_error(errors: list[ValidationError]) -> bool:
+    """Return True if any error has severity='error'."""
+    return any(e.severity == "error" for e in errors)
+
+
+# =========================================================================
+# FIXED: Vector 1 — CustomPropertyRef(0) in Metric.filters
+# =========================================================================
+
+
+class TestVector1MetricFilterCPFixed:
+    """Bug 1 fix: _scan_custom_properties() now scans Metric.filters.
+
+    CustomPropertyRef(0) in Metric.filters is caught by CP1 validation.
+    """
+
+    def test_invalid_cp_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in Metric.filters raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                ),
+                last=7,
+            )
+
+    def test_negative_cp_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(-1) in Metric.filters raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=CustomPropertyRef(-1))],
+                ),
+                last=7,
+            )
+
+    def test_valid_cp_id_passes(self, ws: Workspace) -> None:
+        """CustomPropertyRef(42) in Metric.filters passes validation."""
+        params = ws.build_params(
+            Metric(
+                "AnyEvent",
+                filters=[Filter.is_set(property=CustomPropertyRef(42))],
+            ),
+            last=7,
+        )
+        assert "sections" in params
+
+    def test_l2_also_catches_invalid_cp_id(self, ws: Workspace) -> None:
+        """Defense-in-depth: L2 B18b validates customPropertyId > 0."""
+        params = ws.build_params(
+            Metric(
+                "AnyEvent",
+                filters=[Filter.is_set(property=CustomPropertyRef(42))],
+            ),
+            last=7,
+        )
+        # Mutate to inject invalid ID after build (simulating L2-only check)
+        params["sections"]["show"][0]["behavior"]["filters"][0]["customPropertyId"] = 0
+        errors = validate_bookmark(params)
+        assert _has_error(errors)
+        assert any("B18B" in e.code for e in errors)
+
+
+# =========================================================================
+# FIXED: Vector 2 — CustomPropertyRef(0) in FunnelStep.filters
+# =========================================================================
+
+
+class TestVector2FunnelStepFilterCPFixed:
+    """Bug 1 fix: _scan_custom_properties() now scans FunnelStep.filters.
+
+    CustomPropertyRef(0) in FunnelStep.filters is caught by CP1 validation.
+    """
+
+    def test_invalid_cp_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in FunnelStep.filters raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_funnel_params(
+                [
+                    FunnelStep(
+                        "Step1",
+                        filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                    ),
+                    "Step2",
+                ],
+                last=30,
+            )
+
+    def test_valid_cp_id_passes(self, ws: Workspace) -> None:
+        """CustomPropertyRef(42) in FunnelStep.filters passes validation."""
+        params = ws.build_funnel_params(
+            [
+                FunnelStep(
+                    "Step1",
+                    filters=[Filter.is_set(property=CustomPropertyRef(42))],
+                ),
+                "Step2",
+            ],
+            last=30,
+        )
+        assert "sections" in params
+
+
+# =========================================================================
+# DESIGN CHOICE: Vector 3 — Inline CohortDefinition in CohortBreakdown
+# =========================================================================
+
+
+class TestVector3InlineCohortDesignChoice:
+    """Design choice: CohortDefinition validates at construction time.
+
+    CohortCriteria.did_event("") raises ValueError (CD4).
+    Valid-but-semantically-nonsensical cohorts (fake event names) produce
+    valid JSON — the server returns empty results, not errors.
+    This is intentional: the validation engine trusts type constructors.
+    """
+
+    def test_inline_cohort_breakdown_passes_validation(self, ws: Workspace) -> None:
+        """Inline CohortDefinition in breakdown passes both validation layers."""
+        criteria = CohortCriteria.did_event("FakeEvent", at_least=1, within_days=30)
+        defn = CohortDefinition(criteria)
+        params = ws.build_params(
+            "AnyEvent",
+            group_by=CohortBreakdown(defn, "Test Cohort"),
+            last=7,
+        )
+        assert "sections" in params
+
+    def test_construction_time_validation_catches_empty_event(self) -> None:
+        """CohortCriteria.did_event('') raises ValueError at construction."""
+        with pytest.raises(ValueError, match="non-empty"):
+            CohortCriteria.did_event("", at_least=1, within_days=30)
+
+    def test_raw_cohort_structure_present(self, ws: Workspace) -> None:
+        """raw_cohort is present in group section with valid structure."""
+        criteria = CohortCriteria.did_event("FakeEvent", at_least=1, within_days=30)
+        defn = CohortDefinition(criteria)
+        params = ws.build_params(
+            "AnyEvent",
+            group_by=CohortBreakdown(defn, "Test Cohort"),
+            last=7,
+        )
+        group = params["sections"]["group"]
+        cohorts = group[0]["cohorts"]
+        assert any("raw_cohort" in c for c in cohorts)
+        errors = validate_bookmark(params)
+        assert not _has_error(errors)
+
+
+# =========================================================================
+# DESIGN CHOICE: Vector 4 — Warning-only enum severity
+# =========================================================================
+
+
+class TestVector4WarningOnlyEnumDesignChoice:
+    """Design choice: B7/B16/B17 are warnings for forward compatibility.
+
+    Invalid enum values in bookmark JSON produce warnings, not errors.
+    Builder functions always produce valid enums — these warnings only fire
+    on post-build dict mutation, which is outside the library's responsibility.
+    """
+
+    def test_invalid_resource_type_is_warning_only(self, ws: Workspace) -> None:
+        """Invalid resourceType in group section → warning, not error."""
+        params = ws.build_params("AnyEvent", group_by="country", last=7)
+        params["sections"]["group"][0]["resourceType"] = "BOGUS_TYPE"
+
+        errors = validate_bookmark(params)
+        resource_errors = [e for e in errors if "B16" in e.code]
+        assert len(resource_errors) > 0, "Expected B16 warning"
+        assert all(e.severity == "warning" for e in resource_errors)
+        assert not _has_error(errors)
+
+    def test_invalid_property_type_is_warning_only(self, ws: Workspace) -> None:
+        """Invalid propertyType in group section → warning, not error."""
+        params = ws.build_params("AnyEvent", group_by="country", last=7)
+        params["sections"]["group"][0]["propertyType"] = "FAKE_TYPE"
+
+        errors = validate_bookmark(params)
+        prop_errors = [e for e in errors if "B17" in e.code]
+        assert len(prop_errors) > 0, "Expected B17 warning"
+        assert all(e.severity == "warning" for e in prop_errors)
+        assert not _has_error(errors)
+
+    def test_invalid_behavior_type_is_warning_only(self, ws: Workspace) -> None:
+        """Invalid behavior.type → warning via B7, not error."""
+        params = ws.build_params("AnyEvent", last=7)
+        params["sections"]["show"][0]["behavior"]["type"] = "NONEXISTENT"
+
+        errors = validate_bookmark(params)
+        b7_errors = [e for e in errors if "B7" in e.code]
+        assert len(b7_errors) > 0, "Expected B7 warning"
+        assert all(e.severity == "warning" for e in b7_errors)
+
+
+# =========================================================================
+# FIXED: Vector 5 — Negative CustomPropertyRef ID via Metric.filters
+# =========================================================================
+
+
+class TestVector5NegativeCPRefFixed:
+    """Bug 1 fix: Negative CustomPropertyRef IDs in Metric.filters now caught."""
+
+    def test_negative_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(-1) in Metric.filters raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=CustomPropertyRef(-1))],
+                ),
+                last=7,
+            )
+
+    def test_large_negative_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(-999999) in Metric.filters raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=CustomPropertyRef(-999999))],
+                ),
+                last=7,
+            )
+
+
+# =========================================================================
+# FIXED: Vector 6 — Empty formula InlineCustomProperty in Metric.filters
+# =========================================================================
+
+
+class TestVector6EmptyFormulaFixed:
+    """Bug 1 fix: Empty formula InlineCustomProperty in Metric.filters now caught."""
+
+    def test_empty_formula_raises(self, ws: Workspace) -> None:
+        """Empty formula in per-metric filter raises BookmarkValidationError."""
+        bad_cp = InlineCustomProperty(
+            formula="",
+            inputs={"A": PropertyInput("$browser")},
+        )
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=bad_cp)],
+                ),
+                last=7,
+            )
+
+    def test_valid_inline_cp_in_metric_filter_passes(self, ws: Workspace) -> None:
+        """Valid InlineCustomProperty in Metric.filters passes."""
+        good_cp = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("$browser")},
+        )
+        params = ws.build_params(
+            Metric(
+                "AnyEvent",
+                filters=[Filter.is_set(property=good_cp)],
+            ),
+            last=7,
+        )
+        assert "sections" in params
+
+
+# =========================================================================
+# FIXED: Vector 7 — Formula show clause injection
+# =========================================================================
+
+
+class TestVector7FormulaShowClauseFixed:
+    """Bug 3b fix: Formula key no longer acts as a validation kill-switch.
+
+    Hybrid show clauses (both 'formula' and 'behavior' keys) now get
+    full behavior validation instead of being silently skipped.
+    """
+
+    def test_pure_formula_clause_still_passes(self, ws: Workspace) -> None:
+        """A pure formula clause (no behavior) still gets the fast path."""
+        params = ws.build_params("AnyEvent", last=7)
+        # Inject formula key into a valid show clause
+        params["sections"]["show"][0]["formula"] = ""
+
+        errors = validate_bookmark(params)
+        # Valid behavior + formula key → behavior still validated, no errors
+        assert not _has_error(errors)
+
+    def test_corrupted_behavior_detected_despite_formula_key(
+        self, ws: Workspace
+    ) -> None:
+        """Corrupted behavior IS detected even when 'formula' key present."""
+        params = ws.build_params("AnyEvent", last=7)
+        # Corrupt the behavior block
+        params["sections"]["show"][0]["behavior"]["type"] = "INVALID"
+        # Attempt to hide it with formula key — no longer works
+        params["sections"]["show"][0]["formula"] = ""
+
+        errors = validate_bookmark(params)
+        # B7 (invalid type) IS now reported
+        assert any("B7" in e.code for e in errors), (
+            "B7 should fire even when formula key is present"
+        )
+
+
+# =========================================================================
+# FIXED: Combined — Multiple fixes working together
+# =========================================================================
+
+
+class TestCombinedFixes:
+    """Multiple fix vectors working in combination."""
+
+    def test_cp_bypass_in_metric_filter_now_caught(self, ws: Workspace) -> None:
+        """Invalid CP ID in Metric.filters is caught regardless of other params."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                ),
+                group_by="country",
+                last=7,
+            )
+
+    def test_empty_formula_cp_in_funnel_step_now_caught(self, ws: Workspace) -> None:
+        """Empty-formula InlineCustomProperty in FunnelStep.filters is caught."""
+        bad_cp = InlineCustomProperty(
+            formula="",
+            inputs={"A": PropertyInput("$browser")},
+        )
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_funnel_params(
+                [
+                    FunnelStep(
+                        "Step1",
+                        filters=[Filter.is_set(property=bad_cp)],
+                    ),
+                    "Step2",
+                ],
+                last=30,
+            )

--- a/tests/test_validation_bypass.py
+++ b/tests/test_validation_bypass.py
@@ -37,7 +37,7 @@ from mixpanel_data.types import (
 )
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Fixtures (local — matches existing codebase convention)
 # ---------------------------------------------------------------------------
 
 
@@ -331,10 +331,12 @@ class TestVector7FormulaShowClauseFixed:
     full behavior validation instead of being silently skipped.
     """
 
-    def test_pure_formula_clause_still_passes(self, ws: Workspace) -> None:
-        """A pure formula clause (no behavior) still gets the fast path."""
+    def test_hybrid_formula_behavior_clause_still_validates(
+        self, ws: Workspace
+    ) -> None:
+        """A hybrid clause (formula + behavior) still validates the behavior."""
         params = ws.build_params("AnyEvent", last=7)
-        # Inject formula key into a valid show clause
+        # Inject formula key into a valid show clause — creates hybrid
         params["sections"]["show"][0]["formula"] = ""
 
         errors = validate_bookmark(params)
@@ -352,9 +354,11 @@ class TestVector7FormulaShowClauseFixed:
         params["sections"]["show"][0]["formula"] = ""
 
         errors = validate_bookmark(params)
-        # B7 (invalid type) IS now reported
-        assert any("B7" in e.code for e in errors), (
-            "B7 should fire even when formula key is present"
+        # B7 (invalid type) IS now reported as a warning
+        b7_errors = [e for e in errors if "B7" in e.code]
+        assert len(b7_errors) > 0, "B7 should fire even when formula key is present"
+        assert all(e.severity == "warning" for e in b7_errors), (
+            "B7 is intentionally severity='warning' (forward compatibility)"
         )
 
 

--- a/tests/test_validation_bypass_r2.py
+++ b/tests/test_validation_bypass_r2.py
@@ -1,0 +1,274 @@
+"""Round 2 validation bypass tests: flow, retention, and NaN/Inf fixes.
+
+After fixing Bug 4 (flow CP scanning), Bug 5 (retention event CP scanning),
+and Bug 6 (NaN/Inf filter values), all round 2 bypass vectors are now caught.
+
+- **R2-V1**: FlowStep.filters CP → now raises BookmarkValidationError
+- **R2-V2**: RetentionEvent.filters CP → now raises BookmarkValidationError
+- **R2-V3**: NaN filter values → now raises BookmarkValidationError
+- **R2-V4**: Inf filter values → now raises BookmarkValidationError
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import ConfigManager, Credentials
+from mixpanel_data.exceptions import BookmarkValidationError, ValidationError
+from mixpanel_data.types import (
+    CustomPropertyRef,
+    Filter,
+    FlowStep,
+    InlineCustomProperty,
+    Metric,
+    PropertyInput,
+    RetentionEvent,
+)
+
+
+@pytest.fixture()
+def ws() -> Workspace:
+    """Create a Workspace with mocked dependencies (no network)."""
+    creds = Credentials(
+        username="u", secret=SecretStr("s"), project_id="1", region="us"
+    )
+    mgr = MagicMock(spec=ConfigManager)
+    mgr.resolve_credentials.return_value = creds
+    return Workspace(_config_manager=mgr, _api_client=MagicMock())
+
+
+def _has_error(errors: list[ValidationError]) -> bool:
+    """Return True if any error has severity='error'."""
+    return any(e.severity == "error" for e in errors)
+
+
+# =========================================================================
+# FIXED: R2-V1 — FlowStep.filters custom property scanning
+# =========================================================================
+
+
+class TestR2V1FlowStepFiltersCPFixed:
+    """Bug 4 fix: _scan_custom_properties now scans FlowStep.filters."""
+
+    def test_invalid_cp_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in FlowStep.filters raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_flow_params(
+                FlowStep(
+                    "Purchase",
+                    filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                ),
+                last=7,
+            )
+
+    def test_negative_cp_id_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(-1) in FlowStep.filters raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_flow_params(
+                FlowStep(
+                    "Purchase",
+                    filters=[Filter.is_set(property=CustomPropertyRef(-1))],
+                ),
+                last=7,
+            )
+
+    def test_empty_formula_cp_raises(self, ws: Workspace) -> None:
+        """InlineCustomProperty(formula='') in FlowStep.filters raises."""
+        bad_cp = InlineCustomProperty(
+            formula="",
+            inputs={"A": PropertyInput("$browser")},
+        )
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_flow_params(
+                FlowStep(
+                    "Purchase",
+                    filters=[Filter.is_set(property=bad_cp)],
+                ),
+                last=7,
+            )
+
+    def test_valid_cp_in_flow_step_passes(self, ws: Workspace) -> None:
+        """Valid CustomPropertyRef(42) in FlowStep.filters passes."""
+        params = ws.build_flow_params(
+            FlowStep(
+                "Purchase",
+                filters=[Filter.is_set(property=CustomPropertyRef(42))],
+            ),
+            last=7,
+        )
+        assert "steps" in params
+
+
+# =========================================================================
+# FIXED: R2-V2 — RetentionEvent.filters custom property scanning
+# =========================================================================
+
+
+class TestR2V2RetentionEventFiltersCPFixed:
+    """Bug 5 fix: _scan_custom_properties now scans RetentionEvent.filters."""
+
+    def test_born_event_cp_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in born_event filters raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                RetentionEvent(
+                    "Signup",
+                    filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                ),
+                "Login",
+                last=7,
+            )
+
+    def test_return_event_cp_raises(self, ws: Workspace) -> None:
+        """CustomPropertyRef(0) in return_event filters raises."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                "Signup",
+                RetentionEvent(
+                    "Login",
+                    filters=[Filter.is_set(property=CustomPropertyRef(0))],
+                ),
+                last=7,
+            )
+
+    def test_empty_formula_cp_raises(self, ws: Workspace) -> None:
+        """InlineCustomProperty(formula='') in RetentionEvent.filters raises."""
+        bad_cp = InlineCustomProperty(
+            formula="",
+            inputs={"A": PropertyInput("$browser")},
+        )
+        with pytest.raises(BookmarkValidationError, match="non-empty"):
+            ws.build_retention_params(
+                RetentionEvent(
+                    "Signup",
+                    filters=[Filter.is_set(property=bad_cp)],
+                ),
+                "Login",
+                last=7,
+            )
+
+    def test_valid_cp_in_retention_passes(self, ws: Workspace) -> None:
+        """Valid CustomPropertyRef(42) in RetentionEvent.filters passes."""
+        params = ws.build_retention_params(
+            RetentionEvent(
+                "Signup",
+                filters=[Filter.is_set(property=CustomPropertyRef(42))],
+            ),
+            "Login",
+            last=7,
+        )
+        assert "sections" in params
+
+
+# =========================================================================
+# FIXED: R2-V3 — NaN filter values
+# =========================================================================
+
+
+class TestR2V3NaNFilterFixed:
+    """Bug 6 fix: NaN filter values now caught by B20b at L2."""
+
+    def test_nan_in_where_filter_raises(self, ws: Workspace) -> None:
+        """NaN in where filter raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="finite number"):
+            ws.build_params(
+                "AnyEvent",
+                where=Filter.greater_than("age", float("nan")),
+                last=7,
+            )
+
+    def test_nan_in_per_metric_filter_raises(self, ws: Workspace) -> None:
+        """NaN in Metric.filters raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="finite number"):
+            ws.build_params(
+                Metric(
+                    "AnyEvent",
+                    filters=[Filter.greater_than("age", float("nan"))],
+                ),
+                last=7,
+            )
+
+    def test_finite_value_passes(self, ws: Workspace) -> None:
+        """Normal finite values still pass."""
+        params = ws.build_params(
+            "AnyEvent",
+            where=Filter.greater_than("age", 18),
+            last=7,
+        )
+        assert "sections" in params
+
+
+# =========================================================================
+# FIXED: R2-V4 — Inf filter values
+# =========================================================================
+
+
+class TestR2V4InfFilterFixed:
+    """Bug 6 fix: Inf filter values now caught by B20b at L2."""
+
+    def test_inf_in_where_filter_raises(self, ws: Workspace) -> None:
+        """Inf in where filter raises BookmarkValidationError."""
+        with pytest.raises(BookmarkValidationError, match="finite number"):
+            ws.build_params(
+                "AnyEvent",
+                where=Filter.greater_than("age", float("inf")),
+                last=7,
+            )
+
+    def test_negative_inf_raises(self, ws: Workspace) -> None:
+        """Negative infinity also raises."""
+        with pytest.raises(BookmarkValidationError, match="finite number"):
+            ws.build_params(
+                "AnyEvent",
+                where=Filter.greater_than("age", float("-inf")),
+                last=7,
+            )
+
+    def test_large_finite_value_passes(self, ws: Workspace) -> None:
+        """Large but finite values still pass."""
+        params = ws.build_params(
+            "AnyEvent",
+            where=Filter.greater_than("age", 1e15),
+            last=7,
+        )
+        assert "sections" in params
+
+
+# =========================================================================
+# FIXED: Combined — multiple R2 fixes working together
+# =========================================================================
+
+
+class TestR2CombinedFixes:
+    """Multiple round 2 fixes working in combination."""
+
+    def test_flow_cp_caught_before_nan(self, ws: Workspace) -> None:
+        """FlowStep with invalid CP is caught at L1 (before NaN at L2)."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_flow_params(
+                FlowStep(
+                    "Purchase",
+                    filters=[
+                        Filter.is_set(property=CustomPropertyRef(0)),
+                        Filter.greater_than("amount", float("nan")),
+                    ],
+                ),
+                last=7,
+            )
+
+    def test_retention_cp_caught(self, ws: Workspace) -> None:
+        """RetentionEvent with invalid CP is caught."""
+        with pytest.raises(BookmarkValidationError, match="positive integer"):
+            ws.build_retention_params(
+                RetentionEvent(
+                    "Signup",
+                    filters=[Filter.is_set(property=CustomPropertyRef(-1))],
+                ),
+                "Login",
+                where=Filter.greater_than("age", float("inf")),
+                last=7,
+            )


### PR DESCRIPTION
## Summary

- QA bypass testing discovered 6 bugs in the bookmark validation engine where invalid inputs passed both L1 (argument) and L2 (bookmark structure) validation and reached the Mixpanel API
- Extended `_scan_custom_properties()` to scan per-metric filters (`Metric.filters`), per-funnel-step filters (`FunnelStep.filters`), per-flow-step filters (`FlowStep.filters`), and per-retention-event filters (`RetentionEvent.filters`)
- Added L2 defense-in-depth: `B18b` validates `customPropertyId > 0`, `B20b` rejects NaN/Inf filter values
- Fixed formula show clause guard so hybrid `formula`+`behavior` clauses get full validation

## Test plan

- [x] 20 round 1 bypass tests pass (`tests/test_validation_bypass.py`) — validates fixes for Metric.filters, FunnelStep.filters, formula guard
- [x] 16 round 2 bypass tests pass (`tests/test_validation_bypass_r2.py`) — validates fixes for FlowStep.filters, RetentionEvent.filters, NaN/Inf
- [x] Full suite passes: `just check` — lint, mypy, 4542 tests, 0 failures
- [x] Positive tests verify valid custom properties and finite values still pass