### PR TITLE
feat(plugin): add cross-reference context graph (3.0.3)

### DIFF
--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Turn Claude into a senior data analyst and Mixpanel product analytics expert. CodeMode-first: Claude writes Python using mixpanel_data's 4 typed query engines (insights, funnels, retention, flows) plus pandas, networkx, and anytree for sophisticated multi-engine analysis.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -68,6 +68,8 @@ for tree in result.trees:
     print(tree.render())           # ASCII visualization
 ```
 
+_Each engine has a comprehensive reference: [insights](skills/mixpanel-analyst/references/insights-reference.md) | [funnels](skills/mixpanel-analyst/references/funnels-reference.md) | [retention](skills/mixpanel-analyst/references/retention-reference.md) | [flows](skills/mixpanel-analyst/references/flows-reference.md). For routing questions to the right engine, see [query-taxonomy.md](skills/mixpanel-analyst/references/query-taxonomy.md)._
+
 ## Agents
 
 The plugin uses a specialist agent hierarchy. The **analyst** is the general-purpose entry point — it handles simple queries directly and delegates complex investigations to the appropriate specialist based on question type.
@@ -87,6 +89,8 @@ Task(subagent_type="mixpanel-data:diagnostician", prompt="...")
 Task(subagent_type="mixpanel-data:synthesizer", prompt="...")
 Task(subagent_type="mixpanel-data:narrator", prompt="...")
 ```
+
+_Agents draw on shared analytical frameworks ([AARRR, GQM, Diagnosis](skills/mixpanel-analyst/references/analytical-frameworks.md)) and [cross-query synthesis patterns](skills/mixpanel-analyst/references/cross-query-synthesis.md)._
 
 ## Components
 

--- a/mixpanel-plugin/agents/analyst.md
+++ b/mixpanel-plugin/agents/analyst.md
@@ -85,6 +85,8 @@ User says...                              → Engine
 "product health", "overview"              → MULTI-ENGINE
 ```
 
+_For 50+ NL→engine signal patterns and 12 decomposition templates, see [query-taxonomy.md](../skills/mixpanel-analyst/references/query-taxonomy.md)._
+
 ### Multi-Query Planning
 
 For complex questions requiring multiple engines, decompose into a plan:
@@ -107,6 +109,8 @@ For complex questions requiring multiple engines, decompose into a plan:
 | Executive summary, stakeholder report | **Narrator** | Business-ready formatting |
 | Flow/path analysis | **Handle directly** | Use `ws.query_flow()` |
 | Entity CRUD (dashboards, cohorts, flags) | **Handle directly** | App API calls |
+
+_Each specialist agent has dedicated methodology: Explorer uses [GQM decomposition](../skills/mixpanel-analyst/references/analytical-frameworks.md), Diagnostician follows an [8-step diagnostic protocol](../skills/mixpanel-analyst/references/analytical-frameworks.md), Synthesizer applies [cross-query synthesis patterns](../skills/mixpanel-analyst/references/cross-query-synthesis.md), Narrator uses [AARRR-structured report templates](../skills/mixpanel-analyst/references/analytical-frameworks.md)._
 
 ## Code Pattern — All Four Engines
 
@@ -144,6 +148,8 @@ print(flow.drop_off_summary())
 ```
 
 ## Cohort-Scoped Queries
+
+_(→ [insights-reference.md](../skills/mixpanel-analyst/references/insights-reference.md) §Cohort Capabilities for the complete cohort API including inline CohortDefinition)_
 
 ```python
 from mixpanel_data import CohortBreakdown, CohortMetric
@@ -187,6 +193,8 @@ If `Workspace()` or any query raises `AuthenticationError` or `ConfigError`:
 Manage Mixpanel entities (dashboards, cohorts, bookmarks, feature flags, experiments, alerts, annotations, webhooks) via the App API. Use `help.py` to look up the exact CRUD method signatures.
 
 ### Bookmark Validation
+
+_(→ [bookmark-params.md](../skills/mixpanel-analyst/references/bookmark-params.md) for the full bookmark JSON structure and per-engine validation rules)_
 
 When creating or updating bookmarks, validate params before calling the API:
 

--- a/mixpanel-plugin/agents/diagnostician.md
+++ b/mixpanel-plugin/agents/diagnostician.md
@@ -41,6 +41,8 @@ Write Python code. Never teach CLI commands. Never call MCP tools.
 
 ## 8-Step Diagnostic Protocol
 
+_Expands the 7-step diagnosis methodology from [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §Diagnosis Methodology. For ready-to-run diagnostic templates, see [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md) §Template 1: Revenue Drop Diagnosis._
+
 ### Step 1: QUANTIFY (Insights)
 
 Establish the baseline and magnitude of the change.
@@ -90,6 +92,8 @@ print(trend.nlargest(5, "daily_change")[["daily_change"]])
 
 ### Step 3: SEGMENT (Insights, parallel)
 
+_(→ [insights-reference.md](../skills/mixpanel-analyst/references/insights-reference.md) §GroupBy Deep Reference for numeric bucketing and multiple breakdowns)_
+
 Break down by 4-6 dimensions to find which segment drives the change. Run all queries simultaneously:
 
 ```python
@@ -133,6 +137,8 @@ cohort_result = ws.query("TARGET_EVENT", last=60,
 
 ### Step 4: CHECK CONVERSION (Funnels)
 
+_(→ [funnels-reference.md](../skills/mixpanel-analyst/references/funnels-reference.md) for FunnelStep, Exclusion, display modes, and per-step filter details)_
+
 Did conversion through related steps change?
 
 ```python
@@ -147,6 +153,8 @@ print(f"Overall conversion: {funnel.overall_conversion_rate:.1%}")
 ```
 
 ### Step 5: CHECK RETENTION (Retention)
+
+_(→ [retention-reference.md](../skills/mixpanel-analyst/references/retention-reference.md) for RetentionEvent, alignment modes, and custom bucket_sizes | [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §Retention for industry benchmarks)_
 
 Did return rates change for the affected behavior?
 
@@ -164,6 +172,8 @@ print(ret.df)
 
 ### Step 6: CHECK PATHS (Flows)
 
+_(→ [flows-reference.md](../skills/mixpanel-analyst/references/flows-reference.md) for FlowStep, NetworkX graph analysis, and FlowTreeNode traversal)_
+
 Did user paths change? Are there new drop-offs or route changes?
 
 ```python
@@ -178,6 +188,8 @@ print(flow.drop_off_summary())
 ```
 
 ### Step 7: CORRELATE (pandas)
+
+_(→ [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md) §Synthesis Patterns for correlation analysis and statistical significance testing | [advanced-analysis.md](../skills/mixpanel-analyst/references/advanced-analysis.md) §Statistical Methods for t-tests, confidence intervals, effect sizes)_
 
 Merge results across engines by date. What changed first? What has the largest impact?
 

--- a/mixpanel-plugin/agents/explorer.md
+++ b/mixpanel-plugin/agents/explorer.md
@@ -52,6 +52,8 @@ Write Python code. Never teach CLI commands. Never call MCP tools.
 
 ### Schema Discovery
 
+_(→ [python-api.md](../skills/mixpanel-analyst/references/python-api.md) §Discovery for complete method signatures)_
+
 ```python
 import mixpanel_data as mp
 ws = mp.Workspace()
@@ -113,6 +115,8 @@ print(f"Status: {schema.status}")
 
 ## GQM Decomposition Workflow (Four-Engine)
 
+_Implements the GQM methodology from [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §GQM with a four-engine twist._
+
 ### Step 1: Parse the Implicit Goal
 
 Interpret what the user actually wants to know, even if they stated it vaguely. Write it as a concrete business outcome.
@@ -147,6 +151,8 @@ for event_name in [t.event for t in top[:5]]:
 
 ### Step 3: Classify with AARRR
 
+_(→ [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §AARRR for the complete framework with industry benchmarks and engine mappings)_
+
 Map the question to pirate metric stages:
 
 | Stage | Key Question | Primary Engines |
@@ -171,6 +177,8 @@ For each sub-question, specify the engine, method, and parameters:
 | 6 | Does behavior differ for [cohort]? | Any | `ws.query()` | `where=Filter.in_cohort(...)` or `group_by=CohortBreakdown(...)` |
 
 ### Step 5: Define the Join Strategy
+
+_(→ [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md) for 6 detailed join strategies with full pandas merge code)_
 
 How will results from different engines be combined?
 

--- a/mixpanel-plugin/agents/narrator.md
+++ b/mixpanel-plugin/agents/narrator.md
@@ -135,6 +135,8 @@ print(r["flow"].top_transitions(5))
 
 ### Product Health Report (AARRR)
 
+_Implements the AARRR framework from [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §AARRR with one section per lifecycle stage._
+
 One section per stage, each using the optimal engine:
 
 ```markdown
@@ -172,6 +174,8 @@ One section per stage, each using the optimal engine:
 
 ### Metric Deep Dive
 
+_Structure mirrors the Diagnosis Methodology from [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §Diagnosis Methodology — current state, then cross-engine investigation._
+
 ```markdown
 # [Metric Name] — Deep Dive
 
@@ -195,6 +199,8 @@ One section per stage, each using the optimal engine:
 ```
 
 ### Feature Report
+
+_Follows the 4-step Feature Adoption Framework from [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §Feature Adoption Framework: Discovery→Activation→Habit→Impact._
 
 ```markdown
 # Feature Report: [Feature Name] — [Period]
@@ -225,6 +231,8 @@ One section per stage, each using the optimal engine:
 ```
 
 ## Data Pulling Patterns
+
+_For detailed per-engine parameter references, see [insights-reference.md](../skills/mixpanel-analyst/references/insights-reference.md) | [funnels-reference.md](../skills/mixpanel-analyst/references/funnels-reference.md) | [retention-reference.md](../skills/mixpanel-analyst/references/retention-reference.md) | [flows-reference.md](../skills/mixpanel-analyst/references/flows-reference.md)._
 
 ### Pulling from Each Engine
 
@@ -276,6 +284,8 @@ with ThreadPoolExecutor(max_workers=len(queries)) as pool:
 
 ## Narrative Principles
 
+_(→ [analytical-frameworks.md](../skills/mixpanel-analyst/references/analytical-frameworks.md) §Delivering Insights for detailed guidance on contextualizing findings and structuring recommendations)_
+
 1. **Lead with the headline** — most important finding first
 2. **Quantify everything** — "23% increase (12,400 to 15,252)" not "significant increase"
 3. **Compare for context** — always include a comparison (MoM, WoW, YoY, benchmark)
@@ -284,6 +294,8 @@ with ThreadPoolExecutor(max_workers=len(queries)) as pool:
 6. **Be honest about uncertainty** — "Directional signal (n=47)" vs "Strong finding (n=12,400)"
 
 ## Visual Standards
+
+_(→ [advanced-analysis.md](../skills/mixpanel-analyst/references/advanced-analysis.md) §Visualization Patterns for 6 chart types with code: time series, funnel bars, retention curves, multi-panel dashboards, annotated charts, and export patterns)_
 
 - **Retention heatmaps** — seaborn heatmap with percentage annotations
 - **Flow diagrams** — top transitions bar chart or Graphviz export

--- a/mixpanel-plugin/agents/synthesizer.md
+++ b/mixpanel-plugin/agents/synthesizer.md
@@ -61,6 +61,8 @@ The analyst delegates to you when:
 
 ## Multi-Engine Synthesis Workflow
 
+_For the decomposition patterns that generate these plans, see [query-taxonomy.md](../skills/mixpanel-analyst/references/query-taxonomy.md) §Complex Question Decomposition. For ready-to-run implementation templates, see [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md) §Multi-Engine Investigation Templates._
+
 1. **Receive or create the query plan** — which engines, which parameters, which join keys
 2. **Execute queries** — parallel when independent
 3. **Transform results** to compatible DataFrames (align date formats, column names)
@@ -115,6 +117,8 @@ print(revenue_trend)
 
 ### 2. Graph Analysis (NetworkX)
 
+_Basics here. For the full NetworkX API on flow data (8 patterns), see [flows-reference.md](../skills/mixpanel-analyst/references/flows-reference.md) §NetworkX Integration Patterns. For advanced patterns (subgraph extraction, graph comparison, weighted metrics), see [advanced-analysis.md](../skills/mixpanel-analyst/references/advanced-analysis.md) §Graph Analysis._
+
 Apply graph algorithms to flow data:
 
 ```python
@@ -154,6 +158,8 @@ for cycle in cycles[:5]:
 
 ### 3. Tree Analysis (anytree)
 
+_Basics here. For the full anytree API (4 patterns + FlowTreeNode reference), see [flows-reference.md](../skills/mixpanel-analyst/references/flows-reference.md) §anytree Integration Patterns. For multi-tree comparison and pruning strategies, see [advanced-analysis.md](../skills/mixpanel-analyst/references/advanced-analysis.md) §Tree Analysis._
+
 Traverse and compare flow trees:
 
 ```python
@@ -181,6 +187,8 @@ for root in tree_result.anytree:
 ```
 
 ### 4. Statistical Testing
+
+_(→ [advanced-analysis.md](../skills/mixpanel-analyst/references/advanced-analysis.md) §Statistical Methods for the complete treatment: t-test, chi-squared, Mann-Whitney U, confidence intervals, Cohen's d, sample size validation)_
 
 Apply scipy.stats for significance:
 
@@ -251,7 +259,11 @@ print("Saved: synthesis_dashboard.png")
 
 ## Key Synthesis Patterns
 
+_These patterns correspond to templates in [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md). See that reference for 6 additional templates and the reusable multi-engine runner._
+
 ### Pattern 1: Funnel-Flow Complement
+
+_(→ [cross-query-synthesis.md](../skills/mixpanel-analyst/references/cross-query-synthesis.md) §Funnel-Flow Complement for full implementation | [funnels-reference.md](../skills/mixpanel-analyst/references/funnels-reference.md) + [flows-reference.md](../skills/mixpanel-analyst/references/flows-reference.md) for parameter details)_
 
 **Question**: Where do funnel drop-offs actually go?
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/SKILL.md
@@ -38,6 +38,8 @@ Mixpanel has four fundamentally different query engines. Each answers a differen
 | **Retention** | `ws.query_retention()` | Do users come back? | `RetentionQueryResult` |
 | **Flows** | `ws.query_flow()` | What paths do users take? | `FlowQueryResult` |
 
+_Each engine has a dedicated deep reference — load on demand when the quick reference below is insufficient. For NL→engine routing with 50+ signal patterns, see [query-taxonomy.md](references/query-taxonomy.md)._
+
 ### Mental Model
 
 - **Insights** — "I need to **measure a metric** over time." Counts, aggregations, DAU/WAU/MAU, property math, formulas, rolling averages. The workhorse for any "how much" or "how many" question.
@@ -100,6 +102,8 @@ For complex questions, decompose into a query plan:
 | "Feature adoption?" | Ins+Fun+Ret | Insights (usage) + Funnels (discovery→use) + Retention (continued use) |
 | "Onboarding health?" | Fun+Flow+Ret | Funnels (completion) + Flows (user paths) + Retention (post-onboarding) |
 | "Product health?" | All 4 | DAU (Insights) + Key funnels + Retention curves + Top paths |
+
+_(→ [query-taxonomy.md](references/query-taxonomy.md) §Complex Question Decomposition for 12 detailed decomposition patterns with code | [cross-query-synthesis.md](references/cross-query-synthesis.md) for implementation templates)_
 
 ## On-Demand API Lookup
 
@@ -193,6 +197,8 @@ result = ws.query(
 | `percentile` | Custom percentile (set percentile_value) | Yes |
 | `histogram` | Property value distribution | Yes |
 
+_Complete parameter reference → [insights-reference.md](references/insights-reference.md)_
+
 **Result**: `result.df` (DataFrame) · `result.params` (bookmark JSON) · `result.series` (raw data) · `result.meta`
 
 **Examples**:
@@ -229,6 +235,8 @@ result = ws.query_funnel(
 **Exclusion**: `Exclusion(event, from_step=0, to_step=None)` — step ranges (0-indexed)
 **HoldingConstant**: `HoldingConstant(property, resource_type="events")` — max 3
 
+_Complete parameter reference → [funnels-reference.md](references/funnels-reference.md)_
+
 **FunnelMathType**: `conversion_rate_unique` (default) · `conversion_rate_total` · `conversion_rate_session` · `unique` · `total` · `average` · `median` · `min` · `max` · `p25` · `p75` · `p90` · `p99`
 
 **Result**: `result.overall_conversion_rate` · `result.df` (step, event, count, step_conv_ratio, overall_conv_ratio, avg_time) · `result.params`
@@ -262,6 +270,8 @@ result = ws.query_retention(
 ```
 
 **RetentionEvent**: `RetentionEvent(event, filters=None, filters_combinator="all")`
+
+_Complete parameter reference → [retention-reference.md](references/retention-reference.md)_
 
 **Alignment**: `"birth"` (user's clock starts at born event) vs `"interval_start"` (calendar boundaries)
 
@@ -300,6 +310,8 @@ result = ws.query_flow(
 
 **FlowStep**: `FlowStep(event, forward=None, reverse=None, label=None, filters=None, filters_combinator="all")`
 
+_Complete parameter reference → [flows-reference.md](references/flows-reference.md)_
+
 **Three modes produce different result structures**:
 
 | Mode | Key properties | Use for |
@@ -331,6 +343,8 @@ for tree in result.trees:
 ```
 
 ### Filter Expression Syntax
+
+_Summary of key filters. For the full Filter API (20+ methods, 7 categories, combining logic), see [insights-reference.md](references/insights-reference.md) §Filter Deep Reference._
 
 All 4 query engines share the same `Filter` class:
 
@@ -424,6 +438,8 @@ params = ws.build_flow_params("Purchase", forward=3)
 ```
 
 ## Cross-Query Patterns
+
+_Three common patterns below. For 6 join strategies and 11 investigation templates with full code, see [cross-query-synthesis.md](references/cross-query-synthesis.md)._
 
 The engines complement each other. These patterns combine them for deeper analysis:
 
@@ -592,6 +608,8 @@ Map every question to a pirate metric stage and choose the right engine:
 | **Revenue** | Do they pay? | Insights (revenue metrics), Funnels (purchase conversion) |
 | **Referral** | Do they invite others? | Insights (invite events), Funnels (invite→accept) |
 
+_(→ [analytical-frameworks.md](references/analytical-frameworks.md) §AARRR for the complete framework with engine mappings and industry benchmarks)_
+
 ### 3. GQM for Vague Questions
 
 Decompose with Goal-Question-Metric, specifying the engine for each:
@@ -600,6 +618,8 @@ Decompose with Goal-Question-Metric, specifying the engine for each:
 2. **Questions**: 3-5 specific sub-questions
 3. **Metrics**: For each → which engine? which method? which params?
 4. **Join strategy**: How to combine results?
+
+_(→ [analytical-frameworks.md](references/analytical-frameworks.md) §GQM for 3 worked examples | the explorer agent implements a full 5-step GQM workflow)_
 
 ### 4. Provide Actionable Insights
 
@@ -634,6 +654,8 @@ list(nx.simple_cycles(g))                            # loop detection
 nx.pagerank(g, weight="count")                       # event importance
 ```
 
+_Quick patterns here. For comprehensive graph analysis (subgraphs, centrality, comparison, path enumeration), see [flows-reference.md](references/flows-reference.md) §NetworkX Integration Patterns and [advanced-analysis.md](references/advanced-analysis.md) §Graph Analysis._
+
 ### anytree Quick Patterns
 
 ```python
@@ -656,7 +678,11 @@ for tree in flow_result.trees:
     max(tree.flatten(), key=lambda n: n.drop_off_count)  # worst drop-off
 ```
 
+_Quick patterns here. For tree traversal, pruning, multi-tree comparison, and Graphviz export, see [flows-reference.md](references/flows-reference.md) §anytree Integration Patterns and [advanced-analysis.md](references/advanced-analysis.md) §Tree Analysis._
+
 ## Bookmark Validation
+
+_(→ [bookmark-params.md](references/bookmark-params.md) for the complete bookmark JSON structure and all validation rules across report types)_
 
 All typed query methods (`query()`, `query_funnel()`, `query_retention()`, `query_flow()`) validate automatically before API calls. For manually constructed bookmark params, use the built-in `validate_bookmark()` function:
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/advanced-analysis.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/advanced-analysis.md
@@ -6,6 +6,8 @@ Advanced analytical methods using `mixpanel_data` results with pandas, numpy, sc
 
 ## Statistical Methods
 
+_These methods operate on DataFrames from any query engine. For applying them in multi-engine investigations, see [cross-query-synthesis.md](cross-query-synthesis.md) §Synthesis Patterns with pandas/numpy._
+
 ### t-test for Comparing Means Across Periods
 
 Use when comparing a continuous metric (DAU, revenue, session duration) between two time periods.
@@ -318,6 +320,8 @@ print(f"\nWoW change (smoothed): {wow.iloc[-1]:+.1f}%")
 
 ## Cohort Analysis with pandas
 
+_For the retention API that produces these cohorts, see [retention-reference.md](retention-reference.md). For industry retention benchmarks to contextualize results, see [analytical-frameworks.md](analytical-frameworks.md) §Retention._
+
 ### Cohort Pivot Table from RetentionQueryResult
 
 ```python
@@ -455,6 +459,8 @@ print(comparison.map(lambda x: f"{x:.0%}" if pd.notna(x) else "").to_string())
 ---
 
 ## Graph Analysis with NetworkX (Beyond Basics)
+
+_These patterns extend the basic NetworkX integration in [flows-reference.md](flows-reference.md) §NetworkX Integration Patterns. The flow result's `.graph` property is the entry point._
 
 These patterns build on the flow graph from `result.graph` (see flows-reference.md for fundamentals).
 
@@ -597,6 +603,8 @@ for n, flow in sorted(net_flow.items(), key=lambda x: x[1])[:5]:
 ---
 
 ## Tree Analysis with anytree
+
+_These patterns extend the basic anytree integration in [flows-reference.md](flows-reference.md) §anytree Integration Patterns. Use `result.anytree` to get converted trees._
 
 These patterns build on the anytree integration in flows-reference.md.
 
@@ -1020,6 +1028,8 @@ with PdfPages("report.pdf") as pdf:
         plt.close(fig)
 print("Saved: report.pdf")
 ```
+
+_For multi-panel dashboards combining all four engines, see [cross-query-synthesis.md](cross-query-synthesis.md) §Multi-Engine Health Dashboard._
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/analytical-frameworks.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/analytical-frameworks.md
@@ -15,6 +15,8 @@ The library provides four typed query engines. Choose the right engine for each 
 | **Retention** | `ws.query_retention()` | Cohort curves, return rates over time |
 | **Flows** | `ws.query_flow()` | User path analysis, entry/exit patterns |
 
+_For engine-specific AARRR mappings (which engine for which stage), see the explorer agent's §Classify with AARRR step. For a complete AARRR-structured report template, see the narrator agent's §Product Health Report._
+
 ### Acquisition — "Where do users come from?"
 
 **Questions**: Traffic sources, campaign effectiveness, channel attribution, entry paths
@@ -101,6 +103,8 @@ print(stickiness.df)
 | E-commerce | — | 20-30% | 20-30% |
 | Social/Community | 40-60% | 25-40% | 20-30% |
 
+_For detailed retention API parameters (alignment, custom buckets, retention_unit), see [retention-reference.md](retention-reference.md)._
+
 ### Revenue — "Do they pay?"
 
 **Questions**: Conversion to paid, ARPU, LTV indicators, upgrade triggers
@@ -157,6 +161,8 @@ for step in invite_funnel.steps_data:
 ## GQM (Goal-Question-Metric)
 
 Use GQM to decompose vague questions into actionable queries. This is your primary tool for open-ended requests like "why is X happening?"
+
+_The explorer agent implements a 5-step GQM workflow (Parse→Discover→Classify→Decompose→Join). For the NL signal mappings that connect questions to engines, see [query-taxonomy.md](query-taxonomy.md) §NL-to-Engine Signal Mapping._
 
 ### Process
 
@@ -260,6 +266,8 @@ result = ws.query(
 print(result.df)
 ```
 
+_For a ready-to-run implementation of this framework, see [cross-query-synthesis.md](cross-query-synthesis.md) §Template 2: Feature Adoption Analysis._
+
 ## North Star Metric Framework
 
 A North Star metric captures the core value your product delivers. All analysis should connect back to it.
@@ -308,6 +316,8 @@ print(f"Drop-off summary: {flow.drop_off_summary()}")
 ## Diagnosis Methodology
 
 When a metric changes unexpectedly, follow this structured investigation using all four query engines.
+
+_The diagnostician agent expands this to an 8-step protocol with parallel execution. For ready-to-run diagnostic templates, see [cross-query-synthesis.md](cross-query-synthesis.md) §Template 1: Revenue Drop Diagnosis and [query-taxonomy.md](query-taxonomy.md) §Pattern 1: Diagnostic._
 
 ### Step 1: Quantify the Change (Insights)
 
@@ -418,6 +428,8 @@ Structure findings as:
 8. **Next steps**: Monitor [metric] daily, set up alert at [threshold]
 
 ## Delivering Insights
+
+_The narrator agent implements these principles with audience-specific templates — see its §Audience Awareness and §Narrative Principles sections._
 
 ### Always Provide Context
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -85,6 +85,8 @@ ws.create_bookmark(CreateBookmarkParams(
 ))
 ```
 
+_Each typed query method has a dedicated reference: [insights-reference.md](insights-reference.md) | [funnels-reference.md](funnels-reference.md) | [retention-reference.md](retention-reference.md) | [flows-reference.md](flows-reference.md). Use this document only when you need to construct or modify bookmark JSON directly._
+
 Use manual bookmark JSON (documented below) only for:
 - **Edge cases** where the typed query methods cannot express the exact bookmark structure needed
 
@@ -659,6 +661,8 @@ result = ws.query_saved_flows(bookmark_id)
 ```
 
 ## Validation
+
+_Per-engine validation rules (V-rules, F-rules, R-rules, FL-rules) are documented in each engine reference's §Validation Rules Summary section._
 
 **Always validate params before calling `create_bookmark()` or `update_bookmark()`.**
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/cross-query-synthesis.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/cross-query-synthesis.md
@@ -2,6 +2,8 @@
 
 How to combine results from `query()`, `query_funnel()`, `query_retention()`, and `query_flow()` to answer questions no single engine can. Each engine reveals one facet of user behavior; joining them produces compound insights.
 
+_This playbook implements the decomposition patterns from [query-taxonomy.md](query-taxonomy.md) using the strategic frameworks from [analytical-frameworks.md](analytical-frameworks.md). For per-engine parameter details, see the individual engine references._
+
 ## Engine Quick Reference
 
 | Engine | Method | Returns | Best for |
@@ -96,6 +98,8 @@ print(f"\nCorrelation (purchases vs retention): {combined['purchases'].corr(comb
 
 ## Join Strategy 3: Funnel-Flow Complement
 
+_(→ [funnels-reference.md](funnels-reference.md) for FunnelStep/Exclusion details | [flows-reference.md](flows-reference.md) for FlowStep/NetworkX/anytree)_
+
 **Use when**: Funnels tell you THAT users drop off; flows tell you WHERE they go instead.
 
 **Principle**: Funnels quantify the conversion rate at each step. Flows reveal the specific events users do instead of converting.
@@ -143,6 +147,8 @@ for step, info in flow.drop_off_summary().items():
 ---
 
 ## Join Strategy 4: Insights-Retention Correlation
+
+_(→ [retention-reference.md](retention-reference.md) §Analysis Patterns for retention-specific patterns | [analytical-frameworks.md](analytical-frameworks.md) §Retention for industry benchmarks)_
 
 **Use when**: You want to test whether a specific behavior predicts better retention.
 
@@ -380,6 +386,8 @@ for a, b in sorted(pairs, key=lambda p: abs(corr.loc[p[0], p[1]]), reverse=True)
 
 ### Statistical Significance Testing
 
+_(→ [advanced-analysis.md](advanced-analysis.md) §Statistical Methods for complete treatment: t-tests, chi-squared, Mann-Whitney U, confidence intervals, effect sizes, sample size validation)_
+
 ```python
 from scipy.stats import ttest_ind, chi2_contingency
 import numpy as np
@@ -486,6 +494,8 @@ print(f"\nTrend: {daily_change:+.1f}/day ({weekly_change:+.1f}/week)")
 
 ### Template 1: Revenue Drop Diagnosis (4-engine)
 
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §Diagnosis Methodology for the systematic diagnostic framework)_
+
 **Question**: "Revenue dropped 20% this month. Why?"
 
 | # | Sub-Question | Engine | Method | Key Params |
@@ -501,6 +511,8 @@ print(f"\nTrend: {daily_change:+.1f}/day ({weekly_change:+.1f}/week)")
 **Unique insight**: Combine funnel step-conv with flow transitions to pinpoint exactly WHERE in the purchase path users diverge AND what they do instead.
 
 ### Template 2: Feature Adoption Analysis (4-engine)
+
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §Feature Adoption Framework for the 4-step methodology this template implements)_
 
 **Question**: "How is the new Search feature performing?"
 
@@ -624,6 +636,8 @@ print(f"\nTrend: {daily_change:+.1f}/day ({weekly_change:+.1f}/week)")
 
 ### Template 10: Growth Bottleneck Identification (4-engine)
 
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §AARRR for the pirate metrics framework used in growth analysis)_
+
 **Question**: "Where is the biggest bottleneck in our growth?"
 
 | # | Sub-Question | Engine | Method | Key Params |
@@ -711,6 +725,8 @@ for name, result in results.items():
 ---
 
 ## Tips and Gotchas
+
+_For per-engine pitfalls, see the Common Pitfalls sections in each engine reference: [insights-reference.md](insights-reference.md) | [funnels-reference.md](funnels-reference.md) | [retention-reference.md](retention-reference.md) | [flows-reference.md](flows-reference.md)._
 
 - **Thread safety**: `Workspace` uses `httpx` which is thread-safe. A single `ws` instance can be shared across threads in `ThreadPoolExecutor`.
 - **Date alignment**: Always use the same `from_date`/`to_date` or `last` when comparing across engines. Misaligned dates produce misleading correlations.

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/flows-reference.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/flows-reference.md
@@ -2,6 +2,8 @@
 
 Deep reference for flow queries in `mixpanel_data`. Flows show user paths before and after anchor events -- graph traversal of sequential behavior across the user base.
 
+_Flows use Filter for per-step filtering (see [insights-reference.md](insights-reference.md) §Filter Deep Reference) but do not support GroupBy, CohortBreakdown, or CohortMetric._
+
 ## Complete Signature
 
 ```python
@@ -469,6 +471,8 @@ for tree in result.trees:
 
 ## NetworkX Integration Patterns
 
+_For advanced NetworkX patterns beyond these basics (subgraph extraction, graph comparison, weighted metrics), see [advanced-analysis.md](advanced-analysis.md) §Graph Analysis with NetworkX._
+
 The `.graph` property returns a `networkx.DiGraph` built from sankey mode data. Node keys follow the format `"{event}@{step}"`.
 
 ### Basic Graph Inspection
@@ -653,6 +657,8 @@ edge_df = pd.DataFrame(edges, columns=["source", "target", "count"])
 ---
 
 ## anytree Integration Patterns
+
+_For advanced tree patterns (multi-tree comparison, pruning strategies, Graphviz customization), see [advanced-analysis.md](advanced-analysis.md) §Tree Analysis with anytree._
 
 The `.anytree` property (on FlowQueryResult) and `.to_anytree()` method (on FlowTreeNode) convert flow trees into anytree nodes, gaining parent references and rich rendering.
 
@@ -867,6 +873,8 @@ ws.create_bookmark(CreateBookmarkParams(
     params=params,
 ))
 ```
+
+_For cross-engine workflows that combine flows with funnels/retention/insights, see [cross-query-synthesis.md](cross-query-synthesis.md) §Funnel-Flow Complement and §Multi-Engine Health Dashboard._
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/funnels-reference.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/funnels-reference.md
@@ -2,6 +2,8 @@
 
 Complete reference for `Workspace.query_funnel()`, the typed funnel query engine. Covers every parameter, type, validation rule, and analysis pattern.
 
+_Funnels inherit Filter, GroupBy, and time range handling from Insights — see [insights-reference.md](insights-reference.md) for the authoritative reference on these shared concepts._
+
 ## Complete Signature
 
 ```python
@@ -300,6 +302,8 @@ ws.query_funnel(steps, conversion_window=2, conversion_window_unit="second")
 
 ## FunnelMathType
 
+_Counting and property aggregation types are shared with Insights — see [insights-reference.md](insights-reference.md) §MathType Deep Reference. Funnels add three conversion rate types: conversion_rate_unique, conversion_rate_total, conversion_rate_session._
+
 ```python
 FunnelMathType = Literal[
     "conversion_rate_unique",   # Unique-user conversion rate (default)
@@ -463,6 +467,8 @@ Each entry in `steps_data` is a dict:
 
 ## Cohort-Scoped Funnels
 
+_(→ [insights-reference.md](insights-reference.md) §Cohort Capabilities for the full cohort API including CohortDefinition inline syntax)_
+
 ### Cohort Filters
 
 Restrict funnel analysis to a specific user segment:
@@ -621,6 +627,8 @@ params = ws.build_funnel_params(
 import json
 print(json.dumps(params, indent=2))
 ```
+
+_For multi-engine patterns combining funnels with other engines (e.g., Funnel-Flow Complement), see [cross-query-synthesis.md](cross-query-synthesis.md) §Funnel-Flow Complement._
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/insights-reference.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/insights-reference.md
@@ -32,6 +32,8 @@ Workspace.query(
 
 ## MathType Deep Reference
 
+_Funnels use a subset of these types — see [funnels-reference.md](funnels-reference.md) §FunnelMathType for funnel-specific math._
+
 `MathType = Literal["total", "unique", "dau", "wau", "mau", "average", "median", "min", "max", "p25", "p75", "p90", "p99", "percentile", "histogram"]`
 
 ### Counting Types (no math_property required)
@@ -247,6 +249,8 @@ Metric("Purchase",
     filters_combinator="any",  # OR logic — US or UK
 )
 ```
+
+_Filters apply across all engines. For per-step filters in funnels, see [funnels-reference.md](funnels-reference.md) §Per-Step Filters. For per-event filters in retention, see [retention-reference.md](retention-reference.md) §Filtered Retention. For inline filters in flows, see [flows-reference.md](flows-reference.md) §FlowStep Fields._
 
 ---
 
@@ -632,6 +636,8 @@ Inline `CohortDefinition` is supported. Always provide a descriptive `name` for 
 | Bookmark Layer 2 | Cohort behavior must have `id` or `raw_cohort` | `B22_COHORT_MISSING_IDENTIFIER` |
 | Bookmark Layer 2 | Cohort `resourceType` must be `"cohorts"` | `B23_COHORT_RESOURCE_TYPE` |
 
+_Cohort filters and breakdowns work across all engines — for engine-specific details, see [funnels-reference.md](funnels-reference.md) §Cohort-Scoped Funnels | [retention-reference.md](retention-reference.md) §Cohort-Scoped Retention | [flows-reference.md](flows-reference.md) §Cohort Filters in Flows._
+
 ---
 
 ## QueryResult Structure
@@ -671,6 +677,8 @@ bm = ws.create_bookmark(CreateBookmarkParams(
 ))
 print(f"Report created: {bm.id}")
 ```
+
+_(→ [bookmark-params.md](bookmark-params.md) for manual bookmark JSON construction and the full validation rule set)_
 
 ---
 
@@ -782,6 +790,8 @@ change = (c_total - p_total) / p_total * 100
 print(f"MoM change: {change:+.1f}%")
 ```
 
+> **Related:** [advanced-analysis.md](advanced-analysis.md) for statistical testing, trend analysis, and visualization patterns on query results
+
 ---
 
 ## Validation Rules Summary
@@ -843,6 +853,8 @@ print(f"MoM change: {change:+.1f}%")
 | B18 | Filter has property identifier |
 | B19 | Valid filtersDeterminer (any/all) |
 | B20-B21 | filterValue non-empty and within size limits |
+
+_For bookmark-level validation (Layer 2) across all report types, see [bookmark-params.md](bookmark-params.md) §Validation._
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
@@ -1068,7 +1068,7 @@ All query results have a `.df` property returning a pandas DataFrame. Key types:
 
 ## Exception Hierarchy
 
-_For error handling patterns and recovery strategies, see the Auth Error Recovery section in any agent file._
+_For error handling patterns and recovery strategies, see [Auth Error Recovery](../../../agents/analyst.md#auth-error-recovery) in the analyst agent._
 
 ```
 MixpanelDataError (base)

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/python-api.md
@@ -37,6 +37,8 @@ ws.clear_discovery_cache() -> None
 
 `Workspace.query()` generates valid Mixpanel insights bookmark params from keyword arguments, with two-layer validation (45 rules). Prefer this over legacy segmentation/event_counts methods for all insights-style queries.
 
+_For complete parameter documentation with examples and pitfalls, see [insights-reference.md](insights-reference.md)._
+
 ```python
 ws.query(
     events: str | Metric | CohortMetric | Formula | Sequence[str | Metric | CohortMetric | Formula],
@@ -285,6 +287,8 @@ Useful for debugging, inspecting generated JSON, or passing to `create_bookmark(
 
 ## Typed Query API — Funnels
 
+_Complete reference → [funnels-reference.md](funnels-reference.md)_
+
 `Workspace.query_funnel()` generates valid funnel bookmark params from keyword arguments, posts them inline, and returns a structured `FunnelQueryResult`. Prefer this over the legacy `funnel()` method for all ad-hoc funnel queries.
 
 ```python
@@ -404,6 +408,8 @@ ws.build_funnel_params(
 
 ## Typed Query API — Retention
 
+_Complete reference → [retention-reference.md](retention-reference.md)_
+
 `Workspace.query_retention()` generates valid retention bookmark params from keyword arguments, posts them inline, and returns a structured `RetentionQueryResult`. Prefer this over the legacy `retention()` method for all ad-hoc retention queries.
 
 ```python
@@ -502,6 +508,8 @@ ws.build_retention_params(
 ---
 
 ## Typed Query API — Flows
+
+_Complete reference → [flows-reference.md](flows-reference.md)_
 
 `Workspace.query_flow()` generates valid flow bookmark params from keyword arguments, posts them to `/arb_funnels`, and returns a structured `FlowQueryResult`. Prefer this over the legacy `query_saved_flows()` method for all ad-hoc flow queries.
 
@@ -1059,6 +1067,8 @@ All query results have a `.df` property returning a pandas DataFrame. Key types:
 | `FlowQueryResult` | `query_flow()` | `.df`, `.nodes_df`, `.edges_df`, `.graph`, `.trees`, `.anytree`, `.top_transitions()`, `.drop_off_summary()`, `.params`, `.meta`, `.computed_at` |
 
 ## Exception Hierarchy
+
+_For error handling patterns and recovery strategies, see the Auth Error Recovery section in any agent file._
 
 ```
 MixpanelDataError (base)

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/query-taxonomy.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/query-taxonomy.md
@@ -120,6 +120,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 
 ## Complex Question Decomposition
 
+_Each pattern below decomposes into engine-specific queries. For ready-to-run code implementing these patterns, see [cross-query-synthesis.md](cross-query-synthesis.md) §Multi-Engine Investigation Templates. For the strategic frameworks behind these patterns, see [analytical-frameworks.md](analytical-frameworks.md)._
+
 ### Pattern 1: Diagnostic ("Why is X changing?")
 
 **Question**: "Why are signups dropping?"
@@ -133,6 +135,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 | 5 | Funnel | `ws.query_funnel(["Visit", "Signup"], last=60, group_by="platform")` | Conversion by segment |
 | 6 | Insights | Correlate with `ws.query("Error", ...)` | Root cause candidates |
 
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §Diagnosis Methodology for the complete 7-step protocol | the diagnostician agent expands this to 8 steps)_
+
 ### Pattern 2: Feature Impact Assessment
 
 **Question**: "How is the new feature performing?"
@@ -145,6 +149,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 | 4 | Retention | `ws.query_retention("Signup", "Login")` | Baseline retention |
 | 5 | Funnel | `ws.query_funnel(["Signup", "Purchase"], where=Filter.is_set("used_feature"))` | Feature users funnel |
 | 6 | Funnel | `ws.query_funnel(["Signup", "Purchase"], where=Filter.is_not_set("used_feature"))` | Non-feature funnel |
+
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §Feature Adoption Framework for the 4-step Discovery→Activation→Habit→Impact methodology)_
 
 ### Pattern 3: Revenue Deep Dive
 
@@ -219,6 +225,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 | 4 | Funnel | `ws.query_funnel(["Login", "Core Action"])` | Activation rate |
 | 5 | Flows | `ws.query_flow(["Last Login"], forward=3)` | Pre-churn behavior |
 
+_(→ [analytical-frameworks.md](analytical-frameworks.md) §Retention for industry retention benchmarks to contextualize churn rates)_
+
 ### Pattern 9: Growth Accounting
 
 **Question**: "Break down our growth"
@@ -244,6 +252,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) rema
 ---
 
 ## Join Strategies
+
+_For full code implementations of each join strategy with pandas merge patterns, see [cross-query-synthesis.md](cross-query-synthesis.md) §Join Strategy 1-6._
 
 ### Time-Aligned Join
 
@@ -480,6 +490,8 @@ volume = ws.query(drop_step["event"], math="unique", last=30)
 ---
 
 ## Engine Selection Decision Tree
+
+_For the complete NL signal mapping (50+ patterns) that feeds this tree, see §NL-to-Engine Signal Mapping above. For parameter details once you've selected an engine, see the per-engine references: [insights-reference.md](insights-reference.md) | [funnels-reference.md](funnels-reference.md) | [retention-reference.md](retention-reference.md) | [flows-reference.md](flows-reference.md)._
 
 ```
 Is the question about sequential steps/conversion?

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/retention-reference.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/retention-reference.md
@@ -2,6 +2,8 @@
 
 Complete reference for `Workspace.query_retention()`, the typed retention query engine. Covers every parameter, type, validation rule, and analysis pattern.
 
+_Retention inherits Filter, GroupBy, and time range handling from Insights — see [insights-reference.md](insights-reference.md) for the authoritative reference. Note: retention_unit is separate from the query time unit._
+
 ## Complete Signature
 
 ```python
@@ -352,6 +354,8 @@ for name, avg in result.segment_averages.items():
 
 ## Cohort-Scoped Retention
 
+_(→ [insights-reference.md](insights-reference.md) §Cohort Capabilities for the full cohort API)_
+
 ### Cohort Filters
 
 Measure retention for a specific user segment:
@@ -587,6 +591,8 @@ import json
 print(json.dumps(params, indent=2))
 ```
 
+_For retention benchmarks by industry (Consumer Mobile, SaaS, E-commerce), see [analytical-frameworks.md](analytical-frameworks.md) §Retention. For Insights-Retention correlation patterns, see [cross-query-synthesis.md](cross-query-synthesis.md) §Insights-Retention Correlation._
+
 ---
 
 ## Validation Rules Summary
@@ -642,3 +648,5 @@ print(json.dumps(params, indent=2))
 8. **Bucket 0 is always 100%** — The first bucket represents the born event itself, so its retention rate is always 1.0.
 9. **alignment affects interpretation** — With `"birth"` alignment, each user's W1 starts from their signup date. With `"interval_start"`, W1 is the same calendar week for all users in that cohort.
 10. **QueryTimeUnit differs from retention TimeUnit** — `unit` (the date range unit) supports `"hour"` and `"quarter"` in addition to day/week/month, but `retention_unit` only supports day/week/month.
+
+_For retention heatmaps, cohort pivot tables, and LTV estimation from retention data, see [advanced-analysis.md](advanced-analysis.md) §Cohort Analysis with pandas._

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
@@ -350,38 +350,138 @@ def show_related(type_name: str) -> None:
             print(m)
 
 
-_BOOKMARK_RELATED = frozenset(
-    {
-        "query_saved_report",
-        "query_saved_flows",
-        "SavedReportResult",
-        "SavedReportType",
-        "FlowsResult",
-    }
-)
+# Reference hints: ordered most-specific-first so e.g. "query_funnel" matches
+# funnels before "query" matches insights.  Each entry is
+# (trigger_keywords, reference_filename, one-line description).
+_REFERENCE_HINTS: list[tuple[frozenset[str], str, str]] = [
+    (
+        frozenset(
+            {
+                "query_flow",
+                "build_flow_params",
+                "query_saved_flows",
+                "FlowQueryResult",
+                "FlowStep",
+                "FlowTreeNode",
+                "FlowNodeType",
+                "FlowAnchorType",
+                "FlowCountType",
+                "FlowChartType",
+            }
+        ),
+        "flows-reference.md",
+        "FlowStep, NetworkX graph, anytree trees, modes, pitfalls",
+    ),
+    (
+        frozenset(
+            {
+                "query_retention",
+                "build_retention_params",
+                "RetentionQueryResult",
+                "RetentionEvent",
+                "RetentionMathType",
+                "RetentionAlignment",
+                "RetentionMode",
+            }
+        ),
+        "retention-reference.md",
+        "RetentionEvent, alignment, custom buckets, pitfalls",
+    ),
+    (
+        frozenset(
+            {
+                "query_funnel",
+                "build_funnel_params",
+                "FunnelQueryResult",
+                "FunnelStep",
+                "Exclusion",
+                "HoldingConstant",
+                "FunnelMathType",
+            }
+        ),
+        "funnels-reference.md",
+        "FunnelStep, Exclusion, HoldingConstant, conversion windows, pitfalls",
+    ),
+    (
+        frozenset(
+            {
+                "query",
+                "build_params",
+                "QueryResult",
+                "MathType",
+                "PerUserAggregation",
+                "Filter",
+                "GroupBy",
+                "Formula",
+                "Metric",
+                "CohortBreakdown",
+                "CohortMetric",
+                "CohortDefinition",
+                "CustomPropertyRef",
+                "InlineCustomProperty",
+            }
+        ),
+        "insights-reference.md",
+        "MathType, Filter, GroupBy, Formula, validation rules, pitfalls",
+    ),
+    (
+        frozenset(
+            {
+                "create_bookmark",
+                "update_bookmark",
+                "get_bookmark",
+                "validate_bookmark",
+                "query_saved_report",
+                "CreateBookmarkParams",
+                "UpdateBookmarkParams",
+                "BookmarkInfo",
+                "SavedReportResult",
+                "SavedReportType",
+            }
+        ),
+        "bookmark-params.md",
+        "bookmark JSON structure, validation rules",
+    ),
+]
 
 
-def _maybe_show_bookmark_hint(query: str) -> None:
-    """Print a reference hint if the query relates to bookmarks.
+def _show_reference_hints(query: str) -> None:
+    """Print a contextual reference hint based on the help query.
+
+    Checks each hint rule in priority order (most specific first).
+    Prints the first matching hint, pointing the reader to the
+    relevant deep-dive reference document.
 
     Args:
         query: The user's help query string.
     """
+    refs_dir = Path(__file__).resolve().parent.parent / "references"
     parts = query.replace(".", " ").split()
-    if "bookmark" not in query.lower() and not (set(parts) & _BOOKMARK_RELATED):
+    query_lower = query.lower()
+    part_set = set(parts)
+
+    # Special case: standalone "Workspace" (no dot) → python-api.md
+    if query == "Workspace":
+        ref = refs_dir / "python-api.md"
+        if ref.is_file():
+            print(
+                "\n---\n"
+                "Tip: For complete method signatures organized by domain,\n"
+                "     read references/python-api.md"
+            )
         return
-    ref = Path(__file__).resolve().parent.parent / "references" / "bookmark-params.md"
-    if not ref.is_file():
-        return
-    print(
-        "\n---\n"
-        "Tip: For bookmark params JSON schema, "
-        "read references/bookmark-params.md "
-        "(SQL-to-JSON query translation guide)\n"
-        "     To validate params before API calls: "
-        "from mixpanel_data import validate_bookmark; "
-        "errors = validate_bookmark(params, bookmark_type='insights')"
-    )
+
+    for triggers, filename, description in _REFERENCE_HINTS:
+        # Match if any trigger appears as a keyword or as a substring
+        if part_set & triggers or any(t.lower() in query_lower for t in triggers):
+            ref = refs_dir / filename
+            if ref.is_file():
+                print(
+                    f"\n---\n"
+                    f"Tip: For complete parameter docs ({description}),\n"
+                    f"     read references/{filename}"
+                )
+            return
 
 
 def show_detail(obj: Any, path: str) -> None:
@@ -471,7 +571,7 @@ def main() -> None:
             sys.exit(1)
 
     if query not in ("types", "exceptions"):
-        _maybe_show_bookmark_hint(query)
+        _show_reference_hints(query)
 
 
 if __name__ == "__main__":

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/help.py
@@ -457,7 +457,6 @@ def _show_reference_hints(query: str) -> None:
     """
     refs_dir = Path(__file__).resolve().parent.parent / "references"
     parts = query.replace(".", " ").split()
-    query_lower = query.lower()
     part_set = set(parts)
 
     # Special case: standalone "Workspace" (no dot) → python-api.md
@@ -472,8 +471,10 @@ def _show_reference_hints(query: str) -> None:
         return
 
     for triggers, filename, description in _REFERENCE_HINTS:
-        # Match if any trigger appears as a keyword or as a substring
-        if part_set & triggers or any(t.lower() in query_lower for t in triggers):
+        # Match if any trigger appears as a token (substring matching avoided
+        # because generic triggers like "query" false-positive on compound
+        # names like "query_saved_report")
+        if part_set & triggers:
             ref = refs_dir / filename
             if ref.is_file():
                 print(

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -85,3 +85,5 @@ ws = mp.Workspace(account="production")           # named account (v1)
 ws = mp.Workspace(credential="production")        # named credential (v2)
 ws = mp.Workspace(project_id="67890", region="eu") # explicit project
 ```
+
+_The mixpanel-analyst skill auto-triggers on analytics questions. For the analytical frameworks that guide investigations, see [analytical-frameworks.md](../mixpanel-analyst/references/analytical-frameworks.md). For the complete Python API, see [python-api.md](../mixpanel-analyst/references/python-api.md)._


### PR DESCRIPTION
## Summary

- Weave ~92 surgical cross-reference links across all 18 plugin documents to form a navigable knowledge graph
- Replace single-purpose bookmark hint in `help.py` with generalized reference hints for all 4 query engines + Workspace + bookmarks
- Bump plugin version to 3.0.3

## Test plan

- [x] All link targets verified — zero missing files
- [x] 184 insertions, 0 deletions across 18 doc files (content preservation confirmed)
- [x] Every reference links to at least 1 other reference, every agent links to 3+ references
- [x] help.py hints tested for all 6 query types (insights, funnels, retention, flows, Workspace, bookmarks)
- [x] `types` and `exceptions` commands correctly skip hints
- [x] Pre-commit hooks (ruff lint + format) pass