### PR TITLE
fix: reject inline cohort definitions with event-property filters (CF3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to `mixpanel_data` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- **Cohort event-property filters now raise instead of producing silent wrong results.**
+  `Filter.in_cohort()` and `Filter.not_in_cohort()` with an inline
+  `CohortDefinition` containing `CohortCriteria.did_event(where=...)` now
+  raise `ValueError` with actionable workaround suggestions. Previously,
+  Mixpanel's inline cohort evaluator silently ignored event-property filter
+  operators — string filters collapsed to `is_set` semantics, and numeric
+  filters were dropped entirely — returning plausible but wrong population
+  counts with no error or warning.
+
+  **Affected API surface**: `Filter.in_cohort(CohortDefinition, ...)` and
+  `Filter.not_in_cohort(CohortDefinition, ...)` when the definition contains
+  any `CohortCriteria.did_event(..., where=Filter.X(...))`.
+
+  **Migration**: If your code passes event-property filters inside inline
+  cohort definitions, switch to one of these working alternatives:
+  - Top-level: `ws.query("event", where=Filter.equals("prop", "val"))`
+  - Funnels: `FunnelStep("event", filters=[Filter.equals("prop", "val")])`
+  - Retention: `RetentionEvent("event", filters=[Filter.equals("prop", "val")])`
+  - Saved cohort: `ws.create_cohort(...)` then `Filter.in_cohort(<saved_id>)`
+
+  **Root cause**: The inline cohort selector uses a legacy
+  `event_selector.selector` JSON schema with operators (`==`, `!=`,
+  `defined`, `not defined`, `>`, `<`) that the server's cohort engine
+  does not honor. The top-level filter path uses a different, fully
+  supported schema (`filterOperator`, `filterValue`, etc.). This is a
+  server-side bug; the client-side guard prevents callers from hitting it.

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -535,6 +535,18 @@ result = ws.query("Login", group_by=CohortBreakdown(premium_active, "Premium Act
 
 **Note**: When using inline `CohortDefinition` with `CohortMetric`, always provide a descriptive `name` parameter — it is required for server-side label generation.
 
+> **Known limitation — event-property filters in inline cohorts**: Inline
+> `CohortDefinition` objects containing `CohortCriteria.did_event(where=...)`
+> **cannot** be used with `Filter.in_cohort()`. Mixpanel's inline cohort
+> evaluator silently ignores event-property filter operators, producing wrong
+> results. The SDK raises `ValueError` to prevent this. Use one of these
+> workarounds instead:
+>
+> - **Top-level filter**: `ws.query(event, where=Filter.equals(...))`
+> - **Funnels**: `FunnelStep(event, filters=[Filter.equals(...)])`
+> - **Retention**: `RetentionEvent(event, filters=[Filter.equals(...)])`
+> - **Saved cohort**: `ws.create_cohort(...)` then `Filter.in_cohort(<saved_id>)`
+
 ## Custom Properties in Queries
 
 Use saved custom properties or define computed properties inline — in breakdowns, filters, and measurement. Custom properties work everywhere a plain string property name does.

--- a/mixpanel-plugin/skills/mixpanelyst/references/insights-reference.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/insights-reference.md
@@ -572,7 +572,7 @@ from mixpanel_data import Filter, CohortDefinition, CohortCriteria
 # Saved cohort
 result = ws.query("Login", math="dau", where=Filter.in_cohort(123, "Power Users"), last=30)
 
-# Inline definition
+# Inline definition (behavioral + property criteria, no event-property filters)
 premium = CohortDefinition.all_of(
     CohortCriteria.has_property("plan", "premium"),
     CohortCriteria.did_event("Purchase", at_least=3, within_days=30),
@@ -582,6 +582,17 @@ result = ws.query("Login", where=Filter.in_cohort(premium, "Premium Users"), las
 # Exclude a cohort
 result = ws.query("Login", where=Filter.not_in_cohort(123, "Churned"), last=30)
 ```
+
+> **Known limitation**: Inline `CohortDefinition` objects containing
+> `CohortCriteria.did_event(where=...)` (event-property filters) **cannot**
+> be used with `Filter.in_cohort()`. Mixpanel's inline cohort evaluator
+> silently ignores event-property filter operators. The SDK raises `ValueError`
+> to prevent wrong results. To scope users by an event property, prefer:
+>
+> - **Top-level**: `ws.query("event", where=Filter.equals("prop", "val"))`
+> - **Funnels**: `FunnelStep("event", filters=[Filter.equals("prop", "val")])`
+> - **Retention**: `RetentionEvent("event", filters=[Filter.equals("prop", "val")])`
+> - **Saved cohort**: `ws.create_cohort(...)` then `Filter.in_cohort(<saved_id>)`
 
 ### Cohort Breakdowns (group_by=)
 

--- a/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
@@ -180,7 +180,7 @@ Build inline cohort definitions for use with `Filter.in_cohort()`, `CohortBreakd
 from mixpanel_data import CohortDefinition, CohortCriteria
 
 # Atomic criteria (factory methods)
-CohortCriteria.did_event(event, *, at_least=None, within_days=None)
+CohortCriteria.did_event(event, *, at_least=None, within_days=None, where=None)
 CohortCriteria.has_property(property, value, *, operator="equals")
 CohortCriteria.in_cohort(cohort_id)
 CohortCriteria.not_in_cohort(cohort_id)
@@ -205,6 +205,12 @@ premium_active = CohortDefinition.all_of(
 result = ws.query("Login", where=Filter.in_cohort(premium_active, "Premium Active"), last=30)
 result = ws.query("Login", group_by=CohortBreakdown(premium_active, "Premium Active"))
 ```
+
+> **Limitation**: `CohortCriteria.did_event(where=...)` with event-property
+> filters **cannot** be used in inline cohorts passed to `Filter.in_cohort()`.
+> The SDK raises `ValueError` to prevent silently wrong server results.
+> Use top-level `ws.query(where=...)`, `FunnelStep(filters=[...])`, or
+> `RetentionEvent(filters=[...])` for event-property scoping.
 
 ### Formula
 

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7606,6 +7606,21 @@ class Filter:
         on any query method (``query``, ``query_funnel``,
         ``query_retention``, ``query_flow``).
 
+        .. warning::
+
+            Inline ``CohortDefinition`` objects that contain
+            event-property filters (``CohortCriteria.did_event(where=...)``)
+            are **rejected** with a ``ValueError``. Mixpanel's inline
+            cohort evaluator silently ignores event-property filter
+            operators, producing wrong results. Use one of these
+            workarounds instead:
+
+            - Top-level: ``ws.query(event, where=Filter.equals(...))``
+            - Funnels: ``FunnelStep(event, filters=[Filter.equals(...)])``
+            - Retention: ``RetentionEvent(event, filters=[...])``
+            - Saved cohort: ``ws.create_cohort(...)`` then
+              ``Filter.in_cohort(<saved_id>)``
+
         Args:
             cohort: Saved cohort ID (positive integer) or inline
                 ``CohortDefinition``.
@@ -7616,8 +7631,9 @@ class Filter:
             Filter for cohort membership (contains).
 
         Raises:
-            ValueError: If cohort ID is not positive (CF1) or name
-                is empty when provided (CF2).
+            ValueError: If cohort ID is not positive (CF1), name
+                is empty when provided (CF2), or inline definition
+                contains event-property filters (CF3).
 
         Example:
             ```python
@@ -7626,7 +7642,7 @@ class Filter:
             # Saved cohort
             f = Filter.in_cohort(123, "Power Users")
 
-            # Inline cohort
+            # Inline cohort (no event-property filters)
             f = Filter.in_cohort(cohort_def, name="Frequent Buyers")
             ```
         """
@@ -7644,6 +7660,11 @@ class Filter:
         ``CohortDefinition``. The filter can be passed to ``where=``
         on any query method.
 
+        .. warning::
+
+            See ``in_cohort()`` for the restriction on inline
+            ``CohortDefinition`` objects with event-property filters.
+
         Args:
             cohort: Saved cohort ID (positive integer) or inline
                 ``CohortDefinition``.
@@ -7654,8 +7675,9 @@ class Filter:
             Filter for cohort exclusion (does not contain).
 
         Raises:
-            ValueError: If cohort ID is not positive (CF1) or name
-                is empty when provided (CF2).
+            ValueError: If cohort ID is not positive (CF1), name
+                is empty when provided (CF2), or inline definition
+                contains event-property filters (CF3).
 
         Example:
             ```python
@@ -7688,6 +7710,28 @@ class Filter:
             ValueError: On CF1 or CF2 violations.
         """
         _validate_cohort_args(cohort, name)
+
+        # CF3: Reject inline cohort definitions with event-property filters.
+        # Mixpanel's inline cohort evaluator silently ignores event-property
+        # filter operators in the legacy event_selector.selector schema,
+        # returning wrong results (all operators collapse to "is set"
+        # semantics for strings, or are dropped entirely for numbers).
+        if isinstance(cohort, CohortDefinition) and _cohort_has_event_selector_filters(
+            cohort
+        ):
+            raise ValueError(
+                "Inline CohortDefinition with event-property filters "
+                "(CohortCriteria.did_event(where=...)) cannot be used in "
+                "Filter.in_cohort() because Mixpanel's inline cohort "
+                "evaluator silently ignores event-property filter operators, "
+                "producing wrong results. "
+                "Workarounds: (1) use top-level ws.query(event, where=...) "
+                "for single-event scoping, (2) use "
+                "FunnelStep(event, filters=[...]) or "
+                "RetentionEvent(event, filters=[...]) for multi-step "
+                "queries, or (3) save the cohort via ws.create_cohort() "
+                "and reference it by ID with Filter.in_cohort(<saved_id>)."
+            )
 
         operator = "does not contain" if negated else "contains"
 
@@ -8170,6 +8214,17 @@ class CohortCriteria:
     ) -> CohortCriteria:
         """Create a behavioral criterion based on event frequency.
 
+        .. warning::
+
+            The ``where`` parameter works correctly when the resulting
+            ``CohortDefinition`` is saved via ``ws.create_cohort()``,
+            but **cannot** be used in inline cohort definitions passed
+            to ``Filter.in_cohort()``. Mixpanel's inline cohort
+            evaluator silently ignores event-property filter operators
+            in the legacy ``event_selector.selector`` schema. Calling
+            ``Filter.in_cohort()`` with such a definition raises
+            ``ValueError``. See ``Filter.in_cohort()`` for workarounds.
+
         Args:
             event: Event name (must be non-empty).
             at_least: Minimum event count (``>=``).
@@ -8180,7 +8235,8 @@ class CohortCriteria:
             within_months: Rolling window in months.
             from_date: Absolute start date (YYYY-MM-DD).
             to_date: Absolute end date (YYYY-MM-DD).
-            where: Event property filter(s).
+            where: Event property filter(s). See warning above regarding
+                inline cohort usage.
 
         Returns:
             CohortCriteria with behavioral selector node and behavior entry.
@@ -8581,6 +8637,36 @@ def _sanitize_raw_cohort(raw: dict[str, Any]) -> dict[str, Any]:
             if isinstance(es, dict) and es.get("selector") is None:
                 del es["selector"]
     return result
+
+
+def _cohort_has_event_selector_filters(
+    definition: CohortDefinition,
+) -> bool:
+    """Check whether an inline CohortDefinition contains event-property filters.
+
+    Recursively walks the criteria tree and returns ``True`` if any
+    behavioral criterion (``CohortCriteria.did_event``) has a non-None
+    ``event_selector.selector``, indicating event-property filters were
+    applied via the ``where=`` parameter.
+
+    Args:
+        definition: CohortDefinition to inspect.
+
+    Returns:
+        ``True`` if any criterion contains event-property filters.
+    """
+    for item in definition._criteria:
+        if isinstance(item, CohortCriteria):
+            if item._behavior is not None:
+                count = item._behavior.get("count", {})
+                es = count.get("event_selector", {})
+                if es.get("selector") is not None:
+                    return True
+        elif isinstance(item, CohortDefinition) and _cohort_has_event_selector_filters(
+            item
+        ):
+            return True
+    return False
 
 
 @dataclass(frozen=True, init=False)

--- a/tests/live/test_cohort_event_filter_live.py
+++ b/tests/live/test_cohort_event_filter_live.py
@@ -1,0 +1,203 @@
+"""Live tests for cohort event-property filter rejection (CF3).
+
+Verifies that inline CohortDefinitions with event-property filters
+are rejected client-side with a clear ValueError, preventing the
+server-side bug where Mixpanel's inline cohort evaluator silently
+ignores event-property filter operators.
+
+Also includes a parameterized "ground truth" test that exercises
+top-level event filters via ws.query(where=...) to confirm the
+working path remains correct.
+
+Usage:
+    uv run pytest tests/live/test_cohort_event_filter_live.py -v
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mixpanel_data import (
+    CohortCriteria,
+    CohortDefinition,
+    Filter,
+    QueryResult,
+    Workspace,
+)
+
+pytestmark = pytest.mark.live
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def ws() -> Workspace:
+    """Create Workspace with p8 credentials.
+
+    Returns:
+        Workspace connected to project 8.
+    """
+    return Workspace(account="p8")
+
+
+@pytest.fixture(scope="module")
+def real_event(ws: Workspace) -> str:
+    """Discover a real event name from project 8.
+
+    Returns:
+        First available event name.
+    """
+    events = ws.events()
+    assert len(events) > 0, "No events found in project 8"
+    return events[0]
+
+
+# =============================================================================
+# 1. CF3 Rejection Tests — Client-Side Guard
+# =============================================================================
+
+
+class TestCF3RejectionLive:
+    """Verify CF3 guard prevents silent wrong results from inline cohort filters."""
+
+    @pytest.mark.parametrize(
+        ("label", "filter_factory", "factory_args"),
+        [
+            ("equals", Filter.equals, ("$browser", "Chrome")),
+            ("not_equals", Filter.not_equals, ("$browser", "Chrome")),
+            ("is_set", Filter.is_set, ("$browser",)),
+            ("is_not_set", Filter.is_not_set, ("$browser",)),
+            ("greater_than", Filter.greater_than, ("$screen_width", 1000)),
+            ("less_than", Filter.less_than, ("$screen_width", 500)),
+            ("contains", Filter.contains, ("$browser", "Chrome")),
+        ],
+    )
+    def test_inline_cohort_with_event_filter_raises(
+        self,
+        real_event: str,
+        label: str,
+        filter_factory: Any,
+        factory_args: tuple[Any, ...],
+    ) -> None:
+        """Filter.in_cohort rejects inline definition with event-property filter.
+
+        Args:
+            real_event: Real event name from project.
+            label: Human-readable filter label.
+            filter_factory: Filter class method to call.
+            factory_args: Arguments for the filter factory.
+        """
+        f = filter_factory(*factory_args)
+        defn = CohortDefinition.all_of(
+            CohortCriteria.did_event(real_event, at_least=1, within_days=30, where=f)
+        )
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(defn, f"CF3-{label}")
+
+    def test_inline_cohort_without_event_filter_accepted(
+        self,
+        ws: Workspace,
+        real_event: str,
+    ) -> None:
+        """Inline cohort WITHOUT event-property filters still works end-to-end."""
+        defn = CohortDefinition.all_of(
+            CohortCriteria.did_event(real_event, at_least=1, within_days=90)
+        )
+        result = ws.query(
+            real_event,
+            where=Filter.in_cohort(defn, name="CF3-no-filter"),
+            last=7,
+        )
+        assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# 2. Top-Level Event Filter Ground Truth (Working Path)
+# =============================================================================
+
+
+class TestTopLevelEventFilterGroundTruth:
+    """Verify the top-level where= filter path remains correct.
+
+    These tests confirm that ws.query(event, where=Filter.X(...)) works
+    for all filter operators. This is the recommended workaround for
+    event-property scoping instead of inline cohort filters.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "filter_factory", "factory_args"),
+        [
+            ("equals", Filter.equals, ("$browser", "Chrome")),
+            ("not_equals", Filter.not_equals, ("$browser", "Chrome")),
+            ("is_set", Filter.is_set, ("$browser",)),
+            ("is_not_set", Filter.is_not_set, ("$browser",)),
+            ("contains", Filter.contains, ("$browser", "Chr")),
+        ],
+    )
+    def test_top_level_filter_returns_result(
+        self,
+        ws: Workspace,
+        real_event: str,
+        label: str,  # noqa: ARG002 — used by parametrize for test ID
+        filter_factory: Any,
+        factory_args: tuple[Any, ...],
+    ) -> None:
+        """Top-level event filter returns valid QueryResult.
+
+        Args:
+            ws: Workspace instance.
+            real_event: Real event name.
+            label: Filter operator label (used in test ID).
+            filter_factory: Filter class method.
+            factory_args: Arguments for the filter factory.
+        """
+        f = filter_factory(*factory_args)
+        result = ws.query(real_event, where=f, last=7, mode="total")
+        assert isinstance(result, QueryResult)
+
+    def test_is_set_and_is_not_set_are_complementary(
+        self,
+        ws: Workspace,
+        real_event: str,
+    ) -> None:
+        """is_set + is_not_set unique users should sum to <= total unique users.
+
+        This verifies the top-level filter path produces logically
+        consistent results (the complement property that the broken
+        inline cohort path violates).
+        """
+        total = ws.query(real_event, last=7, math="unique", mode="total")
+        is_set = ws.query(
+            real_event,
+            where=Filter.is_set("$browser"),
+            last=7,
+            math="unique",
+            mode="total",
+        )
+        is_not_set = ws.query(
+            real_event,
+            where=Filter.is_not_set("$browser"),
+            last=7,
+            math="unique",
+            mode="total",
+        )
+
+        def _extract(r: QueryResult) -> int:
+            """Extract scalar count from total-mode QueryResult."""
+            v = r.df["count"].iloc[0]
+            return int(v.get("all", 0)) if isinstance(v, dict) else int(v)
+
+        total_n = _extract(total)
+        set_n = _extract(is_set)
+        not_set_n = _extract(is_not_set)
+
+        # Complementary: set + not_set <= total (may be < due to multi-event users)
+        assert set_n + not_set_n <= total_n + 1  # +1 for rounding tolerance
+        # Each partition should be <= total
+        assert set_n <= total_n
+        assert not_set_n <= total_n

--- a/tests/unit/test_cohort_definition.py
+++ b/tests/unit/test_cohort_definition.py
@@ -850,3 +850,388 @@ class TestDateRangeOrdering:
         )
         assert c._behavior is not None
         assert c._behavior["from_date"] == "2024-06-15"
+
+
+# =============================================================================
+# CF3: Inline Cohort Event-Property Filter Rejection
+# =============================================================================
+
+
+class TestCF3InlineCohortEventPropertyFilters:
+    """Tests for CF3 validation — inline cohorts with event-property filters.
+
+    Mixpanel's inline cohort evaluator silently ignores event-property
+    filter operators, producing wrong results. The SDK must reject these
+    at construction time with a clear ValueError.
+    """
+
+    def _make_definition_with_where(
+        self, where: Filter | list[Filter]
+    ) -> CohortDefinition:
+        """Build a CohortDefinition containing did_event(where=...).
+
+        Args:
+            where: Filter(s) to pass to did_event's where parameter.
+
+        Returns:
+            CohortDefinition wrapping one behavioral criterion with filters.
+        """
+        return CohortDefinition.all_of(
+            CohortCriteria.did_event(
+                "Purchase", at_least=1, within_days=30, where=where
+            )
+        )
+
+    # --- Rejection tests ---
+
+    def test_cf3_in_cohort_rejects_inline_with_equals_filter(self) -> None:
+        """Filter.in_cohort raises ValueError for inline cohort with equals filter."""
+        defn = self._make_definition_with_where(Filter.equals("prop", "val"))
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(defn, "test")
+
+    def test_cf3_not_in_cohort_rejects_inline_with_equals_filter(self) -> None:
+        """Filter.not_in_cohort raises ValueError for inline cohort with equals filter."""
+        defn = self._make_definition_with_where(Filter.equals("prop", "val"))
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.not_in_cohort(defn, "test")
+
+    @pytest.mark.parametrize(
+        ("filter_factory", "factory_args"),
+        [
+            (Filter.equals, ("prop", "val")),
+            (Filter.not_equals, ("prop", "val")),
+            (Filter.is_set, ("prop",)),
+            (Filter.is_not_set, ("prop",)),
+            (Filter.greater_than, ("prop", 10)),
+            (Filter.less_than, ("prop", 100)),
+            (Filter.contains, ("prop", "sub")),
+            (Filter.not_contains, ("prop", "sub")),
+            (Filter.between, ("prop", 1, 100)),
+        ],
+    )
+    def test_cf3_rejects_all_filter_operators(
+        self, filter_factory: Any, factory_args: tuple[Any, ...]
+    ) -> None:
+        """CF3 rejects every supported filter operator in inline cohorts."""
+        f = filter_factory(*factory_args)
+        defn = self._make_definition_with_where(f)
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(defn, "test")
+
+    def test_cf3_rejects_multiple_where_filters(self) -> None:
+        """CF3 rejects inline cohort with multiple where filters."""
+        defn = self._make_definition_with_where(
+            [Filter.equals("plan", "premium"), Filter.greater_than("amount", 100)]
+        )
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(defn, "test")
+
+    def test_cf3_rejects_nested_definition_with_event_filters(self) -> None:
+        """CF3 detects event-property filters in nested CohortDefinitions."""
+        nested = CohortDefinition.any_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortDefinition.all_of(
+                CohortCriteria.did_event(
+                    "Purchase",
+                    at_least=1,
+                    within_days=30,
+                    where=Filter.equals("coupon", "true"),
+                ),
+            ),
+        )
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(nested, "nested test")
+
+    def test_cf3_rejects_deeply_nested_event_filters(self) -> None:
+        """CF3 detects event-property filters at 3+ levels of nesting."""
+        deep = CohortDefinition.any_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortDefinition.all_of(
+                CohortCriteria.has_property("country", "US"),
+                CohortDefinition.any_of(
+                    CohortCriteria.did_event(
+                        "Click",
+                        at_least=1,
+                        within_days=7,
+                        where=Filter.is_set("target"),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(ValueError, match="event-property filters"):
+            Filter.in_cohort(deep, "deep test")
+
+    # --- Acceptance tests (should NOT raise) ---
+
+    def test_cf3_allows_inline_cohort_without_where(self) -> None:
+        """Inline CohortDefinition without where= is accepted."""
+        defn = CohortDefinition.all_of(
+            CohortCriteria.did_event("Login", at_least=1, within_days=30)
+        )
+        f = Filter.in_cohort(defn, "no filters")
+        assert f._property == "$cohorts"
+
+    def test_cf3_allows_inline_cohort_with_empty_where(self) -> None:
+        """Inline CohortDefinition with where=[] is accepted."""
+        defn = CohortDefinition.all_of(
+            CohortCriteria.did_event("Login", at_least=1, within_days=30, where=[])
+        )
+        f = Filter.in_cohort(defn, "empty where")
+        assert f._property == "$cohorts"
+
+    def test_cf3_allows_property_only_cohort(self) -> None:
+        """Inline CohortDefinition with only property criteria is accepted."""
+        defn = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+        )
+        f = Filter.in_cohort(defn, "property only")
+        assert f._property == "$cohorts"
+
+    def test_cf3_allows_saved_cohort_id(self) -> None:
+        """Saved cohort ID always accepted (server evaluates differently)."""
+        f = Filter.in_cohort(123, "saved")
+        assert f._property == "$cohorts"
+
+    def test_cf3_allows_mixed_behavioral_and_property_without_where(self) -> None:
+        """Mixed criteria without where= filters are accepted."""
+        defn = CohortDefinition.all_of(
+            CohortCriteria.has_property("plan", "premium"),
+            CohortCriteria.did_event("Login", at_least=1, within_days=30),
+            CohortCriteria.in_cohort(456),
+        )
+        f = Filter.in_cohort(defn, "mixed no where")
+        assert f._property == "$cohorts"
+
+    def test_cf3_error_message_contains_workarounds(self) -> None:
+        """Error message includes actionable workaround suggestions."""
+        defn = self._make_definition_with_where(Filter.equals("prop", "val"))
+        with pytest.raises(ValueError, match="Workarounds") as exc_info:
+            Filter.in_cohort(defn, "test")
+        msg = str(exc_info.value)
+        assert "ws.query(event, where=...)" in msg
+        assert "FunnelStep" in msg
+        assert "RetentionEvent" in msg
+        assert "ws.create_cohort()" in msg
+
+
+# =============================================================================
+# Event Selector JSON Snapshot Tests
+# =============================================================================
+
+
+class TestEventSelectorJSONSnapshots:
+    """Pin the exact JSON emitted by _build_event_selector for each filter operator.
+
+    These snapshot tests ensure the cohort selector payload structure
+    doesn't silently change across refactors.
+    """
+
+    def test_selector_equals(self) -> None:
+        """equals filter emits == operator with string operand list."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.equals("coupon_injected", "true"),
+        )
+        assert c._behavior is not None
+        selector = c._behavior["count"]["event_selector"]["selector"]
+        assert selector == {
+            "operator": "and",
+            "children": [
+                {
+                    "property": "event",
+                    "value": "coupon_injected",
+                    "operator": "==",
+                    "operand": ["true"],
+                    "type": "string",
+                }
+            ],
+        }
+
+    def test_selector_not_equals(self) -> None:
+        """not_equals filter emits != operator."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.not_equals("coupon_injected", "true"),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "!="
+        assert child["operand"] == ["true"]
+
+    def test_selector_is_not_set(self) -> None:
+        """is_not_set filter emits 'not defined' operator with no operand."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.is_not_set("coupon_injected"),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "not defined"
+        assert "operand" not in child
+
+    def test_selector_is_set(self) -> None:
+        """is_set filter emits 'defined' operator with no operand."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.is_set("coupon_injected"),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "defined"
+        assert "operand" not in child
+
+    def test_selector_greater_than_number(self) -> None:
+        """greater_than filter emits > operator with numeric operand."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.greater_than("discount_value", 50),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child == {
+            "property": "event",
+            "value": "discount_value",
+            "operator": ">",
+            "operand": 50,
+            "type": "number",
+        }
+
+    def test_selector_less_than_number(self) -> None:
+        """less_than filter emits < operator with numeric operand."""
+        c = CohortCriteria.did_event(
+            "coupon applied",
+            at_least=1,
+            within_days=30,
+            where=Filter.less_than("discount_value", 10),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "<"
+        assert child["operand"] == 10
+        assert child["type"] == "number"
+
+    def test_selector_contains(self) -> None:
+        """contains filter emits 'in' operator."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+            where=Filter.contains("category", "electronics"),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "in"
+        assert child["operand"] == "electronics"
+
+    def test_selector_between(self) -> None:
+        """between filter emits 'between' operator with two-element operand."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+            where=Filter.between("amount", 10, 100),
+        )
+        assert c._behavior is not None
+        child = c._behavior["count"]["event_selector"]["selector"]["children"][0]
+        assert child["operator"] == "between"
+        assert child["operand"] == [10, 100]
+        assert child["type"] == "number"
+
+    def test_selector_multiple_filters_and_combined(self) -> None:
+        """Multiple where filters produce AND-combined children list."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+            where=[
+                Filter.equals("plan", "premium"),
+                Filter.greater_than("amount", 100),
+                Filter.is_set("coupon"),
+            ],
+        )
+        assert c._behavior is not None
+        selector = c._behavior["count"]["event_selector"]["selector"]
+        assert selector["operator"] == "and"
+        assert len(selector["children"]) == 3
+        assert selector["children"][0]["operator"] == "=="
+        assert selector["children"][1]["operator"] == ">"
+        assert selector["children"][2]["operator"] == "defined"
+
+
+# =============================================================================
+# Operator Contract Test
+# =============================================================================
+
+
+class TestOperatorContract:
+    """Contract test: SDK-accepted operators match _FILTER_TO_SELECTOR_MAP.
+
+    Ensures no operator is silently added to Filter without a corresponding
+    cohort selector mapping, and vice versa.
+    """
+
+    def test_all_mapped_operators_are_accepted_by_did_event(self) -> None:
+        """Every operator in _FILTER_TO_SELECTOR_MAP can be used in did_event(where=...)."""
+        for op_name in _FILTER_TO_SELECTOR_MAP:
+            # Build a Filter with this operator via internal constructor
+            f = Filter(
+                _property="test_prop",
+                _operator=op_name,
+                _value=["dummy"] if op_name not in ("is set", "is not set") else None,
+                _property_type="string",
+                _resource_type="events",
+            )
+            # Should not raise
+            c = CohortCriteria.did_event(
+                "TestEvent", at_least=1, within_days=30, where=f
+            )
+            assert c._behavior is not None
+            selector = c._behavior["count"]["event_selector"]["selector"]
+            assert selector is not None
+
+    def test_unsupported_operator_rejected_by_did_event(self) -> None:
+        """Operators NOT in _FILTER_TO_SELECTOR_MAP raise ValueError in did_event."""
+        unsupported_ops = ["true", "false", "on", "before", "after", "within"]
+        for op in unsupported_ops:
+            f = Filter(
+                _property="test_prop",
+                _operator=op,
+                _value=["dummy"],
+                _property_type="string",
+                _resource_type="events",
+            )
+            with pytest.raises(ValueError, match="unsupported filter operator"):
+                CohortCriteria.did_event(
+                    "TestEvent", at_least=1, within_days=30, where=f
+                )
+
+    def test_selector_map_covers_all_value_filter_operators(self) -> None:
+        """_FILTER_TO_SELECTOR_MAP covers all non-date, non-boolean Filter operators.
+
+        This is the set of operators that a user would reasonably pass to
+        did_event(where=...). Date and boolean operators are correctly
+        rejected by the existing validator.
+        """
+        expected_covered = {
+            "equals",
+            "does not equal",
+            "contains",
+            "does not contain",
+            "is greater than",
+            "is less than",
+            "is set",
+            "is not set",
+            "is between",
+        }
+        assert set(_FILTER_TO_SELECTOR_MAP.keys()) == expected_covered


### PR DESCRIPTION
## Summary

- **Root cause**: Mixpanel's inline cohort evaluator silently ignores event-property filter operators in the legacy `event_selector.selector` schema. String filters collapse to `is_set` semantics; numeric filters are dropped entirely. This is a server-side bug — the SDK emits structurally correct, distinct payloads for each filter variant, but the server doesn't honor the operator values.
- **Fix**: Client-side guard (CF3) in `Filter.in_cohort()` / `Filter.not_in_cohort()` that raises `ValueError` when an inline `CohortDefinition` contains `CohortCriteria.did_event(where=...)` with event-property filters. Converts silent wrong numbers into a loud failure with actionable workarounds.
- **Scope**: `CohortCriteria.did_event(where=...)` remains usable for saved cohorts via `ws.create_cohort()`. Only the inline-cohort-in-query path is blocked.

### Hypotheses investigated

| # | Hypothesis | Verdict |
|---|-----------|---------|
| H1 | Legacy selector schema parsed loosely by server | **Confirmed** — two different JSON schemas; server doesn't fully support the legacy one |
| H2 | Wrong `property` meta-key | Ruled out — `property: "event"` is correct for event scope |
| H3 | Wrong operator vocabulary for cohort selectors | **Confirmed** — operators like `==`, `not defined`, `>` not honored by server |
| H4 | Server type inference coerces boolean-shaped properties | Ruled out — affects all property types equally |
| H5 | Outer AND wrapper drops the child | Ruled out — server parses wrapper, just ignores operator values |

### Changes

| File | Change |
|------|--------|
| `src/mixpanel_data/types.py` | Add `_cohort_has_event_selector_filters()` helper; CF3 check in `_build_cohort_filter()`; update docstrings with limitation warning |
| `tests/unit/test_cohort_definition.py` | +52 tests: CF3 rejection (all operators, nesting, acceptance), JSON snapshots (8 operators), operator contract |
| `tests/live/test_cohort_event_filter_live.py` | +14 live tests: CF3 guard verification, top-level filter ground truth with complement property check |
| `mixpanel-plugin/skills/mixpanelyst/SKILL.md` | Known limitation note with workarounds |
| `mixpanel-plugin/skills/mixpanelyst/references/insights-reference.md` | Known limitation note |
| `mixpanel-plugin/skills/mixpanelyst/references/python-api.md` | Limitation note, add `where=` to signature |
| `CHANGELOG.md` | New file — bug description, affected API, migration guidance |

### Migration for affected users

If your code passes event-property filters inside inline cohort definitions, switch to:
```python
# Top-level (single-event scoping)
ws.query("event", where=Filter.equals("prop", "val"))

# Funnels (multi-step)
ws.query_funnel([FunnelStep("event", filters=[Filter.equals("prop", "val")]), ...])

# Retention
ws.query_retention(RetentionEvent("event", filters=[...]), ...)

# Saved cohort (if you need cohort semantics)
cohort = ws.create_cohort(CreateCohortParams(name="...", definition=defn.to_dict()))
ws.query("event", where=Filter.in_cohort(cohort.id, "..."))
```

## Test plan

- [x] `just lint` — passes (0 errors)
- [x] `just typecheck` — passes (mypy --strict, 236 source files)
- [x] `just test` — 5032 passed, 7 pre-existing failures (credential config tests unrelated to this change)
- [x] `uv run pytest tests/unit/test_cohort_definition.py` — 112/112 passed
- [ ] `uv run pytest tests/live/test_cohort_event_filter_live.py -m live` — requires live API credentials (14 tests)
- [ ] Verify saved-cohort path (`ws.create_cohort()` + `Filter.in_cohort(<id>)`) as potential future server-side fix path