### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mixpanel_data"
-version = "0.1.1"
+dynamic = ["version"]
 description = "Python library for working with Mixpanel analytics data, designed for AI coding agents"
 readme = "README.md"
 license = "MIT"
@@ -56,6 +56,9 @@ docs = [
     "mkdocs-llmstxt-md>=0.1.0",
 ]
 notebook = ["ipykernel>=6.0"]
+
+[tool.hatch.version]
+path = "src/mixpanel_data/__init__.py"
 
 [project.scripts]
 mp = "mixpanel_data.cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mixpanel_data"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python library for working with Mixpanel analytics data, designed for AI coding agents"
 readme = "README.md"
 license = "MIT"

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -245,7 +245,7 @@ from mixpanel_data.types import (
 )
 from mixpanel_data.workspace import Workspace
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Core


### PR DESCRIPTION
## Summary

Patch version bump to 0.1.1.

### Included since 0.1.0

- **fix**: Cohort event-property filters (`CohortCriteria.did_event(where=...)`) now emit the Insights bookmark filter format (`filterOperator`/`filterValue`) instead of the legacy selector-tree format (`operator`/`operand`), fixing silent wrong results when used in inline `CohortDefinition` via `Filter.in_cohort()`. (#114)

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI