### PR TITLE
fix: use OAuth Bearer auth for data API endpoints

### DIFF
--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -160,15 +160,16 @@ class MixpanelAPIClient:
         self._cached_workspace_id: int | None = None
 
     def _get_auth_header(self) -> str:
-        """Generate HTTP Basic auth header value.
+        """Generate the Authorization header value.
+
+        Delegates to ``Credentials.auth_header()`` which returns
+        ``"Bearer <token>"`` for OAuth or ``"Basic <encoded>"`` for
+        service accounts.
 
         Returns:
-            Base64-encoded "username:secret" prefixed with "Basic ".
+            Authorization header value appropriate for the auth method.
         """
-        secret = self._credentials.secret.get_secret_value()
-        auth_string = f"{self._credentials.username}:{secret}"
-        encoded = base64.b64encode(auth_string.encode()).decode()
-        return f"Basic {encoded}"
+        return self._credentials.auth_header()
 
     def _build_url(self, api_type: str, path: str) -> str:
         """Build full URL for the given API type and path.

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -167,6 +167,9 @@ class MixpanelAPIClient:
 
         Returns:
             Authorization header value appropriate for the auth method.
+
+        Raises:
+            ValueError: If OAuth credentials are missing an access token.
         """
         return self._credentials.auth_header()
 

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -12,7 +12,6 @@ or service layer instead of accessing this module directly.
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import random


### PR DESCRIPTION
## Summary
- `_get_auth_header()` was hardcoded to Basic auth, sending `Basic base64(":")` when using OAuth — all data API calls (`inspect`, `query`, etc.) failed with 401
- Now delegates to `Credentials.auth_header()` which already handles both Bearer (OAuth) and Basic (service account) auth correctly
- The App API path (`app_request`) already used `credentials.auth_header()` — this aligns the data API path to match

## Test plan
- [x] All 134 `test_api_client.py` unit tests pass
- [x] `mp inspect events` works with OAuth credentials (previously 401)
- [x] `mp projects list` still works (OAuth /me endpoint)