### PR TITLE
fix: emit Insights filter format in cohort event-property selectors

### DIFF
--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -8048,18 +8048,27 @@ _PROPERTY_OPERATOR_MAP: dict[str, str] = {
 }
 """Maps ``CohortCriteria.has_property()`` operator names to selector tree operators."""
 
-_FILTER_TO_SELECTOR_MAP: dict[str, str] = {
-    "equals": "==",
-    "does not equal": "!=",
-    "contains": "in",
-    "does not contain": "not in",
-    "is greater than": ">",
-    "is less than": "<",
-    "is set": "defined",
-    "is not set": "not defined",
-    "is between": "between",
-}
-"""Maps ``Filter._operator`` strings to event selector expression operators."""
+_FILTER_TO_SELECTOR_SUPPORTED: frozenset[str] = frozenset(
+    {
+        "equals",
+        "does not equal",
+        "contains",
+        "does not contain",
+        "is greater than",
+        "is less than",
+        "is set",
+        "is not set",
+        "is between",
+    }
+)
+"""Set of ``Filter._operator`` values accepted by ``_build_event_selector``.
+
+These operators are emitted verbatim in the Insights bookmark filter
+format (``filterOperator`` key) — no mapping is needed because the
+server's ``output_leaf_node`` routes ``filterOperator`` nodes through
+``filter_to_arb_selector_string``, which understands these names
+natively.
+"""
 
 
 def _validate_cohort_date(date_str: str) -> None:
@@ -8086,14 +8095,19 @@ def _build_event_selector(
 ) -> dict[str, Any]:
     """Convert Filter objects to an event selector expression tree.
 
-    Reads internal fields from ``Filter`` instances and maps operators
-    via ``_FILTER_TO_SELECTOR_MAP`` to produce selector tree nodes.
+    Each ``Filter`` is emitted as an **Insights bookmark filter** node
+    (``filterOperator`` / ``filterValue`` / ``filterType`` keys) rather
+    than the legacy selector-tree format (``operator`` / ``operand``).
+    The server's ``output_leaf_node`` routes ``filterOperator`` nodes
+    through ``filter_to_arb_selector_string``, which handles all
+    operators correctly.
 
     Args:
         filters: Single Filter or list of Filters to convert.
 
     Returns:
         Expression tree dict with ``operator`` and ``children`` keys.
+        Each child is an Insights bookmark filter node.
 
     Raises:
         ValueError: If a filter uses an unsupported operator.
@@ -8101,22 +8115,22 @@ def _build_event_selector(
     filter_list = [filters] if isinstance(filters, Filter) else filters
     children: list[dict[str, Any]] = []
     for f in filter_list:
-        mapped_op = _FILTER_TO_SELECTOR_MAP.get(f._operator)
-        if mapped_op is None:
-            supported = ", ".join(sorted(_FILTER_TO_SELECTOR_MAP.keys()))
+        if f._operator not in _FILTER_TO_SELECTOR_SUPPORTED:
+            supported = ", ".join(sorted(_FILTER_TO_SELECTOR_SUPPORTED))
             msg = (
                 f"unsupported filter operator for cohort selector: {f._operator!r}. "
                 f"Supported operators: {supported}"
             )
             raise ValueError(msg)
         node: dict[str, Any] = {
-            "property": "event",
+            "resourceType": f._resource_type,
+            "filterType": f._property_type,
+            "defaultType": f._property_type,
+            "filterOperator": f._operator,
             "value": f._property,
-            "operator": mapped_op,
         }
         if f._value is not None:
-            node["operand"] = f._value
-        node["type"] = f._property_type
+            node["filterValue"] = f._value
         children.append(node)
     return {"operator": "and", "children": children}
 

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -8122,13 +8122,43 @@ def _build_event_selector(
                 f"Supported operators: {supported}"
             )
             raise ValueError(msg)
+        prop = f._property
         node: dict[str, Any] = {
             "resourceType": f._resource_type,
             "filterType": f._property_type,
             "defaultType": f._property_type,
             "filterOperator": f._operator,
-            "value": f._property,
         }
+        if isinstance(prop, CustomPropertyRef):
+            node["customPropertyId"] = prop.id
+            node["dataset"] = "$mixpanel"
+        elif isinstance(prop, InlineCustomProperty):
+            effective_type = (
+                prop.property_type
+                if prop.property_type is not None
+                else f._property_type
+            )
+            node["customProperty"] = {
+                "displayFormula": prop.formula,
+                "composedProperties": {
+                    letter: {
+                        "value": pi.name,
+                        "type": pi.type,
+                        "resourceType": pi.resource_type,
+                    }
+                    for letter, pi in prop.inputs.items()
+                },
+                "name": "",
+                "description": "",
+                "propertyType": effective_type,
+                "resourceType": prop.resource_type,
+            }
+            node["filterType"] = effective_type
+            node["defaultType"] = effective_type
+            node["dataset"] = "$mixpanel"
+            node["resourceType"] = prop.resource_type
+        else:
+            node["value"] = prop
         if f._value is not None:
             node["filterValue"] = f._value
         children.append(node)

--- a/tests/unit/test_cohort_definition.py
+++ b/tests/unit/test_cohort_definition.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from mixpanel_data.types import (
-    _FILTER_TO_SELECTOR_MAP,
+    _FILTER_TO_SELECTOR_SUPPORTED,
     _PROPERTY_OPERATOR_MAP,
     CohortCriteria,
     CohortDefinition,
@@ -44,20 +44,20 @@ class TestOperatorMaps:
         }
         assert expected == _PROPERTY_OPERATOR_MAP
 
-    def test_filter_to_selector_map_has_all_operators(self) -> None:
-        """_FILTER_TO_SELECTOR_MAP maps all expected Filter._operator strings."""
+    def test_filter_to_selector_supported_has_all_operators(self) -> None:
+        """_FILTER_TO_SELECTOR_SUPPORTED contains all expected Filter._operator strings."""
         expected = {
-            "equals": "==",
-            "does not equal": "!=",
-            "contains": "in",
-            "does not contain": "not in",
-            "is greater than": ">",
-            "is less than": "<",
-            "is set": "defined",
-            "is not set": "not defined",
-            "is between": "between",
+            "equals",
+            "does not equal",
+            "contains",
+            "does not contain",
+            "is greater than",
+            "is less than",
+            "is set",
+            "is not set",
+            "is between",
         }
-        assert expected == _FILTER_TO_SELECTOR_MAP
+        assert expected == _FILTER_TO_SELECTOR_SUPPORTED
 
 
 # =============================================================================
@@ -125,7 +125,7 @@ class TestCohortCriteriaDidEvent:
         assert c._behavior["to_date"] == "2024-03-31"
 
     def test_where_single_filter(self) -> None:
-        """did_event with single where filter builds event selector expression."""
+        """did_event with single where filter builds Insights bookmark filter node."""
         c = CohortCriteria.did_event(
             "Purchase",
             at_least=1,
@@ -138,11 +138,12 @@ class TestCohortCriteriaDidEvent:
         assert selector["operator"] == "and"
         assert len(selector["children"]) == 1
         child = selector["children"][0]
-        assert child["property"] == "event"
+        assert child["resourceType"] == "events"
         assert child["value"] == "plan"
-        assert child["operator"] == "=="
-        assert child["operand"] == ["premium"]
-        assert child["type"] == "string"
+        assert child["filterOperator"] == "equals"
+        assert child["filterValue"] == ["premium"]
+        assert child["filterType"] == "string"
+        assert child["defaultType"] == "string"
 
     def test_where_multiple_filters(self) -> None:
         """did_event with multiple where filters produces AND-combined children."""
@@ -161,15 +162,15 @@ class TestCohortCriteriaDidEvent:
         assert selector["operator"] == "and"
         assert len(selector["children"]) == 2
 
-        # First child: plan == premium
+        # First child: plan equals premium
         assert selector["children"][0]["value"] == "plan"
-        assert selector["children"][0]["operator"] == "=="
+        assert selector["children"][0]["filterOperator"] == "equals"
 
         # Second child: amount > 100
         assert selector["children"][1]["value"] == "amount"
-        assert selector["children"][1]["operator"] == ">"
-        assert selector["children"][1]["operand"] == 100
-        assert selector["children"][1]["type"] == "number"
+        assert selector["children"][1]["filterOperator"] == "is greater than"
+        assert selector["children"][1]["filterValue"] == 100
+        assert selector["children"][1]["filterType"] == "number"
 
     def test_exactly_zero_is_valid(self) -> None:
         """did_event with exactly=0 is valid (used by did_not_do_event)."""
@@ -250,7 +251,7 @@ class TestCohortCriteriaDidEventValidation:
             )
 
     def test_unsupported_filter_operator_raises(self) -> None:
-        """ValueError when Filter uses an operator not in _FILTER_TO_SELECTOR_MAP."""
+        """ValueError when Filter uses an operator not in _FILTER_TO_SELECTOR_SUPPORTED."""
         with pytest.raises(ValueError, match="unsupported filter operator"):
             CohortCriteria.did_event(
                 "Login",


### PR DESCRIPTION
## Summary

Cohort event-property filters (`CohortCriteria.did_event(where=...)`) previously emitted the **legacy selector-tree format** with `operator`/`operand` keys (e.g. `"operator": "=="`, `"operand": ["true"]`). The server's `output_leaf_node()` only handles the **Insights bookmark filter format** (`filterOperator`/`filterValue`), causing these filters to be **silently ignored**:

- String filters collapsed to `is_set` semantics (wrong population count)
- Numeric filters were dropped entirely (returned unfiltered count)

### Fix

Change `_build_event_selector()` to emit nodes in the Insights bookmark filter format that the server already handles correctly via `filter_to_arb_selector_string()`.

**Before** (broken — server ignores operator):
```json
{"property": "event", "value": "coupon_injected", "operator": "==", "operand": ["true"], "type": "string"}
```

**After** (works — server routes through filter_to_arb_selector_string):
```json
{"resourceType": "events", "filterOperator": "equals", "filterValue": ["true"], "filterType": "string", "defaultType": "string", "value": "coupon_injected"}
```

This is the same format used by the working top-level `ws.query(event, where=Filter.equals(...))` path.

### Changes

| File | Change |
|------|--------|
| `src/mixpanel_data/types.py` | Rewrite `_build_event_selector()` to emit `filterOperator` format; replace `_FILTER_TO_SELECTOR_MAP` dict with `_FILTER_TO_SELECTOR_SUPPORTED` set |
| `tests/unit/test_cohort_definition.py` | Update assertions to match new format |

## Test plan

- [x] `just lint` — 0 errors
- [x] `just typecheck` — mypy --strict, 235 source files, 0 issues
- [x] `uv run pytest tests/unit/test_cohort_definition.py` — 80/80 passed
- [ ] Live verification: run the bug report repro script to confirm `is_not_set`, `not_equals`, `equals("XYZNONE")`, and numeric filters now return correct counts via inline cohort path