### PR TITLE
fix: resolve broken auth flow for new OAuth users

### DIFF
--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -553,7 +553,9 @@ class ConfigManager:
         from mixpanel_data._internal.auth.storage import OAuthStorage
 
         # Determine region and project_id for token lookup
-        region, project_id = self._resolve_region_and_project_for_oauth()
+        region, project_id = self._resolve_region_and_project_for_oauth(
+            _oauth_storage_dir=_oauth_storage_dir,
+        )
         if region is None:
             return None
 
@@ -587,12 +589,19 @@ class ConfigManager:
 
     def _resolve_region_and_project_for_oauth(
         self,
+        *,
+        _oauth_storage_dir: Path | None = None,
     ) -> tuple[str | None, str | None]:
         """Determine region and project_id for OAuth token lookup.
 
         Checks in order:
         1. ``MP_REGION`` / ``MP_PROJECT_ID`` environment variables
         2. Default account from config file
+        3. v2 credentials and active context
+        4. Scan OAuth storage for any valid token
+
+        Args:
+            _oauth_storage_dir: Override OAuth storage directory for testing.
 
         Returns:
             Tuple of ``(region, project_id)``. Either or both may be
@@ -640,7 +649,7 @@ class ConfigManager:
         # Last resort: scan OAuth storage for any valid token
         from mixpanel_data._internal.auth.storage import OAuthStorage
 
-        storage = OAuthStorage()
+        storage = OAuthStorage(storage_dir=_oauth_storage_dir)
         for region_candidate in VALID_REGIONS:
             tokens = storage.load_tokens(region_candidate)
             if tokens is not None and not tokens.is_expired():
@@ -1682,7 +1691,8 @@ class ConfigManager:
             raise ConfigError(
                 "No project selected. "
                 "Run 'mp projects list' to see available projects, then "
-                "'mp projects switch <id>' to select one.",
+                "'mp projects switch <id>' to select one, "
+                "or pass --project for a one-off override.",
             )
 
         project = ProjectContext(

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -501,8 +501,9 @@ class ConfigManager:
         if not accounts:
             raise ConfigError(
                 "No credentials configured. "
-                "Set MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION environment variables, "
-                "or add an account with add_account()."
+                "Run 'mp auth login' to authenticate via OAuth, "
+                "or set MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION "
+                "environment variables."
             )
 
         # Determine which account to use
@@ -607,17 +608,45 @@ class ConfigManager:
         # Fall back to config file default account
         config = self._read_config()
         accounts = config.get("accounts", {})
-        if not accounts:
-            return None, None
 
-        default_name = config.get("default")
-        if default_name and isinstance(default_name, str) and default_name in accounts:
-            account_data = accounts[default_name]
-            return account_data.get("region"), account_data.get("project_id")
+        if accounts:
+            default_name = config.get("default")
+            if (
+                default_name
+                and isinstance(default_name, str)
+                and default_name in accounts
+            ):
+                account_data = accounts[default_name]
+                return account_data.get("region"), account_data.get("project_id")
 
-        # Use first account as fallback
-        first_account = next(iter(accounts.values()))
-        return first_account.get("region"), first_account.get("project_id")
+            # Use first account as fallback
+            first_account = next(iter(accounts.values()))
+            return first_account.get("region"), first_account.get("project_id")
+
+        # v2 config: check active context for project_id
+        active = config.get("active", {})
+        active_project_id = active.get("project_id")
+
+        # Check credentials for region
+        credentials = config.get("credentials", {})
+        active_cred_name = active.get("credential")
+        if active_cred_name and active_cred_name in credentials:
+            cred_data = credentials[active_cred_name]
+            return cred_data.get("region", "us"), active_project_id
+        if credentials:
+            first_cred = next(iter(credentials.values()))
+            return first_cred.get("region", "us"), active_project_id
+
+        # Last resort: scan OAuth storage for any valid token
+        from mixpanel_data._internal.auth.storage import OAuthStorage
+
+        storage = OAuthStorage()
+        for region_candidate in VALID_REGIONS:
+            tokens = storage.load_tokens(region_candidate)
+            if tokens is not None and not tokens.is_expired():
+                # Prefer token's project_id, fall back to active context
+                return region_candidate, tokens.project_id or active_project_id
+        return None, None
 
     def _load_and_refresh_bridge(self) -> AuthBridgeFile | None:
         """Load, refresh, and apply custom headers from a bridge file.
@@ -1598,7 +1627,9 @@ class ConfigManager:
         if not cred_name or cred_name not in credentials:
             raise ConfigError(
                 "No credentials configured. "
-                "Add a credential with add_credential() or set environment variables.",
+                "Run 'mp auth login' to authenticate via OAuth, "
+                "or set MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION "
+                "environment variables.",
             )
 
         cred_data = credentials[cred_name]
@@ -1649,7 +1680,9 @@ class ConfigManager:
 
         if not resolved_project_id:
             raise ConfigError(
-                "No project selected. Run 'mp projects switch <id>' or pass --project.",
+                "No project selected. "
+                "Run 'mp projects list' to see available projects, then "
+                "'mp projects switch <id>' to select one.",
             )
 
         project = ProjectContext(

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -460,7 +460,7 @@ def _post_login_setup(
         headers[custom_name] = custom_value
 
     try:
-        with httpx.Client(timeout=30) as http:
+        with httpx.Client(timeout=60) as http:
             resp = http.get(me_url, headers=headers)
             if resp.status_code != 200:
                 err_console.print(

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -19,6 +19,7 @@ This module provides commands for managing Mixpanel accounts:
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from typing import Annotated, Literal
@@ -36,6 +37,8 @@ from mixpanel_data.cli.utils import (
     output_result,
 )
 from mixpanel_data.exceptions import AccountNotFoundError, ConfigError
+
+logger = logging.getLogger(__name__)
 
 auth_app = typer.Typer(
     name="auth",
@@ -475,8 +478,8 @@ def _post_login_setup(
             try:
                 me_response = MeResponse.model_validate(me_data)
                 MeCache().put(region, me_response)
-            except Exception:
-                pass  # Non-fatal: caching failure doesn't block setup
+            except (ValueError, OSError) as exc:
+                logger.debug("Failed to cache /me response: %s", exc)
 
             if len(projects) == 0:
                 err_console.print(
@@ -506,7 +509,8 @@ def _post_login_setup(
                     "Run 'mp projects list' then "
                     "'mp projects switch <id>' to select one."
                 )
-    except Exception:
+    except (httpx.HTTPError, OSError, ValueError, KeyError) as exc:
+        logger.debug("Post-login /me discovery failed: %s", exc)
         err_console.print(
             "[yellow]Could not auto-discover projects.[/yellow] "
             "Run 'mp projects list' to see available projects."

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -396,6 +396,184 @@ def _resolve_region(ctx: typer.Context, region: str | None) -> str:
     return "us"
 
 
+def _post_login_setup(
+    ctx: typer.Context,
+    region: str,
+    access_token: str,
+    project_id: str | None,
+) -> dict[str, object]:
+    """Set up v2 config and auto-discover projects after OAuth login.
+
+    Ensures the config file has a v2 OAuth credential entry, then
+    calls ``/me`` directly to discover accessible projects. If the
+    user has exactly one project, it is auto-selected. If multiple,
+    the user is informed to pick one.
+
+    Args:
+        ctx: Typer context for accessing ConfigManager.
+        region: Resolved OAuth region (us, eu, in).
+        access_token: The raw access token string from login.
+        project_id: Explicit project ID from ``--project-id`` flag,
+            or ``None`` if not provided.
+
+    Returns:
+        Dict with setup results for inclusion in login output.
+    """
+    import httpx
+
+    from mixpanel_data._internal.api_client import ENDPOINTS
+    from mixpanel_data._internal.me import MeCache, MeResponse
+
+    setup_result: dict[str, object] = {}
+
+    # Step 1: Ensure v2 config with OAuth credential
+    import contextlib
+
+    config = get_config(ctx)
+    cred_name = f"oauth-{region}"
+    with contextlib.suppress(ConfigError, ValueError):
+        config.add_credential(name=cred_name, type="oauth", region=region)
+
+    with contextlib.suppress(ConfigError):
+        config.set_active_credential(cred_name)
+
+    # If explicit project_id was provided, set it and we're done
+    if project_id is not None:
+        config.set_active_project(project_id)
+        setup_result["auto_selected_project"] = project_id
+        err_console.print(f"[green]Project {project_id} set as active.[/green]")
+        return setup_result
+
+    # Step 2: Auto-discover projects via direct /me call
+    # Apply custom headers from config before making the /me call
+    config.apply_config_custom_header()
+
+    app_base = ENDPOINTS[region]["app"]
+    me_url = f"{app_base}/me"
+    headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
+    custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+    custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+    if custom_name and custom_value:
+        headers[custom_name] = custom_value
+
+    try:
+        with httpx.Client(timeout=120) as http:
+            resp = http.get(me_url, headers=headers)
+            if resp.status_code != 200:
+                err_console.print(
+                    "[yellow]Could not auto-discover projects.[/yellow] "
+                    "Run 'mp projects list' to see available projects."
+                )
+                return setup_result
+
+            me_raw = resp.json()
+            # app_request unwraps "results", raw HTTP does not
+            me_data = me_raw.get("results", me_raw)
+            projects: dict[str, object] = me_data.get("projects", {})
+
+            # Cache the /me response for subsequent commands
+            try:
+                me_response = MeResponse.model_validate(me_data)
+                MeCache().put(region, me_response)
+            except Exception:
+                pass  # Non-fatal: caching failure doesn't block setup
+
+            if len(projects) == 0:
+                err_console.print(
+                    "[yellow]No projects found.[/yellow] "
+                    "Check your Mixpanel account has project access."
+                )
+            elif len(projects) == 1:
+                pid = next(iter(projects.keys()))
+                proj_data = projects[pid]
+                proj_name = (
+                    proj_data.get("name", pid) if isinstance(proj_data, dict) else pid
+                )
+                config.set_active_project(pid)
+                setup_result["auto_selected_project"] = pid
+                setup_result["project_name"] = proj_name
+                err_console.print(
+                    f"[green]Auto-selected project:[/green] {proj_name} ({pid})"
+                )
+
+                # Auto-detect default workspace from /me data
+                workspaces: dict[str, object] = me_data.get("workspaces", {})
+                _auto_select_workspace(config, pid, workspaces, setup_result)
+            else:
+                setup_result["projects_found"] = len(projects)
+                err_console.print(
+                    f"[yellow]{len(projects)} projects found.[/yellow] "
+                    "Run 'mp projects list' then "
+                    "'mp projects switch <id>' to select one."
+                )
+    except Exception:
+        err_console.print(
+            "[yellow]Could not auto-discover projects.[/yellow] "
+            "Run 'mp projects list' to see available projects."
+        )
+
+    return setup_result
+
+
+def _auto_select_workspace(
+    config: ConfigManager,
+    project_id: str,
+    workspaces: dict[str, object],
+    setup_result: dict[str, object],
+) -> None:
+    """Auto-select the default workspace for a project if applicable.
+
+    Scans the workspaces dict from the /me response and selects the
+    default workspace for the given project. Updates the active context
+    and setup_result dict.
+
+    Args:
+        config: ConfigManager to persist workspace selection.
+        project_id: The active project ID.
+        workspaces: Workspaces dict from /me response, keyed by
+            workspace ID string.
+        setup_result: Mutable dict to add workspace info to.
+    """
+    project_workspaces: list[tuple[int, str, bool]] = []
+    for ws_id_str, ws_data in workspaces.items():
+        if not isinstance(ws_data, dict):
+            continue
+        ws_project = ws_data.get("project_id")
+        # project_id in /me might be int or str
+        if str(ws_project) != str(project_id):
+            continue
+        try:
+            ws_id = int(ws_id_str)
+        except (ValueError, TypeError):
+            continue
+        ws_name = ws_data.get("name", ws_id_str)
+        is_default = bool(ws_data.get("is_default", False))
+        project_workspaces.append((ws_id, str(ws_name), is_default))
+
+    if not project_workspaces:
+        return
+
+    # Pick the default workspace, or the only one
+    selected = None
+    for ws_id, ws_name, is_default in project_workspaces:
+        if is_default:
+            selected = (ws_id, ws_name)
+            break
+
+    if selected is None and len(project_workspaces) == 1:
+        ws_id, ws_name, _ = project_workspaces[0]
+        selected = (ws_id, ws_name)
+
+    if selected is not None:
+        ws_id, ws_name = selected
+        config.set_active_project(project_id, workspace_id=ws_id)
+        setup_result["auto_selected_workspace"] = ws_id
+        setup_result["workspace_name"] = ws_name
+        err_console.print(
+            f"[green]Auto-selected workspace:[/green] {ws_name} ({ws_id})"
+        )
+
+
 @auth_app.command("login")
 @handle_errors
 def login(
@@ -415,8 +593,8 @@ def login(
     """Log in via OAuth 2.0 PKCE flow.
 
     Opens a browser for Mixpanel authorization. After approving,
-    tokens are saved locally for subsequent API calls. Invalidates
-    the /me cache for the region after successful login.
+    tokens are saved locally. Automatically discovers accessible
+    projects and selects one if possible.
 
     Examples:
 
@@ -434,16 +612,23 @@ def login(
 
     MeCache().invalidate(resolved_region)
 
-    output_result(
+    # Auto-setup: create v2 config, discover projects, select if possible
+    setup = _post_login_setup(
         ctx,
-        {
-            "status": "login_success",
-            "region": resolved_region,
-            "scope": tokens.scope,
-            "expires_at": tokens.expires_at.isoformat(),
-        },
-        format=format,
+        region=resolved_region,
+        access_token=tokens.access_token.get_secret_value(),
+        project_id=project_id,
     )
+
+    result: dict[str, object] = {
+        "status": "login_success",
+        "region": resolved_region,
+        "scope": tokens.scope,
+        "expires_at": tokens.expires_at.isoformat(),
+    }
+    result.update(setup)
+
+    output_result(ctx, result, format=format)
 
 
 @auth_app.command("logout")

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -460,56 +460,59 @@ def _post_login_setup(
         headers[custom_name] = custom_value
 
     try:
-        err_console.print("[dim]Discovering projects...[/dim]")
-        with httpx.Client(timeout=60) as http:
+        with (
+            err_console.status("Discovering projects..."),
+            httpx.Client(timeout=60) as http,
+        ):
             resp = http.get(me_url, headers=headers)
-            if resp.status_code != 200:
-                err_console.print(
-                    "[yellow]Could not auto-discover projects.[/yellow] "
-                    "Run 'mp projects list' to see available projects."
-                )
-                return setup_result
 
-            me_raw = resp.json()
-            # app_request unwraps "results", raw HTTP does not
-            me_data = me_raw.get("results", me_raw)
-            projects: dict[str, object] = me_data.get("projects", {})
+        if resp.status_code != 200:
+            err_console.print(
+                "[yellow]Could not auto-discover projects.[/yellow] "
+                "Run 'mp projects list' to see available projects."
+            )
+            return setup_result
 
-            # Cache the /me response for subsequent commands
-            try:
-                me_response = MeResponse.model_validate(me_data)
-                MeCache().put(region, me_response)
-            except (ValueError, OSError) as exc:
-                logger.debug("Failed to cache /me response: %s", exc)
+        me_raw = resp.json()
+        # app_request unwraps "results", raw HTTP does not
+        me_data = me_raw.get("results", me_raw)
+        projects: dict[str, object] = me_data.get("projects", {})
 
-            if len(projects) == 0:
-                err_console.print(
-                    "[yellow]No projects found.[/yellow] "
-                    "Check your Mixpanel account has project access."
-                )
-            elif len(projects) == 1:
-                pid = next(iter(projects.keys()))
-                proj_data = projects[pid]
-                proj_name = (
-                    proj_data.get("name", pid) if isinstance(proj_data, dict) else pid
-                )
-                config.set_active_project(pid)
-                setup_result["auto_selected_project"] = pid
-                setup_result["project_name"] = proj_name
-                err_console.print(
-                    f"[green]Auto-selected project:[/green] {proj_name} ({pid})"
-                )
+        # Cache the /me response for subsequent commands
+        try:
+            me_response = MeResponse.model_validate(me_data)
+            MeCache().put(region, me_response)
+        except (ValueError, OSError) as exc:
+            logger.debug("Failed to cache /me response: %s", exc)
 
-                # Auto-detect default workspace from /me data
-                workspaces: dict[str, object] = me_data.get("workspaces", {})
-                _auto_select_workspace(config, pid, workspaces, setup_result)
-            else:
-                setup_result["projects_found"] = len(projects)
-                err_console.print(
-                    f"[yellow]{len(projects)} projects found.[/yellow] "
-                    "Run 'mp projects list' then "
-                    "'mp projects switch <id>' to select one."
-                )
+        if len(projects) == 0:
+            err_console.print(
+                "[yellow]No projects found.[/yellow] "
+                "Check your Mixpanel account has project access."
+            )
+        elif len(projects) == 1:
+            pid = next(iter(projects.keys()))
+            proj_data = projects[pid]
+            proj_name = (
+                proj_data.get("name", pid) if isinstance(proj_data, dict) else pid
+            )
+            config.set_active_project(pid)
+            setup_result["auto_selected_project"] = pid
+            setup_result["project_name"] = proj_name
+            err_console.print(
+                f"[green]Auto-selected project:[/green] {proj_name} ({pid})"
+            )
+
+            # Auto-detect default workspace from /me data
+            workspaces: dict[str, object] = me_data.get("workspaces", {})
+            _auto_select_workspace(config, pid, workspaces, setup_result)
+        else:
+            setup_result["projects_found"] = len(projects)
+            err_console.print(
+                f"[yellow]{len(projects)} projects found.[/yellow] "
+                "Run 'mp projects list' then "
+                "'mp projects switch <id>' to select one."
+            )
     except (httpx.HTTPError, OSError, ValueError, KeyError) as exc:
         logger.debug("Post-login /me discovery failed: %s", exc)
         err_console.print(

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -457,7 +457,7 @@ def _post_login_setup(
         headers[custom_name] = custom_value
 
     try:
-        with httpx.Client(timeout=120) as http:
+        with httpx.Client(timeout=30) as http:
             resp = http.get(me_url, headers=headers)
             if resp.status_code != 200:
                 err_console.print(

--- a/src/mixpanel_data/cli/commands/auth.py
+++ b/src/mixpanel_data/cli/commands/auth.py
@@ -460,6 +460,7 @@ def _post_login_setup(
         headers[custom_name] = custom_value
 
     try:
+        err_console.print("[dim]Discovering projects...[/dim]")
         with httpx.Client(timeout=60) as http:
             resp = http.get(me_url, headers=headers)
             if resp.status_code != 200:

--- a/src/mixpanel_data/cli/commands/projects.py
+++ b/src/mixpanel_data/cli/commands/projects.py
@@ -120,7 +120,7 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
             headers[custom_name] = custom_value
 
         try:
-            with httpx.Client(timeout=30) as http:
+            with httpx.Client(timeout=60) as http:
                 resp = http.get(me_url, headers=headers)
                 if resp.status_code != 200:
                     continue
@@ -218,7 +218,14 @@ def projects_list(
             projects = workspace.discover_projects()
 
         data = _projects_to_dicts(projects)
-    except ConfigError:
+    except ConfigError as exc:
+        # Re-raise subclass errors (e.g. AccountNotFoundError) for
+        # proper handling by @handle_errors decorator
+        from mixpanel_data.exceptions import AccountNotFoundError
+
+        if isinstance(exc, AccountNotFoundError):
+            raise
+
         # No project configured yet — fall back to direct OAuth /me call
         with status_spinner(ctx, "Discovering projects via OAuth..."):
             data_or_none = _discover_projects_via_oauth()
@@ -257,7 +264,12 @@ def projects_refresh(
             projects = workspace.discover_projects()
 
         data = _projects_to_dicts(projects)
-    except ConfigError:
+    except ConfigError as exc:
+        from mixpanel_data.exceptions import AccountNotFoundError
+
+        if isinstance(exc, AccountNotFoundError):
+            raise
+
         with status_spinner(ctx, "Discovering projects via OAuth..."):
             data_or_none = _discover_projects_via_oauth()
 

--- a/src/mixpanel_data/cli/commands/projects.py
+++ b/src/mixpanel_data/cli/commands/projects.py
@@ -85,6 +85,8 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
     Returns:
         List of project dicts if discovery succeeds, None otherwise.
     """
+    import os
+
     import httpx
 
     from mixpanel_data._internal.api_client import ENDPOINTS
@@ -93,6 +95,16 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
     from mixpanel_data._internal.me import MeCache, MeProjectInfo, MeResponse
 
     storage = OAuthStorage()
+
+    # Propagate custom headers from env or config (once, outside loop)
+    custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+    custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+    if not (custom_name and custom_value):
+        from mixpanel_data._internal.config import ConfigManager
+
+        ConfigManager().apply_config_custom_header()
+        custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+        custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
 
     # Find a valid token across all regions
     for region in VALID_REGIONS:
@@ -104,27 +116,11 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
         app_base = ENDPOINTS[region]["app"]
         me_url = f"{app_base}/me"
         headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
-
-        # Propagate custom headers from env or config
-        import os
-
-        custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
-        custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
         if custom_name and custom_value:
             headers[custom_name] = custom_value
-        else:
-            # Try reading custom header from config settings
-            from mixpanel_data._internal.config import ConfigManager
-
-            cfg = ConfigManager()
-            cfg.apply_config_custom_header()
-            custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
-            custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
-            if custom_name and custom_value:
-                headers[custom_name] = custom_value
 
         try:
-            with httpx.Client(timeout=120) as http:
+            with httpx.Client(timeout=30) as http:
                 resp = http.get(me_url, headers=headers)
                 if resp.status_code != 200:
                     continue

--- a/src/mixpanel_data/cli/commands/projects.py
+++ b/src/mixpanel_data/cli/commands/projects.py
@@ -132,8 +132,8 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
                 try:
                     me_response = MeResponse.model_validate(me_data)
                     MeCache().put(region, me_response)
-                except Exception:
-                    pass
+                except (ValueError, OSError) as exc:
+                    logger.debug("Failed to cache /me response: %s", exc)
 
                 # Parse projects
                 projects_raw: dict[str, Any] = me_data.get("projects", {})
@@ -156,7 +156,8 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
                                     "has_workspaces": info.has_workspaces,
                                 }
                             )
-                        except Exception:
+                        except (ValueError, TypeError) as exc:
+                            logger.debug("Failed to parse project %s: %s", pid, exc)
                             result.append(
                                 {
                                     "project_id": pid,
@@ -169,8 +170,8 @@ def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
                                 }
                             )
                 return result
-        except Exception:
-            logger.debug("OAuth /me fallback failed for region %s", region)
+        except (httpx.HTTPError, OSError, ValueError, KeyError) as exc:
+            logger.debug("OAuth /me fallback failed for region %s: %s", region, exc)
             continue
 
     return None

--- a/src/mixpanel_data/cli/commands/projects.py
+++ b/src/mixpanel_data/cli/commands/projects.py
@@ -19,6 +19,7 @@ Aliases:
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 import typer
@@ -32,6 +33,9 @@ from mixpanel_data.cli.utils import (
     output_result,
     status_spinner,
 )
+from mixpanel_data.exceptions import ConfigError
+
+logger = logging.getLogger(__name__)
 
 projects_app = typer.Typer(
     name="projects",
@@ -71,6 +75,111 @@ def _projects_to_dicts(
     ]
 
 
+def _discover_projects_via_oauth() -> list[dict[str, Any]] | None:
+    """Discover projects by calling /me directly with OAuth tokens.
+
+    This is a fallback for when no project is configured yet (e.g.,
+    after ``mp auth login`` with multiple projects). Scans OAuth
+    storage for a valid token and calls ``/me`` directly.
+
+    Returns:
+        List of project dicts if discovery succeeds, None otherwise.
+    """
+    import httpx
+
+    from mixpanel_data._internal.api_client import ENDPOINTS
+    from mixpanel_data._internal.auth.storage import OAuthStorage
+    from mixpanel_data._internal.auth_credential import VALID_REGIONS
+    from mixpanel_data._internal.me import MeCache, MeProjectInfo, MeResponse
+
+    storage = OAuthStorage()
+
+    # Find a valid token across all regions
+    for region in VALID_REGIONS:
+        tokens = storage.load_tokens(region)
+        if tokens is None or tokens.is_expired():
+            continue
+
+        access_token = tokens.access_token.get_secret_value()
+        app_base = ENDPOINTS[region]["app"]
+        me_url = f"{app_base}/me"
+        headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
+
+        # Propagate custom headers from env or config
+        import os
+
+        custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+        custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+        if custom_name and custom_value:
+            headers[custom_name] = custom_value
+        else:
+            # Try reading custom header from config settings
+            from mixpanel_data._internal.config import ConfigManager
+
+            cfg = ConfigManager()
+            cfg.apply_config_custom_header()
+            custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
+            custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
+            if custom_name and custom_value:
+                headers[custom_name] = custom_value
+
+        try:
+            with httpx.Client(timeout=120) as http:
+                resp = http.get(me_url, headers=headers)
+                if resp.status_code != 200:
+                    continue
+
+                me_raw = resp.json()
+                me_data = me_raw.get("results", me_raw)
+
+                # Cache for subsequent commands
+                try:
+                    me_response = MeResponse.model_validate(me_data)
+                    MeCache().put(region, me_response)
+                except Exception:
+                    pass
+
+                # Parse projects
+                projects_raw: dict[str, Any] = me_data.get("projects", {})
+                result: list[dict[str, Any]] = []
+                for pid, pdata in sorted(
+                    projects_raw.items(),
+                    key=lambda x: (
+                        x[1].get("name", "").lower() if isinstance(x[1], dict) else ""
+                    ),
+                ):
+                    if isinstance(pdata, dict):
+                        try:
+                            info = MeProjectInfo.model_validate(pdata)
+                            result.append(
+                                {
+                                    "project_id": pid,
+                                    "name": info.name,
+                                    "organization_id": info.organization_id,
+                                    "timezone": info.timezone,
+                                    "has_workspaces": info.has_workspaces,
+                                }
+                            )
+                        except Exception:
+                            result.append(
+                                {
+                                    "project_id": pid,
+                                    "name": pdata.get("name", ""),
+                                    "organization_id": pdata.get(
+                                        "organization_id", None
+                                    ),
+                                    "timezone": pdata.get("timezone", None),
+                                    "has_workspaces": pdata.get("has_workspaces", None),
+                                }
+                            )
+                return result
+        except Exception:
+            logger.debug("OAuth /me fallback failed for region %s", region)
+            continue
+
+    return None
+
+
 # =============================================================================
 # Discovery
 # =============================================================================
@@ -95,19 +204,36 @@ def projects_list(
     Mixpanel /me endpoint (cached for 24 hours). Use ``--refresh``
     to force a fresh API call.
 
+    Works even before a project is selected — falls back to direct
+    OAuth token usage for discovery.
+
     Args:
         ctx: Typer context with global options.
         refresh: If True, bypass the cache and fetch fresh data.
         format: Output format.
     """
-    workspace = get_workspace(ctx)
+    try:
+        workspace = get_workspace(ctx)
 
-    with status_spinner(ctx, "Fetching projects..."):
-        if refresh:
-            workspace.me(force_refresh=True)
-        projects = workspace.discover_projects()
+        with status_spinner(ctx, "Fetching projects..."):
+            if refresh:
+                workspace.me(force_refresh=True)
+            projects = workspace.discover_projects()
 
-    data = _projects_to_dicts(projects)
+        data = _projects_to_dicts(projects)
+    except ConfigError:
+        # No project configured yet — fall back to direct OAuth /me call
+        with status_spinner(ctx, "Discovering projects via OAuth..."):
+            data_or_none = _discover_projects_via_oauth()
+
+        if data_or_none is None:
+            err_console.print(
+                "[red]No valid credentials found.[/red] Run 'mp auth login' first."
+            )
+            raise typer.Exit(1) from None
+
+        data = data_or_none
+
     output_result(ctx, data, columns=_PROJECT_COLUMNS, format=format)
 
 
@@ -126,13 +252,26 @@ def projects_refresh(
         ctx: Typer context with global options.
         format: Output format.
     """
-    workspace = get_workspace(ctx)
+    try:
+        workspace = get_workspace(ctx)
 
-    with status_spinner(ctx, "Refreshing /me cache..."):
-        workspace.me(force_refresh=True)
-        projects = workspace.discover_projects()
+        with status_spinner(ctx, "Refreshing /me cache..."):
+            workspace.me(force_refresh=True)
+            projects = workspace.discover_projects()
 
-    data = _projects_to_dicts(projects)
+        data = _projects_to_dicts(projects)
+    except ConfigError:
+        with status_spinner(ctx, "Discovering projects via OAuth..."):
+            data_or_none = _discover_projects_via_oauth()
+
+        if data_or_none is None:
+            err_console.print(
+                "[red]No valid credentials found.[/red] Run 'mp auth login' first."
+            )
+            raise typer.Exit(1) from None
+
+        data = data_or_none
+
     err_console.print(f"[green]Refreshed.[/green] Found {len(data)} projects.")
     output_result(ctx, data, columns=_PROJECT_COLUMNS, format=format)
 

--- a/tests/qa/test_038_qa.py
+++ b/tests/qa/test_038_qa.py
@@ -1693,6 +1693,9 @@ class TestCLIExitCodes:
     ) -> None:
         """'mp projects list' with no credentials exits non-zero.
 
+        Also patches the OAuth fallback to return None so that locally
+        cached OAuth tokens don't make the command succeed.
+
         Args:
             tmp_path: Pytest-provided temp directory.
             cli_runner: CLI test runner.
@@ -1705,6 +1708,12 @@ class TestCLIExitCodes:
         monkeypatch.setenv("MP_CONFIG_PATH", str(empty_config))
         for var in ("MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"):
             monkeypatch.delenv(var, raising=False)
+
+        # Prevent the OAuth fallback from finding tokens on disk
+        monkeypatch.setattr(
+            "mixpanel_data.cli.commands.projects._discover_projects_via_oauth",
+            lambda: None,
+        )
 
         result = cli_runner.invoke(app, ["projects", "list"])
         assert result.exit_code != 0

--- a/tests/unit/cli/test_projects_cli.py
+++ b/tests/unit/cli/test_projects_cli.py
@@ -100,16 +100,21 @@ class TestProjectsList:
         # Table format should contain project names
         assert "AI Demo" in result.stdout
 
+    @patch("mixpanel_data.cli.commands.projects._discover_projects_via_oauth")
     @patch("mixpanel_data.cli.commands.projects.get_workspace")
     def test_list_config_error(
-        self, mock_get_ws: MagicMock, cli_runner: CliRunner
+        self,
+        mock_get_ws: MagicMock,
+        mock_oauth_fallback: MagicMock,
+        cli_runner: CliRunner,
     ) -> None:
-        """Test mp projects list handles ConfigError."""
+        """Test mp projects list handles ConfigError when no OAuth fallback."""
         mock_get_ws.side_effect = ConfigError("No credentials")
+        mock_oauth_fallback.return_value = None
 
         result = cli_runner.invoke(app, ["projects", "list"])
 
-        assert result.exit_code == ExitCode.GENERAL_ERROR
+        assert result.exit_code != 0
 
 
 class TestProjectsRefresh:

--- a/tests/unit/test_new_user_auth_flow.py
+++ b/tests/unit/test_new_user_auth_flow.py
@@ -372,5 +372,5 @@ class TestErrorMessages:
             )
 
         cm = ConfigManager(config_path=config_path)
-        with pytest.raises(ConfigError, match="mp projects list"):
+        with pytest.raises(ConfigError, match="mp projects list.*--project"):
             cm.resolve_session()

--- a/tests/unit/test_new_user_auth_flow.py
+++ b/tests/unit/test_new_user_auth_flow.py
@@ -1,0 +1,376 @@
+"""Unit tests for the new-user auth flow fixes.
+
+Tests cover:
+- Fix 2: OAuth resolution safety net — scans OAuth storage when no
+  accounts or credentials exist in config.
+- Fix 3: projects list OAuth fallback — discovers projects via direct
+  /me call when no project is configured.
+- Fix 4: Improved error messages mention ``mp auth login``.
+- Region+project_id fallback when active context has project_id but
+  no credential entries.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import tomli_w
+from pydantic import SecretStr
+
+from mixpanel_data._internal.auth.storage import OAuthStorage
+from mixpanel_data._internal.auth.token import OAuthTokens
+from mixpanel_data._internal.config import AuthMethod, ConfigManager
+from mixpanel_data.exceptions import ConfigError
+
+
+def _make_valid_tokens(
+    project_id: str | None = None,
+    access_token: str = "test-access-token",
+) -> OAuthTokens:
+    """Create a non-expired OAuthTokens for testing.
+
+    Args:
+        project_id: Optional project ID to embed in the tokens.
+        access_token: The access token value.
+
+    Returns:
+        A valid, non-expired OAuthTokens instance.
+    """
+    return OAuthTokens(
+        access_token=SecretStr(access_token),
+        refresh_token=SecretStr("test-refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        scope="read:project",
+        token_type="Bearer",
+        project_id=project_id,
+    )
+
+
+def _make_expired_tokens() -> OAuthTokens:
+    """Create an expired OAuthTokens for testing.
+
+    Returns:
+        An expired OAuthTokens instance.
+    """
+    return OAuthTokens(
+        access_token=SecretStr("expired-token"),
+        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        scope="read:project",
+        token_type="Bearer",
+    )
+
+
+# ── Fix 2: OAuth storage scanning ──────────────────────────────────
+
+
+class TestOAuthStorageScan:
+    """Fix 2: _resolve_region_and_project_for_oauth scans storage."""
+
+    def test_empty_config_finds_oauth_tokens(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With no config, scanning OAuth storage finds valid tokens.
+
+        Args:
+            tmp_path: Temporary directory for config and OAuth storage.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        # Clear env vars that would short-circuit resolution
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        # Save valid OAuth tokens to storage
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id="99999")
+        storage.save_tokens(tokens, region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "99999"
+        assert creds.region == "us"
+
+    def test_empty_config_no_tokens_raises_config_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With no config and no tokens, raises ConfigError.
+
+        Args:
+            tmp_path: Temporary directory for config.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError):
+            cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+    def test_expired_tokens_are_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Expired OAuth tokens are skipped during storage scan.
+
+        Args:
+            tmp_path: Temporary directory for config and OAuth storage.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        # Save expired tokens
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        expired = _make_expired_tokens()
+        storage.save_tokens(expired, region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError):
+            cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+    def test_tokens_without_project_id_return_none(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OAuth tokens without project_id fall through (no project set).
+
+        Args:
+            tmp_path: Temporary directory for config and OAuth storage.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        # Tokens without project_id
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id=None)
+        storage.save_tokens(tokens, region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError):
+            cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+
+class TestOAuthStorageScanWithActiveProject:
+    """Fix 2 extension: active project_id used as fallback in scan."""
+
+    def test_active_project_id_used_when_token_has_none(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Config active.project_id fills in when token lacks project_id.
+
+        Args:
+            tmp_path: Temporary directory for config and OAuth storage.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        # Write minimal config with only active.project_id
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("wb") as f:
+            tomli_w.dump({"active": {"project_id": "77777"}}, f)
+
+        # Save tokens without project_id
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id=None)
+        storage.save_tokens(tokens, region="us")
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "77777"
+        assert creds.region == "us"
+
+
+# ── Fix 2: v2 config resolution ────────────────────────────────────
+
+
+class TestV2CredentialResolution:
+    """Fix 2: v2 credentials are used for OAuth region resolution."""
+
+    def test_v2_oauth_credential_resolves_region(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """v2 config OAuth credential provides region for token lookup.
+
+        Args:
+            tmp_path: Temporary directory for config and OAuth storage.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        # Write v2 config with OAuth credential
+        with config_path.open("wb") as f:
+            tomli_w.dump(
+                {
+                    "config_version": 2,
+                    "active": {
+                        "credential": "oauth-eu",
+                        "project_id": "55555",
+                    },
+                    "credentials": {
+                        "oauth-eu": {
+                            "type": "oauth",
+                            "region": "eu",
+                        },
+                    },
+                },
+                f,
+            )
+
+        # Save tokens for EU region
+        storage = OAuthStorage(storage_dir=oauth_dir)
+        tokens = _make_valid_tokens(project_id="55555")
+        storage.save_tokens(tokens, region="eu")
+
+        cm = ConfigManager(config_path=config_path)
+        creds = cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "55555"
+        assert creds.region == "eu"
+
+
+# ── Fix 4: Error message improvements ──────────────────────────────
+
+
+class TestErrorMessages:
+    """Fix 4: Error messages mention mp auth login."""
+
+    def test_no_credentials_error_mentions_login(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ConfigError for missing credentials mentions 'mp auth login'.
+
+        Args:
+            tmp_path: Temporary directory for config.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        oauth_dir = tmp_path / "oauth"
+        oauth_dir.mkdir()
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError, match="mp auth login"):
+            cm.resolve_credentials(_oauth_storage_dir=oauth_dir)
+
+    def test_v2_no_credentials_error_mentions_login(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """v2 ConfigError for missing credentials mentions 'mp auth login'.
+
+        Args:
+            tmp_path: Temporary directory for config.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        with config_path.open("wb") as f:
+            tomli_w.dump({"config_version": 2}, f)
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError, match="mp auth login"):
+            cm.resolve_session()
+
+    def test_v2_no_project_error_mentions_projects_list(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """v2 ConfigError for missing project mentions 'mp projects list'.
+
+        Args:
+            tmp_path: Temporary directory for config.
+            monkeypatch: Pytest fixture for patching environment.
+        """
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+
+        config_path = tmp_path / "config.toml"
+        with config_path.open("wb") as f:
+            tomli_w.dump(
+                {
+                    "config_version": 2,
+                    "active": {"credential": "test-sa"},
+                    "credentials": {
+                        "test-sa": {
+                            "type": "service_account",
+                            "username": "user",
+                            "secret": "secret",
+                            "region": "us",
+                        },
+                    },
+                },
+                f,
+            )
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError, match="mp projects list"):
+            cm.resolve_session()


### PR DESCRIPTION
## Summary

- **Fix 1**: `mp auth login` now auto-sets up v2 config with OAuth credential entry, discovers projects via `/me`, and auto-selects project/workspace if only one exists
- **Fix 2**: `_resolve_region_and_project_for_oauth()` scans OAuth storage across all regions as fallback when config has no accounts or credentials
- **Fix 3**: `mp projects list` catches `ConfigError` and falls back to direct OAuth `/me` call, enabling project discovery before a project is selected
- **Fix 4**: Error messages now mention `mp auth login` instead of only service account env vars

## Root Cause

The auth flow had a chicken-and-egg problem for new OAuth users: OAuth token discovery required a region/project from config, but the config was empty because the user needed to discover their project first. After `mp auth login`, every subsequent command failed with "No credentials configured."

## Test plan

- [x] 9 new unit tests in `test_new_user_auth_flow.py` covering OAuth scan, active project fallback, v2 credential resolution, and error messages
- [x] Updated existing test `test_projects_list_no_credentials_exit_code` to account for new OAuth fallback
- [x] End-to-end verification: fresh config → `projects list` (84 projects) → `projects switch` → `auth test` (success)
- [ ] Verify `mp auth login` with single-project account auto-selects project
- [ ] Verify `mp auth login` with multi-project account shows guidance message