### PR TITLE
fix: accept integer type codes in MeProjectInfo

### DIFF
--- a/src/mixpanel_data/_internal/me.py
+++ b/src/mixpanel_data/_internal/me.py
@@ -73,7 +73,7 @@ class MeProjectInfo(BaseModel):
         timezone: Project timezone (optional).
         has_workspaces: Whether project uses workspaces (optional).
         domain: Mixpanel domain for the project's cluster (optional).
-        type: Project type, e.g. "PROJECT" or "ROLLUP" (optional).
+        type: Project type — string (e.g. "PROJECT", "ROLLUP") or integer code (optional).
 
     Example:
         ```python
@@ -102,8 +102,8 @@ class MeProjectInfo(BaseModel):
     domain: str | None = None
     """Mixpanel domain for the project's cluster."""
 
-    type: str | None = None
-    """Project type (e.g., 'PROJECT', 'ROLLUP')."""
+    type: str | int | None = None
+    """Project type (e.g., 'PROJECT', 'ROLLUP', or integer type code)."""
 
 
 class MeWorkspaceInfo(BaseModel):


### PR DESCRIPTION
## Summary
- `mp projects list` crashed with 84 Pydantic validation errors because the Mixpanel `/me` API returns integer type codes for projects, but `MeProjectInfo.type` only accepted `str | None`
- Widened the type annotation to `str | int | None` to match what the API actually returns
- No downstream code reads this field, so the change is fully backwards-compatible

## Test plan
- [x] All 42 `test_me.py` unit tests pass
- [x] Verified `mp projects list` works against live Mixpanel API