### PR TITLE
fix: resolve 4 bugs found by live/QA test exercise

### DIFF
--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Turn Claude into a senior data analyst and Mixpanel product analytics expert. CodeMode-first: Claude writes Python using mixpanel_data's 4 typed query engines (insights, funnels, retention, flows) plus pandas, networkx, and anytree for sophisticated multi-engine analysis.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -1,7 +1,7 @@
 ---
 name: auth
-description: Manage Mixpanel authentication — check status, add/switch/test accounts, OAuth login. Use with no arguments for a quick status check.
-argument-hint: [status|add|list|switch|test|login|remove|logout]
+description: Manage Mixpanel authentication — check status, add/switch/test accounts, OAuth login, migrate config, discover projects. Use with no arguments for a quick status check.
+argument-hint: [status|add|list|switch|test|login|remove|logout|migrate|projects|context|switch-project]
 ---
 
 # Mixpanel Authentication Management
@@ -25,15 +25,21 @@ Parse `$ARGUMENTS` and route to the appropriate operation:
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py status`
 
 Present the result conversationally:
-- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts exist, mention `/mp-auth list`.
+- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts/credentials exist, mention `/mp-auth list`.
 - If `active_method` is `"none"`: Diagnose what's missing. Suggest `/mp-auth add` (service account) or `/mp-auth login` (OAuth).
 - If `env_vars.partial` is true: Show which variables are set and which are missing.
+- If `config_version` is `1`: Mention that `/mp-auth migrate` can upgrade to v2 for project switching.
+- If `config_version` is `2`: Show active context (credential + project + workspace) and mention project aliases if any exist.
 
 ### "list"
 
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py list`
 
-Present accounts as a clean table. Mark the default account with a star or indicator. Show account name, project ID, and region.
+For **v1 config**: Present accounts as a clean table. Mark the default account with a star. Show account name, project ID, and region.
+
+For **v2 config**: Present two sections:
+1. **Credentials** — name, type (service_account/oauth), region, active status
+2. **Project aliases** — alias name, project ID, credential, workspace ID
 
 ### "add"
 
@@ -63,8 +69,8 @@ If a name is provided:
 - Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py switch <name>`
 
 If no name:
-- First run `list` to show available accounts
-- Ask which account to switch to
+- First run `list` to show available accounts/credentials
+- Ask which one to switch to
 - Then run `switch` with the chosen name
 
 ### "test" or "test <name>"
@@ -90,12 +96,14 @@ On failure: Show the error and suggest retrying.
 
 ### "remove" or "remove <name>"
 
-If no name: run `list` first, then ask which account to remove.
+If no name: run `list` first, then ask which account/credential to remove.
 
 **Always confirm before removing**: "Remove account '<name>'? This cannot be undone."
 
 After confirmation:
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py remove <name>`
+
+For v2 config, if the response includes `orphaned_aliases`, warn the user about project aliases that referenced the removed credential.
 
 ### "logout" or "logout --region <R>"
 
@@ -103,9 +111,43 @@ Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager
 
 If no region specified, removes all OAuth tokens. Confirm first: "This will remove all OAuth tokens. Continue?"
 
+### "migrate"
+
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py migrate --dry-run`
+
+Show the user what will change (credentials created, aliases created). Ask for confirmation.
+
+If confirmed:
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py migrate`
+
+On success: Report migration results. Explain that accounts are now split into credentials (auth identity) and project aliases (project selection), enabling project switching without reconfiguring auth.
+
+If already v2: Tell the user no migration is needed.
+
+### "projects"
+
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py projects`
+
+Present accessible projects as a table: organization, project name, project ID, timezone. Suggest `/mp-auth switch-project <ID>` to switch.
+
+### "context"
+
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py context`
+
+Show the active credential, project ID, and workspace ID. For v1 config, suggest migrating.
+
+### "switch-project" or "switch-project <project_id>"
+
+If no project_id: run `projects` first, then ask which to switch to.
+
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py switch-project <PROJECT_ID> [--workspace-id <WS_ID>]`
+
+On success: Confirm the active project was changed.
+If v1 config: Error suggests running `/mp-auth migrate` first.
+
 ## Presentation Style
 
 - Be concise — show status in 2-3 lines, not a wall of JSON
-- Use tables for lists of accounts
+- Use tables for lists of accounts, credentials, or projects
 - Always suggest a next action when something is missing
 - On errors, be specific about what went wrong and how to fix it

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -124,9 +124,17 @@ Use this before every unfamiliar method. It pulls live docstrings — always acc
 import mixpanel_data as mp
 
 ws = mp.Workspace()                          # default account
-ws = mp.Workspace(account="production")      # named account
+ws = mp.Workspace(account="production")      # named account (v1 config)
+ws = mp.Workspace(credential="production")   # named credential (v2 config)
 ws = mp.Workspace(workspace_id=12345)        # with workspace ID for App API
 # project_id must be a STRING: ws = mp.Workspace(project_id="8")
+
+# v2 config: discover and switch projects without re-constructing
+projects = ws.discover_projects()            # list accessible projects via /me API
+ws.switch_project("67890")                   # switch active project in-session
+ws.switch_workspace(12345)                   # switch active workspace in-session
+print(ws.current_project)                    # active ProjectContext
+print(ws.current_credential)                 # active AuthCredential
 ```
 
 ## Quick API Reference — All Engines
@@ -667,6 +675,7 @@ from mixpanel_data.exceptions import (
     JQLSyntaxError,            # 412 — JQL script error
     WorkspaceScopeError,       # workspace_id required for App API
     ConfigError,               # credentials not configured
+    ProjectNotFoundError,      # project ID not found in /me response
 )
 ```
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
@@ -8,12 +8,15 @@ Full method signatures for `mixpanel_data.Workspace`, organized by domain. Every
 import mixpanel_data as mp
 
 ws = mp.Workspace()                              # default account
-ws = mp.Workspace(account="prod")                # named account
+ws = mp.Workspace(account="prod")                # named account (v1 config)
+ws = mp.Workspace(credential="prod")             # named credential (v2 config)
 ws = mp.Workspace(workspace_id=12345)            # with workspace for App API
 ws = mp.Workspace(project_id="67890", region="eu") # explicit project — project_id is a STRING
 ```
 
 **Gotcha**: `project_id` must be a **string**, not an int. `Workspace(project_id=8)` raises `ValidationError`.
+
+**v1 vs v2 config**: `account=` uses v1 account-based config. `credential=` uses v2 credential-based config (decoupled auth identity from project context). Both work — v2 enables project switching without reconfiguring auth. Migrate with `ConfigManager().migrate_v1_to_v2()`.
 
 ## Discovery
 
@@ -978,6 +981,64 @@ ws.test_credentials() -> bool
 ws.api -> MixpanelAPIClient                     # escape hatch for custom requests
 ```
 
+## Session & Project Management (v2 Config)
+
+These methods require the v2 config schema (credential + project context). Migrate with `ConfigManager().migrate_v1_to_v2()` or `mp auth migrate`.
+
+```python
+# Identity & discovery via /me API
+ws.me(*, force_refresh: bool = False) -> MeResponse
+ws.discover_projects() -> list[tuple[str, MeProjectInfo]]   # (org_name, project_info) pairs
+ws.discover_workspaces(project_id: str | None = None) -> list[MeWorkspaceInfo]
+
+# In-session switching (changes the live Workspace without re-constructing)
+ws.switch_project(project_id: str, workspace_id: int | None = None) -> None
+ws.switch_workspace(workspace_id: int) -> None
+
+# Current session info (properties)
+ws.current_project -> ProjectContext          # active project_id, workspace_id
+ws.current_credential -> AuthCredential       # active auth identity (name, type, region)
+```
+
+### MeResponse / MeProjectInfo / MeWorkspaceInfo
+
+```python
+from mixpanel_data._internal.me import MeResponse, MeProjectInfo, MeWorkspaceInfo
+
+# MeProjectInfo fields
+proj.id          # int — project ID
+proj.name        # str — project display name
+proj.timezone    # str — project timezone
+
+# MeWorkspaceInfo fields
+wsi.id           # int — workspace ID
+wsi.name         # str — workspace display name
+
+# MeResponse fields
+me.organizations  # list[MeOrgInfo] — orgs with nested projects
+```
+
+### Auth v2 Types
+
+```python
+from mixpanel_data import AuthCredential, CredentialType, ProjectContext, ResolvedSession
+
+# AuthCredential — standalone auth identity
+cred.name         # str — credential name
+cred.type         # CredentialType — "service_account" or "oauth"
+cred.region       # str — "us", "eu", "in"
+cred.auth_header() # str — "Bearer <token>" or "Basic <encoded>"
+
+# ProjectContext — project + optional workspace selection
+ctx.project_id    # str
+ctx.workspace_id  # int | None
+
+# ResolvedSession — credential + project context composition
+session.credential   # AuthCredential
+session.project      # ProjectContext
+session.workspace_id # int | None (convenience property)
+```
+
 ## Key Result Types
 
 All query results have a `.df` property returning a pandas DataFrame. Key types:
@@ -1010,6 +1071,7 @@ MixpanelDataError (base)
 │   ├── QueryError (400)
 │   │   └── JQLSyntaxError (412)
 │   └── ServerError (5xx)
+├── ProjectNotFoundError
 ├── OAuthError
 └── WorkspaceScopeError
 ```

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/auth_manager.py
@@ -4,14 +4,21 @@
 Provides JSON-formatted output for all auth operations, designed
 to be called by the /mp-auth command and setup skill.
 
+Supports both v1 (account-based) and v2 (credential + project context)
+config schemas. Detects the active schema version automatically.
+
 Usage:
     python auth_manager.py status                    # Full auth dashboard
-    python auth_manager.py list                      # List configured accounts
+    python auth_manager.py list                      # List configured accounts/credentials
     python auth_manager.py test [account_name]       # Test credentials
     python auth_manager.py switch <account_name>     # Switch default account
-    python auth_manager.py remove <account_name>     # Remove an account
+    python auth_manager.py remove <account_name>     # Remove an account/credential
     python auth_manager.py oauth-login [--region R] [--project-id P]
     python auth_manager.py oauth-logout [--region R]
+    python auth_manager.py migrate [--dry-run]       # Migrate v1 config to v2
+    python auth_manager.py projects                  # List accessible projects
+    python auth_manager.py context                   # Show active context
+    python auth_manager.py switch-project <project_id> [--workspace-id W]
 """
 
 import argparse
@@ -45,6 +52,14 @@ def _get_config_manager() -> Any:
     return ConfigManager()
 
 
+def _config_version(cm: Any) -> int:
+    """Get config schema version (1 or 2)."""
+    try:
+        return cm.config_version()
+    except Exception:
+        return 1
+
+
 def _check_env_vars() -> dict[str, Any]:
     """Check which MP_* environment variables are set."""
     required = ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
@@ -59,7 +74,7 @@ def _check_env_vars() -> dict[str, Any]:
 
 
 def _get_accounts(cm: Any) -> list[dict[str, Any]]:
-    """Get all configured accounts as dicts."""
+    """Get all configured accounts as dicts (v1 config)."""
     try:
         accounts = cm.list_accounts()
         return [
@@ -71,6 +86,57 @@ def _get_accounts(cm: Any) -> list[dict[str, Any]]:
                 "is_default": a.is_default,
             }
             for a in accounts
+        ]
+    except Exception:
+        return []
+
+
+def _get_credentials(cm: Any) -> list[dict[str, Any]]:
+    """Get all configured credentials as dicts (v2 config)."""
+    try:
+        credentials = cm.list_credentials()
+        return [
+            {
+                "name": c.name,
+                "type": c.type,
+                "region": c.region,
+                "is_active": c.is_active,
+            }
+            for c in credentials
+        ]
+    except Exception:
+        return []
+
+
+def _get_active_context(cm: Any) -> dict[str, Any]:
+    """Get the active context from v2 config."""
+    try:
+        ctx = cm.get_active_context()
+        return {
+            "credential": ctx.credential,
+            "project_id": ctx.project_id,
+            "workspace_id": ctx.workspace_id,
+        }
+    except Exception:
+        return {
+            "credential": None,
+            "project_id": None,
+            "workspace_id": None,
+        }
+
+
+def _get_project_aliases(cm: Any) -> list[dict[str, Any]]:
+    """Get all project aliases from v2 config."""
+    try:
+        aliases = cm.list_project_aliases()
+        return [
+            {
+                "name": a.name,
+                "project_id": a.project_id,
+                "credential": a.credential,
+                "workspace_id": a.workspace_id,
+            }
+            for a in aliases
         ]
     except Exception:
         return []
@@ -102,7 +168,7 @@ def _check_oauth() -> list[dict[str, Any]]:
         return [{"region": r, "authenticated": False} for r in ["us", "eu", "in"]]
 
 
-def _resolve_active(cm: Any) -> dict[str, Any]:
+def _resolve_active(cm: Any, version: int) -> dict[str, Any]:
     """Determine the active authentication method."""
     try:
         creds = cm.resolve_credentials()
@@ -118,9 +184,12 @@ def _resolve_active(cm: Any) -> dict[str, Any]:
         else:
             method = "service_account"
 
-        # Find the active account name
+        # Find the active account/credential name
         active_account = None
-        if method == "service_account":
+        if version >= 2:
+            ctx = _get_active_context(cm)
+            active_account = ctx.get("credential")
+        elif method == "service_account":
             for a in cm.list_accounts():
                 if a.is_default:
                     active_account = a.name
@@ -144,6 +213,7 @@ def _resolve_active(cm: Any) -> dict[str, Any]:
 def _generate_suggestion(
     env: dict[str, Any],
     active: dict[str, Any],
+    version: int,
 ) -> str:
     """Generate a human-readable suggestion based on auth state."""
     if active["active_method"] != "none":
@@ -152,7 +222,10 @@ def _generate_suggestion(
             "service_account": f"service account '{active['active_account']}'",
             "oauth": "OAuth",
         }.get(active["active_method"], active["active_method"])
-        return f"Authenticated via {method_label} (project {active['active_project_id']}, {active['active_region']} region)."
+        msg = f"Authenticated via {method_label} (project {active['active_project_id']}, {active['active_region']} region)."
+        if version == 1:
+            msg += " Config is v1 — run /mp-auth migrate to upgrade to v2 for project switching."
+        return msg
 
     if env["partial"]:
         return f"Partial environment config — missing: {', '.join(env['missing'])}. Set all 4 variables or run /mp-auth add."
@@ -166,29 +239,59 @@ def _generate_suggestion(
 def cmd_status(_args: argparse.Namespace) -> None:
     """Full auth status dashboard."""
     cm = _get_config_manager()
+    version = _config_version(cm)
     env = _check_env_vars()
-    accounts = _get_accounts(cm)
     oauth = _check_oauth()
-    active = _resolve_active(cm)
-    suggestion = _generate_suggestion(env, active)
+    active = _resolve_active(cm, version)
+    suggestion = _generate_suggestion(env, active, version)
 
-    _json_out(
-        {
-            "operation": "status",
-            "env_vars": env,
-            "accounts": accounts,
-            "oauth": oauth,
-            **active,
-            "suggestion": suggestion,
-        }
-    )
+    result: dict[str, Any] = {
+        "operation": "status",
+        "config_version": version,
+        "env_vars": env,
+        "oauth": oauth,
+        **active,
+        "suggestion": suggestion,
+    }
+
+    if version >= 2:
+        result["credentials"] = _get_credentials(cm)
+        result["active_context"] = _get_active_context(cm)
+        result["project_aliases"] = _get_project_aliases(cm)
+    else:
+        result["accounts"] = _get_accounts(cm)
+
+    _json_out(result)
 
 
 def cmd_list(_args: argparse.Namespace) -> None:
-    """List configured accounts."""
+    """List configured accounts or credentials."""
     cm = _get_config_manager()
-    accounts = _get_accounts(cm)
-    _json_out({"operation": "list", "accounts": accounts, "count": len(accounts)})
+    version = _config_version(cm)
+
+    if version >= 2:
+        credentials = _get_credentials(cm)
+        aliases = _get_project_aliases(cm)
+        _json_out(
+            {
+                "operation": "list",
+                "config_version": version,
+                "credentials": credentials,
+                "credential_count": len(credentials),
+                "project_aliases": aliases,
+                "alias_count": len(aliases),
+            }
+        )
+    else:
+        accounts = _get_accounts(cm)
+        _json_out(
+            {
+                "operation": "list",
+                "config_version": version,
+                "accounts": accounts,
+                "count": len(accounts),
+            }
+        )
 
 
 def cmd_test(args: argparse.Namespace) -> None:
@@ -203,42 +306,83 @@ def cmd_test(args: argparse.Namespace) -> None:
 
 
 def cmd_switch(args: argparse.Namespace) -> None:
-    """Switch default account."""
+    """Switch default account (v1) or active credential (v2)."""
     cm = _get_config_manager()
-    accounts = _get_accounts(cm)
-    previous = next((a["name"] for a in accounts if a["is_default"]), None)
+    version = _config_version(cm)
 
-    try:
-        cm.set_default(args.name)
-        _json_out(
-            {
-                "operation": "switch",
-                "previous_default": previous,
-                "new_default": args.name,
-            }
-        )
-    except Exception as e:
-        available = [a["name"] for a in accounts]
-        _json_error(type(e).__name__, str(e), available_accounts=available)
+    if version >= 2:
+        try:
+            ctx = _get_active_context(cm)
+            previous = ctx.get("credential")
+            cm.set_active_context(credential=args.name)
+            _json_out(
+                {
+                    "operation": "switch",
+                    "config_version": version,
+                    "previous_credential": previous,
+                    "new_credential": args.name,
+                }
+            )
+        except Exception as e:
+            credentials = _get_credentials(cm)
+            available = [c["name"] for c in credentials]
+            _json_error(type(e).__name__, str(e), available_credentials=available)
+    else:
+        accounts = _get_accounts(cm)
+        previous = next((a["name"] for a in accounts if a["is_default"]), None)
+        try:
+            cm.set_default(args.name)
+            _json_out(
+                {
+                    "operation": "switch",
+                    "config_version": version,
+                    "previous_default": previous,
+                    "new_default": args.name,
+                }
+            )
+        except Exception as e:
+            available = [a["name"] for a in accounts]
+            _json_error(type(e).__name__, str(e), available_accounts=available)
 
 
 def cmd_remove(args: argparse.Namespace) -> None:
-    """Remove an account."""
+    """Remove an account (v1) or credential (v2)."""
     cm = _get_config_manager()
-    try:
-        cm.remove_account(args.name)
-        remaining = _get_accounts(cm)
-        new_default = next((a["name"] for a in remaining if a["is_default"]), None)
-        _json_out(
-            {
+    version = _config_version(cm)
+
+    if version >= 2:
+        try:
+            orphaned = cm.remove_credential(args.name)
+            remaining = _get_credentials(cm)
+            active = next((c["name"] for c in remaining if c["is_active"]), None)
+            result: dict[str, Any] = {
                 "operation": "remove",
+                "config_version": version,
                 "removed": args.name,
                 "remaining_count": len(remaining),
-                "new_default": new_default,
+                "new_active": active,
             }
-        )
-    except Exception as e:
-        _json_error(type(e).__name__, str(e))
+            if orphaned:
+                result["orphaned_aliases"] = orphaned
+            _json_out(result)
+        except Exception as e:
+            _json_error(type(e).__name__, str(e))
+    else:
+        try:
+            cm.remove_account(args.name)
+            remaining = _get_accounts(cm)
+            new_default = next((a["name"] for a in remaining if a["is_default"]), None)
+            _json_out(
+                {
+                    "operation": "remove",
+                    "config_version": version,
+                    "removed": args.name,
+                    "remaining_count": len(remaining),
+                    "new_default": new_default,
+                }
+            )
+        except Exception as e:
+            _json_error(type(e).__name__, str(e))
 
 
 def cmd_oauth_login(args: argparse.Namespace) -> None:
@@ -282,6 +426,126 @@ def cmd_oauth_logout(args: argparse.Namespace) -> None:
         _json_error(type(e).__name__, str(e))
 
 
+def cmd_migrate(args: argparse.Namespace) -> None:
+    """Migrate v1 config to v2."""
+    cm = _get_config_manager()
+    version = _config_version(cm)
+
+    if version >= 2:
+        _json_out(
+            {
+                "operation": "migrate",
+                "already_v2": True,
+                "message": "Config is already v2. No migration needed.",
+            }
+        )
+        return
+
+    try:
+        dry_run = args.dry_run
+        result = cm.migrate_v1_to_v2(dry_run=dry_run)
+        _json_out(
+            {
+                "operation": "migrate",
+                "dry_run": dry_run,
+                "credentials_created": result.credentials_created,
+                "aliases_created": result.aliases_created,
+                "backup_path": str(result.backup_path)
+                if hasattr(result, "backup_path") and result.backup_path
+                else None,
+                "message": "Dry run complete — no changes written."
+                if dry_run
+                else "Migration complete. Config upgraded to v2.",
+            }
+        )
+    except Exception as e:
+        _json_error(type(e).__name__, str(e))
+
+
+def cmd_projects(_args: argparse.Namespace) -> None:
+    """List accessible projects via /me API."""
+    try:
+        from mixpanel_data import Workspace
+
+        ws = Workspace()
+        projects = ws.discover_projects()
+        project_list = []
+        for org_name, proj in projects:
+            project_list.append(
+                {
+                    "organization": org_name,
+                    "project_id": str(proj.id),
+                    "name": proj.name,
+                    "timezone": proj.timezone,
+                }
+            )
+        ws.close()
+        _json_out(
+            {
+                "operation": "projects",
+                "projects": project_list,
+                "count": len(project_list),
+            }
+        )
+    except Exception as e:
+        _json_error(type(e).__name__, str(e))
+
+
+def cmd_context(_args: argparse.Namespace) -> None:
+    """Show active context (v2 config)."""
+    cm = _get_config_manager()
+    version = _config_version(cm)
+
+    if version < 2:
+        active = _resolve_active(cm, version)
+        _json_out(
+            {
+                "operation": "context",
+                "config_version": version,
+                **active,
+                "suggestion": "Config is v1. Run /mp-auth migrate to upgrade to v2 for project switching.",
+            }
+        )
+        return
+
+    ctx = _get_active_context(cm)
+    active = _resolve_active(cm, version)
+    _json_out(
+        {
+            "operation": "context",
+            "config_version": version,
+            **active,
+            "active_context": ctx,
+        }
+    )
+
+
+def cmd_switch_project(args: argparse.Namespace) -> None:
+    """Switch active project (v2 config)."""
+    cm = _get_config_manager()
+    version = _config_version(cm)
+
+    if version < 2:
+        _json_error(
+            "ConfigError",
+            "Project switching requires v2 config. Run /mp-auth migrate first.",
+        )
+        return
+
+    try:
+        workspace_id = int(args.workspace_id) if args.workspace_id else None
+        cm.set_active_context(project_id=args.project_id, workspace_id=workspace_id)
+        _json_out(
+            {
+                "operation": "switch-project",
+                "project_id": args.project_id,
+                "workspace_id": workspace_id,
+            }
+        )
+    except Exception as e:
+        _json_error(type(e).__name__, str(e))
+
+
 def main() -> None:
     """Parse arguments and dispatch to subcommand handler."""
     parser = argparse.ArgumentParser(
@@ -294,19 +558,19 @@ def main() -> None:
     subparsers.add_parser("status", help="Full auth status dashboard")
 
     # list
-    subparsers.add_parser("list", help="List configured accounts")
+    subparsers.add_parser("list", help="List configured accounts/credentials")
 
     # test
     p_test = subparsers.add_parser("test", help="Test credentials")
     p_test.add_argument("account", nargs="?", default=None, help="Account name to test")
 
     # switch
-    p_switch = subparsers.add_parser("switch", help="Switch default account")
-    p_switch.add_argument("name", help="Account name to make default")
+    p_switch = subparsers.add_parser("switch", help="Switch default account/credential")
+    p_switch.add_argument("name", help="Account or credential name")
 
     # remove
-    p_remove = subparsers.add_parser("remove", help="Remove an account")
-    p_remove.add_argument("name", help="Account name to remove")
+    p_remove = subparsers.add_parser("remove", help="Remove an account/credential")
+    p_remove.add_argument("name", help="Account or credential name to remove")
 
     # oauth-login
     p_login = subparsers.add_parser("oauth-login", help="OAuth browser login")
@@ -317,6 +581,27 @@ def main() -> None:
     p_logout = subparsers.add_parser("oauth-logout", help="Remove OAuth tokens")
     p_logout.add_argument(
         "--region", default=None, help="Region to logout (all if omitted)"
+    )
+
+    # migrate (v1 → v2)
+    p_migrate = subparsers.add_parser("migrate", help="Migrate v1 config to v2")
+    p_migrate.add_argument(
+        "--dry-run", action="store_true", help="Preview without writing"
+    )
+
+    # projects (via /me API)
+    subparsers.add_parser("projects", help="List accessible projects")
+
+    # context (show active context)
+    subparsers.add_parser("context", help="Show active context")
+
+    # switch-project
+    p_switch_proj = subparsers.add_parser(
+        "switch-project", help="Switch active project"
+    )
+    p_switch_proj.add_argument("project_id", help="Project ID to switch to")
+    p_switch_proj.add_argument(
+        "--workspace-id", default=None, help="Workspace ID (optional)"
     )
 
     args = parser.parse_args()
@@ -339,6 +624,10 @@ def main() -> None:
         "remove": cmd_remove,
         "oauth-login": cmd_oauth_login,
         "oauth-logout": cmd_oauth_logout,
+        "migrate": cmd_migrate,
+        "projects": cmd_projects,
+        "context": cmd_context,
+        "switch-project": cmd_switch_project,
         None: cmd_status,
     }
 

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -19,7 +19,7 @@ This will:
 1. Verify Python 3.10+ is available
 2. Install `mixpanel_data`, `pandas`, `numpy`, `matplotlib`, `seaborn`, `networkx>=3.0`, `anytree>=2.8.0`, and `scipy` (tries uv, pip in order)
 3. Verify all packages import successfully (including networkx, anytree, and scipy)
-4. Check for configured Mixpanel credentials
+4. Check for configured Mixpanel credentials (supports both v1 and v2 config schemas)
 
 ## Check Credentials
 
@@ -29,7 +29,10 @@ After installation, check auth status:
 uv run python ${CLAUDE_SKILL_DIR}/../mixpanel-analyst/scripts/auth_manager.py status
 ```
 
-Parse the JSON result. If `active_method` is not `"none"`, credentials are configured — proceed to verification.
+Parse the JSON result:
+- If `active_method` is not `"none"`, credentials are configured — proceed to verification.
+- If `config_version` is `1`, suggest `/mp-auth migrate` to upgrade to v2 for project switching.
+- If `config_version` is `2`, show the active credential and project context.
 
 ## If Credentials Are Missing
 
@@ -63,3 +66,22 @@ uv run python ${CLAUDE_SKILL_DIR}/../mixpanel-analyst/scripts/auth_manager.py te
 If the result shows `"success": true`, setup is complete. The user can now ask questions about their Mixpanel data.
 
 If verification fails, suggest `/mp-auth test` for detailed diagnostics.
+
+## Post-Setup: Explore Your Data
+
+Once authenticated, these commands help orient the user:
+
+- `/mp-auth projects` — discover all accessible projects via the /me API
+- `/mp-auth context` — see the active credential + project + workspace
+- `/mp-auth switch-project <ID>` — switch to a different project (v2 config only)
+
+The user can also construct a Workspace targeting a specific credential or project:
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()                              # default credentials
+ws = mp.Workspace(account="production")           # named account (v1)
+ws = mp.Workspace(credential="production")        # named credential (v2)
+ws = mp.Workspace(project_id="67890", region="eu") # explicit project
+```

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -84,17 +84,35 @@ elif env_set:
 try:
     from mixpanel_data.auth import ConfigManager
     cm = ConfigManager()
-    accounts = cm.list_accounts()
-    if accounts:
-        names = [a.name for a in accounts]
-        print(f'✓ {len(accounts)} configured account(s): {\", \".join(names)}')
-        default = next((a.name for a in accounts if a.is_default), None)
-        if default:
-            print(f'  Default: {default}')
+    version = cm.config_version()
+
+    if version >= 2:
+        # v2 config: credential + project context
+        credentials = cm.list_credentials()
+        if credentials:
+            active = [c for c in credentials if c.is_active]
+            print(f'✓ Config v2: {len(credentials)} credential(s)')
+            if active:
+                print(f'  Active: {active[0].name} ({active[0].type}, {active[0].region})')
+            aliases = cm.list_project_aliases()
+            if aliases:
+                print(f'  {len(aliases)} project alias(es) configured')
+        else:
+            print('⚠ Config v2 but no credentials configured.')
+            print('  Run /mp-auth add (service account) or /mp-auth login (OAuth)')
     else:
-        print('⚠ No accounts configured yet.')
-        print('  Set environment variables: MP_USERNAME, MP_SECRET, MP_PROJECT_ID')
-        print('  Or configure an account programmatically (see setup instructions)')
+        # v1 config: account-based
+        accounts = cm.list_accounts()
+        if accounts:
+            names = [a.name for a in accounts]
+            print(f'✓ Config v1: {len(accounts)} account(s): {\", \".join(names)}')
+            default = next((a.name for a in accounts if a.is_default), None)
+            if default:
+                print(f'  Default: {default}')
+            print(f'  Tip: Run /mp-auth migrate to upgrade to v2 for project switching')
+        else:
+            print('⚠ No accounts configured yet.')
+            print('  Run /mp-auth add (service account) or /mp-auth login (OAuth)')
 except Exception as e:
     print(f'⚠ Could not check config file credentials: {e}')
     print('  Set environment variables: MP_USERNAME, MP_SECRET, MP_PROJECT_ID')

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -6641,8 +6641,8 @@ class EventDeletionRequest(BaseModel):
     to_date: str
     """End date."""
 
-    filters: dict[str, Any] | None = None
-    """Deletion filters."""
+    filters: dict[str, Any] | list[Any] | None = None
+    """Deletion filters (dict when populated, empty list when none)."""
 
     status: str
     """Request status: "Submitted", "Processing", "Completed", "Failed"."""

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -48,7 +48,7 @@ from mixpanel_data._literal_types import RetentionMode as RetentionMode
 if TYPE_CHECKING:
     import networkx as nx
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.alias_generators import to_camel
 
 T = TypeVar("T")
@@ -6641,8 +6641,23 @@ class EventDeletionRequest(BaseModel):
     to_date: str
     """End date."""
 
-    filters: dict[str, Any] | list[Any] | None = None
-    """Deletion filters (dict when populated, empty list when none)."""
+    filters: dict[str, Any] | None = None
+    """Deletion filters (dict when populated, None when absent)."""
+
+    @field_validator("filters", mode="before")
+    @classmethod
+    def _normalize_filters(
+        cls,
+        v: dict[str, Any] | list[Any] | None,
+    ) -> dict[str, Any] | None:
+        """Coerce empty list from API to None."""
+        if isinstance(v, list) and len(v) == 0:
+            return None
+        if isinstance(v, list):
+            # Non-empty list is unexpected; preserve as-is would fail type.
+            # Wrap in dict for forward compatibility.
+            return {"items": v}
+        return v
 
     status: str
     """Request status: "Submitted", "Processing", "Completed", "Failed"."""

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -6907,15 +6907,23 @@ class Workspace:
             ws = Workspace()
             tags = ws.list_lexicon_tags()
             for tag in tags:
-                print(f"{tag.id}: {tag.name}")
+                print(tag.name)
             ```
+
+        Note:
+            The list endpoint may return plain tag name strings without IDs.
+            In that case, ``id`` is set to ``0`` as a sentinel value. Do not
+            pass this sentinel to ``update_lexicon_tag()`` — use name-based
+            operations (e.g. ``delete_lexicon_tag(tag.name)``) for tags
+            obtained from this method.
         """
         client = self._require_api_client()
         raw_list = client.list_lexicon_tags()
         result: list[LexiconTag] = []
         for x in raw_list:
             if isinstance(x, str):
-                # List endpoint returns plain tag name strings (no id)
+                # List endpoint returns plain tag name strings (no id);
+                # id=0 is a sentinel — see docstring Note.
                 result.append(LexiconTag(id=0, name=x))
             else:
                 result.append(LexiconTag.model_validate(x))
@@ -7447,7 +7455,7 @@ class Workspace:
         # Upload response may only contain {'id': '...'} without 'name';
         # inject the name from params so LookupTable validation succeeds.
         if isinstance(raw, dict) and "name" not in raw:
-            raw["name"] = params.name
+            raw = {**raw, "name": params.name}
         return LookupTable.model_validate(raw)
 
     def _poll_lookup_upload(

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -6912,7 +6912,14 @@ class Workspace:
         """
         client = self._require_api_client()
         raw_list = client.list_lexicon_tags()
-        return [LexiconTag.model_validate(x) for x in raw_list]
+        result: list[LexiconTag] = []
+        for x in raw_list:
+            if isinstance(x, str):
+                # List endpoint returns plain tag name strings (no id)
+                result.append(LexiconTag(id=0, name=x))
+            else:
+                result.append(LexiconTag.model_validate(x))
+        return result
 
     def create_lexicon_tag(self, params: CreateTagParams) -> LexiconTag:
         """Create a new Lexicon tag.
@@ -7437,6 +7444,10 @@ class Workspace:
                 client, upload_id, poll_interval, max_poll_seconds
             )
 
+        # Upload response may only contain {'id': '...'} without 'name';
+        # inject the name from params so LookupTable validation succeeds.
+        if isinstance(raw, dict) and "name" not in raw:
+            raw["name"] = params.name
         return LookupTable.model_validate(raw)
 
     def _poll_lookup_upload(

--- a/tests/live/test_data_governance_live.py
+++ b/tests/live/test_data_governance_live.py
@@ -161,7 +161,7 @@ class TestTagsCRUD:
     """Tag create / list / update / delete — happy path."""
 
     def test_list_tags(self, ws: Workspace) -> None:
-        """Listing tags returns a list of tag name strings.
+        """Listing tags returns a list of LexiconTag objects.
 
         Args:
             ws: Workspace fixture.
@@ -169,7 +169,8 @@ class TestTagsCRUD:
         tags = ws.list_lexicon_tags()
         assert isinstance(tags, list)
         for t in tags:
-            assert isinstance(t, str)
+            assert isinstance(t, LexiconTag)
+            assert isinstance(t.name, str)
 
     def test_create_update_delete_tag(self, ws: Workspace) -> None:
         """Full lifecycle: create -> update -> delete a tag.
@@ -370,7 +371,8 @@ class TestPropertyDefinitions:
         """Getting property definitions by name returns matching results.
 
         The API may return multiple properties; we verify that at least
-        one of them has the requested name.
+        one result is a PropertyDefinition. The Lexicon API may strip
+        the ``$`` prefix (e.g. ``$browser`` -> ``browser``).
 
         Args:
             ws: Workspace fixture.
@@ -378,10 +380,11 @@ class TestPropertyDefinitions:
         result = ws.get_property_definitions(names=["$browser"])
         assert isinstance(result, list)
         assert len(result) >= 1
-        prop_names = [p.name for p in result]
-        assert "$browser" in prop_names
         # Verify at least one is a PropertyDefinition
         assert isinstance(result[0], PropertyDefinition)
+        # The returned name may or may not have the $ prefix
+        prop_names = [p.name for p in result]
+        assert "$browser" in prop_names or "browser" in prop_names
 
     def test_get_with_resource_type(self, ws: Workspace) -> None:
         """Filtering by resource_type narrows the results.
@@ -1480,9 +1483,8 @@ class TestLookupTablesCRUD:
                     file_path=str(csv_path),
                 )
             )
-            assert isinstance(result, dict)
-            assert "id" in result
-            table_id = int(result["id"])
+            assert isinstance(result, LookupTable)
+            table_id = result.id
 
             # Verify in list
             tables = ws.list_lookup_tables()

--- a/tests/qa/test_038_qa.py
+++ b/tests/qa/test_038_qa.py
@@ -752,19 +752,21 @@ class TestResolveSessionPriorityChain:
         assert session.project.workspace_id == 9999
 
     def test_v1_config_fallback_through_resolve_session(
-        self, v1_config_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, v1_config_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """v1 config falls back through resolve_session correctly.
 
         Args:
             v1_config_path: Path to the v1 config file.
+            tmp_path: Pytest-provided temp directory.
             monkeypatch: Pytest monkeypatch fixture.
         """
         for var in ("MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"):
             monkeypatch.delenv(var, raising=False)
 
         cm = ConfigManager(config_path=v1_config_path)
-        session = cm.resolve_session()
+        # Use empty OAuth dir to prevent real tokens on disk from winning
+        session = cm.resolve_session(_oauth_storage_dir=tmp_path / "no-oauth")
         assert session.project_id == "12345"
         assert session.auth.username == "sa-user"
 


### PR DESCRIPTION
## Summary

- **`workspace.list_lexicon_tags()`**: Handle string API responses — the Mixpanel tags list endpoint returns plain strings, not dicts with id/name. Now wraps strings into `LexiconTag(id=0, name=x)`.
- **`workspace.upload_lookup_table()`**: Inject `name` from params when API response omits it — small-file uploads return only `{id}`.
- **`types.EventDeletionRequest.filters`**: Accept `list` in addition to `dict` — API returns `[]` for empty filters.
- **`test_038_qa`**: Isolate v1 config fallback test from real OAuth tokens on disk via `_oauth_storage_dir`.

### Plugin update (v3.0.1)

- **`auth_manager.py`**: Add config version detection, v2 credential/alias listing, migrate command (v1-to-v2 with dry-run), project discovery via /me API, active context display, and project switching.
- **`commands/auth.md`**: Add routing for migrate, projects, context, and switch-project subcommands with v2-aware presentation guidance.
- **`setup.sh` + `SKILL.md`**: v2-aware credential detection, migration hints for v1 users, post-setup project discovery commands.
- **`python-api.md`**: Document `credential=` constructor, session/project management methods (`me`, `discover_projects`, `discover_workspaces`, `switch_project`, `switch_workspace`, `current_project`, `current_credential`), auth v2 types, and `ProjectNotFoundError`.
- **`SKILL.md` (analyst)**: Add `credential=` construction, project switching examples, and `ProjectNotFoundError` to error handling.

## Test plan

- [x] All 3391 unit tests pass (no regressions)
- [x] `test_038_qa.py`: 96 passed (was 95 passed, 1 failed)
- [x] `test_custom_property_queries_live.py`: 76 passed, 1 skipped
- [x] `test_cohort_behaviors_live.py`: 56 passed
- [x] `test_live_feature_management.py`: 51 passed, 1 xfailed
- [x] `test_data_governance_live.py`: 88 passed (was 75 passed, 16 failed)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass
- [x] `auth_manager.py` syntax check passes
- [x] `setup.sh` syntax check passes
- [x] `plugin.json` valid JSON, version bumped to 3.0.1