### PR TITLE
chore(plugin): remove JQL references from plugin

### DIFF
--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Turn Claude into a senior data analyst and Mixpanel product analytics expert. CodeMode-first: Claude writes Python using mixpanel_data's 4 typed query engines (insights, funnels, retention, flows) plus pandas, networkx, and anytree for sophisticated multi-engine analysis.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/agents/explorer.md
+++ b/mixpanel-plugin/agents/explorer.md
@@ -77,25 +77,6 @@ schemas = ws.lexicon_schemas()                    # all defined schemas
 schema = ws.lexicon_schema("event", "Purchase")   # definition + tags for one event
 ```
 
-### JQL Discovery (Deep Schema Exploration)
-
-```python
-# Property distribution — what values does a property take?
-dist = ws.property_distribution("Purchase", "category", from_date="2025-01-01", to_date="2025-03-31", limit=20)
-
-# Numeric summary — min, max, mean, median, percentiles
-summary = ws.numeric_summary("Purchase", "amount", from_date="2025-01-01", to_date="2025-03-31")
-
-# Daily event counts
-counts = ws.daily_counts(from_date="2025-01-01", to_date="2025-03-31", events=["Login"])
-
-# Engagement distribution — how many times per user?
-engagement = ws.engagement_distribution(from_date="2025-01-01", to_date="2025-03-31")
-
-# Property coverage — what % of events have this property set?
-coverage = ws.property_coverage("Purchase", properties=["utm_source"], from_date="2025-01-01", to_date="2025-03-31")
-```
-
 ### Lexicon Integration
 
 Use Lexicon definitions to understand what properties mean and how they're categorized:

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mixpanelyst
-description: This skill should be used when the user asks about Mixpanel product analytics, event data, funnel analysis, retention curves, cohort analysis, segmentation queries, JQL, user behavior, conversion rates, churn, DAU/MAU, ARPU, revenue metrics, feature adoption, A/B test results, user paths, flow analysis, or any request to query, explore, visualize, or analyze Mixpanel data using Python.
+description: This skill should be used when the user asks about Mixpanel product analytics, event data, funnel analysis, retention curves, cohort analysis, segmentation queries, user behavior, conversion rates, churn, DAU/MAU, ARPU, revenue metrics, feature adoption, A/B test results, user paths, flow analysis, or any request to query, explore, visualize, or analyze Mixpanel data using Python.
 allowed-tools: Bash Read Write
 ---
 
@@ -703,7 +703,6 @@ from mixpanel_data.exceptions import (
     RateLimitError,            # 429 — back off and retry
     QueryError,                # 400 — bad parameters
     BookmarkValidationError,   # pre-flight validation failure
-    JQLSyntaxError,            # 412 — JQL script error
     WorkspaceScopeError,       # workspace_id required for App API
     ConfigError,               # credentials not configured
     ProjectNotFoundError,      # project ID not found in /me response

--- a/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
@@ -1068,7 +1068,6 @@ MixpanelDataError (base)
 │   ├── AuthenticationError (401)
 │   ├── RateLimitError (429)
 │   ├── QueryError (400)
-│   │   └── JQLSyntaxError (412)
 │   └── ServerError (5xx)
 ├── ProjectNotFoundError
 ├── OAuthError

--- a/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/python-api.md
@@ -682,8 +682,6 @@ ws.retention(
 ) -> RetentionResult
 # Legacy — prefer: ws.query_retention() for ad-hoc retention queries
 
-ws.jql(script: str, params: dict | None = None) -> JQLResult
-
 ws.query_saved_report(bookmark_id: int) -> SavedReportResult
 ```
 
@@ -735,16 +733,6 @@ ws.segmentation_average(
     where: str | None = None,
 ) -> NumericAverageResult
 # Legacy — prefer: ws.query(event, math="average", math_property="...")
-```
-
-## Analytics — JQL Discovery Helpers
-
-```python
-ws.property_distribution(event: str, property: str, limit: int = 20) -> PropertyDistributionResult
-ws.numeric_summary(event: str, property: str) -> NumericPropertySummaryResult
-ws.daily_counts(event: str, from_date: str, to_date: str) -> DailyCountsResult
-ws.engagement_distribution(event: str, from_date: str, to_date: str) -> EngagementDistributionResult
-ws.property_coverage(event: str, property: str, from_date: str, to_date: str) -> PropertyCoverageResult
 ```
 
 ## Streaming
@@ -1058,7 +1046,6 @@ All query results have a `.df` property returning a pandas DataFrame. Key types:
 | `SegmentationResult` | `segmentation()` | `.df`, `.data`, `.series` |
 | `FunnelResult` | `funnel()` | `.df`, `.steps` (list of `FunnelResultStep`), `.conversion_rate` |
 | `RetentionResult` | `retention()` | `.df`, `.data` |
-| `JQLResult` | `jql()` | `.df`, `.data` |
 | `EventCountsResult` | `event_counts()` | `.df`, `.data` |
 | `ActivityFeedResult` | `activity_feed()` | `.events` |
 | `FlowsResult` | `query_saved_flows()` | `.df`, `.data` |

--- a/mixpanel-plugin/skills/mixpanelyst/references/query-taxonomy.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/query-taxonomy.md
@@ -11,7 +11,7 @@ Deep reference for mapping natural-language analytics questions to the correct `
 | **Retention** | `ws.query_retention()` | Cohort retention curves, return behavior | `RetentionQueryResult` |
 | **Flows** | `ws.query_flow()` | User path analysis, event sequences | `FlowQueryResult` |
 
-Additionally, legacy methods (`segmentation`, `funnel`, `retention`, `jql`) remain available for specific cases, and discovery methods (`events`, `properties`, `property_values`, `top_events`) provide schema context.
+Additionally, legacy methods (`segmentation`, `funnel`, `retention`) remain available for specific cases, and discovery methods (`events`, `properties`, `property_values`, `top_events`) provide schema context.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove all JQL mentions, JQL discovery helper methods, and JQL result types from the plugin to discourage agents from making JQL API calls
- The underlying `mixpanel_data` library capability remains intact — this only affects what the plugin surfaces to agents
- Bump plugin version to 3.1.2

## Files changed
- `plugin.json` — version bump 3.1.1 → 3.1.2
- `SKILL.md` — removed JQL from trigger keywords, removed `JQLSyntaxError` from error handling
- `python-api.md` — removed `ws.jql()` method, JQL discovery helpers section, `JQLResult` from types table
- `query-taxonomy.md` — removed `jql` from legacy methods list
- `explorer.md` — removed JQL discovery code examples

## Test plan
- [x] `grep -ri jql mixpanel-plugin/` returns zero matches
- [ ] Verify plugin loads correctly in Claude Code