### PR TITLE
feat: Cowork auth bridge for Claude Cowork VM authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency (us, eu, in) |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |
+| `MP_CUSTOM_HEADER_NAME` | Custom HTTP header name (both NAME and VALUE must be set) |
+| `MP_CUSTOM_HEADER_VALUE` | Custom HTTP header value (both NAME and VALUE must be set) |
 | `MP_CONFIG_PATH` | Override config file location |
 
 Config file: `~/.mp/config.toml`

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Turn Claude into a senior data analyst and Mixpanel product analytics expert. CodeMode-first: Claude writes Python using mixpanel_data's 4 typed query engines (insights, funnels, retention, flows) plus pandas, networkx, and anytree for sophisticated multi-engine analysis.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -145,6 +145,24 @@ Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager
 On success: Confirm the active project was changed.
 If v1 config: Error suggests running `/mp-auth migrate` first.
 
+### "cowork-setup"
+
+This command is only available on the host machine, not inside Cowork.
+Tell the user: "Run `mp auth cowork-setup` on your **host machine** (not inside Cowork) to export credentials for Cowork sessions."
+
+### "cowork-status"
+
+Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanel-analyst/scripts/auth_manager.py cowork-status`
+
+Parse the JSON and present:
+- If `bridge_found` is true: Show auth method, project, region, token expiry, custom header presence
+- If `bridge_found` is false: Suggest running `mp auth cowork-setup` on the host machine
+
+### "cowork-teardown"
+
+This command is only available on the host machine, not inside Cowork.
+Tell the user: "Run `mp auth cowork-teardown` on your **host machine** to remove Cowork credentials."
+
 ## Presentation Style
 
 - Be concise — show status in 2-3 lines, not a wall of JSON

--- a/mixpanel-plugin/skills/dashboard-expert/references/chart-types.md
+++ b/mixpanel-plugin/skills/dashboard-expert/references/chart-types.md
@@ -6,41 +6,57 @@ Quick-lookup reference for choosing the right chart type per report type, with w
 
 ## 1. Decision Tree
 
-| Question | Chart Type | Slug |
-|---|---|---|
-| Need a single headline number? | Metric | `insights-metric` |
-| Tracking something over time? | Line | `line` |
-| Comparing categories? | Bar | `bar` |
-| Showing composition? | Pie (max 6 segments) or Stacked Bar | `pie` / `bar-stacked` |
-| Need detailed data? | Table | `table` |
-| Measuring conversion? | Funnel Steps | `funnel-steps` |
-| Measuring retention? | Retention Curve | `retention-curve` |
-| Exploring user paths? | Sankey | `sankey` |
+| Question | Chart Type | `chartType` | `plotStyle` |
+|---|---|---|---|
+| Need a single headline number? | Metric | `insights-metric` | |
+| Tracking something over time? | Line | `line` | |
+| Comparing categories? | Bar | `bar` | |
+| Showing composition over time? | Stacked Line | `line` | `stacked` |
+| Showing composition across categories? | Stacked Bar | `bar` | `stacked` |
+| Need detailed data? | Table | `table` | |
+| Measuring conversion? | Funnel Steps | `funnel-steps` | |
+| Measuring retention? | Retention Curve | `retention-curve` | |
+| Exploring user paths? | Sankey | `sankey` | |
 
 ---
 
 ## 2. Insights Chart Types
 
-| Chart Type | Slug | Best For | Width |
-|---|---|---|---|
-| Line | `line` | Trends over time | 6 or 12 |
-| Bar | `bar` | Categorical comparisons, rankings | 6 or 12 |
-| Stacked Bar | `bar-stacked` | Composition across categories | 12 |
-| Column | `column` | Vertical bar, fewer categories | 6 or 12 |
-| Stacked Line | `stacked-line` | Composition trends over time | 12 |
-| Stacked Column | `stacked-column` | Composition across categories (vertical) | 12 |
-| Pie | `pie` | Share/proportion (max 6 segments) | 6 |
-| Table | `table` | Multi-dimensional detailed data | 12 |
-| Metric | `insights-metric` | Single KPI headline number | 3 or 4 |
+| Chart Type | `chartType` | `plotStyle` | Best For | Width |
+|---|---|---|---|---|
+| Line | `line` | `standard` | Trends over time | 6 or 12 |
+| Stacked Line | `line` | `stacked` | Composition trends over time | 12 |
+| Bar | `bar` | `standard` | Categorical comparisons, rankings | 6 or 12 |
+| Stacked Bar | `bar` | `stacked` | Composition across categories | 12 |
+| Column | `column` | `standard` | Vertical bar, fewer categories | 6 or 12 |
+| Stacked Column | `column` | `stacked` | Composition across categories (vertical) | 12 |
+| Pie | `pie` | | Share/proportion (max 6 segments) | 6 |
+| Table | `table` | | Multi-dimensional detailed data | 12 |
+| Metric | `insights-metric` | | Single KPI headline number | 3 or 4 |
+
+### How Stacking Works
+
+Stacked charts are NOT separate chart types. They use the base `chartType` (`line`, `bar`, or `column`) with `plotStyle` set to `"stacked"` in `displayOptions`:
+
+```json
+"displayOptions": {
+  "chartType": "bar",
+  "plotStyle": "stacked"
+}
+```
+
+**NEVER use** `bar-stacked`, `stacked-line`, or `stacked-column` as `chartType` values — these are display-layer labels used by the Mixpanel frontend, not valid API values. The API will reject them.
+
+Valid `chartType` values: `line`, `bar`, `column`, `pie`, `table`, `insights-metric`, `funnel-steps`, `funnel-top-paths`, `retention-curve`, `frequency-curve`
+
+Valid `plotStyle` values: `standard` (default), `stacked`
 
 ### When to Use / When NOT to Use
 
 - **Line** -- Use for time series with continuous data. Not for categorical comparisons or single data points.
 - **Bar** -- Use for ranking or comparing discrete categories. Not for time series (use line instead).
-- **Stacked Bar** -- Use to show part-to-whole across categories. Not when individual values matter more than composition.
+- **Stacked Bar/Line/Column** -- Use to show part-to-whole composition. Set `chartType` to the base type and `plotStyle` to `"stacked"`. Not when individual values matter more than composition.
 - **Column** -- Use like bar but vertical; better with fewer categories. Not for many categories (labels overlap).
-- **Stacked Line** -- Use for composition trends over time. Not when individual series values matter more than totals.
-- **Stacked Column** -- Use for composition at specific time points. Not for continuous time series.
 - **Pie** -- Use for simple share breakdowns with 2-6 segments. Not for more than 6 segments or precise comparisons.
 - **Table** -- Use when exact values or multiple dimensions are needed. Not for quick visual scanning.
 - **Metric** -- Use for a single KPI number (DAU, revenue, conversion rate). Not for trends or comparisons.
@@ -120,11 +136,11 @@ Quick-lookup reference for choosing the right chart type per report type, with w
 |---|---|---|
 | `insights-metric` | 3 or 4 | Pack 3-4 KPIs per row |
 | `line` | 6 or 12 | 6 for paired comparison, 12 for detail |
+| `line` + stacked | 12 | Composition needs space |
 | `bar` | 6 or 12 | 6 for paired, 12 for many categories |
-| `bar-stacked` | 12 | Needs full width for stacked segments |
+| `bar` + stacked | 12 | Needs full width for stacked segments |
 | `column` | 6 or 12 | Same as bar |
-| `stacked-line` | 12 | Composition needs space |
-| `stacked-column` | 12 | Composition needs space |
+| `column` + stacked | 12 | Composition needs space |
 | `pie` | 6 | Pair with related chart |
 | `table` | 12 | Always full width |
 | `funnel-steps` | 12 | Complex funnels need space |

--- a/mixpanel-plugin/skills/dashboard-expert/references/dashboard-templates.md
+++ b/mixpanel-plugin/skills/dashboard-expert/references/dashboard-templates.md
@@ -25,7 +25,7 @@
 | `line` | Time-series line chart. |
 | `bar` | Categorical bar chart. |
 | `table` | Data table with sortable columns. |
-| `stacked-line` | Stacked area/line chart for composition over time. |
+| `line` + `plotStyle: stacked` | Stacked area/line chart for composition over time. |
 | `funnel-steps` | Funnel visualization showing step-by-step conversion. |
 | `retention-curve` | Retention curve or cohort grid. |
 | `sankey` | Sankey/flow diagram showing user paths. |
@@ -574,7 +574,7 @@ Templates use curly-brace placeholders for event names. The agent replaces these
 | 2 | KPI: Best Channel | w=3 | h=336 | insights-metric |
 | 2 | KPI: Avg Conversion Rate | w=3 | h=336 | insights-metric |
 | 3 | Section header: Channel Trends | w=12 | h=0 | text |
-| 4 | Signups by channel over time | w=12 | h=500 | stacked-line |
+| 4 | Signups by channel over time | w=12 | h=500 | line (plotStyle: stacked) |
 | 5 | Section header: Channel Quality | w=12 | h=0 | text |
 | 6 | Channel conversion funnel | w=12 | h=588 | funnel-steps |
 | 7 | Section header: Channel Retention | w=12 | h=0 | text |

--- a/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
+++ b/mixpanel-plugin/skills/mixpanel-analyst/references/bookmark-params.md
@@ -152,7 +152,7 @@ Not all SQL is expressible: no JOINs, no subqueries, no UNION. Formulas are the 
 
 ### Chart Types
 
-| chartType | Use case |
+| `chartType` | Use case |
 |---|---|
 | `bar` | Aggregate totals (single number per segment, deduplicated across date range) |
 | `line` | Time series (per-period values; NOT additive for unique counts) |
@@ -160,7 +160,12 @@ Not all SQL is expressible: no JOINs, no subqueries, no UNION. Formulas are the 
 | `pie` | Part-of-whole composition |
 | `column` | Vertical bar |
 | `insights-metric` | Single KPI number |
-| `bar-stacked` / `stacked-line` / `stacked-column` | Composition; plotStyle is set to `"stacked"` automatically |
+| `funnel-steps` | Standard funnel visualization |
+| `funnel-top-paths` | Alternative paths through funnel |
+| `retention-curve` | Classic retention decay curve |
+| `frequency-curve` | Frequency distribution |
+
+**Stacking:** To show composition, use a base chart type (`bar`, `line`, or `column`) with `"plotStyle": "stacked"` in `displayOptions`. Do NOT use `bar-stacked`, `stacked-line`, or `stacked-column` as `chartType` values — the API rejects them.
 
 ### Measurement Math
 

--- a/mixpanel-plugin/skills/mixpanel-analyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanel-analyst/scripts/auth_manager.py
@@ -19,6 +19,7 @@ Usage:
     python auth_manager.py projects                  # List accessible projects
     python auth_manager.py context                   # Show active context
     python auth_manager.py switch-project <project_id> [--workspace-id W]
+    python auth_manager.py cowork-status                # Check Cowork bridge file
 """
 
 import argparse
@@ -546,6 +547,47 @@ def cmd_switch_project(args: argparse.Namespace) -> None:
         _json_error(type(e).__name__, str(e))
 
 
+def cmd_cowork_status(_args: argparse.Namespace) -> None:
+    """Check Cowork bridge file status."""
+    try:
+        from mixpanel_data._internal.auth.bridge import (
+            detect_cowork,
+            find_bridge_file,
+            load_bridge_file,
+        )
+    except ImportError:
+        _json_error(
+            "ImportError",
+            "mixpanel_data is not installed or too old for Cowork support.",
+        )
+        return
+
+    is_cowork = detect_cowork()
+    path = find_bridge_file()
+    bridge = load_bridge_file(path) if path else None
+
+    result: dict[str, Any] = {
+        "operation": "cowork-status",
+        "is_cowork": is_cowork,
+        "bridge_found": bridge is not None,
+        "bridge_path": str(path) if path else None,
+    }
+
+    if bridge is not None:
+        result["auth_method"] = bridge.auth_method
+        result["region"] = bridge.region
+        result["project_id"] = bridge.project_id
+        result["workspace_id"] = bridge.workspace_id
+        result["has_custom_header"] = bridge.custom_header is not None
+        if bridge.oauth:
+            result["token_expires_at"] = str(bridge.oauth.expires_at)
+            result["token_expired"] = bridge.oauth.is_expired()
+    else:
+        result["suggestion"] = "Run 'mp auth cowork-setup' on your host machine."
+
+    _json_out(result)
+
+
 def main() -> None:
     """Parse arguments and dispatch to subcommand handler."""
     parser = argparse.ArgumentParser(
@@ -595,6 +637,9 @@ def main() -> None:
     # context (show active context)
     subparsers.add_parser("context", help="Show active context")
 
+    # cowork-status
+    subparsers.add_parser("cowork-status", help="Check Cowork bridge file status")
+
     # switch-project
     p_switch_proj = subparsers.add_parser(
         "switch-project", help="Switch active project"
@@ -627,6 +672,7 @@ def main() -> None:
         "migrate": cmd_migrate,
         "projects": cmd_projects,
         "context": cmd_context,
+        "cowork-status": cmd_cowork_status,
         "switch-project": cmd_switch_project,
         None: cmd_status,
     }

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -57,6 +57,42 @@ export MP_PROJECT_ID="12345"
 export MP_REGION="us"  # or "eu", "in"
 ```
 
+## Cowork Environment
+
+If running inside Claude Cowork (detected automatically), credentials work differently:
+
+- **OAuth login and interactive account setup are NOT available** (no browser, no host terminal access)
+- Credentials must be configured on the **host machine** before starting a Cowork session
+
+### If No Credentials Found in Cowork
+
+Tell the user:
+
+> No Mixpanel credentials found in this Cowork session.
+> 
+> On your **host machine** (outside Cowork), run:
+> ```
+> mp auth cowork-setup
+> ```
+> This exports your credentials to `~/.claude/mixpanel/auth.json`, which is
+> automatically mounted into Cowork sessions.
+> 
+> Then **start a new Cowork session** — credentials will be available automatically.
+
+Do NOT suggest `/mp-auth login`, `/mp-auth add`, or environment variables — these won't work inside Cowork.
+
+### If Bridge File Found But Token Expired
+
+The library will auto-refresh the OAuth token (no browser needed). If refresh fails:
+
+> Your OAuth session has expired and could not be refreshed.
+> On your host machine, run:
+> ```
+> mp auth login        # re-authenticate
+> mp auth cowork-setup # re-export to Cowork
+> ```
+> Then start a new Cowork session.
+
 ## Verify Everything Works
 
 ```bash

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -28,7 +28,8 @@ fi
 
 # Install packages
 # mixpanel_data is not on PyPI — install from GitHub
-MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git"
+# TODO: revert to main branch before merge (currently pinned for Cowork auth bridge testing)
+MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git@cowork-auth-bridge"
 echo ""
 echo "Installing mixpanel_data (from GitHub), pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy..."
 if command -v uv &>/dev/null; then

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -128,17 +128,22 @@ if [ -d "/sessions" ] || [ -n "${CLAUDE_COWORK:-}" ]; then
     if [ -f "$f" ]; then
       echo "✓ Auth bridge file found: $f"
       "$python_cmd" -c "
-import json
-with open('$f') as fh:
-    bridge = json.load(fh)
-print(f'  Auth method: {bridge[\"auth_method\"]}')
-print(f'  Region: {bridge[\"region\"]}')
-print(f'  Project: {bridge[\"project_id\"]}')
-if bridge.get('custom_header'):
-    print(f'  Custom header: {bridge[\"custom_header\"][\"name\"]} ✓')
-if bridge.get('oauth') and bridge['oauth'].get('expires_at'):
-    print(f'  Token expires: {bridge[\"oauth\"][\"expires_at\"]}')
-"
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        bridge = json.load(fh)
+    print(f'  Auth method: {bridge.get(\"auth_method\", \"unknown\")}')
+    print(f'  Region: {bridge.get(\"region\", \"unknown\")}')
+    print(f'  Project: {bridge.get(\"project_id\", \"unknown\")}')
+    ch = bridge.get('custom_header')
+    if ch:
+        print(f'  Custom header: {ch.get(\"name\", \"?\")} ✓')
+    oauth = bridge.get('oauth')
+    if oauth and oauth.get('expires_at'):
+        print(f'  Token expires: {oauth[\"expires_at\"]}')
+except Exception as e:
+    print(f'  Error reading bridge file: {e}')
+" "$f"
       BRIDGE_FOUND=1
       break
     fi

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -28,8 +28,7 @@ fi
 
 # Install packages
 # mixpanel_data is not on PyPI — install from GitHub
-# TODO: revert to main branch before merge (currently pinned for Cowork auth bridge testing)
-MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git@cowork-auth-bridge"
+MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git"
 echo ""
 echo "Installing mixpanel_data (from GitHub), pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy..."
 if command -v uv &>/dev/null; then

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -118,5 +118,37 @@ except Exception as e:
     print('  Set environment variables: MP_USERNAME, MP_SECRET, MP_PROJECT_ID')
 "
 
+# Cowork detection: check for bridge file
+if [ -d "/sessions" ] || [ -n "${CLAUDE_COWORK:-}" ]; then
+  echo ""
+  echo "Cowork environment detected."
+  BRIDGE_FOUND=""
+  for f in "$HOME/.claude/mixpanel/auth.json"; do
+    if [ -f "$f" ]; then
+      echo "✓ Auth bridge file found: $f"
+      "$python_cmd" -c "
+import json
+with open('$f') as fh:
+    bridge = json.load(fh)
+print(f'  Auth method: {bridge[\"auth_method\"]}')
+print(f'  Region: {bridge[\"region\"]}')
+print(f'  Project: {bridge[\"project_id\"]}')
+if bridge.get('custom_header'):
+    print(f'  Custom header: {bridge[\"custom_header\"][\"name\"]} ✓')
+if bridge.get('oauth') and bridge['oauth'].get('expires_at'):
+    print(f'  Token expires: {bridge[\"oauth\"][\"expires_at\"]}')
+"
+      BRIDGE_FOUND=1
+      break
+    fi
+  done
+  if [ -z "$BRIDGE_FOUND" ]; then
+    echo "⚠ No auth bridge file found."
+    echo "  On your HOST machine, run:"
+    echo "    mp auth cowork-setup"
+    echo "  Then start a new Cowork session."
+  fi
+fi
+
 echo ""
 echo "=== Setup complete ==="

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import time
 from collections.abc import Callable, Iterator
@@ -107,10 +108,6 @@ ENDPOINTS: dict[str, dict[str, str]] = {
 }
 
 
-_INTERNAL_SOURCE_HEADER = "Internal-Source"
-_INTERNAL_SOURCE_VALUE = "mixpanel.data"
-
-
 class MixpanelAPIClient:
     """Low-level HTTP client for Mixpanel APIs.
 
@@ -197,10 +194,15 @@ class MixpanelAPIClient:
             The httpx.Client instance.
         """
         if self._client is None:
+            headers: dict[str, str] = {}
+            custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+            custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+            if custom_name and custom_value:
+                headers[custom_name] = custom_value
             self._client = httpx.Client(
                 timeout=self._timeout,
                 transport=self._transport,
-                headers={_INTERNAL_SOURCE_HEADER: _INTERNAL_SOURCE_VALUE},
+                headers=headers,
             )
         return self._client
 
@@ -6483,7 +6485,8 @@ class MixpanelAPIClient:
 
         Performs a direct ``PUT`` to the external signed URL (no Mixpanel auth).
         Uses a fresh HTTP client to avoid sending default headers
-        (e.g., ``Internal-Source``) that would invalidate the GCS signature.
+        (e.g., custom headers from ``MP_CUSTOM_HEADER_*`` env vars) that
+        would invalidate the GCS signature.
 
         Args:
             url: Signed upload URL (from ``get_lookup_upload_url()``).
@@ -6500,8 +6503,9 @@ class MixpanelAPIClient:
             ```
         """
         # Use a clean client without default headers — the shared client
-        # has Internal-Source header that GCS includes in signature
-        # validation, causing SignatureDoesNotMatch errors.
+        # may have custom headers (via MP_CUSTOM_HEADER_* env vars) that
+        # GCS includes in signature validation, causing
+        # SignatureDoesNotMatch errors.
         if self._transport is not None:
             # Test mode: use the mock transport
             upload_client = httpx.Client(

--- a/src/mixpanel_data/_internal/auth/__init__.py
+++ b/src/mixpanel_data/_internal/auth/__init__.py
@@ -1,8 +1,9 @@
-"""OAuth 2.0 PKCE authentication module.
+"""OAuth 2.0 PKCE authentication and Cowork bridge module.
 
 Implements the OAuth 2.0 Authorization Code + PKCE flow for Mixpanel,
 including Dynamic Client Registration (RFC 7591), token management,
-and secure local storage.
+secure local storage, and a JSON-based credential bridge for Claude
+Cowork VMs.
 
 Components:
 - PkceChallenge: PKCE verifier/challenge generation (RFC 7636)
@@ -12,6 +13,15 @@ Components:
 - OAuthFlow: Flow orchestrator (login, token exchange, refresh)
 - CallbackResult: Authorization callback result model
 - ensure_client_registered: Dynamic Client Registration helper
+- AuthBridgeFile: Cowork credential bridge file model
+- detect_cowork: Detect Claude Cowork VM environment
+- load_bridge_file: Load and validate bridge credentials
+- find_bridge_file: Locate bridge file on disk
+- write_bridge_file: Write bridge file with secure permissions
+- bridge_to_credentials: Convert bridge to legacy Credentials
+- bridge_to_resolved_session: Convert bridge to v2 ResolvedSession
+- apply_bridge_custom_header: Set custom header env vars from bridge
+- refresh_bridge_token: Refresh expired OAuth tokens in bridge
 
 Example:
     ```python
@@ -22,14 +32,34 @@ Example:
         OAuthStorage,
         OAuthFlow,
         CallbackResult,
+        AuthBridgeFile,
+        detect_cowork,
+        load_bridge_file,
     )
 
     challenge = PkceChallenge.generate()
     storage = OAuthStorage()
     flow = OAuthFlow(region="us", storage=storage)
+
+    if detect_cowork():
+        bridge = load_bridge_file()
     ```
 """
 
+from mixpanel_data._internal.auth.bridge import (
+    AuthBridgeFile,
+    BridgeCustomHeader,
+    BridgeOAuth,
+    BridgeServiceAccount,
+    apply_bridge_custom_header,
+    bridge_to_credentials,
+    bridge_to_resolved_session,
+    detect_cowork,
+    find_bridge_file,
+    load_bridge_file,
+    refresh_bridge_token,
+    write_bridge_file,
+)
 from mixpanel_data._internal.auth.callback_server import CallbackResult
 from mixpanel_data._internal.auth.client_registration import ensure_client_registered
 from mixpanel_data._internal.auth.flow import OAuthFlow
@@ -38,11 +68,23 @@ from mixpanel_data._internal.auth.storage import OAuthStorage
 from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
 
 __all__ = [
+    "AuthBridgeFile",
+    "BridgeCustomHeader",
+    "BridgeOAuth",
+    "BridgeServiceAccount",
     "CallbackResult",
     "OAuthFlow",
     "OAuthClientInfo",
     "OAuthStorage",
     "OAuthTokens",
     "PkceChallenge",
+    "apply_bridge_custom_header",
+    "bridge_to_credentials",
+    "bridge_to_resolved_session",
+    "detect_cowork",
     "ensure_client_registered",
+    "find_bridge_file",
+    "load_bridge_file",
+    "refresh_bridge_token",
+    "write_bridge_file",
 ]

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -250,6 +250,7 @@ def find_bridge_file() -> Path | None:
     Search order:
         1. ``MP_AUTH_FILE`` environment variable (explicit path)
         2. ``~/.claude/mixpanel/auth.json`` (standard location)
+        3. ``~/mnt/.claude/mixpanel/auth.json`` (Cowork bindfs mount)
 
     Returns:
         Path to the bridge file if found, None otherwise.
@@ -270,10 +271,19 @@ def find_bridge_file() -> Path | None:
         logger.debug("MP_AUTH_FILE set but file not found: %s", env_path)
         return None
 
-    # Priority 2: Default location
+    # Priority 2: Default location (~/.claude/mixpanel/auth.json)
     default = _default_bridge_path()
     if default.is_file():
         return default
+
+    # Priority 3: Cowork bindfs mount (~/mnt/.claude/mixpanel/auth.json)
+    # In Cowork, the host's ~/.claude/ is mounted at $HOME/mnt/.claude/
+    cowork_mount = (
+        Path.home() / "mnt" / _CLAUDE_DIR_NAME / _BRIDGE_DIR_NAME / _BRIDGE_FILENAME
+    )
+    if cowork_mount.is_file():
+        logger.debug("Found bridge file at Cowork mount: %s", cowork_mount)
+        return cowork_mount
 
     return None
 

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -273,29 +273,35 @@ def find_bridge_file() -> Path | None:
         logger.debug("MP_AUTH_FILE set but file not found: %s", env_path)
         return None
 
-    # Priority 2: Default location (~/.claude/mixpanel/auth.json)
+    # Priority 2: Bridge file in CWD (workspace root)
+    # In Cowork, the workspace IS mounted — this is the primary Cowork path
+    cwd_bridge = Path.cwd() / _FLAT_BRIDGE_FILENAME
+    if cwd_bridge.is_file():
+        logger.debug("Found bridge file in workspace: %s", cwd_bridge)
+        return cwd_bridge
+
+    # Priority 3: Default location (~/.claude/mixpanel/auth.json)
     default = _default_bridge_path()
     if default.is_file():
         return default
 
-    # Priority 3: Flat file (~/.claude/mixpanel_auth.json)
-    # For Cowork where subdirectories created after mount may not be visible
+    # Priority 4: Flat file (~/.claude/mixpanel_auth.json)
     flat = Path.home() / _CLAUDE_DIR_NAME / _FLAT_BRIDGE_FILENAME
     if flat.is_file():
         logger.debug("Found flat bridge file: %s", flat)
         return flat
 
-    # Priority 4: Cowork bindfs mount (~/mnt/.claude/...)
-    # In Cowork, the host's ~/.claude/ is mounted at $HOME/mnt/.claude/
-    mnt_base = Path.home() / "mnt" / _CLAUDE_DIR_NAME
-    for name in [
-        Path(_BRIDGE_DIR_NAME) / _BRIDGE_FILENAME,  # mnt/.claude/mixpanel/auth.json
-        Path(_FLAT_BRIDGE_FILENAME),  # mnt/.claude/mixpanel_auth.json
-    ]:
-        cowork_path = mnt_base / name
-        if cowork_path.is_file():
-            logger.debug("Found bridge file at Cowork mount: %s", cowork_path)
-            return cowork_path
+    # Priority 5: Cowork workspace mount (~/mnt/{folder}/mixpanel_auth.json)
+    # In Cowork, the workspace is at $HOME/mnt/{folder}/
+    mnt_base = Path.home() / "mnt"
+    if mnt_base.is_dir():
+        for child in mnt_base.iterdir():
+            if not child.is_dir():
+                continue
+            cowork_path = child / _FLAT_BRIDGE_FILENAME
+            if cowork_path.is_file():
+                logger.debug("Found bridge file at Cowork mount: %s", cowork_path)
+                return cowork_path
 
     return None
 

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -1,0 +1,616 @@
+"""Auth bridge for Claude Cowork credential transfer.
+
+Provides a JSON-based credential bridge that allows ``mixpanel_data``
+to authenticate inside Claude Cowork VMs. Credentials are exported
+from the host machine to ``~/.claude/mixpanel/auth.json``, which is
+bindfs-mounted into the Cowork VM.
+
+The bridge supports both OAuth 2.0 and service account credentials,
+optional custom HTTP headers, and automatic OAuth token refresh
+(no browser required — uses HTTP POST with refresh token).
+
+Bridge file search order:
+    1. ``MP_AUTH_FILE`` environment variable (explicit path)
+    2. ``~/.claude/mixpanel/auth.json`` (standard location)
+
+Example:
+    ```python
+    from mixpanel_data._internal.auth.bridge import (
+        load_bridge_file,
+        bridge_to_credentials,
+        detect_cowork,
+    )
+
+    if detect_cowork():
+        bridge = load_bridge_file()
+        if bridge is not None:
+            creds = bridge_to_credentials(bridge)
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
+
+from mixpanel_data._internal.auth.flow import OAuthFlow
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data._internal.auth_credential import (
+    VALID_REGIONS,
+    AuthCredential,
+    CredentialType,
+    ProjectContext,
+    RegionType,
+    ResolvedSession,
+)
+from mixpanel_data._internal.config import AuthMethod, Credentials
+
+logger = logging.getLogger(__name__)
+
+# Sentinel path for Cowork detection
+_COWORK_SESSIONS_PATH = Path("/sessions")
+
+# Default bridge file location
+_BRIDGE_FILENAME = "auth.json"
+_BRIDGE_DIR_NAME = "mixpanel"
+_CLAUDE_DIR_NAME = ".claude"
+
+
+class BridgeCustomHeader(BaseModel):
+    """Custom HTTP header to include in all API requests.
+
+    Both name and value must be provided. The value is stored as a
+    ``SecretStr`` to prevent accidental exposure in logs.
+
+    Attributes:
+        name: HTTP header name (e.g., ``X-Custom-Auth``).
+        value: HTTP header value (redacted in output).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    """HTTP header name."""
+
+    value: SecretStr
+    """HTTP header value (redacted in output)."""
+
+
+class BridgeOAuth(BaseModel):
+    """OAuth 2.0 token data stored in the bridge file.
+
+    Contains everything needed for Bearer auth and token refresh
+    without a browser.
+
+    Attributes:
+        access_token: OAuth access token (redacted in output).
+        refresh_token: OAuth refresh token for silent renewal.
+        expires_at: UTC datetime when access_token expires.
+        scope: Space-separated granted scopes.
+        token_type: Token type, typically ``"Bearer"``.
+        client_id: OAuth client ID for token refresh requests.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    access_token: SecretStr
+    """OAuth access token (redacted in output)."""
+
+    refresh_token: SecretStr | None = None
+    """OAuth refresh token for silent renewal."""
+
+    expires_at: datetime
+    """UTC datetime when access_token expires."""
+
+    scope: str
+    """Space-separated granted scopes."""
+
+    token_type: str
+    """Token type, typically ``'Bearer'``."""
+
+    client_id: str
+    """OAuth client ID for token refresh requests."""
+
+    def is_expired(self) -> bool:
+        """Check whether the access token is expired or about to expire.
+
+        Uses a 30-second safety buffer to avoid sending tokens that
+        expire during in-flight requests.
+
+        Returns:
+            True if the token is expired or will expire within 30 seconds.
+        """
+        return datetime.now(timezone.utc) + timedelta(seconds=30) >= self.expires_at
+
+
+class BridgeServiceAccount(BaseModel):
+    """Service account credentials stored in the bridge file.
+
+    Attributes:
+        username: Service account username.
+        secret: Service account secret (redacted in output).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    username: str
+    """Service account username."""
+
+    secret: SecretStr
+    """Service account secret (redacted in output)."""
+
+
+class AuthBridgeFile(BaseModel):
+    """Complete auth bridge file model.
+
+    Represents the JSON structure at ``~/.claude/mixpanel/auth.json``.
+    Contains credentials (OAuth or service account), project context,
+    and optional custom headers for Mixpanel API access.
+
+    Attributes:
+        version: Bridge file format version (must be 1).
+        auth_method: Authentication method (``"oauth"`` or ``"service_account"``).
+        region: Mixpanel data residency region.
+        project_id: Mixpanel project identifier.
+        workspace_id: Optional workspace ID for App API scoping.
+        custom_header: Optional custom HTTP header for all requests.
+        oauth: OAuth token data (required when auth_method is ``"oauth"``).
+        service_account: SA credentials (required when auth_method is ``"service_account"``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    version: Literal[1]
+    """Bridge file format version (must be 1)."""
+
+    auth_method: Literal["oauth", "service_account"]
+    """Authentication method."""
+
+    region: RegionType
+    """Mixpanel data residency region (us, eu, or in)."""
+
+    project_id: str
+    """Mixpanel project identifier."""
+
+    workspace_id: int | None = None
+    """Optional workspace ID for App API scoping."""
+
+    custom_header: BridgeCustomHeader | None = None
+    """Optional custom HTTP header for all requests."""
+
+    oauth: BridgeOAuth | None = None
+    """OAuth token data (required when auth_method is 'oauth')."""
+
+    service_account: BridgeServiceAccount | None = None
+    """SA credentials (required when auth_method is 'service_account')."""
+
+    @field_validator("region", mode="before")
+    @classmethod
+    def validate_region(cls, v: str) -> str:
+        """Validate and normalize region to lowercase.
+
+        Args:
+            v: Raw region string.
+
+        Returns:
+            Lowercased, validated region string.
+
+        Raises:
+            ValueError: If region is not one of ``us``, ``eu``, ``in``.
+        """
+        if not isinstance(v, str):
+            raise ValueError(f"Region must be a string. Got: {type(v).__name__}")
+        v_lower = v.lower()
+        if v_lower not in VALID_REGIONS:
+            valid = ", ".join(VALID_REGIONS)
+            raise ValueError(f"Region must be one of: {valid}. Got: {v}")
+        return v_lower
+
+
+def detect_cowork() -> bool:
+    """Detect if running inside a Claude Cowork VM.
+
+    Checks two indicators:
+    1. ``/sessions/`` mount point exists (Cowork session disk)
+    2. ``CLAUDE_COWORK`` environment variable is set
+
+    Returns:
+        True if running inside a Cowork VM.
+
+    Example:
+        ```python
+        if detect_cowork():
+            print("Running inside Claude Cowork")
+        ```
+    """
+    if os.environ.get("CLAUDE_COWORK"):
+        return True
+    return _COWORK_SESSIONS_PATH.is_dir()
+
+
+def _default_bridge_path() -> Path:
+    """Return the default bridge file path.
+
+    Returns:
+        Path to ``~/.claude/mixpanel/auth.json``.
+    """
+    return Path.home() / _CLAUDE_DIR_NAME / _BRIDGE_DIR_NAME / _BRIDGE_FILENAME
+
+
+def find_bridge_file() -> Path | None:
+    """Find the auth bridge file using the search order.
+
+    Search order:
+        1. ``MP_AUTH_FILE`` environment variable (explicit path)
+        2. ``~/.claude/mixpanel/auth.json`` (standard location)
+
+    Returns:
+        Path to the bridge file if found, None otherwise.
+
+    Example:
+        ```python
+        path = find_bridge_file()
+        if path is not None:
+            bridge = load_bridge_file(path)
+        ```
+    """
+    # Priority 1: Explicit env var
+    env_path = os.environ.get("MP_AUTH_FILE")
+    if env_path:
+        p = Path(env_path)
+        if p.is_file():
+            return p
+        logger.debug("MP_AUTH_FILE set but file not found: %s", env_path)
+        return None
+
+    # Priority 2: Default location
+    default = _default_bridge_path()
+    if default.is_file():
+        return default
+
+    return None
+
+
+def load_bridge_file(path: Path | None = None) -> AuthBridgeFile | None:
+    """Load and validate a bridge file.
+
+    Args:
+        path: Explicit path to the bridge file. If None, uses
+            ``find_bridge_file()`` to locate it.
+
+    Returns:
+        Validated AuthBridgeFile if found and valid, None otherwise.
+        Returns None (does not raise) for missing files, invalid JSON,
+        or schema validation failures.
+
+    Example:
+        ```python
+        bridge = load_bridge_file()
+        if bridge is not None:
+            creds = bridge_to_credentials(bridge)
+        ```
+    """
+    if path is None:
+        path = find_bridge_file()
+    if path is None:
+        return None
+    if not path.is_file():
+        return None
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return AuthBridgeFile.model_validate(data)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("Failed to read bridge file %s: %s", path, exc)
+        return None
+    except Exception as exc:
+        logger.debug("Failed to validate bridge file %s: %s", path, exc)
+        return None
+
+
+def write_bridge_file(bridge: AuthBridgeFile, path: Path) -> None:
+    """Write a bridge file with secure permissions.
+
+    Creates the parent directory if needed. Sets directory permissions
+    to ``0o700`` and file permissions to ``0o600``.
+
+    Args:
+        bridge: The bridge file model to write.
+        path: Destination file path.
+
+    Raises:
+        OSError: If the file cannot be written.
+
+    Example:
+        ```python
+        bridge = AuthBridgeFile(...)
+        write_bridge_file(bridge, Path.home() / ".claude/mixpanel/auth.json")
+        ```
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, stat.S_IRWXU)  # 0o700
+
+    data = _bridge_to_json_dict(bridge)
+    raw = json.dumps(data, indent=2, default=str)
+    path.write_text(raw, encoding="utf-8")
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+
+
+def _bridge_to_json_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
+    """Serialize an AuthBridgeFile to a JSON-compatible dict.
+
+    Unwraps ``SecretStr`` fields to plain strings for JSON output.
+
+    Args:
+        bridge: The bridge file model to serialize.
+
+    Returns:
+        JSON-serializable dictionary with all secrets unwrapped.
+    """
+    d: dict[str, Any] = {
+        "version": bridge.version,
+        "auth_method": bridge.auth_method,
+        "region": bridge.region,
+        "project_id": bridge.project_id,
+        "workspace_id": bridge.workspace_id,
+        "custom_header": None,
+        "oauth": None,
+        "service_account": None,
+    }
+    if bridge.custom_header is not None:
+        d["custom_header"] = {
+            "name": bridge.custom_header.name,
+            "value": bridge.custom_header.value.get_secret_value(),
+        }
+    if bridge.oauth is not None:
+        d["oauth"] = {
+            "access_token": bridge.oauth.access_token.get_secret_value(),
+            "refresh_token": bridge.oauth.refresh_token.get_secret_value()
+            if bridge.oauth.refresh_token
+            else None,
+            "expires_at": bridge.oauth.expires_at.isoformat(),
+            "scope": bridge.oauth.scope,
+            "token_type": bridge.oauth.token_type,
+            "client_id": bridge.oauth.client_id,
+        }
+    if bridge.service_account is not None:
+        d["service_account"] = {
+            "username": bridge.service_account.username,
+            "secret": bridge.service_account.secret.get_secret_value(),
+        }
+    return d
+
+
+def bridge_to_credentials(bridge: AuthBridgeFile) -> Credentials:
+    """Convert an AuthBridgeFile to a legacy Credentials object.
+
+    Creates a ``Credentials`` instance suitable for passing to
+    ``MixpanelAPIClient``.
+
+    Args:
+        bridge: The bridge file to convert.
+
+    Returns:
+        Credentials configured for the bridge's auth method.
+
+    Raises:
+        ValueError: If auth_method is ``"oauth"`` but no OAuth data
+            is present, or ``"service_account"`` but no SA data.
+
+    Example:
+        ```python
+        bridge = load_bridge_file()
+        creds = bridge_to_credentials(bridge)
+        client = MixpanelAPIClient(creds)
+        ```
+    """
+    if bridge.auth_method == "oauth":
+        if bridge.oauth is None:
+            raise ValueError("OAuth bridge file missing 'oauth' section")
+        return Credentials(
+            username="",
+            secret=SecretStr(""),
+            project_id=bridge.project_id,
+            region=bridge.region,
+            auth_method=AuthMethod.oauth,
+            oauth_access_token=bridge.oauth.access_token,
+        )
+
+    if bridge.service_account is None:
+        raise ValueError(
+            "Service account bridge file missing 'service_account' section"
+        )
+    return Credentials(
+        username=bridge.service_account.username,
+        secret=bridge.service_account.secret,
+        project_id=bridge.project_id,
+        region=bridge.region,
+        auth_method=AuthMethod.basic,
+    )
+
+
+def bridge_to_resolved_session(bridge: AuthBridgeFile) -> ResolvedSession:
+    """Convert an AuthBridgeFile to a v2 ResolvedSession.
+
+    Creates an ``AuthCredential`` and ``ProjectContext`` from the
+    bridge file data.
+
+    Args:
+        bridge: The bridge file to convert.
+
+    Returns:
+        ResolvedSession with auth and project context.
+
+    Example:
+        ```python
+        bridge = load_bridge_file()
+        session = bridge_to_resolved_session(bridge)
+        # session.project_id, session.auth_header()
+        ```
+    """
+    if bridge.auth_method == "oauth":
+        if bridge.oauth is None:
+            raise ValueError("OAuth bridge file missing 'oauth' section")
+        auth = AuthCredential(
+            name="cowork-bridge",
+            type=CredentialType.oauth,
+            region=bridge.region,
+            oauth_access_token=bridge.oauth.access_token,
+        )
+    else:
+        if bridge.service_account is None:
+            raise ValueError("SA bridge file missing 'service_account' section")
+        auth = AuthCredential(
+            name="cowork-bridge",
+            type=CredentialType.service_account,
+            region=bridge.region,
+            username=bridge.service_account.username,
+            secret=bridge.service_account.secret,
+        )
+
+    project = ProjectContext(
+        project_id=bridge.project_id,
+        workspace_id=bridge.workspace_id,
+    )
+    return ResolvedSession(auth=auth, project=project)
+
+
+def apply_bridge_custom_header(bridge: AuthBridgeFile) -> None:
+    """Set custom header env vars from bridge file.
+
+    Sets ``MP_CUSTOM_HEADER_NAME`` and ``MP_CUSTOM_HEADER_VALUE``
+    environment variables if the bridge file contains a custom header
+    and the env vars are not already set.
+
+    This allows the existing ``MixpanelAPIClient._ensure_client()``
+    to pick up custom headers without code changes.
+
+    Args:
+        bridge: The bridge file containing optional custom header.
+
+    Example:
+        ```python
+        bridge = load_bridge_file()
+        apply_bridge_custom_header(bridge)
+        # Now MP_CUSTOM_HEADER_* env vars are set if bridge has a header
+        ```
+    """
+    if bridge.custom_header is None:
+        return
+
+    # Don't override existing env vars
+    if os.environ.get("MP_CUSTOM_HEADER_NAME") and os.environ.get(
+        "MP_CUSTOM_HEADER_VALUE"
+    ):
+        logger.debug(
+            "MP_CUSTOM_HEADER_* env vars already set, skipping bridge custom header"
+        )
+        return
+
+    os.environ["MP_CUSTOM_HEADER_NAME"] = bridge.custom_header.name
+    os.environ["MP_CUSTOM_HEADER_VALUE"] = bridge.custom_header.value.get_secret_value()
+    logger.debug(
+        "Applied custom header from bridge file: %s", bridge.custom_header.name
+    )
+
+
+def refresh_bridge_token(
+    bridge: AuthBridgeFile,
+    bridge_path: Path,
+) -> AuthBridgeFile:
+    """Refresh an expired OAuth token in the bridge file.
+
+    If the bridge uses service account auth or the OAuth token is not
+    expired, returns the bridge unchanged. Otherwise, uses the refresh
+    token to obtain a new access token via HTTP POST (no browser needed).
+
+    Attempts to write the updated bridge file back to disk. Write
+    failures are silently ignored (e.g., read-only mount in Cowork).
+
+    Args:
+        bridge: The bridge file to check and potentially refresh.
+        bridge_path: Path to the bridge file for write-back.
+
+    Returns:
+        The original bridge if no refresh needed, or a new
+        AuthBridgeFile with updated OAuth tokens.
+
+    Raises:
+        OAuthError: If the refresh request fails (e.g., revoked token).
+
+    Example:
+        ```python
+        bridge = load_bridge_file(path)
+        bridge = refresh_bridge_token(bridge, path)
+        creds = bridge_to_credentials(bridge)
+        ```
+    """
+    # SA credentials don't expire
+    if bridge.auth_method != "oauth" or bridge.oauth is None:
+        return bridge
+
+    # Check if token is expired
+    if not bridge.oauth.is_expired():
+        return bridge
+
+    logger.info("Bridge OAuth token expired, attempting refresh...")
+
+    if bridge.oauth.refresh_token is None:
+        raise ValueError(
+            "Cannot refresh: no refresh token in bridge file. "
+            "Re-run 'mp auth cowork-setup' on your host machine."
+        )
+
+    # Build OAuthTokens for the refresh call
+    old_tokens = OAuthTokens(
+        access_token=bridge.oauth.access_token,
+        refresh_token=bridge.oauth.refresh_token,
+        expires_at=bridge.oauth.expires_at,
+        scope=bridge.oauth.scope,
+        token_type=bridge.oauth.token_type,
+        project_id=bridge.project_id,
+    )
+
+    # Refresh via HTTP POST (no browser needed)
+    flow = OAuthFlow(region=bridge.region)
+    new_tokens = flow.refresh_tokens(
+        tokens=old_tokens, client_id=bridge.oauth.client_id
+    )
+
+    # Build updated bridge
+    new_oauth = BridgeOAuth(
+        access_token=new_tokens.access_token,
+        refresh_token=new_tokens.refresh_token or bridge.oauth.refresh_token,
+        expires_at=new_tokens.expires_at,
+        scope=new_tokens.scope or bridge.oauth.scope,
+        token_type=new_tokens.token_type,
+        client_id=bridge.oauth.client_id,
+    )
+
+    updated = AuthBridgeFile(
+        version=bridge.version,
+        auth_method=bridge.auth_method,
+        region=bridge.region,
+        project_id=bridge.project_id,
+        workspace_id=bridge.workspace_id,
+        custom_header=bridge.custom_header,
+        oauth=new_oauth,
+        service_account=bridge.service_account,
+    )
+
+    # Try to write back (ignore errors for read-only mounts)
+    try:
+        write_bridge_file(updated, bridge_path)
+        logger.info("Updated bridge file with refreshed token")
+    except OSError:
+        logger.debug("Could not write refreshed token to bridge file (read-only?)")
+
+    return updated

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -11,7 +11,10 @@ optional custom HTTP headers, and automatic OAuth token refresh
 
 Bridge file search order:
     1. ``MP_AUTH_FILE`` environment variable (explicit path)
-    2. ``~/.claude/mixpanel/auth.json`` (standard location)
+    2. ``mixpanel_auth.json`` in current working directory (Cowork workspace)
+    3. ``~/.claude/mixpanel/auth.json`` (standard location)
+    4. ``~/.claude/mixpanel_auth.json`` (flat file alternative)
+    5. ``~/mnt/{folder}/mixpanel_auth.json`` (Cowork bindfs mount)
 
 Example:
     ```python
@@ -38,7 +41,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, SecretStr, field_validator, model_validator
 
 from mixpanel_data._internal.auth.flow import OAuthFlow
 from mixpanel_data._internal.auth.token import OAuthTokens
@@ -51,6 +54,7 @@ from mixpanel_data._internal.auth_credential import (
     ResolvedSession,
 )
 from mixpanel_data._internal.config import AuthMethod, Credentials
+from mixpanel_data.exceptions import OAuthError
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +66,7 @@ _BRIDGE_FILENAME = "auth.json"
 _BRIDGE_DIR_NAME = "mixpanel"
 _CLAUDE_DIR_NAME = ".claude"
 # Flat file alternative (for Cowork where subdirectories may not be visible)
-_FLAT_BRIDGE_FILENAME = "mixpanel_auth.json"
+FLAT_BRIDGE_FILENAME = "mixpanel_auth.json"
 
 
 class BridgeCustomHeader(BaseModel):
@@ -215,13 +219,34 @@ class AuthBridgeFile(BaseModel):
             raise ValueError(f"Region must be one of: {valid}. Got: {v}")
         return v_lower
 
+    @model_validator(mode="after")
+    def validate_auth_sections(self) -> AuthBridgeFile:
+        """Validate that the correct credential section is present.
+
+        Raises:
+            ValueError: If ``auth_method`` does not match the provided
+                credential section (e.g., ``"oauth"`` without ``oauth``).
+        """
+        if self.auth_method == "oauth" and self.oauth is None:
+            raise ValueError("auth_method='oauth' requires 'oauth' section")
+        if self.auth_method == "service_account" and self.service_account is None:
+            raise ValueError(
+                "auth_method='service_account' requires 'service_account' section"
+            )
+        return self
+
 
 def detect_cowork() -> bool:
     """Detect if running inside a Claude Cowork VM.
 
     Checks two indicators:
-    1. ``/sessions/`` mount point exists (Cowork session disk)
-    2. ``CLAUDE_COWORK`` environment variable is set
+    1. ``CLAUDE_COWORK`` environment variable is set (reliable)
+    2. ``/sessions/`` mount point exists (heuristic — may false-positive
+       on systems with a ``/sessions`` directory unrelated to Cowork)
+
+    This function is used for informational purposes (CLI output,
+    plugin guidance). Bridge file discovery (``find_bridge_file()``)
+    runs unconditionally and does not depend on this function.
 
     Returns:
         True if running inside a Cowork VM.
@@ -237,7 +262,7 @@ def detect_cowork() -> bool:
     return _COWORK_SESSIONS_PATH.is_dir()
 
 
-def _default_bridge_path() -> Path:
+def default_bridge_path() -> Path:
     """Return the default bridge file path.
 
     Returns:
@@ -251,8 +276,10 @@ def find_bridge_file() -> Path | None:
 
     Search order:
         1. ``MP_AUTH_FILE`` environment variable (explicit path)
-        2. ``~/.claude/mixpanel/auth.json`` (standard location)
-        3. ``~/mnt/.claude/mixpanel/auth.json`` (Cowork bindfs mount)
+        2. ``mixpanel_auth.json`` in current working directory (Cowork workspace)
+        3. ``~/.claude/mixpanel/auth.json`` (standard location)
+        4. ``~/.claude/mixpanel_auth.json`` (flat file alternative)
+        5. ``~/mnt/{folder}/mixpanel_auth.json`` (Cowork bindfs mount)
 
     Returns:
         Path to the bridge file if found, None otherwise.
@@ -275,18 +302,18 @@ def find_bridge_file() -> Path | None:
 
     # Priority 2: Bridge file in CWD (workspace root)
     # In Cowork, the workspace IS mounted — this is the primary Cowork path
-    cwd_bridge = Path.cwd() / _FLAT_BRIDGE_FILENAME
+    cwd_bridge = Path.cwd() / FLAT_BRIDGE_FILENAME
     if cwd_bridge.is_file():
         logger.debug("Found bridge file in workspace: %s", cwd_bridge)
         return cwd_bridge
 
     # Priority 3: Default location (~/.claude/mixpanel/auth.json)
-    default = _default_bridge_path()
+    default = default_bridge_path()
     if default.is_file():
         return default
 
     # Priority 4: Flat file (~/.claude/mixpanel_auth.json)
-    flat = Path.home() / _CLAUDE_DIR_NAME / _FLAT_BRIDGE_FILENAME
+    flat = Path.home() / _CLAUDE_DIR_NAME / FLAT_BRIDGE_FILENAME
     if flat.is_file():
         logger.debug("Found flat bridge file: %s", flat)
         return flat
@@ -298,7 +325,7 @@ def find_bridge_file() -> Path | None:
         for child in mnt_base.iterdir():
             if not child.is_dir():
                 continue
-            cowork_path = child / _FLAT_BRIDGE_FILENAME
+            cowork_path = child / FLAT_BRIDGE_FILENAME
             if cowork_path.is_file():
                 logger.debug("Found bridge file at Cowork mount: %s", cowork_path)
                 return cowork_path
@@ -364,15 +391,21 @@ def write_bridge_file(bridge: AuthBridgeFile, path: Path) -> None:
         ```
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    os.chmod(path.parent, stat.S_IRWXU)  # 0o700
+    try:
+        os.chmod(path.parent, stat.S_IRWXU)  # 0o700
+    except OSError:
+        logger.debug("Could not set directory permissions on %s", path.parent)
 
-    data = _bridge_to_json_dict(bridge)
+    data = bridge_to_json_dict(bridge)
     raw = json.dumps(data, indent=2, default=str)
     path.write_text(raw, encoding="utf-8")
-    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+    try:
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+    except OSError:
+        logger.debug("Could not set file permissions on %s", path)
 
 
-def _bridge_to_json_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
+def bridge_to_json_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
     """Serialize an AuthBridgeFile to a JSON-compatible dict.
 
     Unwraps ``SecretStr`` fields to plain strings for JSON output.
@@ -572,7 +605,8 @@ def refresh_bridge_token(
         AuthBridgeFile with updated OAuth tokens.
 
     Raises:
-        OAuthError: If the refresh request fails (e.g., revoked token).
+        OAuthError: If the refresh token is missing or the refresh
+            request fails (e.g., revoked token).
 
     Example:
         ```python
@@ -592,9 +626,10 @@ def refresh_bridge_token(
     logger.info("Bridge OAuth token expired, attempting refresh...")
 
     if bridge.oauth.refresh_token is None:
-        raise ValueError(
+        raise OAuthError(
             "Cannot refresh: no refresh token in bridge file. "
-            "Re-run 'mp auth cowork-setup' on your host machine."
+            "Re-run 'mp auth cowork-setup' on your host machine.",
+            code="OAUTH_REFRESH_ERROR",
         )
 
     # Build OAuthTokens for the refresh call

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -61,6 +61,8 @@ _COWORK_SESSIONS_PATH = Path("/sessions")
 _BRIDGE_FILENAME = "auth.json"
 _BRIDGE_DIR_NAME = "mixpanel"
 _CLAUDE_DIR_NAME = ".claude"
+# Flat file alternative (for Cowork where subdirectories may not be visible)
+_FLAT_BRIDGE_FILENAME = "mixpanel_auth.json"
 
 
 class BridgeCustomHeader(BaseModel):
@@ -276,14 +278,24 @@ def find_bridge_file() -> Path | None:
     if default.is_file():
         return default
 
-    # Priority 3: Cowork bindfs mount (~/mnt/.claude/mixpanel/auth.json)
+    # Priority 3: Flat file (~/.claude/mixpanel_auth.json)
+    # For Cowork where subdirectories created after mount may not be visible
+    flat = Path.home() / _CLAUDE_DIR_NAME / _FLAT_BRIDGE_FILENAME
+    if flat.is_file():
+        logger.debug("Found flat bridge file: %s", flat)
+        return flat
+
+    # Priority 4: Cowork bindfs mount (~/mnt/.claude/...)
     # In Cowork, the host's ~/.claude/ is mounted at $HOME/mnt/.claude/
-    cowork_mount = (
-        Path.home() / "mnt" / _CLAUDE_DIR_NAME / _BRIDGE_DIR_NAME / _BRIDGE_FILENAME
-    )
-    if cowork_mount.is_file():
-        logger.debug("Found bridge file at Cowork mount: %s", cowork_mount)
-        return cowork_mount
+    mnt_base = Path.home() / "mnt" / _CLAUDE_DIR_NAME
+    for name in [
+        Path(_BRIDGE_DIR_NAME) / _BRIDGE_FILENAME,  # mnt/.claude/mixpanel/auth.json
+        Path(_FLAT_BRIDGE_FILENAME),  # mnt/.claude/mixpanel_auth.json
+    ]:
+        cowork_path = mnt_base / name
+        if cowork_path.is_file():
+            logger.debug("Found bridge file at Cowork mount: %s", cowork_path)
+            return cowork_path
 
     return None
 

--- a/src/mixpanel_data/_internal/auth/bridge.py
+++ b/src/mixpanel_data/_internal/auth/bridge.py
@@ -390,11 +390,13 @@ def write_bridge_file(bridge: AuthBridgeFile, path: Path) -> None:
         write_bridge_file(bridge, Path.home() / ".claude/mixpanel/auth.json")
         ```
     """
+    dir_existed = path.parent.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(path.parent, stat.S_IRWXU)  # 0o700
-    except OSError:
-        logger.debug("Could not set directory permissions on %s", path.parent)
+    if not dir_existed:
+        try:
+            os.chmod(path.parent, stat.S_IRWXU)  # 0o700
+        except OSError:
+            logger.warning("Could not set directory permissions on %s", path.parent)
 
     data = bridge_to_json_dict(bridge)
     raw = json.dumps(data, indent=2, default=str)
@@ -402,7 +404,7 @@ def write_bridge_file(bridge: AuthBridgeFile, path: Path) -> None:
     try:
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
     except OSError:
-        logger.debug("Could not set file permissions on %s", path)
+        logger.warning("Could not set file permissions on %s", path)
 
 
 def bridge_to_json_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
@@ -510,6 +512,10 @@ def bridge_to_resolved_session(bridge: AuthBridgeFile) -> ResolvedSession:
     Returns:
         ResolvedSession with auth and project context.
 
+    Raises:
+        ValueError: If auth_method is ``"oauth"`` but no OAuth data
+            is present, or ``"service_account"`` but no SA data.
+
     Example:
         ```python
         bridge = load_bridge_file()
@@ -571,9 +577,7 @@ def apply_bridge_custom_header(bridge: AuthBridgeFile) -> None:
     if os.environ.get("MP_CUSTOM_HEADER_NAME") and os.environ.get(
         "MP_CUSTOM_HEADER_VALUE"
     ):
-        logger.debug(
-            "MP_CUSTOM_HEADER_* env vars already set, skipping bridge custom header"
-        )
+        logger.debug("MP_CUSTOM_HEADER_* already set, skipping bridge custom header")
         return
 
     os.environ["MP_CUSTOM_HEADER_NAME"] = bridge.custom_header.name

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from mixpanel_data._internal.auth.bridge import AuthBridgeFile
     from mixpanel_data._internal.auth_credential import ResolvedSession
 
 if sys.version_info >= (3, 11):
@@ -618,24 +619,38 @@ class ConfigManager:
         first_account = next(iter(accounts.values()))
         return first_account.get("region"), first_account.get("project_id")
 
-    def _load_and_refresh_bridge(self) -> Any | None:
+    def _load_and_refresh_bridge(self) -> AuthBridgeFile | None:
         """Load, refresh, and apply custom headers from a bridge file.
 
         Finds the bridge file, loads it, applies custom headers to env
         vars, and refreshes expired OAuth tokens. Returns the ready-to-use
         bridge model, or ``None`` if no valid bridge is found.
 
+        Bridge resolution is only attempted when:
+        - ``MP_AUTH_FILE`` environment variable is explicitly set, OR
+        - Running inside a Cowork VM (detected via ``detect_cowork()``)
+
+        This prevents host-side auth lockout after running
+        ``mp auth cowork-setup``, which writes a bridge file that would
+        otherwise shadow normal credential resolution.
+
         Returns:
             An ``AuthBridgeFile`` instance if a valid bridge file is found
-            and ready, ``None`` otherwise. Typed as ``Any`` to avoid
-            importing bridge types at module level (lazy import).
+            and ready, ``None`` otherwise.
         """
         from mixpanel_data._internal.auth.bridge import (
             apply_bridge_custom_header,
+            detect_cowork,
             find_bridge_file,
             load_bridge_file,
             refresh_bridge_token,
         )
+
+        # Only consult bridge files when explicitly requested (MP_AUTH_FILE)
+        # or when running inside a Cowork VM.  On the host, bridge files
+        # written by cowork-setup must not shadow normal auth resolution.
+        if not os.environ.get("MP_AUTH_FILE") and not detect_cowork():
+            return None
 
         path = find_bridge_file()
         if path is None:
@@ -656,8 +671,16 @@ class ConfigManager:
         ):
             try:
                 bridge = refresh_bridge_token(bridge, path)
-            except Exception:
-                logger.debug("Bridge token refresh failed, skipping bridge")
+            except Exception as exc:
+                if type(exc).__name__ == "OAuthError":
+                    logger.warning("Bridge token refresh failed: %s", exc)
+                else:
+                    logger.warning(
+                        "Bridge token refresh failed (%s): %s. "
+                        "Falling back to other auth methods.",
+                        type(exc).__name__,
+                        exc,
+                    )
                 return None
 
         return bridge
@@ -928,11 +951,13 @@ class ConfigManager:
             return
 
         header = self.get_custom_header()
-        if header is not None:
-            name, value = header
-            os.environ["MP_CUSTOM_HEADER_NAME"] = name
-            os.environ["MP_CUSTOM_HEADER_VALUE"] = value
-            logger.debug("Applied custom header from config: %s", name)
+        if header is None:
+            return
+
+        name, value = header
+        os.environ["MP_CUSTOM_HEADER_NAME"] = name
+        os.environ["MP_CUSTOM_HEADER_VALUE"] = value
+        logger.debug("Applied custom header from config: %s", name)
 
     def _write_config_atomic(self, config: dict[str, Any]) -> None:
         """Write config atomically via temp file + os.replace().
@@ -1443,17 +1468,15 @@ class ConfigManager:
             bridge_session = self._resolve_session_from_bridge()
             if bridge_session is not None:
                 # Apply overrides if provided
-                if project_id or workspace_id is not None:
+                if project_id is not None or workspace_id is not None:
                     from mixpanel_data._internal.auth_credential import (
-                        ProjectContext as PC,
-                    )
-                    from mixpanel_data._internal.auth_credential import (
-                        ResolvedSession as RS,
+                        ProjectContext,
+                        ResolvedSession,
                     )
 
-                    bridge_session = RS(
+                    bridge_session = ResolvedSession(
                         auth=bridge_session.auth,
-                        project=PC(
+                        project=ProjectContext(
                             project_id=project_id or bridge_session.project_id,
                             workspace_id=workspace_id
                             if workspace_id is not None
@@ -1516,7 +1539,7 @@ class ConfigManager:
         session = creds.to_resolved_session()
 
         # Apply overrides
-        if project_id or workspace_id:
+        if project_id is not None or workspace_id is not None:
             from mixpanel_data._internal.auth_credential import (
                 ProjectContext,
                 ResolvedSession,

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -469,6 +469,10 @@ class ConfigManager:
             print(creds.auth_method)  # AuthMethod.basic or AuthMethod.oauth
             ```
         """
+        # Apply custom headers from config [settings] section early —
+        # they should be available regardless of which resolution path succeeds.
+        self.apply_config_custom_header()
+
         # Priority 1: Environment variables (all four must be set)
         env_creds = self._resolve_from_env()
         if env_creds is not None:
@@ -488,9 +492,7 @@ class ConfigManager:
             if oauth_creds is not None:
                 return oauth_creds
 
-        # Priority 3 & 4: Config file (named account or default)
-        # Apply custom headers from config [settings] section
-        self.apply_config_custom_header()
+        # Priority 4: Config file (named account or default)
 
         config = self._read_config()
         accounts = config.get("accounts", {})
@@ -616,21 +618,20 @@ class ConfigManager:
         first_account = next(iter(accounts.values()))
         return first_account.get("region"), first_account.get("project_id")
 
-    def _resolve_from_bridge(self) -> Credentials | None:
-        """Attempt to resolve credentials from an auth bridge file.
+    def _load_and_refresh_bridge(self) -> Any | None:
+        """Load, refresh, and apply custom headers from a bridge file.
 
-        Loads the bridge file from ``MP_AUTH_FILE`` env var or the
-        default location (``~/.claude/mixpanel/auth.json``). If the
-        bridge contains an expired OAuth token, attempts to refresh it.
-
-        Also applies custom headers from the bridge file to env vars.
+        Finds the bridge file, loads it, applies custom headers to env
+        vars, and refreshes expired OAuth tokens. Returns the ready-to-use
+        bridge model, or ``None`` if no valid bridge is found.
 
         Returns:
-            Credentials if a valid bridge file is found, None otherwise.
+            An ``AuthBridgeFile`` instance if a valid bridge file is found
+            and ready, ``None`` otherwise. Typed as ``Any`` to avoid
+            importing bridge types at module level (lazy import).
         """
         from mixpanel_data._internal.auth.bridge import (
             apply_bridge_custom_header,
-            bridge_to_credentials,
             find_bridge_file,
             load_bridge_file,
             refresh_bridge_token,
@@ -658,6 +659,25 @@ class ConfigManager:
             except Exception:
                 logger.debug("Bridge token refresh failed, skipping bridge")
                 return None
+
+        return bridge
+
+    def _resolve_from_bridge(self) -> Credentials | None:
+        """Attempt to resolve credentials from an auth bridge file.
+
+        Loads the bridge file from ``MP_AUTH_FILE`` env var or the
+        default location (``~/.claude/mixpanel/auth.json``). If the
+        bridge contains an expired OAuth token, attempts to refresh it.
+
+        Also applies custom headers from the bridge file to env vars.
+
+        Returns:
+            Credentials if a valid bridge file is found, None otherwise.
+        """
+        bridge = self._load_and_refresh_bridge()
+        if bridge is None:
+            return None
+        from mixpanel_data._internal.auth.bridge import bridge_to_credentials
 
         return bridge_to_credentials(bridge)
 
@@ -671,36 +691,10 @@ class ConfigManager:
         Returns:
             ResolvedSession if a valid bridge file is found, None otherwise.
         """
-        from mixpanel_data._internal.auth.bridge import (
-            apply_bridge_custom_header,
-            bridge_to_resolved_session,
-            find_bridge_file,
-            load_bridge_file,
-            refresh_bridge_token,
-        )
-
-        path = find_bridge_file()
-        if path is None:
-            return None
-
-        bridge = load_bridge_file(path)
+        bridge = self._load_and_refresh_bridge()
         if bridge is None:
             return None
-
-        # Apply custom headers to env vars
-        apply_bridge_custom_header(bridge)
-
-        # Refresh expired OAuth tokens
-        if (
-            bridge.auth_method == "oauth"
-            and bridge.oauth is not None
-            and bridge.oauth.is_expired()
-        ):
-            try:
-                bridge = refresh_bridge_token(bridge, path)
-            except Exception:
-                logger.debug("Bridge token refresh failed, skipping bridge")
-                return None
+        from mixpanel_data._internal.auth.bridge import bridge_to_resolved_session
 
         return bridge_to_resolved_session(bridge)
 
@@ -1435,6 +1429,10 @@ class ConfigManager:
             # session.project_id, session.auth_header(), session.region
             ```
         """
+        # Apply custom headers from config [settings] section early —
+        # they should be available regardless of which resolution path succeeds.
+        self.apply_config_custom_header()
+
         # Priority 1: Environment variables
         env_creds = self._resolve_from_env()
         if env_creds is not None:

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -433,13 +433,14 @@ class ConfigManager:
         Resolution order when ``account`` is None:
 
         1. Environment variables (MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION)
-        2. OAuth tokens from local storage (if valid and not expired)
-        3. Default account from config file
+        2. Auth bridge file (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
+        3. OAuth tokens from local storage (if valid and not expired)
+        4. Default account from config file
 
         Resolution order when ``account`` is provided:
 
         1. Environment variables (all four must be set)
-        2. Named account from config file (OAuth is skipped)
+        2. Named account from config file (bridge and OAuth are skipped)
 
         For OAuth resolution, the region and project_id are determined from:
         - ``MP_PROJECT_ID`` / ``MP_REGION`` env vars (partial env mode), or
@@ -473,7 +474,13 @@ class ConfigManager:
         if env_creds is not None:
             return env_creds
 
-        # Priority 2: OAuth tokens (only when no explicit account requested)
+        # Priority 2: Auth bridge file (only when no explicit account requested)
+        if account is None:
+            bridge_creds = self._resolve_from_bridge()
+            if bridge_creds is not None:
+                return bridge_creds
+
+        # Priority 3: OAuth tokens (only when no explicit account requested)
         if account is None:
             oauth_creds = self._resolve_from_oauth(
                 _oauth_storage_dir=_oauth_storage_dir,
@@ -482,6 +489,9 @@ class ConfigManager:
                 return oauth_creds
 
         # Priority 3 & 4: Config file (named account or default)
+        # Apply custom headers from config [settings] section
+        self.apply_config_custom_header()
+
         config = self._read_config()
         accounts = config.get("accounts", {})
 
@@ -605,6 +615,94 @@ class ConfigManager:
         # Use first account as fallback
         first_account = next(iter(accounts.values()))
         return first_account.get("region"), first_account.get("project_id")
+
+    def _resolve_from_bridge(self) -> Credentials | None:
+        """Attempt to resolve credentials from an auth bridge file.
+
+        Loads the bridge file from ``MP_AUTH_FILE`` env var or the
+        default location (``~/.claude/mixpanel/auth.json``). If the
+        bridge contains an expired OAuth token, attempts to refresh it.
+
+        Also applies custom headers from the bridge file to env vars.
+
+        Returns:
+            Credentials if a valid bridge file is found, None otherwise.
+        """
+        from mixpanel_data._internal.auth.bridge import (
+            apply_bridge_custom_header,
+            bridge_to_credentials,
+            find_bridge_file,
+            load_bridge_file,
+            refresh_bridge_token,
+        )
+
+        path = find_bridge_file()
+        if path is None:
+            return None
+
+        bridge = load_bridge_file(path)
+        if bridge is None:
+            return None
+
+        # Apply custom headers to env vars
+        apply_bridge_custom_header(bridge)
+
+        # Refresh expired OAuth tokens
+        if (
+            bridge.auth_method == "oauth"
+            and bridge.oauth is not None
+            and bridge.oauth.is_expired()
+        ):
+            try:
+                bridge = refresh_bridge_token(bridge, path)
+            except Exception:
+                logger.debug("Bridge token refresh failed, skipping bridge")
+                return None
+
+        return bridge_to_credentials(bridge)
+
+    def _resolve_session_from_bridge(self) -> ResolvedSession | None:
+        """Attempt to resolve a session from an auth bridge file.
+
+        Loads the bridge file and converts it to a ``ResolvedSession``.
+        If the bridge contains an expired OAuth token, attempts to
+        refresh it. Also applies custom headers.
+
+        Returns:
+            ResolvedSession if a valid bridge file is found, None otherwise.
+        """
+        from mixpanel_data._internal.auth.bridge import (
+            apply_bridge_custom_header,
+            bridge_to_resolved_session,
+            find_bridge_file,
+            load_bridge_file,
+            refresh_bridge_token,
+        )
+
+        path = find_bridge_file()
+        if path is None:
+            return None
+
+        bridge = load_bridge_file(path)
+        if bridge is None:
+            return None
+
+        # Apply custom headers to env vars
+        apply_bridge_custom_header(bridge)
+
+        # Refresh expired OAuth tokens
+        if (
+            bridge.auth_method == "oauth"
+            and bridge.oauth is not None
+            and bridge.oauth.is_expired()
+        ):
+            try:
+                bridge = refresh_bridge_token(bridge, path)
+            except Exception:
+                logger.debug("Bridge token refresh failed, skipping bridge")
+                return None
+
+        return bridge_to_resolved_session(bridge)
 
     def _resolve_from_env(self) -> Credentials | None:
         """Attempt to resolve credentials from environment variables.
@@ -790,6 +888,57 @@ class ConfigManager:
         """
         config = self._read_config()
         return int(config.get("config_version", 1))
+
+    def get_custom_header(self) -> tuple[str, str] | None:
+        """Return custom header from config ``[settings]`` section.
+
+        Looks for ``custom_header_name`` and ``custom_header_value``
+        keys in the ``[settings]`` table. Both must be present and
+        non-empty to return a result.
+
+        Returns:
+            Tuple of ``(name, value)`` if both are configured,
+            ``None`` otherwise.
+
+        Example:
+            ```python
+            cm = ConfigManager()
+            header = cm.get_custom_header()
+            if header:
+                name, value = header
+            ```
+        """
+        config = self._read_config()
+        settings = config.get("settings", {})
+        if not isinstance(settings, dict):
+            return None
+        name = settings.get("custom_header_name")
+        value = settings.get("custom_header_value")
+        if name and value and isinstance(name, str) and isinstance(value, str):
+            return (name, value)
+        return None
+
+    def apply_config_custom_header(self) -> None:
+        """Apply custom header from config to env vars.
+
+        Sets ``MP_CUSTOM_HEADER_NAME`` and ``MP_CUSTOM_HEADER_VALUE``
+        if the config ``[settings]`` section has both values and the
+        env vars are not already set.
+
+        This allows the existing ``MixpanelAPIClient._ensure_client()``
+        to pick up custom headers from config.toml.
+        """
+        if os.environ.get("MP_CUSTOM_HEADER_NAME") and os.environ.get(
+            "MP_CUSTOM_HEADER_VALUE"
+        ):
+            return
+
+        header = self.get_custom_header()
+        if header is not None:
+            name, value = header
+            os.environ["MP_CUSTOM_HEADER_NAME"] = name
+            os.environ["MP_CUSTOM_HEADER_VALUE"] = value
+            logger.debug("Applied custom header from config: %s", name)
 
     def _write_config_atomic(self, config: dict[str, Any]) -> None:
         """Write config atomically via temp file + os.replace().
@@ -1259,10 +1408,11 @@ class ConfigManager:
 
         Priority order:
         1. ENV VARS (MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION)
-        2. EXPLICIT PARAMS (credential + project_id + workspace_id)
-        3. ACTIVE CONTEXT (config [active] section)
-        4. OAUTH FALLBACK (valid token + active.project_id)
-        5. FIRST AVAILABLE (first credential + first known project)
+        2. AUTH BRIDGE FILE (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
+        3. EXPLICIT PARAMS (credential + project_id + workspace_id)
+        4. ACTIVE CONTEXT (config [active] section)
+        5. OAUTH FALLBACK (valid token + active.project_id)
+        6. FIRST AVAILABLE (first credential + first known project)
 
         Works with both v1 and v2 configs.
 
@@ -1289,6 +1439,30 @@ class ConfigManager:
         env_creds = self._resolve_from_env()
         if env_creds is not None:
             return env_creds.to_resolved_session()
+
+        # Priority 2: Auth bridge file (only when no explicit credential requested)
+        if credential is None:
+            bridge_session = self._resolve_session_from_bridge()
+            if bridge_session is not None:
+                # Apply overrides if provided
+                if project_id or workspace_id is not None:
+                    from mixpanel_data._internal.auth_credential import (
+                        ProjectContext as PC,
+                    )
+                    from mixpanel_data._internal.auth_credential import (
+                        ResolvedSession as RS,
+                    )
+
+                    bridge_session = RS(
+                        auth=bridge_session.auth,
+                        project=PC(
+                            project_id=project_id or bridge_session.project_id,
+                            workspace_id=workspace_id
+                            if workspace_id is not None
+                            else bridge_session.workspace_id,
+                        ),
+                    )
+                return bridge_session
 
         config = self._read_config()
         version = int(config.get("config_version", 1))

--- a/src/mixpanel_data/_internal/me.py
+++ b/src/mixpanel_data/_internal/me.py
@@ -354,8 +354,17 @@ class MeCache:
                 e,
             )
 
-        # Add cache metadata
+        # Add cache metadata, stripping bulky fields that bloat the cache.
+        # Workspace member_list and unified_member_list can be 10-30MB each
+        # (preserved by extra="allow") and are not needed for project/workspace
+        # discovery.
         data = response.model_dump(mode="json")
+        _STRIP_FROM_WORKSPACES = {"member_list", "unified_member_list"}
+        if "workspaces" in data and isinstance(data["workspaces"], dict):
+            for ws_data in data["workspaces"].values():
+                if isinstance(ws_data, dict):
+                    for key in _STRIP_FROM_WORKSPACES:
+                        ws_data.pop(key, None)
         data["cached_at"] = time.time()
         data["cached_region"] = region
 

--- a/src/mixpanel_data/auth.py
+++ b/src/mixpanel_data/auth.py
@@ -12,17 +12,34 @@ Re-exported classes:
     CredentialType: Enum distinguishing service_account from oauth.
     ProjectContext: Project and optional workspace selection.
     ResolvedSession: Composition of AuthCredential + ProjectContext.
+    AuthBridgeFile: Cowork credential bridge file model.
+    detect_cowork: Detect Claude Cowork VM environment.
+    load_bridge_file: Load and validate bridge credentials from disk.
 
 For full documentation of these classes, see:
-    mixpanel_data._internal.config, mixpanel_data._internal.auth_credential
+    mixpanel_data._internal.config, mixpanel_data._internal.auth_credential,
+    mixpanel_data._internal.auth.bridge
 
 Example usage:
+    ```python
     from mixpanel_data.auth import ConfigManager, Credentials, AuthMethod
 
     config = ConfigManager()
     creds = config.resolve_credentials()
+
+    # Cowork bridge
+    from mixpanel_data.auth import AuthBridgeFile, detect_cowork, load_bridge_file
+
+    if detect_cowork():
+        bridge = load_bridge_file()
+    ```
 """
 
+from mixpanel_data._internal.auth.bridge import (
+    AuthBridgeFile,
+    detect_cowork,
+    load_bridge_file,
+)
 from mixpanel_data._internal.auth_credential import (
     AuthCredential,
     CredentialType,
@@ -37,12 +54,15 @@ from mixpanel_data._internal.config import (
 )
 
 __all__ = [
+    "AccountInfo",
+    "AuthBridgeFile",
     "AuthCredential",
     "AuthMethod",
     "ConfigManager",
     "Credentials",
     "CredentialType",
-    "AccountInfo",
     "ProjectContext",
     "ResolvedSession",
+    "detect_cowork",
+    "load_bridge_file",
 ]

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -11,13 +11,17 @@ This module provides commands for managing Mixpanel accounts:
 - logout: Remove OAuth tokens
 - status: Show OAuth auth state
 - token: Output raw access token
+- migrate: Migrate v1 config to v2 format
+- cowork-setup: Export credentials for Cowork VMs
+- cowork-teardown: Remove Cowork bridge files
+- cowork-status: Show Cowork bridge status
 """
 
 from __future__ import annotations
 
 import os
 import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 import typer
 
@@ -682,6 +686,7 @@ def cowork_setup(
         mp auth cowork-setup --credential demo-sa --project-id 12345
         mp auth cowork-setup --workspace-id 3448413
     """
+    import contextlib
     from pathlib import Path as _Path
 
     from pydantic import SecretStr
@@ -696,7 +701,9 @@ def cowork_setup(
         write_bridge_file,
     )
     from mixpanel_data._internal.auth.storage import OAuthStorage
-    from mixpanel_data._internal.config import AuthMethod as _AuthMethod
+    from mixpanel_data._internal.auth_credential import (
+        CredentialType as _CredentialType,
+    )
 
     config = get_config(ctx)
     if dir is not None:
@@ -704,21 +711,26 @@ def cowork_setup(
     else:
         bridge_path = default_bridge_path()
 
-    # Resolve credentials via the standard priority chain
-    creds = config.resolve_credentials(account=credential)
-
-    # Determine workspace_id from env or config if not explicitly provided
+    # Determine workspace_id override: explicit flag > MP_WORKSPACE_ID env var
     resolved_workspace_id = workspace_id
     if resolved_workspace_id is None:
         env_ws = os.environ.get("MP_WORKSPACE_ID")
         if env_ws:
-            import contextlib
-
             with contextlib.suppress(ValueError):
                 resolved_workspace_id = int(env_ws)
 
-    # Override project_id if explicitly provided
-    resolved_project_id = project_id or creds.project_id
+    # Resolve a full session via the v2 priority chain.
+    # This picks up workspace_id from the active context when no
+    # explicit override is provided, fixing the gap where
+    # resolve_credentials() couldn't carry workspace_id.
+    session = config.resolve_session(
+        credential=credential,
+        project_id=project_id,
+        workspace_id=resolved_workspace_id,
+    )
+
+    resolved_project_id = session.project_id
+    resolved_workspace_id = session.workspace_id
 
     # Gather custom header from env vars or config [settings]
     custom_header: BridgeCustomHeader | None = None
@@ -741,13 +753,13 @@ def cowork_setup(
     # Build auth-method-specific sections
     oauth_section: BridgeOAuth | None = None
     sa_section: BridgeServiceAccount | None = None
-    auth_method_str: str
+    auth_method_str: Literal["oauth", "service_account"]
 
-    if creds.auth_method == _AuthMethod.oauth:
+    if session.auth.type == _CredentialType.oauth:
         auth_method_str = "oauth"
         # Load full token data from OAuthStorage for refresh capability
         storage = OAuthStorage()
-        region = creds.region
+        region = session.region
         tokens = storage.load_tokens(region)
         if tokens is None:
             err_console.print(
@@ -778,16 +790,18 @@ def cowork_setup(
         )
     else:
         auth_method_str = "service_account"
+        assert session.auth.username is not None
+        assert session.auth.secret is not None
         sa_section = BridgeServiceAccount(
-            username=creds.username,
-            secret=SecretStr(creds.secret.get_secret_value()),
+            username=session.auth.username,
+            secret=SecretStr(session.auth.secret.get_secret_value()),
         )
 
     # Build and write the bridge file
     bridge = AuthBridgeFile(
         version=1,
         auth_method=auth_method_str,
-        region=creds.region,
+        region=session.region,
         project_id=resolved_project_id,
         workspace_id=resolved_workspace_id,
         custom_header=custom_header,
@@ -798,31 +812,31 @@ def cowork_setup(
 
     # When using default path, also write flat file at ~/.claude/mixpanel_auth.json
     if dir is None:
-        import contextlib as _contextlib
-
         flat_path = bridge_path.parent.parent / FLAT_BRIDGE_FILENAME
-        with _contextlib.suppress(OSError):
+        with contextlib.suppress(OSError):
             write_bridge_file(bridge, flat_path)
 
     # Test credentials with a lightweight API call
     test_ok = False
+    test_error: str | None = None
     try:
         from mixpanel_data.workspace import Workspace
 
         test_result = Workspace.test_credentials(credential)
         test_ok = bool(test_result.get("success", False))
-    except Exception:
-        pass
+    except Exception as exc:
+        test_error = f"{type(exc).__name__}: {exc}"
 
     data: dict[str, object] = {
         "status": "cowork_setup_complete",
         "bridge_path": str(bridge_path),
         "auth_method": auth_method_str,
-        "region": creds.region,
+        "region": session.region,
         "project_id": resolved_project_id,
         "workspace_id": resolved_workspace_id,
         "has_custom_header": custom_header is not None,
         "credentials_valid": test_ok,
+        "test_error": test_error,
     }
     output_result(ctx, data, format=format)
 
@@ -831,19 +845,31 @@ def cowork_setup(
 @handle_errors
 def cowork_teardown(
     ctx: typer.Context,
+    dir: Annotated[
+        str | None,
+        typer.Option(
+            "--dir",
+            help="Also remove bridge file from this directory (matching cowork-setup --dir).",
+        ),
+    ] = None,
     format: FormatOption = "json",
 ) -> None:
     """Remove the Cowork auth bridge file(s).
 
     Deletes ``~/.claude/mixpanel/auth.json`` and the flat alternative
-    ``~/.claude/mixpanel_auth.json`` if they exist. This revokes
+    ``~/.claude/mixpanel_auth.json`` if they exist. If ``--dir`` is
+    provided, also removes the bridge file from that directory
+    (matching the ``--dir`` used in ``cowork-setup``). This revokes
     Cowork VM access to Mixpanel credentials exported by
     ``cowork-setup``.
 
     Examples:
 
         mp auth cowork-teardown
+        mp auth cowork-teardown --dir /path/to/workspace
     """
+    from pathlib import Path as _Path
+
     from mixpanel_data._internal.auth.bridge import (
         FLAT_BRIDGE_FILENAME,
         default_bridge_path,
@@ -852,11 +878,20 @@ def cowork_teardown(
     bridge_path = default_bridge_path()
     flat_path = bridge_path.parent.parent / FLAT_BRIDGE_FILENAME
 
+    paths_to_check: list[_Path] = [bridge_path, flat_path]
+    if dir is not None:
+        paths_to_check.append(_Path(dir) / FLAT_BRIDGE_FILENAME)
+
     removed_paths: list[str] = []
-    for p in [bridge_path, flat_path]:
+    for p in paths_to_check:
         if p.is_file():
-            p.unlink()
-            removed_paths.append(str(p))
+            try:
+                p.unlink()
+                removed_paths.append(str(p))
+            except OSError as exc:
+                err_console.print(
+                    f"[yellow]Warning:[/yellow] Could not remove {p}: {exc}"
+                )
 
     if removed_paths:
         output_result(

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -647,14 +647,24 @@ def cowork_setup(
         int | None,
         typer.Option("--workspace-id", help="Workspace ID for App API scoping."),
     ] = None,
+    dir: Annotated[
+        str | None,
+        typer.Option(
+            "--dir",
+            help="Write bridge file to this directory (e.g. your Cowork workspace folder).",
+        ),
+    ] = None,
     format: FormatOption = "json",
 ) -> None:
     """Export credentials to a bridge file for Claude Cowork VMs.
 
-    Resolves the current credentials (from env vars, config, or OAuth
-    tokens) and writes them to ``~/.claude/mixpanel/auth.json`` so that
-    ``mixpanel_data`` running inside a Cowork VM can authenticate
+    Resolves the current credentials and writes them to a bridge file
+    so that ``mixpanel_data`` running inside a Cowork VM can authenticate
     without browser access.
+
+    By default writes to ``~/.claude/mixpanel/auth.json``. Use ``--dir``
+    to write to your Cowork workspace folder instead (recommended, since
+    the workspace folder is always mounted into Cowork).
 
     For OAuth credentials, includes the refresh token so the VM can
     silently renew expired access tokens.
@@ -672,9 +682,12 @@ def cowork_setup(
         mp auth cowork-setup --credential demo-sa --project-id 12345
         mp auth cowork-setup --workspace-id 3448413
     """
+    from pathlib import Path as _Path
+
     from pydantic import SecretStr
 
     from mixpanel_data._internal.auth.bridge import (
+        _FLAT_BRIDGE_FILENAME,
         AuthBridgeFile,
         BridgeCustomHeader,
         BridgeOAuth,
@@ -686,7 +699,10 @@ def cowork_setup(
     from mixpanel_data._internal.config import AuthMethod as _AuthMethod
 
     config = get_config(ctx)
-    bridge_path = _default_bridge_path()
+    if dir is not None:
+        bridge_path = _Path(dir) / _FLAT_BRIDGE_FILENAME
+    else:
+        bridge_path = _default_bridge_path()
 
     # Resolve credentials via the standard priority chain
     creds = config.resolve_credentials(account=credential)
@@ -774,12 +790,13 @@ def cowork_setup(
     )
     write_bridge_file(bridge, bridge_path)
 
-    # Also write flat file at ~/.claude/mixpanel_auth.json
-    # In Cowork, subdirectories created after mount may not be visible,
-    # but files in the root of ~/.claude/ are.
-    flat_path = bridge_path.parent.parent / "mixpanel_auth.json"
-    with contextlib.suppress(OSError):
-        write_bridge_file(bridge, flat_path)
+    # When using default path, also write flat file at ~/.claude/mixpanel_auth.json
+    if dir is None:
+        import contextlib as _contextlib
+
+        flat_path = bridge_path.parent.parent / _FLAT_BRIDGE_FILENAME
+        with _contextlib.suppress(OSError):
+            write_bridge_file(bridge, flat_path)
 
     # Test credentials with a lightweight API call
     test_ok = False

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -774,6 +774,13 @@ def cowork_setup(
     )
     write_bridge_file(bridge, bridge_path)
 
+    # Also write flat file at ~/.claude/mixpanel_auth.json
+    # In Cowork, subdirectories created after mount may not be visible,
+    # but files in the root of ~/.claude/ are.
+    flat_path = bridge_path.parent.parent / "mixpanel_auth.json"
+    with contextlib.suppress(OSError):
+        write_bridge_file(bridge, flat_path)
+
     # Test credentials with a lightweight API call
     test_ok = False
     try:

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -629,3 +629,286 @@ def migrate_config(
         data["backup_path"] = str(result.backup_path)
 
     output_result(ctx, data, format=format)
+
+
+@auth_app.command("cowork-setup")
+@handle_errors
+def cowork_setup(
+    ctx: typer.Context,
+    credential: Annotated[
+        str | None,
+        typer.Option("--credential", help="Named credential to export."),
+    ] = None,
+    project_id: Annotated[
+        str | None,
+        typer.Option("--project-id", help="Mixpanel project ID."),
+    ] = None,
+    workspace_id: Annotated[
+        int | None,
+        typer.Option("--workspace-id", help="Workspace ID for App API scoping."),
+    ] = None,
+    format: FormatOption = "json",
+) -> None:
+    """Export credentials to a bridge file for Claude Cowork VMs.
+
+    Resolves the current credentials (from env vars, config, or OAuth
+    tokens) and writes them to ``~/.claude/mixpanel/auth.json`` so that
+    ``mixpanel_data`` running inside a Cowork VM can authenticate
+    without browser access.
+
+    For OAuth credentials, includes the refresh token so the VM can
+    silently renew expired access tokens.
+
+    For service accounts, includes username and secret.
+
+    Custom headers from env vars or config ``[settings]`` are also
+    included if present.
+
+    After writing, tests the credentials with a lightweight API call.
+
+    Examples:
+
+        mp auth cowork-setup
+        mp auth cowork-setup --credential demo-sa --project-id 12345
+        mp auth cowork-setup --workspace-id 3448413
+    """
+    from pydantic import SecretStr
+
+    from mixpanel_data._internal.auth.bridge import (
+        AuthBridgeFile,
+        BridgeCustomHeader,
+        BridgeOAuth,
+        BridgeServiceAccount,
+        _default_bridge_path,
+        write_bridge_file,
+    )
+    from mixpanel_data._internal.auth.storage import OAuthStorage
+    from mixpanel_data._internal.config import AuthMethod as _AuthMethod
+
+    config = get_config(ctx)
+    bridge_path = _default_bridge_path()
+
+    # Resolve credentials via the standard priority chain
+    creds = config.resolve_credentials(account=credential)
+
+    # Determine workspace_id from env or config if not explicitly provided
+    resolved_workspace_id = workspace_id
+    if resolved_workspace_id is None:
+        env_ws = os.environ.get("MP_WORKSPACE_ID")
+        if env_ws:
+            import contextlib
+
+            with contextlib.suppress(ValueError):
+                resolved_workspace_id = int(env_ws)
+
+    # Override project_id if explicitly provided
+    resolved_project_id = project_id or creds.project_id
+
+    # Gather custom header from env vars or config [settings]
+    custom_header: BridgeCustomHeader | None = None
+    env_header_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+    env_header_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+    if env_header_name and env_header_value:
+        custom_header = BridgeCustomHeader(
+            name=env_header_name,
+            value=SecretStr(env_header_value),
+        )
+    else:
+        config_header = config.get_custom_header()
+        if config_header is not None:
+            header_name, header_value = config_header
+            custom_header = BridgeCustomHeader(
+                name=header_name,
+                value=SecretStr(header_value),
+            )
+
+    # Build auth-method-specific sections
+    oauth_section: BridgeOAuth | None = None
+    sa_section: BridgeServiceAccount | None = None
+    auth_method_str: str
+
+    if creds.auth_method == _AuthMethod.oauth:
+        auth_method_str = "oauth"
+        # Load full token data from OAuthStorage for refresh capability
+        storage = OAuthStorage()
+        region = creds.region
+        tokens = storage.load_tokens(region)
+        if tokens is None:
+            err_console.print(
+                "[red]Error:[/red] OAuth tokens not found in local storage. "
+                "Run 'mp auth login' first."
+            )
+            raise typer.Exit(1)
+
+        # Load client info for client_id
+        client_info = storage.load_client_info(region)
+        client_id = client_info.client_id if client_info else "unknown"
+
+        oauth_section = BridgeOAuth(
+            access_token=SecretStr(tokens.access_token.get_secret_value()),
+            refresh_token=SecretStr(tokens.refresh_token.get_secret_value())
+            if tokens.refresh_token
+            else None,
+            expires_at=tokens.expires_at,
+            scope=tokens.scope,
+            token_type=tokens.token_type,
+            client_id=client_id,
+        )
+    else:
+        auth_method_str = "service_account"
+        sa_section = BridgeServiceAccount(
+            username=creds.username,
+            secret=SecretStr(creds.secret.get_secret_value()),
+        )
+
+    # Build and write the bridge file
+    bridge = AuthBridgeFile(
+        version=1,
+        auth_method=auth_method_str,
+        region=creds.region,
+        project_id=resolved_project_id,
+        workspace_id=resolved_workspace_id,
+        custom_header=custom_header,
+        oauth=oauth_section,
+        service_account=sa_section,
+    )
+    write_bridge_file(bridge, bridge_path)
+
+    # Test credentials with a lightweight API call
+    test_ok = False
+    try:
+        from mixpanel_data.workspace import Workspace
+
+        test_result = Workspace.test_credentials(credential)
+        test_ok = bool(test_result.get("success", False))
+    except Exception:
+        pass
+
+    data: dict[str, object] = {
+        "status": "cowork_setup_complete",
+        "bridge_path": str(bridge_path),
+        "auth_method": auth_method_str,
+        "region": creds.region,
+        "project_id": resolved_project_id,
+        "workspace_id": resolved_workspace_id,
+        "has_custom_header": custom_header is not None,
+        "credentials_valid": test_ok,
+    }
+    output_result(ctx, data, format=format)
+
+
+@auth_app.command("cowork-teardown")
+@handle_errors
+def cowork_teardown(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+) -> None:
+    """Remove the Cowork auth bridge file.
+
+    Deletes ``~/.claude/mixpanel/auth.json`` if it exists. This
+    revokes Cowork VM access to Mixpanel credentials exported by
+    ``cowork-setup``.
+
+    Examples:
+
+        mp auth cowork-teardown
+    """
+    from mixpanel_data._internal.auth.bridge import (
+        _default_bridge_path,
+    )
+
+    bridge_path = _default_bridge_path()
+
+    if bridge_path.is_file():
+        bridge_path.unlink()
+        output_result(
+            ctx,
+            {
+                "status": "cowork_teardown_complete",
+                "bridge_path": str(bridge_path),
+                "removed": True,
+            },
+            format=format,
+        )
+    else:
+        output_result(
+            ctx,
+            {
+                "status": "cowork_teardown_complete",
+                "bridge_path": str(bridge_path),
+                "removed": False,
+                "message": "Bridge file did not exist.",
+            },
+            format=format,
+        )
+
+
+@auth_app.command("cowork-status")
+@handle_errors
+def cowork_status(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+) -> None:
+    """Show the status of the Cowork auth bridge file.
+
+    Checks whether ``~/.claude/mixpanel/auth.json`` exists and, if
+    so, displays its auth method, project, region, token expiry, and
+    custom header status.
+
+    If the bridge file does not exist, suggests running
+    ``cowork-setup``.
+
+    Examples:
+
+        mp auth cowork-status
+        mp auth cowork-status --format table
+    """
+    from mixpanel_data._internal.auth.bridge import (
+        _default_bridge_path,
+        load_bridge_file,
+    )
+
+    bridge_path = _default_bridge_path()
+
+    if not bridge_path.is_file():
+        data: dict[str, object] = {
+            "exists": False,
+            "bridge_path": str(bridge_path),
+            "message": "No bridge file found. Run 'mp auth cowork-setup' to create one.",
+        }
+        output_result(ctx, data, format=format)
+        return
+
+    bridge = load_bridge_file(bridge_path)
+    if bridge is None:
+        data = {
+            "exists": True,
+            "valid": False,
+            "bridge_path": str(bridge_path),
+            "message": "Bridge file exists but is invalid. "
+            "Run 'mp auth cowork-setup' to recreate it.",
+        }
+        output_result(ctx, data, format=format)
+        return
+
+    # Build status info
+    data = {
+        "exists": True,
+        "valid": True,
+        "bridge_path": str(bridge_path),
+        "auth_method": bridge.auth_method,
+        "region": bridge.region,
+        "project_id": bridge.project_id,
+        "workspace_id": bridge.workspace_id,
+        "has_custom_header": bridge.custom_header is not None,
+    }
+
+    if bridge.oauth is not None:
+        data["oauth_expires_at"] = bridge.oauth.expires_at.isoformat()
+        data["oauth_is_expired"] = bridge.oauth.is_expired()
+        data["oauth_scope"] = bridge.oauth.scope
+
+    if bridge.service_account is not None:
+        data["sa_username"] = bridge.service_account.username
+
+    output_result(ctx, data, format=format)

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -687,12 +687,12 @@ def cowork_setup(
     from pydantic import SecretStr
 
     from mixpanel_data._internal.auth.bridge import (
-        _FLAT_BRIDGE_FILENAME,
+        FLAT_BRIDGE_FILENAME,
         AuthBridgeFile,
         BridgeCustomHeader,
         BridgeOAuth,
         BridgeServiceAccount,
-        _default_bridge_path,
+        default_bridge_path,
         write_bridge_file,
     )
     from mixpanel_data._internal.auth.storage import OAuthStorage
@@ -700,9 +700,9 @@ def cowork_setup(
 
     config = get_config(ctx)
     if dir is not None:
-        bridge_path = _Path(dir) / _FLAT_BRIDGE_FILENAME
+        bridge_path = _Path(dir) / FLAT_BRIDGE_FILENAME
     else:
-        bridge_path = _default_bridge_path()
+        bridge_path = default_bridge_path()
 
     # Resolve credentials via the standard priority chain
     creds = config.resolve_credentials(account=credential)
@@ -758,7 +758,13 @@ def cowork_setup(
 
         # Load client info for client_id
         client_info = storage.load_client_info(region)
-        client_id = client_info.client_id if client_info else "unknown"
+        if client_info is None:
+            err_console.print(
+                "[red]Error:[/red] OAuth client registration info not found. "
+                "Run 'mp auth login' first to register the OAuth client."
+            )
+            raise typer.Exit(1)
+        client_id = client_info.client_id
 
         oauth_section = BridgeOAuth(
             access_token=SecretStr(tokens.access_token.get_secret_value()),
@@ -794,7 +800,7 @@ def cowork_setup(
     if dir is None:
         import contextlib as _contextlib
 
-        flat_path = bridge_path.parent.parent / _FLAT_BRIDGE_FILENAME
+        flat_path = bridge_path.parent.parent / FLAT_BRIDGE_FILENAME
         with _contextlib.suppress(OSError):
             write_bridge_file(bridge, flat_path)
 
@@ -827,10 +833,11 @@ def cowork_teardown(
     ctx: typer.Context,
     format: FormatOption = "json",
 ) -> None:
-    """Remove the Cowork auth bridge file.
+    """Remove the Cowork auth bridge file(s).
 
-    Deletes ``~/.claude/mixpanel/auth.json`` if it exists. This
-    revokes Cowork VM access to Mixpanel credentials exported by
+    Deletes ``~/.claude/mixpanel/auth.json`` and the flat alternative
+    ``~/.claude/mixpanel_auth.json`` if they exist. This revokes
+    Cowork VM access to Mixpanel credentials exported by
     ``cowork-setup``.
 
     Examples:
@@ -838,18 +845,25 @@ def cowork_teardown(
         mp auth cowork-teardown
     """
     from mixpanel_data._internal.auth.bridge import (
-        _default_bridge_path,
+        FLAT_BRIDGE_FILENAME,
+        default_bridge_path,
     )
 
-    bridge_path = _default_bridge_path()
+    bridge_path = default_bridge_path()
+    flat_path = bridge_path.parent.parent / FLAT_BRIDGE_FILENAME
 
-    if bridge_path.is_file():
-        bridge_path.unlink()
+    removed_paths: list[str] = []
+    for p in [bridge_path, flat_path]:
+        if p.is_file():
+            p.unlink()
+            removed_paths.append(str(p))
+
+    if removed_paths:
         output_result(
             ctx,
             {
                 "status": "cowork_teardown_complete",
-                "bridge_path": str(bridge_path),
+                "removed_paths": removed_paths,
                 "removed": True,
             },
             format=format,
@@ -888,11 +902,11 @@ def cowork_status(
         mp auth cowork-status --format table
     """
     from mixpanel_data._internal.auth.bridge import (
-        _default_bridge_path,
+        default_bridge_path,
         load_bridge_file,
     )
 
-    bridge_path = _default_bridge_path()
+    bridge_path = default_bridge_path()
 
     if not bridge_path.is_file():
         data: dict[str, object] = {

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -6770,13 +6770,12 @@ class EventDeletionRequest(BaseModel):
         v: dict[str, Any] | list[Any] | None,
     ) -> dict[str, Any] | None:
         """Coerce empty list from API to None."""
-        if isinstance(v, list) and len(v) == 0:
+        if not isinstance(v, list):
+            return v
+        if len(v) == 0:
             return None
-        if isinstance(v, list):
-            # Non-empty list is unexpected; preserve as-is would fail type.
-            # Wrap in dict for forward compatibility.
-            return {"items": v}
-        return v
+        # Non-empty list is unexpected; wrap in dict for forward compatibility.
+        return {"items": v}
 
     status: str
     """Request status: "Submitted", "Processing", "Completed", "Failed"."""

--- a/tests/integration/cli/test_cowork_commands.py
+++ b/tests/integration/cli/test_cowork_commands.py
@@ -17,8 +17,15 @@ from mixpanel_data._internal.auth.bridge import (
     BridgeServiceAccount,
 )
 from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
-from mixpanel_data._internal.config import AuthMethod, Credentials
+from mixpanel_data._internal.auth_credential import (
+    AuthCredential,
+    CredentialType,
+    ProjectContext,
+    ResolvedSession,
+)
 from mixpanel_data.cli.main import app
+
+# ruff: noqa: ARG001
 
 # Patch targets — lazy imports inside function bodies resolve from source module
 _BRIDGE_MOD = "mixpanel_data._internal.auth.bridge"
@@ -45,35 +52,39 @@ def mock_config_manager() -> MagicMock:
 
 
 @pytest.fixture
-def sa_credentials() -> Credentials:
-    """Create service account credentials for testing.
+def sa_session() -> ResolvedSession:
+    """Create a resolved session with service account auth for testing.
 
     Returns:
-        Credentials configured with basic auth method.
+        ResolvedSession with service account credentials.
     """
-    return Credentials(
-        username="sa-user",
-        secret=SecretStr("sa-secret"),
-        project_id="12345",
-        region="us",
-        auth_method=AuthMethod.basic,
+    return ResolvedSession(
+        auth=AuthCredential(
+            name="sa-user",
+            type=CredentialType.service_account,
+            region="us",
+            username="sa-user",
+            secret=SecretStr("sa-secret"),
+        ),
+        project=ProjectContext(project_id="12345"),
     )
 
 
 @pytest.fixture
-def oauth_credentials() -> Credentials:
-    """Create OAuth credentials for testing.
+def oauth_session() -> ResolvedSession:
+    """Create a resolved session with OAuth auth for testing.
 
     Returns:
-        Credentials configured with OAuth auth method.
+        ResolvedSession with OAuth credentials.
     """
-    return Credentials(
-        username="",
-        secret=SecretStr(""),
-        project_id="12345",
-        region="us",
-        auth_method=AuthMethod.oauth,
-        oauth_access_token=SecretStr("test-access-token"),
+    return ResolvedSession(
+        auth=AuthCredential(
+            name="oauth-user",
+            type=CredentialType.oauth,
+            region="us",
+            oauth_access_token=SecretStr("test-access-token"),
+        ),
+        project=ProjectContext(project_id="12345"),
     )
 
 
@@ -130,11 +141,11 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup with service account credentials."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        mock_config_manager.resolve_session.return_value = sa_session
 
         with (
             patch(
@@ -165,13 +176,13 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        oauth_credentials: Credentials,
+        oauth_session: ResolvedSession,
         mock_oauth_tokens: OAuthTokens,
         mock_client_info: OAuthClientInfo,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup with OAuth credentials."""
-        mock_config_manager.resolve_credentials.return_value = oauth_credentials
+        mock_config_manager.resolve_session.return_value = oauth_session
 
         mock_storage = MagicMock()
         mock_storage.load_tokens.return_value = mock_oauth_tokens
@@ -209,11 +220,16 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup with explicit --project-id override."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        # resolve_session receives project_id and returns session with it
+        overridden = ResolvedSession(
+            auth=sa_session.auth,
+            project=ProjectContext(project_id="99999"),
+        )
+        mock_config_manager.resolve_session.return_value = overridden
 
         with (
             patch(
@@ -241,11 +257,15 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup with explicit --workspace-id."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        overridden = ResolvedSession(
+            auth=sa_session.auth,
+            project=ProjectContext(project_id="12345", workspace_id=3448413),
+        )
+        mock_config_manager.resolve_session.return_value = overridden
 
         with (
             patch(
@@ -269,16 +289,56 @@ class TestCoworkSetup:
         data = json.loads(result.stdout)
         assert data["workspace_id"] == 3448413
 
+    def test_setup_workspace_id_from_active_context(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup picks up workspace_id from active context via resolve_session."""
+        session_with_ws = ResolvedSession(
+            auth=AuthCredential(
+                name="sa-user",
+                type=CredentialType.service_account,
+                region="us",
+                username="sa-user",
+                secret=SecretStr("sa-secret"),
+            ),
+            project=ProjectContext(project_id="12345", workspace_id=7777),
+        )
+        mock_config_manager.resolve_session.return_value = session_with_ws
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}.default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            # No --workspace-id flag — should come from session
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["workspace_id"] == 7777
+
     def test_setup_with_custom_header_from_env(
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test cowork-setup picks up custom headers from env vars."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        mock_config_manager.resolve_session.return_value = sa_session
         monkeypatch.setenv("MP_CUSTOM_HEADER_NAME", "X-Custom")
         monkeypatch.setenv("MP_CUSTOM_HEADER_VALUE", "secret-value")
 
@@ -306,12 +366,12 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test cowork-setup picks up custom headers from config [settings]."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        mock_config_manager.resolve_session.return_value = sa_session
         mock_config_manager.get_custom_header.return_value = ("X-Config", "config-val")
         monkeypatch.delenv("MP_CUSTOM_HEADER_NAME", raising=False)
         monkeypatch.delenv("MP_CUSTOM_HEADER_VALUE", raising=False)
@@ -340,11 +400,11 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        oauth_credentials: Credentials,
+        oauth_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup fails when OAuth tokens are not in storage."""
-        mock_config_manager.resolve_credentials.return_value = oauth_credentials
+        mock_config_manager.resolve_session.return_value = oauth_session
 
         mock_storage = MagicMock()
         mock_storage.load_tokens.return_value = None
@@ -372,11 +432,11 @@ class TestCoworkSetup:
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
         """Test cowork-setup succeeds even when credential test fails."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        mock_config_manager.resolve_session.return_value = sa_session
 
         with (
             patch(
@@ -397,17 +457,91 @@ class TestCoworkSetup:
         assert result.exit_code == 0, f"stderr: {result.stderr}"
         data = json.loads(result.stdout)
         assert data["credentials_valid"] is False
+        assert data["test_error"] is not None
+        assert "network error" in data["test_error"]
         assert bridge_path.exists()
+
+    def test_setup_with_dir_option(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_session: ResolvedSession,
+        tmp_path: Path,
+    ) -> None:
+        """Test cowork-setup --dir writes bridge file to custom directory."""
+        mock_config_manager.resolve_session.return_value = sa_session
+        custom_dir = tmp_path / "my-workspace"
+        custom_dir.mkdir()
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["auth", "cowork-setup", "--dir", str(custom_dir)],
+            )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_setup_complete"
+        # Bridge file should be in the custom directory
+        bridge_file = custom_dir / "mixpanel_auth.json"
+        assert bridge_file.exists()
+        # Verify the bridge file is valid JSON with expected content
+        bridge_data = json.loads(bridge_file.read_text())
+        assert bridge_data["auth_method"] == "service_account"
+        assert bridge_data["project_id"] == "12345"
+
+    def test_setup_oauth_no_client_info_fails(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        oauth_session: ResolvedSession,
+        mock_oauth_tokens: OAuthTokens,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup fails when OAuth client info is missing."""
+        mock_config_manager.resolve_session.return_value = oauth_session
+
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = mock_oauth_tokens
+        mock_storage.load_client_info.return_value = None  # client info missing
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}.default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.storage.OAuthStorage",
+                return_value=mock_storage,
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 1
+        assert "client registration info not found" in result.stderr
 
     def test_setup_with_named_credential(
         self,
         cli_runner: CliRunner,
         mock_config_manager: MagicMock,
-        sa_credentials: Credentials,
+        sa_session: ResolvedSession,
         bridge_path: Path,
     ) -> None:
-        """Test cowork-setup passes credential name to resolve_credentials."""
-        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        """Test cowork-setup passes credential name to resolve_session."""
+        mock_config_manager.resolve_session.return_value = sa_session
 
         with (
             patch(
@@ -428,8 +562,10 @@ class TestCoworkSetup:
             )
 
         assert result.exit_code == 0, f"stderr: {result.stderr}"
-        mock_config_manager.resolve_credentials.assert_called_once_with(
-            account="demo-sa"
+        mock_config_manager.resolve_session.assert_called_once_with(
+            credential="demo-sa",
+            project_id=None,
+            workspace_id=None,
         )
 
 
@@ -478,6 +614,36 @@ class TestCoworkTeardown:
         assert data["status"] == "cowork_teardown_complete"
         assert data["removed"] is False
         assert "did not exist" in data["message"]
+
+    def test_teardown_with_dir_option(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Test cowork-teardown --dir removes workspace bridge file."""
+        # Create bridge in custom directory
+        custom_dir = tmp_path / "my-workspace"
+        custom_dir.mkdir()
+        workspace_bridge = custom_dir / "mixpanel_auth.json"
+        workspace_bridge.write_text('{"version": 1}', encoding="utf-8")
+        assert workspace_bridge.exists()
+
+        with patch(
+            f"{_BRIDGE_MOD}.default_bridge_path",
+            return_value=bridge_path,
+        ):
+            result = cli_runner.invoke(
+                app,
+                ["auth", "cowork-teardown", "--dir", str(custom_dir)],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_teardown_complete"
+        assert data["removed"] is True
+        assert str(workspace_bridge) in data["removed_paths"]
+        assert not workspace_bridge.exists()
 
 
 class TestCoworkStatus:

--- a/tests/integration/cli/test_cowork_commands.py
+++ b/tests/integration/cli/test_cowork_commands.py
@@ -142,7 +142,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -183,7 +183,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -221,7 +221,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -253,7 +253,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -288,7 +288,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -322,7 +322,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -355,7 +355,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -384,7 +384,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -415,7 +415,7 @@ class TestCoworkSetup:
                 return_value=mock_config_manager,
             ),
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -448,7 +448,7 @@ class TestCoworkTeardown:
         assert bridge_path.exists()
 
         with patch(
-            f"{_BRIDGE_MOD}._default_bridge_path",
+            f"{_BRIDGE_MOD}.default_bridge_path",
             return_value=bridge_path,
         ):
             result = cli_runner.invoke(app, ["auth", "cowork-teardown"])
@@ -468,7 +468,7 @@ class TestCoworkTeardown:
         assert not bridge_path.exists()
 
         with patch(
-            f"{_BRIDGE_MOD}._default_bridge_path",
+            f"{_BRIDGE_MOD}.default_bridge_path",
             return_value=bridge_path,
         ):
             result = cli_runner.invoke(app, ["auth", "cowork-teardown"])
@@ -492,7 +492,7 @@ class TestCoworkStatus:
         assert not bridge_path.exists()
 
         with patch(
-            f"{_BRIDGE_MOD}._default_bridge_path",
+            f"{_BRIDGE_MOD}.default_bridge_path",
             return_value=bridge_path,
         ):
             result = cli_runner.invoke(app, ["auth", "cowork-status"])
@@ -526,7 +526,7 @@ class TestCoworkStatus:
 
         with (
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -574,7 +574,7 @@ class TestCoworkStatus:
 
         with (
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(
@@ -606,7 +606,7 @@ class TestCoworkStatus:
 
         with (
             patch(
-                f"{_BRIDGE_MOD}._default_bridge_path",
+                f"{_BRIDGE_MOD}.default_bridge_path",
                 return_value=bridge_path,
             ),
             patch(

--- a/tests/integration/cli/test_cowork_commands.py
+++ b/tests/integration/cli/test_cowork_commands.py
@@ -1,0 +1,623 @@
+"""Integration tests for cowork auth bridge CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+from typer.testing import CliRunner
+
+from mixpanel_data._internal.auth.bridge import (
+    AuthBridgeFile,
+    BridgeOAuth,
+    BridgeServiceAccount,
+)
+from mixpanel_data._internal.auth.token import OAuthClientInfo, OAuthTokens
+from mixpanel_data._internal.config import AuthMethod, Credentials
+from mixpanel_data.cli.main import app
+
+# Patch targets — lazy imports inside function bodies resolve from source module
+_BRIDGE_MOD = "mixpanel_data._internal.auth.bridge"
+_AUTH_CMD_MOD = "mixpanel_data.cli.commands.auth"
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config_manager() -> MagicMock:
+    """Create a mock ConfigManager for testing cowork commands.
+
+    Returns:
+        MagicMock configured as a v1 ConfigManager with no custom header.
+    """
+    config = MagicMock()
+    config.config_version.return_value = 1
+    config.get_custom_header.return_value = None
+    return config
+
+
+@pytest.fixture
+def sa_credentials() -> Credentials:
+    """Create service account credentials for testing.
+
+    Returns:
+        Credentials configured with basic auth method.
+    """
+    return Credentials(
+        username="sa-user",
+        secret=SecretStr("sa-secret"),
+        project_id="12345",
+        region="us",
+        auth_method=AuthMethod.basic,
+    )
+
+
+@pytest.fixture
+def oauth_credentials() -> Credentials:
+    """Create OAuth credentials for testing.
+
+    Returns:
+        Credentials configured with OAuth auth method.
+    """
+    return Credentials(
+        username="",
+        secret=SecretStr(""),
+        project_id="12345",
+        region="us",
+        auth_method=AuthMethod.oauth,
+        oauth_access_token=SecretStr("test-access-token"),
+    )
+
+
+@pytest.fixture
+def mock_oauth_tokens() -> OAuthTokens:
+    """Create mock OAuth tokens for testing.
+
+    Returns:
+        OAuthTokens with a future expiration time.
+    """
+    return OAuthTokens(
+        access_token=SecretStr("test-access-token"),
+        refresh_token=SecretStr("test-refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        scope="read:project write:project",
+        token_type="Bearer",
+        project_id="12345",
+    )
+
+
+@pytest.fixture
+def mock_client_info() -> OAuthClientInfo:
+    """Create mock OAuth client info for testing.
+
+    Returns:
+        OAuthClientInfo with a test client ID.
+    """
+    return OAuthClientInfo(
+        client_id="test-client-id",
+        region="us",
+        redirect_uri="http://localhost:8080/callback",
+        scope="read:project write:project",
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture
+def bridge_path(tmp_path: Path) -> Path:
+    """Create a temporary bridge file path for testing.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path to a temporary bridge file location.
+    """
+    return tmp_path / ".claude" / "mixpanel" / "auth.json"
+
+
+class TestCoworkSetup:
+    """Tests for mp auth cowork-setup command."""
+
+    def test_setup_service_account(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup with service account credentials."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_setup_complete"
+        assert data["auth_method"] == "service_account"
+        assert data["region"] == "us"
+        assert data["project_id"] == "12345"
+        assert data["credentials_valid"] is True
+        assert bridge_path.exists()
+
+    def test_setup_oauth(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        oauth_credentials: Credentials,
+        mock_oauth_tokens: OAuthTokens,
+        mock_client_info: OAuthClientInfo,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup with OAuth credentials."""
+        mock_config_manager.resolve_credentials.return_value = oauth_credentials
+
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = mock_oauth_tokens
+        mock_storage.load_client_info.return_value = mock_client_info
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.storage.OAuthStorage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_setup_complete"
+        assert data["auth_method"] == "oauth"
+        assert data["region"] == "us"
+        assert data["project_id"] == "12345"
+        assert bridge_path.exists()
+
+    def test_setup_with_project_id_override(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup with explicit --project-id override."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(
+                app, ["auth", "cowork-setup", "--project-id", "99999"]
+            )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["project_id"] == "99999"
+
+    def test_setup_with_workspace_id(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup with explicit --workspace-id."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(
+                app, ["auth", "cowork-setup", "--workspace-id", "3448413"]
+            )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["workspace_id"] == 3448413
+
+    def test_setup_with_custom_header_from_env(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test cowork-setup picks up custom headers from env vars."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        monkeypatch.setenv("MP_CUSTOM_HEADER_NAME", "X-Custom")
+        monkeypatch.setenv("MP_CUSTOM_HEADER_VALUE", "secret-value")
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["has_custom_header"] is True
+
+    def test_setup_with_custom_header_from_config(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test cowork-setup picks up custom headers from config [settings]."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+        mock_config_manager.get_custom_header.return_value = ("X-Config", "config-val")
+        monkeypatch.delenv("MP_CUSTOM_HEADER_NAME", raising=False)
+        monkeypatch.delenv("MP_CUSTOM_HEADER_VALUE", raising=False)
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["has_custom_header"] is True
+
+    def test_setup_oauth_no_tokens_fails(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        oauth_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup fails when OAuth tokens are not in storage."""
+        mock_config_manager.resolve_credentials.return_value = oauth_credentials
+
+        mock_storage = MagicMock()
+        mock_storage.load_tokens.return_value = None
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.storage.OAuthStorage",
+                return_value=mock_storage,
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 1
+        assert "OAuth tokens not found" in result.stderr
+
+    def test_setup_credentials_test_failure_still_succeeds(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup succeeds even when credential test fails."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                side_effect=Exception("network error"),
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-setup"])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["credentials_valid"] is False
+        assert bridge_path.exists()
+
+    def test_setup_with_named_credential(
+        self,
+        cli_runner: CliRunner,
+        mock_config_manager: MagicMock,
+        sa_credentials: Credentials,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-setup passes credential name to resolve_credentials."""
+        mock_config_manager.resolve_credentials.return_value = sa_credentials
+
+        with (
+            patch(
+                f"{_AUTH_CMD_MOD}.get_config",
+                return_value=mock_config_manager,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                "mixpanel_data.workspace.Workspace.test_credentials",
+                return_value={"success": True},
+            ),
+        ):
+            result = cli_runner.invoke(
+                app, ["auth", "cowork-setup", "--credential", "demo-sa"]
+            )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        mock_config_manager.resolve_credentials.assert_called_once_with(
+            account="demo-sa"
+        )
+
+
+class TestCoworkTeardown:
+    """Tests for mp auth cowork-teardown command."""
+
+    def test_teardown_removes_existing_file(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-teardown deletes an existing bridge file."""
+        # Create the bridge file
+        bridge_path.parent.mkdir(parents=True, exist_ok=True)
+        bridge_path.write_text('{"version": 1}', encoding="utf-8")
+        assert bridge_path.exists()
+
+        with patch(
+            f"{_BRIDGE_MOD}._default_bridge_path",
+            return_value=bridge_path,
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-teardown"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_teardown_complete"
+        assert data["removed"] is True
+        assert not bridge_path.exists()
+
+    def test_teardown_no_file_exists(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-teardown when no bridge file exists."""
+        assert not bridge_path.exists()
+
+        with patch(
+            f"{_BRIDGE_MOD}._default_bridge_path",
+            return_value=bridge_path,
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-teardown"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "cowork_teardown_complete"
+        assert data["removed"] is False
+        assert "did not exist" in data["message"]
+
+
+class TestCoworkStatus:
+    """Tests for mp auth cowork-status command."""
+
+    def test_status_no_bridge_file(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-status when no bridge file exists."""
+        assert not bridge_path.exists()
+
+        with patch(
+            f"{_BRIDGE_MOD}._default_bridge_path",
+            return_value=bridge_path,
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-status"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["exists"] is False
+        assert "cowork-setup" in data["message"]
+
+    def test_status_valid_sa_bridge(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-status with a valid service account bridge file."""
+        sa_bridge = AuthBridgeFile(
+            version=1,
+            auth_method="service_account",
+            region="us",
+            project_id="12345",
+            workspace_id=100,
+            service_account=BridgeServiceAccount(
+                username="sa-user",
+                secret=SecretStr("sa-secret"),
+            ),
+        )
+
+        # Create the file so is_file() passes
+        bridge_path.parent.mkdir(parents=True, exist_ok=True)
+        bridge_path.write_text("{}", encoding="utf-8")
+
+        with (
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}.load_bridge_file",
+                return_value=sa_bridge,
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-status"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["exists"] is True
+        assert data["valid"] is True
+        assert data["auth_method"] == "service_account"
+        assert data["region"] == "us"
+        assert data["project_id"] == "12345"
+        assert data["workspace_id"] == 100
+        assert data["sa_username"] == "sa-user"
+        assert data["has_custom_header"] is False
+
+    def test_status_valid_oauth_bridge(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-status with a valid OAuth bridge file."""
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        oauth_bridge = AuthBridgeFile(
+            version=1,
+            auth_method="oauth",
+            region="eu",
+            project_id="67890",
+            oauth=BridgeOAuth(
+                access_token=SecretStr("access-tok"),
+                refresh_token=SecretStr("refresh-tok"),
+                expires_at=expires,
+                scope="read:project",
+                token_type="Bearer",
+                client_id="cid-123",
+            ),
+        )
+
+        bridge_path.parent.mkdir(parents=True, exist_ok=True)
+        bridge_path.write_text("{}", encoding="utf-8")
+
+        with (
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}.load_bridge_file",
+                return_value=oauth_bridge,
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-status"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["exists"] is True
+        assert data["valid"] is True
+        assert data["auth_method"] == "oauth"
+        assert data["region"] == "eu"
+        assert data["project_id"] == "67890"
+        assert data["oauth_is_expired"] is False
+        assert data["oauth_scope"] == "read:project"
+        assert "oauth_expires_at" in data
+
+    def test_status_invalid_bridge_file(
+        self,
+        cli_runner: CliRunner,
+        bridge_path: Path,
+    ) -> None:
+        """Test cowork-status with an invalid bridge file."""
+        bridge_path.parent.mkdir(parents=True, exist_ok=True)
+        bridge_path.write_text("not valid json", encoding="utf-8")
+
+        with (
+            patch(
+                f"{_BRIDGE_MOD}._default_bridge_path",
+                return_value=bridge_path,
+            ),
+            patch(
+                f"{_BRIDGE_MOD}.load_bridge_file",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(app, ["auth", "cowork-status"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["exists"] is True
+        assert data["valid"] is False
+        assert "invalid" in data["message"].lower()

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -10,7 +10,6 @@ import json
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +22,7 @@ from mixpanel_data._internal.auth.bridge import (
     BridgeServiceAccount,
     apply_bridge_custom_header,
     bridge_to_credentials,
+    bridge_to_json_dict,
     bridge_to_resolved_session,
     detect_cowork,
     find_bridge_file,
@@ -118,49 +118,6 @@ def _make_sa_bridge(
     )
 
 
-def _bridge_to_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
-    """Serialize an AuthBridgeFile to a JSON-compatible dict.
-
-    Args:
-        bridge: The bridge file to serialize.
-
-    Returns:
-        JSON-serializable dictionary.
-    """
-    d: dict[str, Any] = {
-        "version": bridge.version,
-        "auth_method": bridge.auth_method,
-        "region": bridge.region,
-        "project_id": bridge.project_id,
-        "workspace_id": bridge.workspace_id,
-        "custom_header": None,
-        "oauth": None,
-        "service_account": None,
-    }
-    if bridge.custom_header is not None:
-        d["custom_header"] = {
-            "name": bridge.custom_header.name,
-            "value": bridge.custom_header.value.get_secret_value(),
-        }
-    if bridge.oauth is not None:
-        d["oauth"] = {
-            "access_token": bridge.oauth.access_token.get_secret_value(),
-            "refresh_token": bridge.oauth.refresh_token.get_secret_value()
-            if bridge.oauth.refresh_token
-            else None,
-            "expires_at": bridge.oauth.expires_at.isoformat(),
-            "scope": bridge.oauth.scope,
-            "token_type": bridge.oauth.token_type,
-            "client_id": bridge.oauth.client_id,
-        }
-    if bridge.service_account is not None:
-        d["service_account"] = {
-            "username": bridge.service_account.username,
-            "secret": bridge.service_account.secret.get_secret_value(),
-        }
-    return d
-
-
 class TestAuthBridgeFileModel:
     """Tests for AuthBridgeFile Pydantic model validation."""
 
@@ -223,6 +180,26 @@ class TestAuthBridgeFileModel:
                 project_id="123",
             )
 
+    def test_oauth_without_oauth_section_rejected(self) -> None:
+        """Test that auth_method='oauth' without oauth section is rejected."""
+        with pytest.raises((ValueError, ValidationError)):
+            AuthBridgeFile(
+                version=1,
+                auth_method="oauth",
+                region="us",
+                project_id="123",
+            )
+
+    def test_sa_without_sa_section_rejected(self) -> None:
+        """Test that auth_method='service_account' without SA section is rejected."""
+        with pytest.raises((ValueError, ValidationError)):
+            AuthBridgeFile(
+                version=1,
+                auth_method="service_account",
+                region="us",
+                project_id="123",
+            )
+
     def test_version_must_be_1(self) -> None:
         """Test that version must be 1."""
         with pytest.raises((ValueError, ValidationError)):
@@ -269,8 +246,6 @@ class TestDetectCowork:
             ),
             patch.dict(os.environ, {}, clear=True),
         ):
-            # Remove CLAUDE_COWORK if present
-            os.environ.pop("CLAUDE_COWORK", None)
             assert detect_cowork() is False
 
 
@@ -301,7 +276,7 @@ class TestFindBridgeFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=auth_file,
             ),
         ):
@@ -320,7 +295,7 @@ class TestFindBridgeFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -335,7 +310,7 @@ class TestFindBridgeFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
             patch("pathlib.Path.home", return_value=tmp_path / "fakehome"),
@@ -353,7 +328,7 @@ class TestLoadBridgeFile:
         """Test loading a valid OAuth bridge file."""
         bridge = _make_oauth_bridge()
         bridge_file = tmp_path / "auth.json"
-        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+        bridge_file.write_text(json.dumps(bridge_to_json_dict(bridge)))
 
         loaded = load_bridge_file(bridge_file)
         assert loaded is not None
@@ -366,7 +341,7 @@ class TestLoadBridgeFile:
         """Test loading a valid service account bridge file."""
         bridge = _make_sa_bridge()
         bridge_file = tmp_path / "auth.json"
-        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+        bridge_file.write_text(json.dumps(bridge_to_json_dict(bridge)))
 
         loaded = load_bridge_file(bridge_file)
         assert loaded is not None
@@ -378,7 +353,7 @@ class TestLoadBridgeFile:
         """Test loading bridge file with custom header."""
         bridge = _make_oauth_bridge(with_custom_header=True)
         bridge_file = tmp_path / "auth.json"
-        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+        bridge_file.write_text(json.dumps(bridge_to_json_dict(bridge)))
 
         loaded = load_bridge_file(bridge_file)
         assert loaded is not None
@@ -395,7 +370,7 @@ class TestLoadBridgeFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -586,6 +561,28 @@ class TestRefreshBridgeToken:
         result = refresh_bridge_token(bridge, Path("/dummy"))
         assert result is bridge  # Same object, no refresh needed
 
+    def test_refresh_raises_oauth_error_when_no_refresh_token(self) -> None:
+        """Test that missing refresh token raises OAuthError."""
+        from mixpanel_data.exceptions import OAuthError
+
+        bridge = AuthBridgeFile(
+            version=1,
+            auth_method="oauth",
+            region="us",
+            project_id="123",
+            oauth=BridgeOAuth(
+                access_token=SecretStr("expired_token"),
+                refresh_token=None,
+                expires_at=_utcnow() - timedelta(hours=1),
+                scope="projects",
+                token_type="Bearer",
+                client_id="client_1",
+            ),
+        )
+
+        with pytest.raises(OAuthError, match="no refresh token"):
+            refresh_bridge_token(bridge, Path("/dummy"))
+
     def test_refreshes_expired_token(self) -> None:
         """Test that expired OAuth token is refreshed."""
         bridge = _make_oauth_bridge(expired=True)
@@ -613,7 +610,7 @@ class TestRefreshBridgeToken:
         """Test that refreshed token is written back to bridge file."""
         bridge = _make_oauth_bridge(expired=True)
         bridge_file = tmp_path / "auth.json"
-        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+        bridge_file.write_text(json.dumps(bridge_to_json_dict(bridge)))
 
         new_expires = _utcnow() + timedelta(hours=1)
         mock_tokens = MagicMock()

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -442,6 +442,21 @@ class TestWriteBridgeFile:
         loaded = json.loads(bridge_file.read_text())
         assert loaded["auth_method"] == "service_account"
 
+    def test_write_handles_chmod_failure(self, tmp_path: Path) -> None:
+        """Test that write succeeds even if chmod raises OSError."""
+        bridge = _make_oauth_bridge()
+        bridge_file = tmp_path / "mixpanel" / "auth.json"
+
+        with patch(
+            "mixpanel_data._internal.auth.bridge.os.chmod",
+            side_effect=OSError("permission denied"),
+        ):
+            write_bridge_file(bridge, bridge_file)
+
+        assert bridge_file.exists()
+        loaded = json.loads(bridge_file.read_text())
+        assert loaded["auth_method"] == "oauth"
+
 
 class TestBridgeToCredentials:
     """Tests for bridge_to_credentials() conversion."""

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -310,10 +310,11 @@ class TestFindBridgeFile:
             assert result == auth_file
 
     def test_cowork_mount_path(self, tmp_path: Path) -> None:
-        """Test finding bridge file at ~/mnt/.claude/mixpanel/auth.json."""
-        mnt_dir = tmp_path / "mnt" / ".claude" / "mixpanel"
-        mnt_dir.mkdir(parents=True)
-        auth_file = mnt_dir / "auth.json"
+        """Test finding bridge file at ~/mnt/{folder}/mixpanel_auth.json."""
+        # Simulate Cowork mount: ~/mnt/workspace/mixpanel_auth.json
+        workspace_dir = tmp_path / "mnt" / "my-project"
+        workspace_dir.mkdir(parents=True)
+        auth_file = workspace_dir / "mixpanel_auth.json"
         auth_file.write_text("{}")
 
         with (
@@ -323,19 +324,22 @@ class TestFindBridgeFile:
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
             patch("pathlib.Path.home", return_value=tmp_path),
+            patch("pathlib.Path.cwd", return_value=tmp_path / "fakecwd"),
         ):
             os.environ.pop("MP_AUTH_FILE", None)
             result = find_bridge_file()
             assert result == auth_file
 
-    def test_no_bridge_file_returns_none(self) -> None:
+    def test_no_bridge_file_returns_none(self, tmp_path: Path) -> None:
         """Test returns None when no bridge file exists."""
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
                 "mixpanel_data._internal.auth.bridge._default_bridge_path",
-                return_value=Path("/nonexistent/.claude/mixpanel/auth.json"),
+                return_value=tmp_path / "nonexistent" / "auth.json",
             ),
+            patch("pathlib.Path.home", return_value=tmp_path / "fakehome"),
+            patch("pathlib.Path.cwd", return_value=tmp_path / "fakecwd"),
         ):
             os.environ.pop("MP_AUTH_FILE", None)
             result = find_bridge_file()

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -309,6 +309,25 @@ class TestFindBridgeFile:
             result = find_bridge_file()
             assert result == auth_file
 
+    def test_cowork_mount_path(self, tmp_path: Path) -> None:
+        """Test finding bridge file at ~/mnt/.claude/mixpanel/auth.json."""
+        mnt_dir = tmp_path / "mnt" / ".claude" / "mixpanel"
+        mnt_dir.mkdir(parents=True)
+        auth_file = mnt_dir / "auth.json"
+        auth_file.write_text("{}")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=tmp_path / "nonexistent" / "auth.json",
+            ),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            os.environ.pop("MP_AUTH_FILE", None)
+            result = find_bridge_file()
+            assert result == auth_file
+
     def test_no_bridge_file_returns_none(self) -> None:
         """Test returns None when no bridge file exists."""
         with (
@@ -367,10 +386,18 @@ class TestLoadBridgeFile:
         result = load_bridge_file(Path("/nonexistent/auth.json"))
         assert result is None
 
-    def test_load_none_path_returns_none(self) -> None:
-        """Test loading with None path returns None."""
-        result = load_bridge_file(None)
-        assert result is None
+    def test_load_none_path_returns_none(self, tmp_path: Path) -> None:
+        """Test loading with None path and no bridge file returns None."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=tmp_path / "nonexistent" / "auth.json",
+            ),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            result = load_bridge_file(None)
+            assert result is None
 
     def test_load_invalid_json_returns_none(self, tmp_path: Path) -> None:
         """Test loading invalid JSON returns None."""

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -1,0 +1,641 @@
+"""Unit tests for auth bridge module (Cowork credential bridge).
+
+Tests the AuthBridgeFile model, Cowork detection, bridge file discovery,
+credential conversion, custom header application, and token refresh.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from mixpanel_data._internal.auth.bridge import (
+    AuthBridgeFile,
+    BridgeCustomHeader,
+    BridgeOAuth,
+    BridgeServiceAccount,
+    apply_bridge_custom_header,
+    bridge_to_credentials,
+    bridge_to_resolved_session,
+    detect_cowork,
+    find_bridge_file,
+    load_bridge_file,
+    refresh_bridge_token,
+    write_bridge_file,
+)
+from mixpanel_data._internal.auth_credential import CredentialType
+from mixpanel_data._internal.config import AuthMethod
+
+
+def _utcnow() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+def _make_oauth_bridge(
+    *,
+    expired: bool = False,
+    with_custom_header: bool = False,
+    workspace_id: int | None = 67890,
+) -> AuthBridgeFile:
+    """Create an OAuth AuthBridgeFile for testing.
+
+    Args:
+        expired: If True, set token expiry in the past.
+        with_custom_header: If True, include a custom header.
+        workspace_id: Optional workspace ID.
+
+    Returns:
+        Configured AuthBridgeFile instance.
+    """
+    if expired:
+        expires_at = _utcnow() - timedelta(hours=1)
+    else:
+        expires_at = _utcnow() + timedelta(hours=1)
+
+    custom_header = None
+    if with_custom_header:
+        custom_header = BridgeCustomHeader(
+            name="X-Test-Header",
+            value=SecretStr("test-header-value"),
+        )
+
+    return AuthBridgeFile(
+        version=1,
+        auth_method="oauth",
+        region="us",
+        project_id="12345",
+        workspace_id=workspace_id,
+        custom_header=custom_header,
+        oauth=BridgeOAuth(
+            access_token=SecretStr("access_abc123"),
+            refresh_token=SecretStr("refresh_xyz789"),
+            expires_at=expires_at,
+            scope="projects analysis events",
+            token_type="Bearer",
+            client_id="client_123",
+        ),
+    )
+
+
+def _make_sa_bridge(
+    *,
+    with_custom_header: bool = False,
+) -> AuthBridgeFile:
+    """Create a service account AuthBridgeFile for testing.
+
+    Args:
+        with_custom_header: If True, include a custom header.
+
+    Returns:
+        Configured AuthBridgeFile instance.
+    """
+    custom_header = None
+    if with_custom_header:
+        custom_header = BridgeCustomHeader(
+            name="X-Test-Header",
+            value=SecretStr("test-header-value"),
+        )
+
+    return AuthBridgeFile(
+        version=1,
+        auth_method="service_account",
+        region="eu",
+        project_id="67890",
+        workspace_id=None,
+        custom_header=custom_header,
+        service_account=BridgeServiceAccount(
+            username="sa-user.abc.mp-service-account",
+            secret=SecretStr("sa-secret-value"),
+        ),
+    )
+
+
+def _bridge_to_dict(bridge: AuthBridgeFile) -> dict[str, Any]:
+    """Serialize an AuthBridgeFile to a JSON-compatible dict.
+
+    Args:
+        bridge: The bridge file to serialize.
+
+    Returns:
+        JSON-serializable dictionary.
+    """
+    d: dict[str, Any] = {
+        "version": bridge.version,
+        "auth_method": bridge.auth_method,
+        "region": bridge.region,
+        "project_id": bridge.project_id,
+        "workspace_id": bridge.workspace_id,
+        "custom_header": None,
+        "oauth": None,
+        "service_account": None,
+    }
+    if bridge.custom_header is not None:
+        d["custom_header"] = {
+            "name": bridge.custom_header.name,
+            "value": bridge.custom_header.value.get_secret_value(),
+        }
+    if bridge.oauth is not None:
+        d["oauth"] = {
+            "access_token": bridge.oauth.access_token.get_secret_value(),
+            "refresh_token": bridge.oauth.refresh_token.get_secret_value()
+            if bridge.oauth.refresh_token
+            else None,
+            "expires_at": bridge.oauth.expires_at.isoformat(),
+            "scope": bridge.oauth.scope,
+            "token_type": bridge.oauth.token_type,
+            "client_id": bridge.oauth.client_id,
+        }
+    if bridge.service_account is not None:
+        d["service_account"] = {
+            "username": bridge.service_account.username,
+            "secret": bridge.service_account.secret.get_secret_value(),
+        }
+    return d
+
+
+class TestAuthBridgeFileModel:
+    """Tests for AuthBridgeFile Pydantic model validation."""
+
+    def test_valid_oauth_bridge(self) -> None:
+        """Test creating a valid OAuth bridge file."""
+        bridge = _make_oauth_bridge()
+        assert bridge.auth_method == "oauth"
+        assert bridge.region == "us"
+        assert bridge.project_id == "12345"
+        assert bridge.workspace_id == 67890
+        assert bridge.oauth is not None
+        assert bridge.service_account is None
+
+    def test_valid_sa_bridge(self) -> None:
+        """Test creating a valid service account bridge file."""
+        bridge = _make_sa_bridge()
+        assert bridge.auth_method == "service_account"
+        assert bridge.region == "eu"
+        assert bridge.project_id == "67890"
+        assert bridge.service_account is not None
+        assert bridge.oauth is None
+
+    def test_with_custom_header(self) -> None:
+        """Test bridge file with custom header."""
+        bridge = _make_oauth_bridge(with_custom_header=True)
+        assert bridge.custom_header is not None
+        assert bridge.custom_header.name == "X-Test-Header"
+        assert bridge.custom_header.value.get_secret_value() == "test-header-value"
+
+    def test_without_workspace_id(self) -> None:
+        """Test bridge file without workspace_id."""
+        bridge = _make_oauth_bridge(workspace_id=None)
+        assert bridge.workspace_id is None
+
+    def test_invalid_region(self) -> None:
+        """Test that invalid region is rejected."""
+        with pytest.raises((ValueError, ValidationError)):
+            AuthBridgeFile(
+                version=1,
+                auth_method="oauth",
+                region="invalid",
+                project_id="123",
+                oauth=BridgeOAuth(
+                    access_token=SecretStr("token"),
+                    refresh_token=None,
+                    expires_at=_utcnow() + timedelta(hours=1),
+                    scope="projects",
+                    token_type="Bearer",
+                    client_id="client_1",
+                ),
+            )
+
+    def test_invalid_auth_method(self) -> None:
+        """Test that invalid auth_method is rejected."""
+        with pytest.raises((ValueError, ValidationError)):
+            AuthBridgeFile(
+                version=1,
+                auth_method="invalid",
+                region="us",
+                project_id="123",
+            )
+
+    def test_version_must_be_1(self) -> None:
+        """Test that version must be 1."""
+        with pytest.raises((ValueError, ValidationError)):
+            _bridge = AuthBridgeFile(
+                version=2,
+                auth_method="oauth",
+                region="us",
+                project_id="123",
+                oauth=BridgeOAuth(
+                    access_token=SecretStr("token"),
+                    refresh_token=None,
+                    expires_at=_utcnow() + timedelta(hours=1),
+                    scope="projects",
+                    token_type="Bearer",
+                    client_id="client_1",
+                ),
+            )
+
+
+class TestDetectCowork:
+    """Tests for detect_cowork() function."""
+
+    def test_detects_cowork_via_sessions_dir(self, tmp_path: Path) -> None:
+        """Test detection via /sessions/ directory."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        with patch(
+            "mixpanel_data._internal.auth.bridge._COWORK_SESSIONS_PATH",
+            sessions_dir,
+        ):
+            assert detect_cowork() is True
+
+    def test_detects_cowork_via_env_var(self) -> None:
+        """Test detection via CLAUDE_COWORK env var."""
+        with patch.dict(os.environ, {"CLAUDE_COWORK": "1"}):
+            assert detect_cowork() is True
+
+    def test_not_cowork_when_neither(self) -> None:
+        """Test returns False when not in Cowork."""
+        with (
+            patch(
+                "mixpanel_data._internal.auth.bridge._COWORK_SESSIONS_PATH",
+                Path("/nonexistent/sessions"),
+            ),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            # Remove CLAUDE_COWORK if present
+            os.environ.pop("CLAUDE_COWORK", None)
+            assert detect_cowork() is False
+
+
+class TestFindBridgeFile:
+    """Tests for find_bridge_file() function."""
+
+    def test_explicit_mp_auth_file_env_var(self, tmp_path: Path) -> None:
+        """Test MP_AUTH_FILE env var takes highest priority."""
+        auth_file = tmp_path / "custom_auth.json"
+        auth_file.write_text("{}")
+        with patch.dict(os.environ, {"MP_AUTH_FILE": str(auth_file)}):
+            result = find_bridge_file()
+            assert result == auth_file
+
+    def test_mp_auth_file_missing_returns_none(self, tmp_path: Path) -> None:
+        """Test MP_AUTH_FILE pointing to nonexistent file returns None."""
+        with patch.dict(os.environ, {"MP_AUTH_FILE": str(tmp_path / "nope.json")}):
+            result = find_bridge_file()
+            assert result is None
+
+    def test_default_claude_dir(self, tmp_path: Path) -> None:
+        """Test finding bridge file at ~/.claude/mixpanel/auth.json."""
+        bridge_dir = tmp_path / ".claude" / "mixpanel"
+        bridge_dir.mkdir(parents=True)
+        auth_file = bridge_dir / "auth.json"
+        auth_file.write_text("{}")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=auth_file,
+            ),
+        ):
+            os.environ.pop("MP_AUTH_FILE", None)
+            result = find_bridge_file()
+            assert result == auth_file
+
+    def test_no_bridge_file_returns_none(self) -> None:
+        """Test returns None when no bridge file exists."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=Path("/nonexistent/.claude/mixpanel/auth.json"),
+            ),
+        ):
+            os.environ.pop("MP_AUTH_FILE", None)
+            result = find_bridge_file()
+            assert result is None
+
+
+class TestLoadBridgeFile:
+    """Tests for load_bridge_file() function."""
+
+    def test_load_valid_oauth_bridge(self, tmp_path: Path) -> None:
+        """Test loading a valid OAuth bridge file."""
+        bridge = _make_oauth_bridge()
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+
+        loaded = load_bridge_file(bridge_file)
+        assert loaded is not None
+        assert loaded.auth_method == "oauth"
+        assert loaded.project_id == "12345"
+        assert loaded.oauth is not None
+        assert loaded.oauth.access_token.get_secret_value() == "access_abc123"
+
+    def test_load_valid_sa_bridge(self, tmp_path: Path) -> None:
+        """Test loading a valid service account bridge file."""
+        bridge = _make_sa_bridge()
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+
+        loaded = load_bridge_file(bridge_file)
+        assert loaded is not None
+        assert loaded.auth_method == "service_account"
+        assert loaded.service_account is not None
+        assert loaded.service_account.username == "sa-user.abc.mp-service-account"
+
+    def test_load_with_custom_header(self, tmp_path: Path) -> None:
+        """Test loading bridge file with custom header."""
+        bridge = _make_oauth_bridge(with_custom_header=True)
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+
+        loaded = load_bridge_file(bridge_file)
+        assert loaded is not None
+        assert loaded.custom_header is not None
+        assert loaded.custom_header.name == "X-Test-Header"
+
+    def test_load_nonexistent_returns_none(self) -> None:
+        """Test loading nonexistent file returns None."""
+        result = load_bridge_file(Path("/nonexistent/auth.json"))
+        assert result is None
+
+    def test_load_none_path_returns_none(self) -> None:
+        """Test loading with None path returns None."""
+        result = load_bridge_file(None)
+        assert result is None
+
+    def test_load_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        """Test loading invalid JSON returns None."""
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text("not json")
+
+        result = load_bridge_file(bridge_file)
+        assert result is None
+
+    def test_load_invalid_schema_returns_none(self, tmp_path: Path) -> None:
+        """Test loading valid JSON with invalid schema returns None."""
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text(json.dumps({"version": 1, "bad": "data"}))
+
+        result = load_bridge_file(bridge_file)
+        assert result is None
+
+
+class TestWriteBridgeFile:
+    """Tests for write_bridge_file() function."""
+
+    def test_write_creates_file(self, tmp_path: Path) -> None:
+        """Test writing a bridge file creates the file."""
+        bridge = _make_oauth_bridge()
+        bridge_file = tmp_path / "mixpanel" / "auth.json"
+
+        write_bridge_file(bridge, bridge_file)
+
+        assert bridge_file.exists()
+        loaded = json.loads(bridge_file.read_text())
+        assert loaded["auth_method"] == "oauth"
+        assert loaded["project_id"] == "12345"
+
+    def test_write_sets_directory_permissions(self, tmp_path: Path) -> None:
+        """Test that directory permissions are set to 0o700."""
+        bridge = _make_oauth_bridge()
+        bridge_dir = tmp_path / "mixpanel"
+        bridge_file = bridge_dir / "auth.json"
+
+        write_bridge_file(bridge, bridge_file)
+
+        dir_mode = bridge_dir.stat().st_mode & 0o777
+        assert dir_mode == 0o700
+
+    def test_write_sets_file_permissions(self, tmp_path: Path) -> None:
+        """Test that file permissions are set to 0o600."""
+        bridge = _make_oauth_bridge()
+        bridge_file = tmp_path / "auth.json"
+
+        write_bridge_file(bridge, bridge_file)
+
+        file_mode = bridge_file.stat().st_mode & 0o777
+        assert file_mode == 0o600
+
+    def test_write_overwrites_existing(self, tmp_path: Path) -> None:
+        """Test writing overwrites an existing bridge file."""
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text('{"old": "data"}')
+
+        bridge = _make_sa_bridge()
+        write_bridge_file(bridge, bridge_file)
+
+        loaded = json.loads(bridge_file.read_text())
+        assert loaded["auth_method"] == "service_account"
+
+
+class TestBridgeToCredentials:
+    """Tests for bridge_to_credentials() conversion."""
+
+    def test_oauth_bridge_to_credentials(self) -> None:
+        """Test converting OAuth bridge to Credentials."""
+        bridge = _make_oauth_bridge()
+        creds = bridge_to_credentials(bridge)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "12345"
+        assert creds.region == "us"
+        assert creds.oauth_access_token is not None
+        assert creds.oauth_access_token.get_secret_value() == "access_abc123"
+
+    def test_sa_bridge_to_credentials(self) -> None:
+        """Test converting service account bridge to Credentials."""
+        bridge = _make_sa_bridge()
+        creds = bridge_to_credentials(bridge)
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.project_id == "67890"
+        assert creds.region == "eu"
+        assert creds.username == "sa-user.abc.mp-service-account"
+        assert creds.secret.get_secret_value() == "sa-secret-value"
+
+    def test_oauth_credentials_auth_header(self) -> None:
+        """Test that OAuth credentials produce correct auth header."""
+        bridge = _make_oauth_bridge()
+        creds = bridge_to_credentials(bridge)
+
+        assert creds.auth_header() == "Bearer access_abc123"
+
+    def test_sa_credentials_auth_header(self) -> None:
+        """Test that SA credentials produce correct auth header."""
+        bridge = _make_sa_bridge()
+        creds = bridge_to_credentials(bridge)
+
+        assert creds.auth_header().startswith("Basic ")
+
+
+class TestBridgeToResolvedSession:
+    """Tests for bridge_to_resolved_session() conversion."""
+
+    def test_oauth_with_workspace(self) -> None:
+        """Test converting OAuth bridge with workspace to ResolvedSession."""
+        bridge = _make_oauth_bridge(workspace_id=67890)
+        session = bridge_to_resolved_session(bridge)
+
+        assert session.project_id == "12345"
+        assert session.region == "us"
+        assert session.workspace_id == 67890
+        assert session.auth.type == CredentialType.oauth
+
+    def test_sa_without_workspace(self) -> None:
+        """Test converting SA bridge without workspace to ResolvedSession."""
+        bridge = _make_sa_bridge()
+        session = bridge_to_resolved_session(bridge)
+
+        assert session.project_id == "67890"
+        assert session.region == "eu"
+        assert session.workspace_id is None
+        assert session.auth.type == CredentialType.service_account
+
+    def test_session_auth_header(self) -> None:
+        """Test that session produces correct auth header."""
+        bridge = _make_oauth_bridge()
+        session = bridge_to_resolved_session(bridge)
+
+        assert session.auth_header() == "Bearer access_abc123"
+
+
+class TestApplyBridgeCustomHeader:
+    """Tests for apply_bridge_custom_header() function."""
+
+    def test_sets_env_vars_when_header_present(self) -> None:
+        """Test that custom header sets MP_CUSTOM_HEADER_* env vars."""
+        bridge = _make_oauth_bridge(with_custom_header=True)
+
+        with patch.dict(os.environ, {}, clear=True):
+            apply_bridge_custom_header(bridge)
+            assert os.environ.get("MP_CUSTOM_HEADER_NAME") == "X-Test-Header"
+            assert os.environ.get("MP_CUSTOM_HEADER_VALUE") == "test-header-value"
+
+    def test_does_not_override_existing_env_vars(self) -> None:
+        """Test that existing env vars are not overridden."""
+        bridge = _make_oauth_bridge(with_custom_header=True)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MP_CUSTOM_HEADER_NAME": "X-Existing",
+                "MP_CUSTOM_HEADER_VALUE": "existing-value",
+            },
+        ):
+            apply_bridge_custom_header(bridge)
+            assert os.environ["MP_CUSTOM_HEADER_NAME"] == "X-Existing"
+            assert os.environ["MP_CUSTOM_HEADER_VALUE"] == "existing-value"
+
+    def test_noop_when_no_custom_header(self) -> None:
+        """Test that nothing happens when no custom header in bridge."""
+        bridge = _make_oauth_bridge(with_custom_header=False)
+
+        with patch.dict(os.environ, {}, clear=True):
+            apply_bridge_custom_header(bridge)
+            assert "MP_CUSTOM_HEADER_NAME" not in os.environ
+            assert "MP_CUSTOM_HEADER_VALUE" not in os.environ
+
+
+class TestRefreshBridgeToken:
+    """Tests for refresh_bridge_token() function."""
+
+    def test_returns_same_bridge_if_not_expired(self) -> None:
+        """Test that non-expired bridge is returned unchanged."""
+        bridge = _make_oauth_bridge(expired=False)
+
+        result = refresh_bridge_token(bridge, Path("/dummy"))
+        assert result is bridge  # Same object, no refresh needed
+
+    def test_refreshes_expired_token(self) -> None:
+        """Test that expired OAuth token is refreshed."""
+        bridge = _make_oauth_bridge(expired=True)
+        new_expires = _utcnow() + timedelta(hours=1)
+
+        mock_tokens = MagicMock()
+        mock_tokens.access_token = SecretStr("new_access_token")
+        mock_tokens.refresh_token = SecretStr("new_refresh_token")
+        mock_tokens.expires_at = new_expires
+        mock_tokens.scope = "projects analysis events"
+        mock_tokens.token_type = "Bearer"
+
+        with patch("mixpanel_data._internal.auth.bridge.OAuthFlow") as mock_flow_cls:
+            mock_flow = mock_flow_cls.return_value
+            mock_flow.refresh_tokens.return_value = mock_tokens
+
+            result = refresh_bridge_token(bridge, Path("/dummy"))
+
+            assert result is not bridge
+            assert result.oauth is not None
+            assert result.oauth.access_token.get_secret_value() == "new_access_token"
+            mock_flow.refresh_tokens.assert_called_once()
+
+    def test_refresh_writes_back_if_writable(self, tmp_path: Path) -> None:
+        """Test that refreshed token is written back to bridge file."""
+        bridge = _make_oauth_bridge(expired=True)
+        bridge_file = tmp_path / "auth.json"
+        bridge_file.write_text(json.dumps(_bridge_to_dict(bridge)))
+
+        new_expires = _utcnow() + timedelta(hours=1)
+        mock_tokens = MagicMock()
+        mock_tokens.access_token = SecretStr("new_access")
+        mock_tokens.refresh_token = SecretStr("new_refresh")
+        mock_tokens.expires_at = new_expires
+        mock_tokens.scope = "projects"
+        mock_tokens.token_type = "Bearer"
+
+        with patch("mixpanel_data._internal.auth.bridge.OAuthFlow") as mock_flow_cls:
+            mock_flow = mock_flow_cls.return_value
+            mock_flow.refresh_tokens.return_value = mock_tokens
+
+            refresh_bridge_token(bridge, bridge_file)
+
+        # Verify the file was updated
+        updated = json.loads(bridge_file.read_text())
+        assert updated["oauth"]["access_token"] == "new_access"
+
+    def test_refresh_ignores_write_errors(self) -> None:
+        """Test that write errors during refresh are silently ignored."""
+        bridge = _make_oauth_bridge(expired=True)
+
+        mock_tokens = MagicMock()
+        mock_tokens.access_token = SecretStr("new_access")
+        mock_tokens.refresh_token = SecretStr("new_refresh")
+        mock_tokens.expires_at = _utcnow() + timedelta(hours=1)
+        mock_tokens.scope = "projects"
+        mock_tokens.token_type = "Bearer"
+
+        with patch("mixpanel_data._internal.auth.bridge.OAuthFlow") as mock_flow_cls:
+            mock_flow = mock_flow_cls.return_value
+            mock_flow.refresh_tokens.return_value = mock_tokens
+
+            # Pass a read-only path — should not raise
+            result = refresh_bridge_token(bridge, Path("/read-only/auth.json"))
+            assert result.oauth is not None
+            assert result.oauth.access_token.get_secret_value() == "new_access"
+
+    def test_returns_original_on_refresh_failure(self) -> None:
+        """Test that original bridge is returned if refresh fails."""
+        bridge = _make_oauth_bridge(expired=True)
+
+        with patch("mixpanel_data._internal.auth.bridge.OAuthFlow") as mock_flow_cls:
+            mock_flow = mock_flow_cls.return_value
+            mock_flow.refresh_tokens.side_effect = Exception("refresh failed")
+
+            with pytest.raises(Exception, match="refresh failed"):
+                refresh_bridge_token(bridge, Path("/dummy"))
+
+    def test_sa_bridge_returns_unchanged(self) -> None:
+        """Test that SA bridge is returned unchanged (no refresh needed)."""
+        bridge = _make_sa_bridge()
+
+        result = refresh_bridge_token(bridge, Path("/dummy"))
+        assert result is bridge

--- a/tests/unit/test_auth_bridge.py
+++ b/tests/unit/test_auth_bridge.py
@@ -410,8 +410,8 @@ class TestWriteBridgeFile:
         assert loaded["auth_method"] == "oauth"
         assert loaded["project_id"] == "12345"
 
-    def test_write_sets_directory_permissions(self, tmp_path: Path) -> None:
-        """Test that directory permissions are set to 0o700."""
+    def test_write_sets_directory_permissions_on_new_dir(self, tmp_path: Path) -> None:
+        """Test that directory permissions are set to 0o700 for newly created dirs."""
         bridge = _make_oauth_bridge()
         bridge_dir = tmp_path / "mixpanel"
         bridge_file = bridge_dir / "auth.json"
@@ -420,6 +420,21 @@ class TestWriteBridgeFile:
 
         dir_mode = bridge_dir.stat().st_mode & 0o777
         assert dir_mode == 0o700
+
+    def test_write_preserves_existing_directory_permissions(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that existing directory permissions are not changed."""
+        bridge = _make_oauth_bridge()
+        # Create directory with broader permissions before writing
+        existing_dir = tmp_path / "workspace"
+        existing_dir.mkdir(mode=0o755)
+        bridge_file = existing_dir / "mixpanel_auth.json"
+
+        write_bridge_file(bridge, bridge_file)
+
+        dir_mode = existing_dir.stat().st_mode & 0o777
+        assert dir_mode == 0o755  # Permissions unchanged
 
     def test_write_sets_file_permissions(self, tmp_path: Path) -> None:
         """Test that file permissions are set to 0o600."""

--- a/tests/unit/test_config_bridge_resolution.py
+++ b/tests/unit/test_config_bridge_resolution.py
@@ -316,6 +316,195 @@ class TestBridgeInResolveSession:
         assert session.project_id == "config-project"  # config wins
 
 
+class TestBridgeExpiredOAuthRefresh:
+    """Tests for expired OAuth bridge token refresh in _load_and_refresh_bridge."""
+
+    def test_bridge_expired_oauth_refreshes_successfully(self, tmp_path: Path) -> None:
+        """Test that an expired bridge token is refreshed and used."""
+        from pydantic import SecretStr
+
+        from mixpanel_data._internal.auth.bridge import AuthBridgeFile, BridgeOAuth
+
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir, expired=True)
+
+        refreshed_bridge = AuthBridgeFile(
+            version=1,
+            auth_method="oauth",
+            region="us",
+            project_id="bridge-project",
+            workspace_id=99999,
+            oauth=BridgeOAuth(
+                access_token=SecretStr("refreshed-access-token"),
+                refresh_token=SecretStr("bridge-refresh-token"),
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                scope="projects analysis",
+                token_type="Bearer",
+                client_id="bridge-client-id",
+            ),
+        )
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(
+                os.environ,
+                {"MP_AUTH_FILE": str(bridge_file)},
+                clear=True,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.bridge.refresh_bridge_token",
+                return_value=refreshed_bridge,
+            ) as mock_refresh,
+        ):
+            session = cm.resolve_session()
+
+        mock_refresh.assert_called_once()
+        assert session.auth_header() == "Bearer refreshed-access-token"
+        assert session.project_id == "bridge-project"
+
+    def test_bridge_expired_oauth_refresh_fails_falls_through(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that refresh failure causes fallthrough to config."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir, expired=True)
+
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(
+                os.environ,
+                {"MP_AUTH_FILE": str(bridge_file)},
+                clear=True,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.bridge.refresh_bridge_token",
+                side_effect=RuntimeError("network error"),
+            ),
+        ):
+            session = cm.resolve_session(_oauth_storage_dir=empty_oauth)
+
+        # Falls through to config
+        assert session.project_id == "config-project"
+
+    def test_bridge_expired_oauth_no_refresh_token_falls_through(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that OAuthError from missing refresh token causes fallthrough."""
+        from mixpanel_data.exceptions import OAuthError
+
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir, expired=True)
+
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(
+                os.environ,
+                {"MP_AUTH_FILE": str(bridge_file)},
+                clear=True,
+            ),
+            patch(
+                "mixpanel_data._internal.auth.bridge.refresh_bridge_token",
+                side_effect=OAuthError("No refresh token", code="OAUTH_REFRESH_ERROR"),
+            ),
+        ):
+            session = cm.resolve_session(_oauth_storage_dir=empty_oauth)
+
+        # Falls through to config
+        assert session.project_id == "config-project"
+
+
+class TestBridgeGating:
+    """Tests that bridge resolution is gated to Cowork/MP_AUTH_FILE."""
+
+    def test_bridge_skipped_on_host_without_mp_auth_file(self, tmp_path: Path) -> None:
+        """Test that bridge file on host is ignored without MP_AUTH_FILE or Cowork."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        # Create a bridge file at the default location
+        bridge_dir = tmp_path / ".claude" / "mixpanel"
+        _write_bridge_file(bridge_dir)
+
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
+                return_value=bridge_dir / "auth.json",
+            ),
+            # Not in Cowork — detect_cowork() returns False
+            patch(
+                "mixpanel_data._internal.auth.bridge._COWORK_SESSIONS_PATH",
+                Path("/nonexistent/sessions"),
+            ),
+        ):
+            # Bridge file exists but should be skipped on host
+            session = cm.resolve_session(_oauth_storage_dir=empty_oauth)
+
+        # Should fall through to config, not bridge
+        assert session.project_id == "config-project"
+
+    def test_bridge_used_when_mp_auth_file_set(self, tmp_path: Path) -> None:
+        """Test that bridge file IS used when MP_AUTH_FILE is explicitly set."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            session = cm.resolve_session()
+
+        assert session.project_id == "bridge-project"
+
+    def test_bridge_used_when_in_cowork(self, tmp_path: Path) -> None:
+        """Test that bridge file IS used when running inside Cowork VM."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        # Create bridge at default location
+        bridge_dir = tmp_path / ".claude" / "mixpanel"
+        _write_bridge_file(bridge_dir)
+
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(os.environ, {"CLAUDE_COWORK": "1"}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
+                return_value=bridge_dir / "auth.json",
+            ),
+        ):
+            session = cm.resolve_session(_oauth_storage_dir=empty_oauth)
+
+        assert session.project_id == "bridge-project"
+
+
 class TestBridgeNoFile:
     """Tests that resolution falls through when no bridge file exists."""
 

--- a/tests/unit/test_config_bridge_resolution.py
+++ b/tests/unit/test_config_bridge_resolution.py
@@ -332,7 +332,7 @@ class TestBridgeNoFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
         ):
@@ -354,7 +354,7 @@ class TestBridgeNoFile:
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
-                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                "mixpanel_data._internal.auth.bridge.default_bridge_path",
                 return_value=tmp_path / "nonexistent" / "auth.json",
             ),
         ):

--- a/tests/unit/test_config_bridge_resolution.py
+++ b/tests/unit/test_config_bridge_resolution.py
@@ -1,0 +1,363 @@
+"""Unit tests for bridge file credential resolution in ConfigManager.
+
+Tests the integration of auth bridge files into the credential
+resolution chain in ConfigManager.resolve_credentials() and
+resolve_session().
+
+Verifies:
+- Resolution order: env vars > bridge > OAuth > config
+- Bridge file is skipped when explicit account/credential requested
+- Bridge with expired OAuth token triggers refresh
+- Bridge custom headers are applied to env vars
+- resolve_session() applies project/workspace overrides from bridge
+"""
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from mixpanel_data._internal.config import (
+    AuthMethod,
+    ConfigManager,
+)
+
+
+def _write_v1_config(config_path: Path) -> None:
+    """Write a minimal v1 config file for testing.
+
+    Args:
+        config_path: Path to write the config file.
+    """
+    import tomli_w
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config: dict[str, Any] = {
+        "default": "test-account",
+        "accounts": {
+            "test-account": {
+                "username": "sa-config-user",
+                "secret": "sa-config-secret",
+                "project_id": "config-project",
+                "region": "us",
+            }
+        },
+    }
+    config_path.write_bytes(tomli_w.dumps(config).encode())
+
+
+def _write_bridge_file(
+    bridge_dir: Path,
+    *,
+    auth_method: str = "oauth",
+    expired: bool = False,
+    with_custom_header: bool = False,
+) -> Path:
+    """Write a bridge file for testing.
+
+    Args:
+        bridge_dir: Directory to write auth.json in.
+        auth_method: Auth method ('oauth' or 'service_account').
+        expired: If True, create an expired token.
+        with_custom_header: If True, include a custom header.
+
+    Returns:
+        Path to the written bridge file.
+    """
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    bridge_file = bridge_dir / "auth.json"
+
+    if expired:
+        expires_at = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    else:
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+
+    data: dict[str, Any] = {
+        "version": 1,
+        "auth_method": auth_method,
+        "region": "us",
+        "project_id": "bridge-project",
+        "workspace_id": 99999,
+        "custom_header": None,
+        "oauth": None,
+        "service_account": None,
+    }
+
+    if with_custom_header:
+        data["custom_header"] = {
+            "name": "X-Bridge-Header",
+            "value": "bridge-header-value",
+        }
+
+    if auth_method == "oauth":
+        data["oauth"] = {
+            "access_token": "bridge-access-token",
+            "refresh_token": "bridge-refresh-token",
+            "expires_at": expires_at,
+            "scope": "projects analysis",
+            "token_type": "Bearer",
+            "client_id": "bridge-client-id",
+        }
+    else:
+        data["service_account"] = {
+            "username": "sa-bridge-user",
+            "secret": "sa-bridge-secret",
+        }
+
+    bridge_file.write_text(json.dumps(data))
+    return bridge_file
+
+
+class TestBridgeInResolveCredentials:
+    """Tests for bridge resolution in resolve_credentials()."""
+
+    def test_bridge_resolves_oauth_credentials(self, tmp_path: Path) -> None:
+        """Test that bridge file resolves OAuth credentials."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            creds = cm.resolve_credentials()
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "bridge-project"
+        assert creds.oauth_access_token is not None
+        assert creds.oauth_access_token.get_secret_value() == "bridge-access-token"
+
+    def test_bridge_resolves_sa_credentials(self, tmp_path: Path) -> None:
+        """Test that bridge file resolves service account credentials."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir, auth_method="service_account")
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            creds = cm.resolve_credentials()
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.project_id == "bridge-project"
+        assert creds.username == "sa-bridge-user"
+
+    def test_env_vars_beat_bridge(self, tmp_path: Path) -> None:
+        """Test that env vars take priority over bridge file."""
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=tmp_path / "config.toml")
+        with patch.dict(
+            os.environ,
+            {
+                "MP_AUTH_FILE": str(bridge_file),
+                "MP_USERNAME": "env-user",
+                "MP_SECRET": "env-secret",
+                "MP_PROJECT_ID": "env-project",
+                "MP_REGION": "us",
+            },
+        ):
+            creds = cm.resolve_credentials()
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.project_id == "env-project"
+        assert creds.username == "env-user"
+
+    def test_bridge_beats_config(self, tmp_path: Path) -> None:
+        """Test that bridge file beats config file."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            creds = cm.resolve_credentials()
+
+        assert creds.project_id == "bridge-project"  # bridge wins
+        assert creds.project_id != "config-project"
+
+    def test_bridge_skipped_when_account_specified(self, tmp_path: Path) -> None:
+        """Test that bridge is skipped when explicit account is given."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            creds = cm.resolve_credentials(account="test-account")
+
+        assert creds.project_id == "config-project"  # config wins
+        assert creds.username == "sa-config-user"
+
+    def test_bridge_applies_custom_header(self, tmp_path: Path) -> None:
+        """Test that bridge custom header sets env vars."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir, with_custom_header=True)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            cm.resolve_credentials()
+            assert os.environ.get("MP_CUSTOM_HEADER_NAME") == "X-Bridge-Header"
+            assert os.environ.get("MP_CUSTOM_HEADER_VALUE") == "bridge-header-value"
+
+
+class TestBridgeInResolveSession:
+    """Tests for bridge resolution in resolve_session()."""
+
+    def test_bridge_resolves_session(self, tmp_path: Path) -> None:
+        """Test that bridge file resolves a session."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            session = cm.resolve_session()
+
+        assert session.project_id == "bridge-project"
+        assert session.workspace_id == 99999
+        assert session.auth_header() == "Bearer bridge-access-token"
+
+    def test_session_overrides_project_id(self, tmp_path: Path) -> None:
+        """Test that explicit project_id overrides bridge value."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            session = cm.resolve_session(project_id="override-project")
+
+        assert session.project_id == "override-project"
+        assert session.workspace_id == 99999  # preserved from bridge
+
+    def test_session_overrides_workspace_id(self, tmp_path: Path) -> None:
+        """Test that explicit workspace_id overrides bridge value."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            session = cm.resolve_session(workspace_id=11111)
+
+        assert session.project_id == "bridge-project"
+        assert session.workspace_id == 11111  # overridden
+
+    def test_bridge_skipped_when_credential_specified(self, tmp_path: Path) -> None:
+        """Test that bridge is skipped when explicit credential is given."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        bridge_dir = tmp_path / "bridge"
+        bridge_file = _write_bridge_file(bridge_dir)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {"MP_AUTH_FILE": str(bridge_file)},
+            clear=True,
+        ):
+            session = cm.resolve_session(credential="test-account")
+
+        assert session.project_id == "config-project"  # config wins
+
+
+class TestBridgeNoFile:
+    """Tests that resolution falls through when no bridge file exists."""
+
+    def test_falls_through_to_config(self, tmp_path: Path) -> None:
+        """Test that missing bridge file falls through to config."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        # Use empty OAuth storage dir so no real tokens interfere
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=tmp_path / "nonexistent" / "auth.json",
+            ),
+        ):
+            creds = cm.resolve_credentials(_oauth_storage_dir=empty_oauth)
+
+        assert creds.project_id == "config-project"
+        assert creds.username == "sa-config-user"
+
+    def test_session_falls_through_to_config(self, tmp_path: Path) -> None:
+        """Test that missing bridge file falls through in session resolution."""
+        config_path = tmp_path / "config.toml"
+        _write_v1_config(config_path)
+
+        # Use empty OAuth storage dir so no real tokens interfere
+        empty_oauth = tmp_path / "empty_oauth"
+        empty_oauth.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "mixpanel_data._internal.auth.bridge._default_bridge_path",
+                return_value=tmp_path / "nonexistent" / "auth.json",
+            ),
+        ):
+            session = cm.resolve_session(_oauth_storage_dir=empty_oauth)
+
+        assert session.project_id == "config-project"

--- a/tests/unit/test_config_custom_header.py
+++ b/tests/unit/test_config_custom_header.py
@@ -1,0 +1,160 @@
+"""Unit tests for custom header support in config.toml.
+
+Tests the [settings] section with custom_header_name/value
+in ConfigManager.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import tomli_w
+
+from mixpanel_data._internal.config import ConfigManager
+
+
+def _write_config_with_header(
+    config_path: Path,
+    *,
+    header_name: str = "X-Config-Header",
+    header_value: str = "config-value",
+) -> None:
+    """Write a v2 config with custom header settings.
+
+    Args:
+        config_path: Path to write the config.
+        header_name: Custom header name.
+        header_value: Custom header value.
+    """
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config: dict[str, Any] = {
+        "config_version": 2,
+        "settings": {
+            "custom_header_name": header_name,
+            "custom_header_value": header_value,
+        },
+        "credentials": {
+            "test-sa": {
+                "type": "service_account",
+                "username": "sa-user",
+                "secret": "sa-secret",
+                "region": "us",
+            }
+        },
+        "active": {
+            "credential": "test-sa",
+            "project_id": "12345",
+        },
+    }
+    config_path.write_bytes(tomli_w.dumps(config).encode())
+
+
+def _write_config_without_header(config_path: Path) -> None:
+    """Write a v2 config without custom header settings.
+
+    Args:
+        config_path: Path to write the config.
+    """
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config: dict[str, Any] = {
+        "config_version": 2,
+        "credentials": {
+            "test-sa": {
+                "type": "service_account",
+                "username": "sa-user",
+                "secret": "sa-secret",
+                "region": "us",
+            }
+        },
+        "active": {
+            "credential": "test-sa",
+            "project_id": "12345",
+        },
+    }
+    config_path.write_bytes(tomli_w.dumps(config).encode())
+
+
+class TestGetCustomHeader:
+    """Tests for ConfigManager.get_custom_header()."""
+
+    def test_returns_header_when_configured(self, tmp_path: Path) -> None:
+        """Test returning custom header from [settings]."""
+        config_path = tmp_path / "config.toml"
+        _write_config_with_header(config_path)
+
+        cm = ConfigManager(config_path=config_path)
+        header = cm.get_custom_header()
+
+        assert header is not None
+        assert header == ("X-Config-Header", "config-value")
+
+    def test_returns_none_when_not_configured(self, tmp_path: Path) -> None:
+        """Test returning None when no [settings] section."""
+        config_path = tmp_path / "config.toml"
+        _write_config_without_header(config_path)
+
+        cm = ConfigManager(config_path=config_path)
+        header = cm.get_custom_header()
+
+        assert header is None
+
+    def test_returns_none_when_partial(self, tmp_path: Path) -> None:
+        """Test returning None when only name is set."""
+        config_path = tmp_path / "config.toml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config: dict[str, Any] = {
+            "settings": {"custom_header_name": "X-Test"},
+        }
+        config_path.write_bytes(tomli_w.dumps(config).encode())
+
+        cm = ConfigManager(config_path=config_path)
+        assert cm.get_custom_header() is None
+
+    def test_returns_none_for_empty_config(self, tmp_path: Path) -> None:
+        """Test returning None when config file doesn't exist."""
+        cm = ConfigManager(config_path=tmp_path / "nonexistent.toml")
+        assert cm.get_custom_header() is None
+
+
+class TestApplyConfigCustomHeader:
+    """Tests for ConfigManager.apply_config_custom_header()."""
+
+    def test_sets_env_vars(self, tmp_path: Path) -> None:
+        """Test that custom header sets env vars."""
+        config_path = tmp_path / "config.toml"
+        _write_config_with_header(config_path)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(os.environ, {}, clear=True):
+            cm.apply_config_custom_header()
+            assert os.environ.get("MP_CUSTOM_HEADER_NAME") == "X-Config-Header"
+            assert os.environ.get("MP_CUSTOM_HEADER_VALUE") == "config-value"
+
+    def test_does_not_override_existing(self, tmp_path: Path) -> None:
+        """Test that existing env vars are preserved."""
+        config_path = tmp_path / "config.toml"
+        _write_config_with_header(config_path)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(
+            os.environ,
+            {
+                "MP_CUSTOM_HEADER_NAME": "X-Existing",
+                "MP_CUSTOM_HEADER_VALUE": "existing",
+            },
+        ):
+            cm.apply_config_custom_header()
+            assert os.environ["MP_CUSTOM_HEADER_NAME"] == "X-Existing"
+
+    def test_noop_when_no_header(self, tmp_path: Path) -> None:
+        """Test noop when no header in config."""
+        config_path = tmp_path / "config.toml"
+        _write_config_without_header(config_path)
+
+        cm = ConfigManager(config_path=config_path)
+        with patch.dict(os.environ, {}, clear=True):
+            cm.apply_config_custom_header()
+            assert "MP_CUSTOM_HEADER_NAME" not in os.environ


### PR DESCRIPTION
## Summary

- Adds credential bridge system enabling `mixpanel_data` to authenticate inside Claude Cowork VMs, where browser-based OAuth login and persistent `~/.mp/` storage are unavailable
- New CLI commands (`mp auth cowork-setup`, `cowork-status`, `cowork-teardown`) export credentials to a bridge file that the library auto-discovers inside the Cowork workspace
- Bridge supports both OAuth (with in-VM token refresh via HTTP POST — no browser needed) and service account credentials
- Plugin setup skill updated with Cowork-aware guidance — suppresses OAuth/interactive suggestions when running inside a Cowork VM

## How it works

1. On the host: `mp auth cowork-setup --credential my-sa --dir ~/my-workspace`
2. In Cowork (pointing at that workspace): `from mixpanel_data import Workspace; ws = Workspace()` — credentials auto-resolve from the bridge file
3. OAuth tokens refresh silently inside the VM when they expire

## Key files

- `src/mixpanel_data/_internal/auth/bridge.py` — Bridge models, Cowork detection, file discovery, token refresh
- `src/mixpanel_data/_internal/config.py` — Bridge integrated into credential resolution chain (env vars > bridge > OAuth > config)
- `src/mixpanel_data/cli/commands/auth.py` — `cowork-setup`, `cowork-teardown`, `cowork-status` commands
- Plugin updates: setup skill, auth command, auth_manager script

## Test plan

- [ ] 76 new unit/integration tests covering bridge models, credential resolution, CLI commands
- [ ] Manual verification: `cowork-setup` → bridge file written → `Workspace()` resolves from bridge → API calls succeed
- [ ] Tested end-to-end in actual Cowork session
- [ ] `just check` passes (lint + typecheck + 4982 tests)