### PR TITLE
chore: add pyarrow dep, bump plugin to 3.2.1, add context docs

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/039-query-user-engine"
+}

--- a/context/BACKPORT-PLAN.md
+++ b/context/BACKPORT-PLAN.md
@@ -1,0 +1,463 @@
+# Backport Plan: TypeScript Feature Parity → Python mixpanel_data
+
+## Context
+
+The TypeScript `@mixpanel-data/bookmark` library has added several features that originated from `mixpanel-power-tools` but don't yet exist in the Python `mixpanel_data` library. This plan backports them to Python to maintain cross-language parity.
+
+## Features to Backport
+
+| # | Feature | TS Source | Python Target |
+|---|---------|-----------|---------------|
+| 1 | Funnel reentry mode | `build-funnel-params.ts` | `workspace.py:query_funnel()` |
+| 2 | Retention unbounded mode | `build-retention-params.ts` | `workspace.py:query_retention()` |
+| 3 | Time comparison | `build-params.ts`, `build-funnel-params.ts`, `build-retention-params.ts` | All query methods |
+| 4 | Frequency breakdowns | `build-helpers.ts`, `filter-factories.ts` | `workspace.py:query()` |
+| 5 | Display formatting | `types.ts` (Metric.display, Formula.display) | `types.py:Metric`, `types.py:Formula` |
+| 6 | Y-axis, lift, value mode | `build-params.ts` | `workspace.py:query()` |
+| 7 | Legend pass-through | All builders | All query methods |
+
+---
+
+## Feature 1: Funnel Reentry Mode
+
+### Type Alias
+**File**: `src/mixpanel_data/_literal_types.py`
+```python
+FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]
+```
+
+### Validation Constant
+**File**: `src/mixpanel_data/_internal/bookmark_enums.py`
+```python
+VALID_FUNNEL_REENTRY_MODES: frozenset[str] = frozenset({
+    "default", "basic", "aggressive", "optimized",
+})
+```
+
+### Validation Rule
+**File**: `src/mixpanel_data/_internal/validation.py` (in `validate_funnel_args()`)
+```python
+# F12: reentry_mode must be valid
+if reentry_mode not in VALID_FUNNEL_REENTRY_MODES:
+    errors.append(validation_error(
+        "reentry_mode", "reentryMode", reentry_mode,
+        VALID_FUNNEL_REENTRY_MODES, "F12_INVALID_REENTRY_MODE",
+    ))
+```
+
+### Public API
+**File**: `src/mixpanel_data/workspace.py`
+
+Add to `query_funnel()` (line ~2622):
+```python
+def query_funnel(
+    self,
+    steps: list[str | FunnelStep],
+    *,
+    # ... existing params ...
+    reentry_mode: FunnelReentryMode = "default",  # NEW
+) -> FunnelQueryResult:
+```
+
+Add to `_build_funnel_params()` (line ~2338):
+```python
+# In the behavior dict construction:
+behavior["funnelReentryMode"] = reentry_mode
+```
+
+Pass through `_resolve_and_build_funnel_params()` (line ~2501).
+
+### Export
+**File**: `src/mixpanel_data/__init__.py`
+```python
+from ._literal_types import FunnelReentryMode
+```
+
+### Tests
+**File**: `tests/unit/test_funnel_params.py` (or existing test file)
+- Test each valid mode produces correct `behavior.funnelReentryMode`
+- Test invalid mode triggers `F12_INVALID_REENTRY_MODE`
+- Test default is `"default"`
+
+---
+
+## Feature 2: Retention Unbounded Mode
+
+### Type Alias
+**File**: `src/mixpanel_data/_literal_types.py`
+```python
+RetentionUnboundedMode = Literal["none", "carry_back", "carry_forward", "consecutive_forward"]
+```
+
+### Validation Constant
+**File**: `src/mixpanel_data/_internal/bookmark_enums.py`
+```python
+VALID_RETENTION_UNBOUNDED_MODES: frozenset[str] = frozenset({
+    "none", "carry_back", "carry_forward", "consecutive_forward",
+})
+```
+
+### Validation Rule
+**File**: `src/mixpanel_data/_internal/validation.py` (in `validate_retention_args()`)
+```python
+# R13: unbounded_mode must be valid
+if unbounded_mode not in VALID_RETENTION_UNBOUNDED_MODES:
+    errors.append(validation_error(
+        "unbounded_mode", "unboundedMode", unbounded_mode,
+        VALID_RETENTION_UNBOUNDED_MODES, "R13_INVALID_UNBOUNDED_MODE",
+    ))
+```
+
+### Public API
+**File**: `src/mixpanel_data/workspace.py`
+
+Add to `query_retention()` (line ~3618):
+```python
+def query_retention(
+    self,
+    born_event: str | RetentionEvent,
+    return_event: str | RetentionEvent,
+    *,
+    # ... existing params ...
+    unbounded_mode: RetentionUnboundedMode = "none",  # NEW
+) -> RetentionQueryResult:
+```
+
+Add to `_build_retention_params()` (line ~2853):
+```python
+# In the retention behavior dict:
+retention_behavior["retentionUnboundedMode"] = unbounded_mode
+```
+
+Pass through `_resolve_and_build_retention_params()` (line ~3509).
+
+### Export
+**File**: `src/mixpanel_data/__init__.py`
+```python
+from ._literal_types import RetentionUnboundedMode
+```
+
+### Tests
+- Test each valid mode
+- Test invalid mode triggers `R13_INVALID_UNBOUNDED_MODE`
+- Test default is `"none"`
+
+---
+
+## Feature 3: Time Comparison
+
+### Dataclass
+**File**: `src/mixpanel_data/types.py`
+```python
+@dataclass(frozen=True)
+class RelativeTimeComparison:
+    """Compare to same period in previous time unit."""
+    type: Literal["relative"] = "relative"
+    unit: Literal["day", "week", "month", "quarter", "year"] = "week"
+
+@dataclass(frozen=True)
+class AbsoluteTimeComparison:
+    """Compare to a specific date range."""
+    type: Literal["absolute-start", "absolute-end"]
+    date: str  # YYYY-MM-DD
+
+TimeComparison = RelativeTimeComparison | AbsoluteTimeComparison
+```
+
+### Public API
+**File**: `src/mixpanel_data/workspace.py`
+
+Add to `query()`, `query_funnel()`, `query_retention()`:
+```python
+time_comparison: TimeComparison | None = None,  # NEW
+```
+
+In each `_build_*_params()`, after assembling params:
+```python
+if time_comparison is not None:
+    params["timeComparison"] = {
+        "type": time_comparison.type,
+        **({"unit": time_comparison.unit} if isinstance(time_comparison, RelativeTimeComparison) else {"date": time_comparison.date}),
+    }
+```
+
+### Export
+```python
+from .types import RelativeTimeComparison, AbsoluteTimeComparison, TimeComparison
+```
+
+### Tests
+- Test relative comparison with each unit
+- Test absolute-start and absolute-end with dates
+- Test None (omitted) produces no `timeComparison` key
+
+---
+
+## Feature 4: Frequency Breakdowns
+
+### Dataclass
+**File**: `src/mixpanel_data/types.py`
+```python
+@dataclass(frozen=True)
+class FrequencyBreakdown:
+    """Break down by event frequency (how many times users performed an event)."""
+    event: str
+    window_length: int = 7
+    window_length_unit: Literal["day", "week", "month"] = "day"
+    custom_bucket: FrequencyCustomBucket | None = None
+
+@dataclass(frozen=True)
+class FrequencyCustomBucket:
+    """Custom bucketing for frequency breakdowns."""
+    bucket_size: int = 1
+    min: int = 0
+    max: int = 10
+    groups: list[int] | None = None
+```
+
+### Builder
+**File**: `src/mixpanel_data/_internal/bookmark_builders.py`
+```python
+def _build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
+    group = {
+        "dataset": "$mixpanel",
+        "behavior": {
+            "aggregationOperator": "total",
+            "event": {"label": fb.event, "value": fb.event},
+            "filters": [],
+            "filtersOperator": "and",
+            "dateRange": None,
+            "behaviorType": "$frequency",
+            "windowLength": fb.window_length,
+            "windowLengthUnit": fb.window_length_unit,
+        },
+        "value": f"{fb.event} Frequency",
+        "resourceType": "people",
+        "profileType": None,
+        "search": "",
+        "dataGroupId": None,
+        "propertyType": "number",
+        "typeCast": None,
+        "unit": None,
+        "isHidden": False,
+    }
+    if fb.custom_bucket is not None:
+        group["customBucket"] = {
+            "bucketSize": fb.custom_bucket.bucket_size,
+            "min": fb.custom_bucket.min,
+            "max": fb.custom_bucket.max,
+            "offset": None,
+            "disabled": False,
+            "groups": list(fb.custom_bucket.groups) if fb.custom_bucket.groups else None,
+            "unit": None,
+        }
+    return group
+```
+
+Integrate into `build_group_section()`:
+```python
+elif isinstance(g, FrequencyBreakdown):
+    group_section.append(_build_frequency_group_entry(g))
+```
+
+### Public API
+Extend `group_by` parameter type in `query()`:
+```python
+group_by: str | GroupBy | CohortBreakdown | FrequencyBreakdown | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown] | None = None,
+```
+
+### Frequency Filter
+Add `Filter.by_frequency()` class method to `types.py`:
+```python
+@classmethod
+def by_frequency(
+    cls,
+    event: str,
+    *,
+    operator: str = "is at least",
+    value: int = 1,
+    aggregation: str = "total",
+    date_range: dict[str, Any] | None = None,
+    event_filters: list[Filter] | None = None,
+) -> Filter:
+    """Create a frequency filter (users who did event N times)."""
+```
+
+### Export
+```python
+from .types import FrequencyBreakdown, FrequencyCustomBucket
+```
+
+### Tests
+- Test breakdown produces correct `behavior.behaviorType: "$frequency"`
+- Test custom bucket
+- Test frequency filter with operator/value options
+
+---
+
+## Feature 5: Display Formatting
+
+### Dataclass
+**File**: `src/mixpanel_data/types.py`
+```python
+@dataclass(frozen=True)
+class DisplayFormatting:
+    """Per-metric display formatting options."""
+    prefix: str | None = None
+    suffix: str | None = None
+    direction: str | None = None
+    precision: int | None = None
+```
+
+### Type Changes
+Add optional `display` field to `Metric` (line ~6999) and `Formula` (line ~7078):
+```python
+@dataclass(frozen=True)
+class Metric:
+    # ... existing fields ...
+    display: DisplayFormatting | None = None  # NEW
+
+@dataclass(frozen=True)
+class Formula:
+    # ... existing fields ...
+    display: DisplayFormatting | None = None  # NEW
+```
+
+### Builder
+**File**: `src/mixpanel_data/workspace.py` (in `_build_query_params()`)
+When building show clauses, if `metric.display` is not None:
+```python
+if hasattr(item, 'display') and item.display is not None:
+    entry["display"] = {
+        k: v for k, v in {
+            "prefix": item.display.prefix,
+            "suffix": item.display.suffix,
+            "direction": item.display.direction,
+            "precision": item.display.precision,
+        }.items() if v is not None
+    }
+```
+
+### Export
+```python
+from .types import DisplayFormatting
+```
+
+### Tests
+- Test metric with `display=DisplayFormatting(prefix="$")` produces `show[].display.prefix`
+- Test formula with `display=DisplayFormatting(suffix="%")`
+- Test None display is omitted
+
+---
+
+## Feature 6: Y-Axis, Lift, Value Mode
+
+### Dataclass
+**File**: `src/mixpanel_data/types.py`
+```python
+@dataclass(frozen=True)
+class YAxisOptions:
+    """Y-axis configuration options."""
+    min: float | None = None
+    max: float | None = None
+    log_scale: bool | None = None
+```
+
+### Public API
+**File**: `src/mixpanel_data/workspace.py`
+
+Add to `query()`:
+```python
+def query(
+    self,
+    events: ...,
+    *,
+    # ... existing params ...
+    y_axis_options: YAxisOptions | None = None,  # NEW
+    lift_comparison: dict[str, Any] | None = None,  # NEW
+    value_mode: Literal["absolute", "relative"] = "absolute",  # NEW
+) -> QueryResult:
+```
+
+In `_build_query_params()`:
+```python
+if y_axis_options is not None:
+    display_options["primaryYAxisOptions"] = {
+        k: v for k, v in {
+            "min": y_axis_options.min,
+            "max": y_axis_options.max,
+            "logScale": y_axis_options.log_scale,
+        }.items() if v is not None
+    }
+if lift_comparison is not None:
+    display_options["liftComparison"] = lift_comparison
+if value_mode == "relative":
+    display_options["value"] = "relative"
+```
+
+### Export
+```python
+from .types import YAxisOptions
+```
+
+### Tests
+- Test y_axis_options produces `displayOptions.primaryYAxisOptions`
+- Test lift_comparison pass-through
+- Test value_mode="relative" sets `displayOptions.value`
+
+---
+
+## Feature 7: Legend Pass-Through
+
+### Public API
+**File**: `src/mixpanel_data/workspace.py`
+
+Add to `query()`, `query_funnel()`, `query_retention()`:
+```python
+legend: dict[str, Any] | None = None,  # NEW
+```
+
+In each `_build_*_params()`:
+```python
+if legend is not None:
+    params["legend"] = legend
+```
+
+### Tests
+- Test legend dict is passed through to params
+- Test None legend is omitted
+
+---
+
+## Implementation Order
+
+1. Features 1 + 2 (funnel reentry + retention unbounded) — smallest, independent, good warmup
+2. Feature 3 (time comparison) — touches multiple query methods
+3. Feature 4 (frequency breakdowns) — new type + builder + group_by extension
+4. Features 5 + 6 + 7 (display/formatting) — simple pass-throughs, batch together
+
+## Files Modified (Summary)
+
+| File | Changes |
+|------|---------|
+| `_literal_types.py` | Add `FunnelReentryMode`, `RetentionUnboundedMode` |
+| `_internal/bookmark_enums.py` | Add `VALID_FUNNEL_REENTRY_MODES`, `VALID_RETENTION_UNBOUNDED_MODES` |
+| `_internal/validation.py` | Add `F12_INVALID_REENTRY_MODE`, `R13_INVALID_UNBOUNDED_MODE` rules |
+| `_internal/bookmark_builders.py` | Add `_build_frequency_group_entry()`, integrate in `build_group_section()` |
+| `types.py` | Add `TimeComparison`, `FrequencyBreakdown`, `FrequencyCustomBucket`, `DisplayFormatting`, `YAxisOptions` dataclasses. Add `display` field to `Metric` and `Formula`. |
+| `workspace.py` | Add keyword params to `query()`, `query_funnel()`, `query_retention()` and internal `_build_*_params()` / `_resolve_and_build_*_params()` methods |
+| `__init__.py` | Export new types and literals |
+
+## Validation Error Codes (must match TypeScript)
+
+| Code | Rule | Feature |
+|------|------|---------|
+| `F12_INVALID_REENTRY_MODE` | Funnel reentry mode must be in valid set | #1 |
+| `R13_INVALID_UNBOUNDED_MODE` | Retention unbounded mode must be in valid set | #2 |
+
+## Testing Strategy
+
+- Unit tests in `tests/unit/` for each new parameter
+- Bookmark output tests comparing Python output against TypeScript output for identical inputs
+- Conformance test cases in `conformance/suites/` that run against both implementations
+- `uv run pytest tests/` + `uv run mypy src/` must pass

--- a/context/cowork-bundling-feasibility.md
+++ b/context/cowork-bundling-feasibility.md
@@ -1,0 +1,311 @@
+# Feasibility Report: Bundling mixpanel_data into the Claude Cowork Plugin
+
+**Date**: 2026-04-13
+**Author**: Claude (at Jared's request)
+**Status**: Analysis complete
+
+---
+
+## Executive Summary
+
+**Can we package the entire `mixpanel_data` Python library into a ZIP with the existing plugin so it works in Cowork without `pip install`?**
+
+**Verdict: Not fully, but close.** The library source code (1.8 MB) can be bundled easily. However, four of its nine runtime dependencies contain **native C/Rust extensions** that are platform-specific binaries — they cannot be pre-compiled into a universal ZIP. A hybrid approach (bundled source + SessionStart hook for native deps) is the recommended path.
+
+---
+
+## Current State
+
+### Plugin (mixpanel-plugin/)
+| Metric | Value |
+|--------|-------|
+| Size | 740 KB |
+| Components | 5 agents, 3 skills, 1 command, 2 scripts |
+| Cowork support | Full (auth bridge, auto-detection, token refresh) |
+| Distribution | Not yet packaged as ZIP |
+
+### Library (src/mixpanel_data/)
+| Metric | Value |
+|--------|-------|
+| Source files | 66 Python files |
+| Lines of code | 55,334 |
+| Source size (no cache) | 1.8 MB |
+| Python version | 3.10+ |
+| Version | 0.2.0 |
+
+### Current Install Flow
+1. User runs `/mixpanel-data:setup`
+2. `setup.sh` executes `pip install git+https://github.com/jaredmcfarland/mixpanel_data.git`
+3. Also installs pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy
+4. Total download + install: **~103 MB** of site-packages
+
+---
+
+## The Blocker: Native Extensions
+
+Four runtime dependencies ship **compiled C/Rust binaries** (`.so`/`.dylib` files):
+
+| Package | Size | Extension Type | Why Native |
+|---------|------|---------------|------------|
+| **numpy** | 21.7 MB | C + Fortran | Linear algebra, array operations |
+| **pandas** | 45.5 MB | Cython → C | DataFrame internals, parsers |
+| **pydantic-core** | 4.4 MB | Rust (PyO3) | Validation engine |
+| **jq** | < 0.1 MB | C (libjq) | JSON query processing |
+
+These `.so` files are compiled for a specific platform + Python version combination (e.g., `cpython-312-darwin-arm64`). **Cowork VMs run Linux x86_64** — macOS binaries won't load there.
+
+### Pure-Python Dependencies (safe to bundle)
+
+| Package | Size | Notes |
+|---------|------|-------|
+| networkx | 10.9 MB | Graph algorithms |
+| rich | 1.9 MB | Terminal formatting |
+| httpx + httpcore | 1.2 MB | HTTP client |
+| click | 0.8 MB | CLI framework |
+| typer | 0.4 MB | CLI framework (wraps click) |
+| anyio | 1.3 MB | Async I/O |
+| pygments | 4.7 MB | Syntax highlighting |
+| anytree | 0.3 MB | Tree structures |
+| certifi, idna, h11, etc. | ~1.5 MB | HTTP internals |
+
+**Total pure-Python deps**: ~23 MB (uncompressed)
+
+---
+
+## Cowork Plugin Constraints
+
+| Constraint | Value | Source |
+|------------|-------|--------|
+| Max ZIP size | **50 MB** | Cowork admin plugin upload |
+| Plugin root | `${CLAUDE_PLUGIN_ROOT}` | Read-only after install, changes on update |
+| Persistent data | `${CLAUDE_PLUGIN_DATA}` | Survives updates, at `~/.claude/plugins/data/{id}/` |
+| VM platform | **Linux x86_64** | Sandboxed Cowork VM |
+| VM Python | Typically 3.12+ | Pre-installed in sandbox |
+| Network access | **Yes** (public internet) | pip/uv can reach PyPI |
+| Local filesystem | Sandboxed per session | No host access except workspace dir |
+
+---
+
+## Options Evaluated
+
+### Option A: Bundle Everything (Source + All Deps) in ZIP
+
+**Verdict: NOT FEASIBLE**
+
+- Uncompressed size: 1.8 MB (source) + 103 MB (deps) = **~105 MB** — exceeds 50 MB ZIP limit even with compression
+- Native extensions are platform-specific — macOS `.so` files won't load on Linux Cowork VMs
+- Would need separate ZIPs per platform (macOS arm64, macOS x86, Linux x86_64) per Python version (3.10, 3.11, 3.12, 3.13) = **8+ variants**
+- Maintenance nightmare for updates
+
+### Option B: Bundle Source Only, pip Install Deps at Runtime
+
+**Verdict: FEASIBLE — Marginal Improvement**
+
+- Bundle: plugin (740 KB) + library source (1.8 MB) = **~2.5 MB ZIP**
+- SessionStart hook installs deps from PyPI: `pip install pandas numpy pydantic httpx ...`
+- Eliminates: GitHub clone of `mixpanel_data` (~10s)
+- Still requires: ~60s for pip install of native deps on first session
+- Complexity: need `sys.path` manipulation so bundled source is importable
+
+### Option C: Bundle Source + Pure-Python Deps, pip Install Native Deps Only
+
+**Verdict: FEASIBLE — Moderate Improvement, High Complexity**
+
+- Bundle: plugin (740 KB) + source (1.8 MB) + pure deps (~23 MB) = **~12 MB ZIP** (compressed ~8 MB)
+- SessionStart hook installs only: `numpy pandas pydantic-core jq` (~72 MB)
+- Saves: ~30% of install time (pure deps already present)
+- Risk: version conflicts between bundled pure deps and pip-resolved native deps
+- Complexity: vendoring with `sys.path` manipulation, namespace isolation
+
+### Option D: SessionStart Hook + CLAUDE_PLUGIN_DATA Venv (Recommended Pattern)
+
+**Verdict: RECOMMENDED — Best Practice**
+
+- Bundle: plugin (740 KB) + source (1.8 MB) + `requirements.txt` = **~2.5 MB ZIP**
+- SessionStart hook creates/reuses a Python venv in `${CLAUDE_PLUGIN_DATA}/venv/`
+- Diffs `requirements.txt` against cached copy — only reinstalls when deps change
+- First session: ~60-90s for venv creation + pip install
+- Subsequent sessions: **< 1s** (diff check passes, venv already exists)
+- No platform concerns — pip resolves correct wheels for the VM
+- Official Anthropic-recommended pattern for plugin dependencies
+
+### Option E: Thin Plugin, Full PyPI Publish
+
+**Verdict: BEST LONG-TERM — Requires PyPI Presence**
+
+- Publish `mixpanel_data` to PyPI (currently GitHub-only)
+- SessionStart hook: `pip install mixpanel_data[analytics]`
+- Single command installs everything, pip handles caching
+- Fastest install (PyPI CDN + wheel caching), simplest maintenance
+- Blocked by: package not yet on PyPI
+
+---
+
+## Recommendation: Option D (with path to E)
+
+### Phase 1: Hybrid Bundle (Option D)
+
+Package structure:
+
+```
+mixpanel-data-plugin.zip
+├── .claude-plugin/
+│   └── plugin.json          # Add hooks section
+├── agents/                   # Existing 5 agents
+├── commands/                 # Existing auth command
+├── skills/                   # Existing 3 skills
+├── docs/                     # Existing docs
+├── lib/                      # NEW: bundled library source
+│   └── mixpanel_data/        # Copy of src/mixpanel_data/
+├── requirements.txt          # NEW: pinned runtime deps
+├── bin/
+│   └── ensure-deps.sh        # NEW: venv bootstrap script
+└── README.md
+```
+
+**plugin.json additions**:
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/ensure-deps.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**ensure-deps.sh** logic:
+1. Check if `${CLAUDE_PLUGIN_DATA}/venv/` exists
+2. Diff `${CLAUDE_PLUGIN_ROOT}/requirements.txt` against `${CLAUDE_PLUGIN_DATA}/requirements.txt`
+3. If diff or no venv: create venv, `pip install -r requirements.txt`, install bundled source via `pip install -e ${CLAUDE_PLUGIN_ROOT}/lib/`
+4. Copy requirements.txt to data dir for next session's diff
+5. Export `PYTHONPATH` or activate venv for subsequent Bash tool calls
+
+**Estimated ZIP size**: ~2.5 MB (well under 50 MB limit)
+
+**First-session install time**: ~60-90s (venv creation + pip from PyPI)
+
+**Repeat-session time**: < 1s (requirements diff passes)
+
+### Phase 2: PyPI Publish (Option E)
+
+Once `mixpanel_data` is on PyPI:
+- Remove `lib/` from plugin ZIP
+- `requirements.txt` becomes just `mixpanel_data[analytics]>=0.2.0`
+- Install time drops (PyPI wheel caching, CDN)
+- Plugin ZIP shrinks to ~800 KB
+
+---
+
+## What "Zero Install" Actually Means in Cowork
+
+True zero-install (no network, no pip) is **not achievable** for this project because of native extensions. However, the **user experience** can feel like zero-install:
+
+| Scenario | User Experience | What Happens Behind the Scenes |
+|----------|----------------|-------------------------------|
+| First session ever | ~60s wait at session start | SessionStart hook builds venv |
+| Repeat session | Instant | Hook diffs requirements, skips install |
+| Plugin update (same deps) | Instant | requirements.txt unchanged, venv reused |
+| Plugin update (new deps) | ~30s | Hook detects diff, updates venv |
+
+The user never runs `/mixpanel-data:setup` manually — the hook handles everything.
+
+---
+
+## Risk Matrix
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Cowork VM lacks Python 3.10+ | Low | High | Check in hook, fail with clear message |
+| pip/uv not available in VM | Low | High | Fall back to `python -m ensurepip` |
+| PyPI unreachable from VM | Very Low | High | Cowork VMs have public internet |
+| Venv corrupted between sessions | Low | Medium | Hook detects import failure, rebuilds venv |
+| requirements.txt drift vs library | Medium | Medium | Pin exact versions from uv.lock |
+| Native extension build fails (no compiler) | Low | High | Use `--only-binary :all:` to force wheel-only install |
+| 50 MB ZIP limit exceeded | Very Low | High | Current estimate: ~2.5 MB |
+
+---
+
+## Appendix A: Dependency Size Breakdown
+
+### Uncompressed Runtime Dependencies (103.4 MB total)
+
+```
+ pandas          45.5 MB  ██████████████████████████████████████████  (native)
+ numpy           21.7 MB  ████████████████████                       (native)
+ networkx        10.9 MB  ██████████                                 (pure)
+ pydantic         7.1 MB  ███████                                    (pure model)
+ pygments         4.7 MB  █████                                      (pure)
+ pydantic-core    4.4 MB  ████                                       (native)
+ rich             1.9 MB  ██                                         (pure)
+ anyio            1.3 MB  █                                          (pure)
+ pytz             1.0 MB  █                                          (pure)
+ click            0.8 MB  █                                          (pure)
+ httpx            0.6 MB  █                                          (pure)
+ httpcore         0.6 MB  █                                          (pure)
+ tzdata           0.6 MB  █                                          (pure)
+ idna             0.5 MB  ▌                                          (pure)
+ typer            0.4 MB  ▌                                          (pure)
+ anytree          0.3 MB  ▌                                          (pure)
+ certifi          0.3 MB  ▌                                          (pure)
+ h11              0.2 MB  ▌                                          (pure)
+ others           1.1 MB  █                                          (pure)
+```
+
+### Packages with Native Extensions
+- `numpy`: 21.7 MB — C/Fortran (LAPACK, BLAS bindings)
+- `pandas`: 45.5 MB — Cython-compiled (parsers, indexing, groupby)
+- `pydantic-core`: 4.4 MB — Rust via PyO3 (validation engine)
+- `jq`: < 0.1 MB — C (wraps libjq)
+
+**Total native**: ~71.6 MB (69% of deps)
+**Total pure-Python**: ~31.8 MB (31% of deps)
+
+---
+
+## Appendix B: Files to Bundle from Source
+
+```
+src/mixpanel_data/
+├── __init__.py              # Public API
+├── workspace.py             # Main facade (9,408 lines)
+├── types.py                 # Result types (10,869 lines)
+├── auth.py                  # Public auth module
+├── exceptions.py            # Exception hierarchy
+├── _literal_types.py        # Type aliases
+├── py.typed                 # PEP 561 marker
+├── _internal/               # Private implementation
+│   ├── api_client.py        # HTTP client (7,577 lines)
+│   ├── config.py            # Credential management
+│   ├── validation.py        # Input validation
+│   ├── pagination.py        # Cursor pagination
+│   ├── bookmark_builders.py # Query building
+│   ├── segfilter.py         # Segmentation filters
+│   ├── transforms.py        # Data transforms
+│   ├── auth/                # OAuth (6 modules)
+│   ├── services/            # Discovery + LiveQuery
+│   └── query/               # User query builders
+└── cli/                     # CLI (25 command modules)
+    ├── main.py
+    ├── commands/             # 24 command files
+    ├── formatters.py
+    └── utils.py
+
+66 files, 55,334 lines, 1.8 MB
+```
+
+---
+
+## Appendix C: Cowork Plugin Path Variables
+
+| Variable | Path | Lifecycle | Use For |
+|----------|------|-----------|---------|
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin install dir | Changes on update | Read-only assets: scripts, source, configs |
+| `${CLAUDE_PLUGIN_DATA}` | `~/.claude/plugins/data/{id}/` | Persists across updates | venv, caches, state files |

--- a/context/hybrid-pydantic-validation-refactor.md
+++ b/context/hybrid-pydantic-validation-refactor.md
@@ -1,0 +1,1026 @@
+# Hybrid Pydantic Validation Refactor
+
+> **Status**: Design Document (Pre-Implementation)  
+> **Scope**: Migrate 14 frozen dataclasses to Pydantic BaseModel; consolidate dual validation channels; preserve agent-friendly error reporting and conformance suite compatibility.  
+> **Date**: 2026-04-08
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Problem Statement](#2-problem-statement)
+3. [Design Constraints](#3-design-constraints)
+4. [Architecture Overview](#4-architecture-overview)
+5. [Type Migration Strategy](#5-type-migration-strategy)
+6. [Validation Rule Disposition](#6-validation-rule-disposition)
+7. [Error Channel Unification](#7-error-channel-unification)
+8. [Conformance Suite Compatibility](#8-conformance-suite-compatibility)
+9. [Implementation Plan](#9-implementation-plan)
+10. [Risk Assessment](#10-risk-assessment)
+11. [Appendices](#11-appendices)
+
+---
+
+## 1. Executive Summary
+
+The `mixpanel_data` validation system currently has **two independent error channels** that surface the same class of problems through incompatible mechanisms:
+
+1. **`__post_init__` on frozen dataclasses** — raises raw `ValueError` at construction time, bypassing the structured error system entirely.
+2. **`validation.py` functions** — returns `list[ValidationError]` with rich metadata (`code`, `path`, `severity`, `suggestion`, `fix`), collected non-fail-fast, wrapped in `BookmarkValidationError`.
+
+This creates **15 duplicate validation rules** implemented in both places, **two different error formats** for callers to handle, and a fundamental incoherence: constructing `GroupBy("", bucket_size=-1)` raises a bare `ValueError`, but passing that same configuration through `validate_query_args()` would return structured errors with codes `V17_EMPTY_EVENT` and `V12_BUCKET_SIZE_POSITIVE`.
+
+### The Hybrid Approach
+
+Convert the 14 frozen dataclasses to Pydantic `BaseModel(frozen=True)`, moving single-field constraints into `@field_validator` methods that produce the project's native `ValidationError` objects. Keep `validation.py` for cross-field business rules and the query-level validation API. Eliminate the dual error channel.
+
+### What Changes
+
+| Before | After |
+|--------|-------|
+| 14 frozen dataclasses with `__post_init__` | 14 frozen Pydantic models with `@field_validator` |
+| `ValueError` from construction | `PydanticValidationError` from construction (with structured details) |
+| 15 duplicate rules across two systems | Single source of truth per rule |
+| validation.py: 2,854 lines, 76 rules | validation.py: ~2,200 lines, ~55 rules (~15 redundant rules removed) |
+| Two error channels for callers | One error channel: `BookmarkValidationError` everywhere |
+| 3 types with no construction validation | All types validate invariants at construction |
+
+### What Does NOT Change
+
+| Preserved | Why |
+|-----------|-----|
+| All 100+ error codes | Stable public contract shared with TypeScript |
+| All error paths | Machine-parseable locations for agent self-correction |
+| All severity levels | Error (blocks) vs warning (informational) distinction |
+| Fuzzy "did you mean?" suggestions | Agent-friendliness differentiator |
+| `fix` suggestion dicts | Agent-friendliness differentiator |
+| Non-fail-fast error accumulation | Critical for agent workflows (fix N issues in one pass) |
+| validation.py public function signatures | Public API and harness compatibility |
+| `BookmarkValidationError` exception type | Public API contract |
+| `ValidationError` dataclass shape | Shared with TypeScript implementation |
+
+**What adapts**: Conformance suite is regenerated from updated Python oracle. ~545 Python tests are updated per-phase to reflect structured errors replacing bare `ValueError`.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Dual Error Channel
+
+```
+                    Caller (workspace.py / user code)
+                    ┌──────────────────────────────────┐
+                    │                                  │
+            ┌───────┴───────┐              ┌───────────┴──────────┐
+            │  ValueError   │              │ BookmarkValidation   │
+            │  (unstructured)│              │ Error (structured)   │
+            └───────┬───────┘              └───────────┬──────────┘
+                    │                                  │
+         ┌──────────┴──────────┐           ┌───────────┴──────────┐
+         │ __post_init__       │           │ validation.py        │
+         │ (10 dataclasses)    │           │ (9 public functions) │
+         └─────────────────────┘           └──────────────────────┘
+```
+
+**Impact**: An LLM agent calling the Python API receives a bare `ValueError("GroupBy.bucket_size must be positive, got -1")` for construction errors but a rich `BookmarkValidationError` with error codes, suggestions, and fixes for query-level errors. The agent cannot programmatically distinguish error categories or apply automated fixes from the `ValueError` path.
+
+### 2.2 Duplicate Rules
+
+15 rules are implemented in both `__post_init__` (raising `ValueError`) and `validation.py` (returning `ValidationError`). These can diverge:
+
+| Rule | `__post_init__` check | `validation.py` check | Divergence |
+|------|----------------------|----------------------|------------|
+| Exclusion step order | `to_step < from_step` (EX3) | `to_step <= from_step` (F4) | `>=` vs `>` — different boundary behavior |
+| Event name empty | Raises `ValueError` immediately | Returns `ValidationError`, continues collecting | Fail-fast vs accumulate |
+| Bucket size positive | Raises `ValueError` | Returns `ValidationError` with code | No code in ValueError |
+
+The `>=` vs `>` divergence for exclusion step ordering is a real semantic difference — `__post_init__` allows `to_step == from_step` but `validation.py` does not.
+
+### 2.3 Missed Validation in Dataclasses
+
+Several types perform **no construction-time validation** despite having obvious invariants:
+
+| Type | Missing validation |
+|------|-------------------|
+| `PropertyInput` | `name` can be empty string |
+| `InlineCustomProperty` | `formula` can be empty, `inputs` can be empty dict, input keys can be lowercase |
+| `CustomPropertyRef` | `id` can be 0 or negative |
+
+These invariants are only checked by `_validate_custom_property()` in validation.py (rules CP1-CP6), meaning an `InlineCustomProperty(formula="", inputs={})` constructs successfully and silently, only failing later during query validation.
+
+---
+
+## 3. Design Constraints
+
+### 3.1 Conformance Suite (Downstream Artifact)
+
+The `conformance/` suite in `jaredmixpanel/mixpanel-bookmark` is **generated from the Python implementation** via `conformance/generate.py`. Python is the oracle — the suite is derived from the validators, not the other way around.
+
+**This means the conformance suite is regenerated after refactoring, not preserved as-is.**
+
+The suite's structural properties are worth preserving as design goals (not hard constraints):
+
+1. **Error codes are stable** — 100+ codes like `V1_MATH_REQUIRES_PROPERTY`. Avoid unnecessary renames.
+2. **Error paths are meaningful** — paths like `"math"`, `"events[0]"` provide machine-parseable locations.
+3. **Severity levels distinguish blocking vs informational** — `"error"` vs `"warning"`.
+4. **Non-fail-fast accumulation** — validators report ALL errors in a single pass.
+5. **Suggestion presence** — fuzzy "did you mean?" for misspelled enum values.
+
+After the refactor, the workflow is:
+1. Update Python validators
+2. Run `conformance/generate.py` to regenerate test fixtures from the updated oracle
+3. Update TypeScript implementation to match any behavioral changes
+4. Run `conformance/differential.py` to verify parity
+
+### 3.2 Public API (Hard Constraints)
+
+- All 14 types are exported from `__init__.py` and documented in `__all__`.
+- **Positional-first construction is pervasive**: `Metric("Login")`, `GroupBy("country")`, `FunnelStep("Signup")`, `Exclusion("Logout")`, `CohortMetric(123, "Power Users")`.
+- `Filter` uses class methods exclusively — never direct construction.
+- `CohortDefinition` uses `init=False` with custom `__init__` and `object.__setattr__` for frozen fields.
+
+### 3.3 Existing Pydantic Conventions (Soft Constraints)
+
+The project already has ~105 Pydantic `BaseModel` subclasses with established patterns:
+
+| Pattern | Usage |
+|---------|-------|
+| `ConfigDict(frozen=True, extra="allow")` | API response entities |
+| `ConfigDict(frozen=True, extra="allow", populate_by_name=True)` | Response entities with aliases |
+| No `model_config` | Simple mutation params |
+| Only 1 `@field_validator` in the entire codebase | Very sparing use |
+| Only 1 `@model_validator` in the entire codebase | Very sparing use |
+
+### 3.4 TypeScript Parity (Soft Constraint)
+
+The TypeScript implementation uses discriminated unions with a `kind` tag field (e.g., `kind: "metric"`). The Python types do not need this tag since Python has `isinstance()`, but any **behavioral** changes to validation must be reflected in both implementations (with Python as the oracle).
+
+---
+
+## 4. Architecture Overview
+
+### 4.1 Current Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  workspace.py                    │
+│  ┌───────────────────────────────────────────┐   │
+│  │ build_*_params() methods                  │   │
+│  │                                           │   │
+│  │  1. Pre-validation type guards            │   │
+│  │  2. validate_*_args() → list[VErr]        │──▶│── validation.py (L1)
+│  │  3. _build_*_params() → dict              │   │
+│  │  4. validate_bookmark() → list[VErr]      │──▶│── validation.py (L2)
+│  │  5. Raise BookmarkValidationError         │   │
+│  └───────────────────────────────────────────┘   │
+│                                                  │
+│  User constructs types:                          │
+│  ┌───────────────────────────────────────────┐   │
+│  │ Metric("Login", math="average")           │   │
+│  │ GroupBy("country", bucket_size=50)         │──▶│── __post_init__ → ValueError
+│  │ Filter.equals("status", "active")         │   │
+│  └───────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────┘
+```
+
+### 4.2 Target Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  workspace.py                    │
+│  ┌───────────────────────────────────────────┐   │
+│  │ build_*_params() methods                  │   │
+│  │                                           │   │
+│  │  1. Pre-validation type guards            │   │
+│  │  2. validate_*_args() → list[VErr]        │──▶│── validation.py (L1, cross-field only)
+│  │  3. _build_*_params() → dict              │   │     delegates single-field to models
+│  │  4. validate_bookmark() → list[VErr]      │──▶│── validation.py (L2, unchanged)
+│  │  5. Raise BookmarkValidationError         │   │
+│  └───────────────────────────────────────────┘   │
+│                                                  │
+│  User constructs types:                          │
+│  ┌───────────────────────────────────────────┐   │
+│  │ Metric("Login", math="average")           │   │
+│  │ GroupBy("country", bucket_size=50)         │──▶│── Pydantic @field_validator
+│  │ Filter.equals("status", "active")         │   │     → PydanticValidationError
+│  └───────────────────────────────────────────┘   │     (with structured details)
+└─────────────────────────────────────────────────┘
+```
+
+### 4.3 Key Architectural Decisions
+
+**AD-1: Pydantic models validate at construction, validation.py validates at composition.**
+
+Single-field invariants (non-empty event name, positive bucket_size, valid enum values) belong on the model — they are properties of the **type itself**. Cross-field rules (math requires property, formula references valid event positions, rolling and cumulative are mutually exclusive) belong in validation.py — they are properties of the **query composition**.
+
+**AD-2: validation.py functions remain the conformance-facing API.**
+
+The conformance harness calls `validate_query_args()`, `validate_funnel_args()`, etc. These functions continue to exist with identical signatures and return `list[ValidationError]`. Internally, they no longer re-check single-field rules that the Pydantic models already enforce — but this is invisible to the conformance suite because those rules cannot be triggered (the model would have already rejected the input at construction time).
+
+**AD-3: Construction errors become structured.**
+
+When a Pydantic model rejects input (e.g., `GroupBy("", bucket_size=-1)`), it raises `pydantic.ValidationError` with structured error details. The project provides a utility to convert this to `BookmarkValidationError` for callers who want the agent-friendly format. The raw Pydantic error is also useful on its own — it includes field paths and error types.
+
+**AD-4: Filter keeps its class method factory pattern.**
+
+`Filter` is unique among the 14 types: it's constructed exclusively via class methods (`Filter.equals(...)`, `Filter.between(...)`) that encode operator/type logic. Converting to Pydantic doesn't change this pattern — the class methods simply return `cls(...)` which triggers Pydantic validation instead of `__post_init__`.
+
+**AD-5: CohortDefinition is deferred.**
+
+`CohortDefinition` uses `init=False` with a custom `__init__` that accepts `*criteria` varargs and `object.__setattr__` to set frozen fields. This pattern is fundamentally incompatible with Pydantic's model initialization. `CohortDefinition` stays as a frozen dataclass in this refactor. It has no `__post_init__` validation duplication and no conformance issues.
+
+---
+
+## 5. Type Migration Strategy
+
+### 5.1 Migration Template
+
+Each frozen dataclass migrates to a Pydantic `BaseModel` following this template:
+
+```python
+from pydantic import BaseModel, ConfigDict, field_validator
+
+class Metric(BaseModel):
+    """Encapsulates a single event to query with its aggregation settings."""
+
+    model_config = ConfigDict(frozen=True)
+
+    event: str
+    math: MathType = "total"
+    property: str | CustomPropertyRef | InlineCustomProperty | None = None
+    per_user: PerUserAggregation | None = None
+    percentile_value: int | float | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: FiltersCombinator = "all"
+
+    @field_validator("event")
+    @classmethod
+    def _validate_event(cls, v: str) -> str:
+        """M1: Event name must be non-empty with no control characters."""
+        validate_event_name(v, "Metric")  # reuse shared helper
+        return v
+```
+
+**Key differences from current frozen dataclass:**
+
+| Aspect | Frozen Dataclass | Pydantic Model |
+|--------|-----------------|----------------|
+| Decorator | `@dataclass(frozen=True)` | `model_config = ConfigDict(frozen=True)` |
+| Validation hook | `__post_init__` | `@field_validator` / `@model_validator` |
+| Error type | `ValueError` | `pydantic.ValidationError` |
+| Immutability | `frozen=True` on decorator | `frozen=True` in ConfigDict |
+| Positional args | Supported natively | Requires explicit field ordering (Pydantic v2 preserves definition order) |
+| `isinstance` check | Works naturally | Works naturally (BaseModel subclass) |
+
+### 5.2 Migration Per Type
+
+#### Tier 1: Simple Types (No Validation)
+
+These types have no `__post_init__` and no class methods. Migration is mechanical.
+
+| Type | Fields | Notes |
+|------|--------|-------|
+| `PropertyInput` | 3 | Add `@field_validator("name")` for CP6 (non-empty) |
+| `CustomPropertyRef` | 1 | Add `@field_validator("id")` for CP1 (positive int) |
+
+**PropertyInput gains validation it never had** — currently `PropertyInput("")` succeeds silently but fails later at CP6. After migration, it fails at construction.
+
+#### Tier 2: Types with Simple Validation
+
+These have `__post_init__` that calls `_validate_event_name()` and nothing else.
+
+| Type | Current `__post_init__` | Migration |
+|------|------------------------|-----------|
+| `FunnelStep` | FS1: event name check | `@field_validator("event")` calling shared helper |
+| `RetentionEvent` | RE1: event name check | `@field_validator("event")` calling shared helper |
+| `HoldingConstant` | HC1: non-empty property | `@field_validator("property")` |
+| `Formula` | FM1: non-empty expression | `@field_validator("expression")` |
+
+#### Tier 3: Types with Multi-Field Validation
+
+These have `__post_init__` checking relationships between fields.
+
+| Type | Current `__post_init__` | Migration |
+|------|------------------------|-----------|
+| `Metric` | M1 (event name), M2 (math↔property), M3 (percentile↔value) | `@field_validator("event")` for M1; `@model_validator(mode="after")` for M2, M3 |
+| `GroupBy` | GB1 (non-empty property), GB2 (bucket_size > 0), GB3 (bucket_min < bucket_max) | `@field_validator("property")` for GB1; `@field_validator("bucket_size")` for GB2; `@model_validator(mode="after")` for GB3 |
+| `Exclusion` | EX1 (event name), EX2 (from_step >= 0), EX3 (to_step order) | `@field_validator("event")` for EX1; `@field_validator("from_step")` for EX2; `@model_validator(mode="after")` for EX3 |
+| `FlowStep` | FL1 (event name), FL2 (forward/reverse range 0-5) | `@field_validator("event")` for FL1; `@field_validator("forward", "reverse")` for FL2 |
+| `CohortBreakdown` | CB1/CB2 via `_validate_cohort_args` | `@model_validator(mode="after")` |
+| `CohortMetric` | CM1/CM2 via `_validate_cohort_args`, CM5 (reject inline CohortDefinition) | `@model_validator(mode="after")` |
+
+#### Tier 4: Types with Class Method Factories
+
+| Type | Pattern | Migration |
+|------|---------|-----------|
+| `Filter` | 22 class methods, no `__post_init__`, underscore-prefixed fields | Class methods become `@classmethod` on BaseModel returning `cls(...)`. Internal field naming with underscore prefix preserved. Validation in class methods (date format, positive quantity, cohort args) stays in the class methods. |
+| `InlineCustomProperty` | `numeric()` class method | Simple migration; add field validators for CP2-CP5 (formula non-empty, inputs non-empty, key format, formula length). **This type gains validation it never had.** |
+
+#### Tier 5: Deferred
+
+| Type | Reason |
+|------|--------|
+| `CohortDefinition` | `init=False` + custom `__init__` with `*criteria` varargs + `object.__setattr__`. Incompatible with Pydantic initialization. No validation duplication. Stays as frozen dataclass. |
+
+### 5.3 Positional Construction Compatibility
+
+Pydantic v2 supports positional construction **only if fields are defined in order without defaults before fields with defaults**. All 14 types already follow this pattern (required fields first, optional fields with defaults after). Verify:
+
+| Type | Positional field(s) | Works with Pydantic? |
+|------|---------------------|---------------------|
+| `Metric("Login")` | `event` (first field) | Yes |
+| `GroupBy("country")` | `property` (first field) | Yes |
+| `FunnelStep("Signup")` | `event` (first field) | Yes |
+| `Exclusion("Refund")` | `event` (first field) | Yes |
+| `CohortMetric(123, "Power Users")` | `cohort`, `name` (first two) | Yes |
+| `CohortBreakdown(123)` | `cohort` (first field) | Yes |
+| `RetentionEvent("Login")` | `event` (first field) | Yes |
+| `FlowStep("Purchase")` | `event` (first field) | Yes |
+| `Formula("A + B")` | `expression` (first field) | Yes |
+| `CustomPropertyRef(42)` | `id` (only field) | Yes |
+| `PropertyInput("price")` | `name` (first field) | Yes |
+
+**No compatibility issue.** Pydantic v2 BaseModel accepts positional args for fields defined before any field with a default value.
+
+### 5.4 Serialization Compatibility
+
+Current frozen dataclasses have hand-written `to_dict()` methods on **result types** (`SegmentationResult`, `FunnelResult`, etc.) but the 14 query-builder types do **not** have `to_dict()`. They are consumed internally by the bookmark builder which reads their attributes directly.
+
+The migration to Pydantic adds `model_dump()` for free but does **not** require removing any existing methods. The bookmark builder code in `workspace.py` accesses fields via attribute access (e.g., `metric.event`, `group_by.bucket_size`), which works identically on Pydantic models.
+
+**One concern**: `Filter` uses underscore-prefixed fields (`_property`, `_operator`, `_value`). Pydantic treats leading underscores as private by default. Solution: use `Field(alias="_property")` with `populate_by_name=True`, or rename to non-underscore fields. Recommended: **rename to non-underscore fields** since these fields are already accessed directly by the bookmark builder (e.g., `f._property`, `f._operator`). The underscore prefix was a convention choice, not a privacy requirement. The bookmark builder code that accesses these fields will need updating either way.
+
+**Alternative for Filter**: Keep underscore-prefixed fields with `model_config = ConfigDict(frozen=True, populate_by_name=True)` and explicitly declare each field with `Field(alias="...")`. This preserves backward compatibility for any code accessing `filter._property` directly. Given that Filter is only constructed via class methods and consumed internally, the rename is cleaner.
+
+---
+
+## 6. Validation Rule Disposition
+
+### 6.1 Rules That Move INTO Models (42 rules)
+
+These rules become `@field_validator` or `@model_validator` on the Pydantic models. They are **removed from validation.py** because Pydantic enforces them at construction time — by the time validation.py sees the objects, these invariants are already guaranteed.
+
+#### 6.1.1 String Sanity Checks → `@field_validator` (21 rules)
+
+All use a shared `validate_event_name()` helper (already exists as `_validate_event_name` in types.py):
+
+| Rules | Model | Field |
+|-------|-------|-------|
+| V17, V22, V22_INVISIBLE | `Metric` | `event` |
+| F2, F2_CONTROL, F2_INVISIBLE | `FunnelStep` | `event` |
+| F4, F4_CONTROL | `Exclusion` | `event` |
+| F8_EMPTY | `HoldingConstant` | `property` |
+| R1, R1_CONTROL, R1_INVISIBLE | `RetentionEvent` (via born_event path) | `event` |
+| R2, R2_CONTROL, R2_INVISIBLE | `RetentionEvent` (via return_event path) | `event` |
+| FL2, FL2_CONTROL, FL2_INVISIBLE | `FlowStep` | `event` |
+| CP2 | `InlineCustomProperty` | `formula` |
+| CP6 | `PropertyInput` | `name` |
+| FM1 | `Formula` | `expression` |
+
+#### 6.1.2 Single-Field Constraints → `@field_validator` (12 rules)
+
+| Rule | Model | Field | Check |
+|------|-------|-------|-------|
+| V6 | (query-level, stays in validation.py) | `rolling` | positive |
+| V12 / GB2 | `GroupBy` | `bucket_size` | positive when not None |
+| V24 | `GroupBy` | `bucket_size`, `bucket_min`, `bucket_max` | finite (not NaN/Inf) |
+| F3_TYPE | (query-level, stays) | `conversion_window` | must be int |
+| F3_POSITIVE | (query-level, stays) | `conversion_window` | positive |
+| F4_NEGATIVE_STEP / EX2 | `Exclusion` | `from_step` | >= 0 |
+| FL3 / FL2 | `FlowStep` | `forward` | 0-5 range when not None |
+| FL4 / FL2 | `FlowStep` | `reverse` | 0-5 range when not None |
+| CP1 | `CustomPropertyRef` | `id` | positive integer |
+| CP3 | `InlineCustomProperty` | `inputs` | non-empty dict |
+| CP4 | `InlineCustomProperty` | `inputs` (keys) | single uppercase A-Z |
+| CP5 | `InlineCustomProperty` | `formula` | max 20,000 chars |
+
+#### 6.1.3 Cross-Field Checks Within a Single Model → `@model_validator` (9 rules)
+
+| Rule | Model | Fields | Check |
+|------|-------|--------|-------|
+| V1/M2 | `Metric` | `math` + `property` | math requiring property |
+| V26/M3 | `Metric` | `math` + `percentile_value` | percentile requires value |
+| V18/GB3 | `GroupBy` | `bucket_min` + `bucket_max` | min < max |
+| V11 | `GroupBy` | `bucket_min`/`bucket_max` + `bucket_size` | bounds require size |
+| V12B | `GroupBy` | `bucket_size` + `property_type` | size requires number type |
+| V12C | `GroupBy` | `bucket_size` + `bucket_min`/`bucket_max` | size requires bounds |
+| EX3/F4_ORDER | `Exclusion` | `from_step` + `to_step` | order check |
+| CB1/CB2 | `CohortBreakdown` | `cohort` + `name` | cohort args |
+| CM1/CM2/CM5 | `CohortMetric` | `cohort` + `name` | cohort args + inline rejection |
+
+### 6.2 Rules Removed from validation.py (~15 rules)
+
+These rules only fire on **model instances** (guarded by `isinstance` checks), never on raw string/int inputs. Once the Pydantic models enforce these at construction, these checks become unreachable — the model would have rejected the input before the validator ever sees it.
+
+| Rule | Model | Why redundant |
+|------|-------|---------------|
+| V13_METRIC_MATH_PROPERTY | `Metric` | Only fires on `isinstance(item, Metric)` — Metric's `@model_validator` enforces M2 |
+| V14_METRIC_REJECTS_PROPERTY | `Metric` | Same — only fires on Metric instances |
+| V26 (per-Metric percentile) | `Metric` | Same — Metric's `@model_validator` enforces M3 |
+| V27 (per-Metric histogram per_user) | `Metric` | Same — checked per-Metric in the events loop |
+| V3 (per-Metric per_user incompatible) | `Metric` | Same — per-Metric check in events loop |
+| V3B (per-Metric per_user requires property) | `Metric` | Same — per-Metric check in events loop |
+| V11/V12/V12B/V12C (GroupBy bucket deps) | `GroupBy` | Only fires on `isinstance(g, GroupBy)` — GroupBy's validators enforce |
+| V18 (bucket ordering) | `GroupBy` | Same |
+| V24 (bucket finite) | `GroupBy` | Same |
+| CM5 (inline CohortDefinition) | `CohortMetric` | Only fires on `isinstance(item, CohortMetric)` |
+| F4_EMPTY_EXCLUSION / F4_CONTROL | `Exclusion` | Always `Exclusion` instances — validated at construction |
+| F4_NEGATIVE_STEP | `Exclusion` | Same |
+| F4_STEP_ORDER | `Exclusion` | Same (within-Exclusion ordering; F4_STEP_BOUNDS stays — cross-collection) |
+| F8_EMPTY (HoldingConstant path) | `HoldingConstant` | Only the `isinstance(hc, HoldingConstant)` branch; the `str` branch stays |
+
+**Note**: Some rules like F8_EMPTY have a dual path — the `isinstance(hc, HoldingConstant)` branch is redundant but the `str` branch must stay.
+
+### 6.3 Rules That Stay in validation.py (~55 rules)
+
+These are **cross-field rules that span multiple objects**, **query-composition rules**, **raw-string input checks**, or **Layer 2 bookmark dict validation**:
+
+#### Cross-field / query-level rules (34 rules)
+
+| Rule | Why it stays |
+|------|-------------|
+| V0_NO_EVENTS | Collection-level: events list must be non-empty |
+| V1_MATH_REQUIRES_PROPERTY | Top-level math↔math_property (applies to plain string events) |
+| V2_MATH_REJECTS_PROPERTY | Top-level math↔math_property interaction |
+| V3_PER_USER_INCOMPATIBLE | Top-level per_user↔math interaction |
+| V3B_PER_USER_REQUIRES_PROPERTY | Top-level per_user↔math_property interaction |
+| V4_FORMULA_MIN_EVENTS | Formula↔events count relationship |
+| V5_ROLLING_CUMULATIVE | Rolling↔cumulative mutual exclusion |
+| V7, V8, V9, V10, V15, V20 | Time range validation (from_date, to_date, last interactions) |
+| V16/V19 | Formula expression↔events count referential integrity |
+| V21 | Event type guard (str, Metric, or CohortMetric) |
+| V23 | Rolling window sanity cap |
+| F1 | Min/max step count (collection-level) |
+| F3_MAX | Conversion window max per unit (cross-field) |
+| F4_BOUNDS | Exclusion step indices vs total step count (cross-collection) |
+| F7_SECOND_MIN | Second unit minimum window (cross-field) |
+| F8_MAX | Holding constant max count (collection-level) |
+| F9 | Session math↔session window (cross-field) |
+| F10/F11 | Funnel math↔math_property (cross-field) |
+| FL1 | At least one flow step (collection-level) |
+| FL5 | Forward + reverse > 0 (cross-field) |
+| FL6 | Cardinality range (query-level param) |
+| FL7/FL7_MAX | Conversion window validation (query-level) |
+| FL9/FL10 | Session count_type↔window (cross-field) |
+| R5/R6 | Bucket sizes validation (list-internal ordering) |
+| R7-R11 | Retention enum validation (query-level params, not model fields) |
+| R12 | Group-by non-empty in retention context |
+| CB3 | CohortBreakdown + GroupBy mutual exclusion in retention |
+
+#### Raw-string input checks (~21 rules)
+
+These checks apply to parameters that accept `str` directly (not model instances). The validator functions accept union types like `Sequence[str | Metric]` and `str | GroupBy`, so the string path needs its own validation:
+
+| Rule | Validator | Why it stays |
+|------|-----------|-------------|
+| V17/V22/V22_INVISIBLE | `validate_query_args` | `events` accepts plain `str` |
+| F2/F2_CONTROL/F2_INVISIBLE | `validate_funnel_args` | `steps` accepts plain `str` |
+| R1/R1_CONTROL/R1_INVISIBLE | `validate_retention_args` | `born_event` is `str` directly |
+| R2/R2_CONTROL/R2_INVISIBLE | `validate_retention_args` | `return_event` is `str` directly |
+| FL2/FL2_CONTROL/FL2_INVISIBLE | `validate_flow_args` | `steps` is `list[str]` |
+| R12_EMPTY_GROUP_BY | `validate_retention_args` | `group_by` accepts plain `str` |
+| F8_EMPTY (str path) | `validate_funnel_args` | `holding_constant` accepts plain `str` |
+
+#### Layer 2 bookmark dict validation (32 rules)
+
+All B-series and FLB-series rules — these validate raw `dict[str, Any]` bookmark JSON, unchanged by this refactor.
+
+### 6.4 Enum Rules: Dual Strategy
+
+The 21 pure enum checks use `_enum_error()` which provides fuzzy "did you mean?" suggestions. These are the rules where Pydantic `Literal` types and the current behavior **differ most**:
+
+| Approach | Behavior |
+|----------|----------|
+| Pydantic `Literal["day", "week", "month"]` | Rejects invalid value at construction with Pydantic's generic error message. No fuzzy suggestions. |
+| Current `_enum_error()` + `_suggest()` | Returns `ValidationError` with `suggestion=("day", "week")` from `difflib.get_close_matches`. |
+
+**Decision**: Use Pydantic `Literal` types on the models for **construction-time safety**. Enum checks in validation.py fall into two categories:
+
+1. **Model field enums** (e.g., `Metric.math`, `FlowStep.filters_combinator`): These become unreachable in validation.py after the model enforces `Literal` at construction. **Remove these checks** from validation.py. The fuzzy suggestions are lost at the Pydantic level, but the error message from `Literal` rejection clearly lists valid values, and static type checkers catch these before runtime.
+
+2. **Query-level parameter enums** (e.g., `conversion_window_unit`, `retention_unit`, `alignment`, `mode`): These are parameters to `validate_retention_args()` etc., not fields on models. **Keep these checks** in validation.py with fuzzy suggestions intact — they are the only validation layer for these values.
+
+---
+
+## 7. Error Channel Unification
+
+### 7.1 Current State
+
+| Channel | Error Type | Contains | Catchable As |
+|---------|-----------|----------|-------------|
+| `__post_init__` | `ValueError` | Message string only | `except ValueError` |
+| validation.py | `BookmarkValidationError` | `list[ValidationError]` with code, path, severity, suggestion, fix | `except BookmarkValidationError` |
+
+### 7.2 Target State
+
+| Channel | Error Type | Contains | Catchable As |
+|---------|-----------|----------|-------------|
+| Pydantic construction | `pydantic.ValidationError` | Structured field errors with types and locations | `except pydantic.ValidationError` |
+| validation.py | `BookmarkValidationError` | `list[ValidationError]` with code, path, severity, suggestion, fix | `except BookmarkValidationError` |
+
+### 7.3 Bridging Pydantic Errors to BookmarkValidationError
+
+For callers who want a **uniform error experience**, provide a utility that converts `pydantic.ValidationError` to `BookmarkValidationError`:
+
+```python
+# mixpanel_data/exceptions.py
+
+def pydantic_to_validation_errors(
+    exc: PydanticValidationError,
+) -> list[ValidationError]:
+    """Convert a pydantic.ValidationError to a list of ValidationError.
+
+    Maps Pydantic's structured error format to the project's
+    agent-friendly ValidationError with error codes and paths.
+
+    Args:
+        exc: The Pydantic validation error to convert.
+
+    Returns:
+        List of ValidationError objects with appropriate codes and paths.
+    """
+    errors: list[ValidationError] = []
+    for err in exc.errors():
+        path = ".".join(str(loc) for loc in err["loc"])
+        # Map Pydantic error types to our error codes
+        code = _pydantic_type_to_code(err["type"], path)
+        errors.append(
+            ValidationError(
+                path=path,
+                message=err["msg"],
+                code=code,
+                severity="error",
+            )
+        )
+    return errors
+```
+
+**The `_pydantic_type_to_code` mapping** translates Pydantic error types to project error codes:
+
+| Pydantic `type` | Context | Project Code |
+|-----------------|---------|-------------|
+| `string_too_short` | `Metric.event` | `M1_EMPTY_EVENT` |
+| `value_error` | `GroupBy` model_validator | `GB3_BUCKET_ORDER` |
+| `literal_error` | `Metric.math` | (Pydantic-specific, no legacy code) |
+| `greater_than` | `Exclusion.from_step` | `EX2_NEGATIVE_STEP` |
+
+**Important**: This bridge is a **convenience**, not a requirement. Callers who catch `pydantic.ValidationError` directly get Pydantic's native error format, which is also structured and machine-parseable. The bridge exists for callers who want the project-specific error codes.
+
+### 7.4 workspace.py Error Handling Update
+
+Currently workspace.py does not catch `ValueError` from `__post_init__`. After migration:
+
+```python
+# Before (current):
+# GroupBy("", bucket_size=-1)  → raises ValueError (uncaught)
+# validate_query_args(...)     → returns list[ValidationError]
+
+# After (target):
+# GroupBy("", bucket_size=-1)  → raises pydantic.ValidationError (structured)
+# validate_query_args(...)     → returns list[ValidationError] (no change)
+```
+
+workspace.py does **not** need to change its validation flow. The Pydantic errors fire **before** workspace.py is even called — they fire when the user constructs the types. workspace.py's `build_*_params()` methods receive already-valid type instances.
+
+---
+
+## 8. Conformance Suite Compatibility
+
+### 8.1 The Conformance Suite Is Downstream
+
+The conformance suite is **generated from** the Python validators (`conformance/generate.py`). Python is the oracle. The workflow after refactoring:
+
+1. Refactor Python validators (this design document).
+2. Run `conformance/generate.py` to regenerate test fixtures from the updated oracle.
+3. Update the TypeScript implementation to match any behavioral changes.
+4. Run `conformance/differential.py` to verify cross-language parity.
+
+The conformance suite **adapts to the refactor**, not the other way around.
+
+### 8.2 What Changes for the Conformance Harness
+
+The harness (`conformance/harness/run_python.py`) imports:
+
+```python
+from mixpanel_data._internal.validation import (
+    validate_bookmark, validate_flow_args, validate_flow_bookmark,
+    validate_funnel_args, validate_query_args, validate_retention_args,
+    validate_time_args,
+)
+from mixpanel_data.exceptions import ValidationError
+from mixpanel_data.types import Exclusion
+```
+
+All imports remain valid. The harness passes raw primitives (strings, ints, dicts) to the validator functions, not model instances. Validator function signatures and return types are unchanged.
+
+The only type import is `Exclusion` (used to construct test inputs). After migration, `Exclusion` is a Pydantic model — construction behavior is identical for valid inputs.
+
+### 8.3 Rules Removed from validation.py
+
+~15 rules that only fire on model instances (guarded by `isinstance` checks) are removed from validation.py (see Section 6.2). The conformance harness never exercises these code paths because it passes raw primitives, so the removal has no conformance impact.
+
+After removal, `generate.py` is re-run to produce updated fixtures. Any tests that previously exercised now-removed rules via model-instance inputs would need new test cases that construct the model directly (expecting `pydantic.ValidationError` instead of a `ValidationError` list entry).
+
+### 8.4 Net Effect
+
+| Before | After |
+|--------|-------|
+| `__post_init__` (ValueError) + validation.py (ValidationError) | Pydantic model (PydanticValidationError) + validation.py (ValidationError) |
+| Two implementations, two error formats, one divergence (EX3) | One validation per rule, two structured error formats, zero divergence |
+| 3 types with no construction validation | All types validate invariants at construction |
+| ~15 redundant checks in validation.py | Removed — models enforce at construction |
+
+The wins: **eliminate the unstructured error channel**, **unify semantics** (fix the EX3 divergence), **gain construction-time validation on 3 types**, and **remove ~15 genuinely redundant rules** from validation.py.
+
+---
+
+## 9. Implementation Plan
+
+### Phase 1: Foundation (No Behavior Change)
+
+**Goal**: Establish shared validation infrastructure without changing any types or behavior.
+
+#### 1.1 Create `_internal/field_validators.py`
+
+Extract reusable validation helpers that both Pydantic `@field_validator` methods and validation.py functions can call:
+
+```python
+# _internal/field_validators.py
+
+def validate_event_name(value: str, class_name: str) -> str:
+    """Validate and return an event name string.
+
+    Reusable by both @field_validator (returns cleaned value)
+    and validation.py (called for error checking).
+
+    Raises:
+        ValueError: If event name is empty, contains control
+            characters, or consists only of invisible characters.
+    """
+    ...
+
+def validate_positive_int(value: int, field_name: str) -> int:
+    """Validate that an integer is positive."""
+    ...
+
+def validate_finite(value: int | float | None, field_name: str) -> int | float | None:
+    """Validate that a numeric value is finite (not NaN/Inf)."""
+    ...
+```
+
+This is the shared helper layer that both systems call — eliminating the risk of behavioral divergence.
+
+#### 1.2 Create `exceptions.pydantic_to_validation_errors()`
+
+Add the bridge utility (Section 7.3) to `exceptions.py`.
+
+#### 1.3 Fix the EX3 Divergence
+
+Align `Exclusion.__post_init__` (currently `to_step < from_step`) with validation.py's F4_EXCLUSION_STEP_ORDER (currently `to_step <= from_step`). The correct semantics is `to_step > from_step` (strict, matching validation.py). Fix in `__post_init__` now, before migration.
+
+**Deliverables**: New `_internal/field_validators.py`, bridge utility in `exceptions.py`, EX3 fix.  
+**Tests**: Unit tests for field validators, test for bridge utility, update EX3 test expectations.  
+**Risk**: None — no public API change.
+
+---
+
+### Phase 2: Tier 1 Migration (Simple Types)
+
+**Goal**: Migrate the simplest types to establish the pattern. 3 types, 4 fields total.
+
+#### 2.1 Migrate `PropertyInput`
+
+```python
+# Before:
+@dataclass(frozen=True)
+class PropertyInput:
+    name: str
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    resource_type: Literal["event", "user"] = "event"
+
+# After:
+class PropertyInput(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    type: Literal["string", "number", "boolean", "datetime", "list"] = "string"
+    resource_type: Literal["event", "user"] = "event"
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("PropertyInput.name must be a non-empty string")
+        return v
+```
+
+**Gains validation it never had** (CP6 at construction).
+
+#### 2.2 Migrate `CustomPropertyRef`
+
+```python
+class CustomPropertyRef(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: int  # noqa: A003
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(
+                f"CustomPropertyRef.id must be a positive integer (got {v})"
+            )
+        return v
+```
+
+**Gains validation it never had** (CP1 at construction).
+
+#### 2.3 Migrate `InlineCustomProperty`
+
+```python
+class InlineCustomProperty(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    formula: str
+    inputs: dict[str, PropertyInput]
+    property_type: Literal["string", "number", "boolean", "datetime"] | None = None
+    resource_type: Literal["events", "people"] = "events"
+
+    @field_validator("formula")
+    @classmethod
+    def _validate_formula(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("InlineCustomProperty.formula must be non-empty")
+        if len(v) > 20_000:
+            raise ValueError(
+                f"InlineCustomProperty.formula exceeds 20,000 char limit "
+                f"(got {len(v)})"
+            )
+        return v
+
+    @field_validator("inputs")
+    @classmethod
+    def _validate_inputs(cls, v: dict[str, PropertyInput]) -> dict[str, PropertyInput]:
+        if len(v) == 0:
+            raise ValueError(
+                "InlineCustomProperty must have at least one input"
+            )
+        key_re = re.compile(r"^[A-Z]$")
+        for key in v:
+            if not key_re.match(key):
+                raise ValueError(
+                    f"Input keys must be single uppercase letters (A-Z), got {key!r}"
+                )
+        return v
+
+    @classmethod
+    def numeric(cls, formula: str, /, **properties: str) -> InlineCustomProperty:
+        """Convenience constructor for all-numeric inputs."""
+        inputs = {
+            k.upper(): PropertyInput(name=v, type="number")
+            for k, v in properties.items()
+        }
+        return cls(formula=formula, inputs=inputs, property_type="number")
+```
+
+**Gains validation it never had** (CP2-CP5 at construction).
+
+**Deliverables**: 3 migrated types.  
+**Tests**: Update all construction tests from dataclass to BaseModel behavior. Verify `isinstance` still works. Verify positional construction. Add new tests for gained validations.  
+**Risk**: Low — these types are leaf nodes with no downstream dependencies except as fields on other types.
+
+---
+
+### Phase 3: Tier 2 Migration (Event Name Types)
+
+**Goal**: Migrate the 4 types that only validate event names. Establish the `@field_validator` pattern for `_validate_event_name`.
+
+#### 3.1 Migrate `Formula`, `FunnelStep`, `RetentionEvent`, `HoldingConstant`
+
+All follow the same pattern — single `@field_validator` on the primary string field, calling the shared helper from Phase 1.
+
+**Deliverables**: 4 migrated types.  
+**Tests**: Update construction tests. Verify `isinstance`. Verify factory patterns (e.g., `FunnelStep` accepts `order`, `filters`, `filters_combinator`).  
+**Risk**: Low — simple single-field validators.
+
+---
+
+### Phase 4: Tier 3 Migration (Multi-Field Types)
+
+**Goal**: Migrate types with cross-field `@model_validator` relationships.
+
+#### 4.1 Migrate `GroupBy`
+
+Combines `@field_validator` (positive bucket_size, finite values, non-empty property) with `@model_validator(mode="after")` (bucket ordering, size↔bounds↔type dependencies).
+
+#### 4.2 Migrate `Exclusion`
+
+`@field_validator` (event name, non-negative from_step) + `@model_validator(mode="after")` (step ordering).
+
+#### 4.3 Migrate `FlowStep`
+
+`@field_validator` (event name, forward/reverse range).
+
+#### 4.4 Migrate `CohortBreakdown`, `CohortMetric`
+
+`@model_validator(mode="after")` calling shared cohort validation.
+
+#### 4.5 Migrate `Metric`
+
+Most complex: `@field_validator("event")` + `@model_validator(mode="after")` for math↔property, percentile↔value.
+
+**Deliverables**: 6 migrated types.  
+**Tests**: Update all construction tests. Update all test_validation_* files that test the `__post_init__` ValueError path to expect `pydantic.ValidationError`. Verify workspace.py integration (build_*_params still works).  
+**Risk**: Medium — `Metric` is heavily used. Model validators must match exact semantics.
+
+---
+
+### Phase 5: Tier 4 Migration (Filter)
+
+**Goal**: Migrate `Filter` — the most architecturally unique type.
+
+#### 5.1 Decide on Field Naming
+
+**Option A** (recommended): Rename `_property` → `prop`, `_operator` → `operator`, `_value` → `value`, `_property_type` → `property_type`, `_resource_type` → `resource_type`, `_date_unit` → `date_unit`. Update all bookmark builder code that accesses these fields.
+
+**Option B**: Keep underscore names with `Field(alias="...")` and `populate_by_name=True`.
+
+#### 5.2 Migrate Filter Class
+
+```python
+class Filter(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    prop: str | CustomPropertyRef | InlineCustomProperty  # renamed from _property
+    operator: str
+    value: str | int | float | list[str] | list[int | float] | list[dict[str, Any]] | None
+    property_type: FilterPropertyType = "string"
+    resource_type: Literal["events", "people"] = "events"
+    date_unit: FilterDateUnit | None = None
+
+    @classmethod
+    def equals(cls, property: str | CustomPropertyRef | InlineCustomProperty, ...) -> Filter:
+        """Create an equality filter."""
+        val = [value] if isinstance(value, str) else value
+        return cls(prop=property, operator="equals", value=val, ...)
+
+    # ... 21 more class methods (unchanged logic)
+```
+
+**Deliverables**: Migrated `Filter` type, updated bookmark builder field access.  
+**Tests**: Comprehensive Filter test updates (22 factory methods × multiple input types).  
+**Risk**: Medium-High — `Filter` is used everywhere. Field rename touches bookmark builder code.
+
+---
+
+### Phase 6: Cleanup and Verification
+
+**Goal**: Remove dead code, run full test suites, verify conformance.
+
+#### 6.1 Remove Dead Code
+
+- Delete `_validate_event_name()` from types.py (moved to `_internal/field_validators.py`).
+- Delete `_validate_cohort_args()` from types.py (logic now in model validators).
+- Delete `_MATH_REQUIRING_PROPERTY` from types.py (already defined in `bookmark_enums.py`).
+- Delete `_CONTROL_CHAR_RE` from types.py (moved to field_validators.py).
+
+#### 6.2 Verification
+
+```bash
+# All must pass:
+just check               # lint + typecheck + test
+just test-ci             # thorough Hypothesis (200 examples)
+just test-pbt            # property-based tests
+just mutate-check        # mutation score >= 80%
+```
+
+#### 6.3 Conformance Suite Regeneration
+
+```bash
+# Regenerate conformance fixtures from updated Python oracle:
+cd conformance && python generate.py
+
+# Verify TypeScript implementation still passes:
+cd conformance && npm test
+
+# Run differential testing (Python vs TypeScript):
+cd conformance && python differential.py  # zero divergences
+```
+
+If `differential.py` reports divergences, update the TypeScript implementation to match the Python oracle's new behavior (e.g., removed rules that are now enforced at model construction).
+
+#### 6.3 Documentation
+
+- Update `CLAUDE.md` type descriptions.
+- Update `types.py` module CLAUDE.md.
+- Update docstrings for migrated types (Pydantic-specific notes).
+
+**Deliverables**: Clean codebase, passing CI, passing conformance.  
+**Risk**: Low — this is verification, not implementation.
+
+---
+
+## 10. Risk Assessment
+
+### 10.1 High Risk
+
+| Risk | Mitigation |
+|------|-----------|
+| `isinstance` checks break | Pydantic BaseModel supports `isinstance` natively. Verify in Phase 2. |
+| Positional construction breaks | Pydantic v2 supports positional args for ordered fields. Verify in Phase 2. |
+| `frozen=True` behavior differs | Pydantic's `ConfigDict(frozen=True)` raises `ValidationError` on attribute assignment (vs dataclass's `FrozenInstanceError`). Callers catching `FrozenInstanceError` need updating. Search codebase for this. |
+| Filter underscore fields | Addressed in Phase 5 with rename or alias strategy. |
+
+### 10.2 Medium Risk
+
+| Risk | Mitigation |
+|------|-----------|
+| Test count (545 tests, 6900 lines) | Phase-by-phase migration limits blast radius. Each phase has its own test verification. |
+| Pydantic error message format | Callers catching `ValueError` from `__post_init__` now get `pydantic.ValidationError`. Different message format. Addressed by bridge utility. |
+| `hash()` behavior change | Frozen dataclasses are hashable by default. Pydantic frozen models are also hashable. Verify. |
+| `==` comparison behavior | Dataclass equality compares all fields. Pydantic model equality also compares all fields. Verify. |
+
+### 10.3 Low Risk
+
+| Risk | Mitigation |
+|------|-----------|
+| Conformance suite divergence | Suite is regenerated from Python oracle (Section 8). TypeScript implementation updated to match. |
+| Performance regression | Pydantic v2 is compiled (Rust core). Construction may actually be faster. Benchmark if needed. |
+| Serialization change | Query-builder types don't have `to_dict()`. Bookmark builder uses attribute access. No change needed. |
+
+---
+
+## 11. Appendices
+
+### A. Complete Type Migration Matrix
+
+| # | Type | Tier | Fields | Current `__post_init__` | `@field_validator` | `@model_validator` | New Validation Gained |
+|---|------|------|--------|------------------------|-------------------|-------------------|----------------------|
+| 1 | `PropertyInput` | 1 | 3 | None | name (CP6) | None | CP6 at construction |
+| 2 | `CustomPropertyRef` | 1 | 1 | None | id (CP1) | None | CP1 at construction |
+| 3 | `InlineCustomProperty` | 1 | 4 | None | formula (CP2,CP5), inputs (CP3,CP4) | None | CP2-CP5 at construction |
+| 4 | `Formula` | 2 | 2 | FM1 | expression (FM1) | None | None (already validated) |
+| 5 | `FunnelStep` | 2 | 5 | FS1 | event (FS1) | None | None |
+| 6 | `RetentionEvent` | 2 | 3 | RE1 | event (RE1) | None | None |
+| 7 | `HoldingConstant` | 2 | 2 | HC1 | property (HC1) | None | None |
+| 8 | `GroupBy` | 3 | 5 | GB1,GB2,GB3 | property (GB1), bucket_size (GB2), buckets (V24 finite) | GB3 (ordering), V11/V12B/V12C (dependencies) | V24 finite check at construction |
+| 9 | `Exclusion` | 3 | 3 | EX1,EX2,EX3 | event (EX1), from_step (EX2) | EX3 (step ordering) | None |
+| 10 | `FlowStep` | 3 | 6 | FL1,FL2 | event (FL1), forward (FL2), reverse (FL2) | None | None |
+| 11 | `CohortBreakdown` | 3 | 3 | CB1,CB2 | None | CB1/CB2 (cohort args) | None |
+| 12 | `CohortMetric` | 3 | 2 | CM1,CM2,CM5 | None | CM1/CM2/CM5 (cohort args + inline rejection) | None |
+| 13 | `Metric` | 3 | 7 | M1,M2,M3 | event (M1) | M2 (math↔property), M3 (percentile↔value) | None |
+| 14 | `Filter` | 4 | 6 | None (class methods) | None (validation in class methods) | None | None |
+| -- | `CohortDefinition` | Deferred | -- | None | -- | -- | -- |
+
+### B. Validation Rule Count Summary
+
+| Category | Count | Disposition |
+|----------|-------|------------|
+| Rules that move into models (single-field) | 33 | `@field_validator` on Pydantic models |
+| Rules that move into models (cross-field, within model) | 9 | `@model_validator` on Pydantic models |
+| Rules removed from validation.py (redundant — only fire on model instances) | ~15 | Covered by model validators above |
+| Rules that stay in validation.py (cross-object/query-level) | 34 | No change |
+| Rules that stay in validation.py (raw-string input checks) | ~21 | Needed for `str` input paths |
+| Layer 2 rules (bookmark dict validation) | 32 | No change |
+| **Total unique rules** | **108** | |
+
+Note: The ~15 removed rules overlap with the 42 "move into models" rules — they are the subset where validation.py's check is genuinely unreachable because it only fires on model instances (guarded by `isinstance`). The remaining ~27 of the 42 "move into models" rules are **also** needed in validation.py for raw-string input paths, making them intentional defense-in-depth rather than duplication.
+
+### C. Error Code Stability
+
+All 100+ error codes remain stable in their semantics. ~15 codes are removed from validation.py (Section 6.2) because their checks become unreachable — the Pydantic model enforces the same invariant at construction. These codes continue to exist conceptually (the invariant is still enforced), but via Pydantic's error format rather than the project's `ValidationError`. The conformance suite is regenerated to reflect this.
+
+### D. Files Modified Per Phase
+
+| Phase | Files Modified | Files Created |
+|-------|---------------|---------------|
+| 1 | `exceptions.py`, types.py (EX3 fix only) | `_internal/field_validators.py` |
+| 2 | `types.py` (3 types), test files | None |
+| 3 | `types.py` (4 types), test files | None |
+| 4 | `types.py` (6 types), test files | None |
+| 5 | `types.py` (Filter), `workspace.py` (field access), `_internal/` builders, test files | None |
+| 6 | `types.py` (dead code removal), CLAUDE.md files | None |
+
+### E. Conformance Harness Compatibility
+
+The conformance harness (`conformance/harness/run_python.py`) imports:
+
+```python
+from mixpanel_data._internal.validation import (
+    validate_bookmark,
+    validate_flow_args,
+    validate_flow_bookmark,
+    validate_funnel_args,
+    validate_query_args,
+    validate_retention_args,
+    validate_time_args,
+)
+from mixpanel_data.exceptions import ValidationError
+from mixpanel_data.types import Exclusion
+```
+
+**All imports remain valid.** The only type import is `Exclusion` (used to construct test inputs). After migration, `Exclusion` is a Pydantic model instead of a dataclass — construction behavior is identical for valid inputs.
+
+After refactoring, run `conformance/generate.py` to regenerate the suite from the updated Python oracle. Tests that exercised now-removed rules (Section 6.2) may produce different results — the rule is enforced at model construction rather than via `validate_*_args()`. The generator handles this automatically since it derives expectations from the Python implementation.

--- a/context/source-aware-plugin-design.md
+++ b/context/source-aware-plugin-design.md
@@ -1,0 +1,320 @@
+# Source-Aware Plugin Architecture — Design Spec
+
+**Status:** Design approved, ready for implementation planning
+**Date:** 2026-04-13
+
+## Motivation
+
+The mixpanel-data marketplace plugin (`mixpanel-plugin/`) is a sibling directory to the library source (`src/mixpanel_data/`) in the same repository. When Claude Code clones the marketplace, it clones the entire repo — meaning the full library source, tests, design docs, and CI config are all available inside the plugin installation at `~/.claude/plugins/marketplaces/mixpanel-data-marketplace/`.
+
+This structural property is currently unexploited. The agents have hand-written API references and a `help.py` introspection script, but no awareness that the actual source code is sitting right next to them.
+
+### Use Cases
+
+1. **Error diagnosis** — Agent hits an exception, reads the source to understand why (e.g., reads validators to understand rule U30 that rejected its query). Reactive, triggered by failure.
+
+2. **API deepening** — Agent wants to understand a parameter's behavior more deeply than the docstring explains (e.g., what does `alignment="birth"` actually do to the date math?). Exploratory, triggered by uncertainty.
+
+3. **Bug discovery / fix PRs** — Agent notices something wrong during a session and can investigate, confirm, and open a fix PR against the library. Proactive, triggered by the agent's judgment.
+
+### Target Audience
+
+Mixpanel engineers who install the plugin. They are both users and potential contributors. The plugin becomes an analytics tool AND a development accelerator — use it, find issues, fix them, all in the same session.
+
+## Architecture — Four Components
+
+### Component 1: Source Awareness in Existing Prompts
+
+Every agent and the mixpanelyst skill get a "Source Code Access" section. This is the foundation — agents simply *know* the source is there.
+
+#### Mixpanelyst SKILL.md Addition
+
+```markdown
+## Source Code Access
+
+The full `mixpanel_data` library source ships with this plugin. Use it to diagnose errors,
+understand parameter behavior, and discover bugs.
+
+### Paths
+
+| Resource | Path |
+|----------|------|
+| Library source | `${CLAUDE_PLUGIN_ROOT}/../src/mixpanel_data/` |
+| Tests | `${CLAUDE_PLUGIN_ROOT}/../tests/` |
+| Design docs | `${CLAUDE_PLUGIN_ROOT}/../context/` |
+| Project standards | `${CLAUDE_PLUGIN_ROOT}/../CLAUDE.md` |
+
+### Package Map
+
+workspace.py              — All public query & CRUD methods (the facade)
+types.py                  — Result types, params models, enums
+exceptions.py             — Exception hierarchy
+auth.py                   — Public auth module
+_internal/
+  api_client.py           — HTTP client, request/response handling
+  config.py               — Credential & config resolution
+  bookmark_builders.py    — Query params → bookmark JSON translation
+  validation.py           — Bookmark validation rules
+  transforms.py           — API response → result type transforms
+  services/
+    discovery.py          — Schema discovery (events, properties, cohorts)
+    live_query.py         — Query execution against Mixpanel APIs
+
+### Escalation Order
+
+1. **help.py** — signatures + docstrings (fastest, cheapest)
+2. **help.py source** — targeted source snippet (20-50 lines)
+3. **Read/Grep** — full file reads (when you need surrounding context)
+4. **Librarian agent** — deep investigation (multi-file tracing, bug confirmation)
+
+### When to Read Source
+
+- Exception with a code/message you don't understand → read the raising method
+- Parameter behavior unclear after checking docstring → read the builder
+- Unexpected result shape → read the type's `.df` property implementation
+- Suspect a library bug → delegate to librarian agent
+```
+
+#### Agent Prompts (analyst, diagnostician, explorer, narrator, synthesizer)
+
+Each gets a condensed version:
+
+```markdown
+## Source Code Access
+
+Library source is at `${CLAUDE_PLUGIN_ROOT}/../src/mixpanel_data/`. Use `help.py source <symbol>`
+for targeted snippets. For deep investigation or bug discovery, delegate to the **librarian** agent.
+```
+
+---
+
+### Component 2: help.py `source` Subcommand
+
+Extend the existing `help.py` with a `source` subcommand that uses Python's `inspect` module to locate and display the actual source code for any symbol.
+
+#### Usage
+
+```bash
+python3 help.py source Workspace.query_user     # method body + file:line
+python3 help.py source UserQueryResult           # class definition + fields
+python3 help.py source BookmarkValidationError   # exception class
+python3 help.py source Workspace.query_user 50   # show 50 lines of context (default: 30)
+```
+
+#### Output Format
+
+```
+# Workspace.query_user — source
+# File: /path/to/src/mixpanel_data/workspace.py:842-892
+
+    def query_user(
+        self,
+        *,
+        where: Filter | list[Filter] | str | None = None,
+        ...
+    ) -> UserQueryResult:
+        """Query user profiles from Mixpanel's Engage API.
+        ...
+        """
+        params = self._build_user_params(...)
+        response = self._service.engage_query(params)
+        return UserQueryResult.from_response(response, params)
+```
+
+#### Implementation Approach
+
+- Uses `inspect.getsource()` and `inspect.getsourcefile()` to resolve symbol → file + line
+- Falls back to reading from `${CLAUDE_PLUGIN_ROOT}/../src/` if inspect doesn't resolve
+- Optional context-lines argument (default 30) to control output size
+- Shows file path relative to source root for readability
+
+#### Why This Matters
+
+Reading all of `workspace.py` (~600 lines) to understand one method burns context. `help.py source` returns just the relevant 20-50 lines. This is the difference between source access being practical vs. wasteful.
+
+---
+
+### Component 3: Librarian Agent
+
+A new agent at `mixpanel-plugin/agents/librarian.md` that specializes in library source navigation, implementation Q&A, and bug fix PRs.
+
+#### Definition
+
+```yaml
+name: librarian
+description: |
+  Deep-dive into the mixpanel_data library source code. Use for implementation questions
+  ("how does credential resolution work?"), error diagnosis ("why does query_user reject
+  as_of in aggregate mode?"), and bug fix PRs. Has full read access to source, tests,
+  and design documents.
+model: sonnet
+tools: Read, Write, Bash, Grep, Glob
+```
+
+#### Three Modes of Operation
+
+| Mode | Trigger | Output |
+|---|---|---|
+| **Explain** | "How does X work?" | Source-grounded explanation with file:line references |
+| **Diagnose** | "Why did this error occur?" | Root cause with exact source location + fix suggestion |
+| **Fix** | "Create a fix PR for this bug" | Branch, fix, tests, commit, PR |
+
+#### Explain Mode
+
+Answers implementation questions by tracing through source:
+
+```
+Agent dispatches: "How does Workspace resolve credentials when both
+account= and credential= are provided?"
+
+Librarian reads: workspace.py __init__, _internal/config.py, auth.py
+Returns: "Credential resolution follows this priority: (1) explicit credential=
+uses v2 config lookup via ConfigManager.get_credential(). (2) explicit account=
+uses v1 config lookup. (3) Neither provided → tries env vars MP_USERNAME/MP_SECRET,
+then falls back to default credential/account. See workspace.py:45-67 and
+_internal/config.py:120-145."
+```
+
+#### Diagnose Mode
+
+Traces errors to their source location:
+
+```
+Agent dispatches: "query_user raised QueryError: 'as_of is not supported
+in aggregate mode'. Explain why and suggest the correct usage."
+
+Librarian reads: workspace.py query_user method, finds validation check
+Returns: "Validation rule U30 at workspace.py:892 rejects as_of when
+mode='aggregate'. as_of is only valid for mode='profiles' — it sets
+a point-in-time snapshot. For aggregate counts, the API always uses
+current state. Fix: remove as_of parameter, or switch to mode='profiles'."
+```
+
+#### Fix Mode
+
+Context-aware workflow depending on where the agent is running:
+
+**If current working directory IS the library repo:**
+1. Create feature branch from main
+2. Write failing test (TDD per CLAUDE.md standards)
+3. Implement fix
+4. Run `just check` (lint + typecheck + test)
+5. Commit with conventional format
+6. Push and create PR via `gh`
+
+**If current working directory is NOT the library repo:**
+1. Investigate in the marketplace clone (read-only)
+2. Produce a structured bug report:
+   - File, line, root cause
+   - Suggested fix (code diff)
+   - Test that would catch it
+   - Severity assessment
+3. Offer: "Want me to clone the repo and create a fix PR?"
+4. If approved, clone to a temp worktree and proceed with fix workflow
+
+#### What the Librarian Knows (baked into prompt)
+
+- Full package map with file descriptions
+- Project code quality standards (from CLAUDE.md — TDD, mypy --strict, docstrings, 90% coverage)
+- How to run tests (`just check`, `just test -k <name>`)
+- Exception hierarchy and validation rule naming conventions
+- How to navigate the layered architecture (CLI → Workspace → Services → API Client)
+
+---
+
+### Component 4: Integration — How Agents Delegate
+
+#### Delegation Rules
+
+| Situation | Who handles |
+|---|---|
+| Quick error → read one method to understand | Agent handles directly (Read tool) |
+| "How does X work internally?" | Delegate to librarian (Explain) |
+| Unexpected behavior, suspect a bug | Delegate to librarian (Diagnose) |
+| Confirmed bug, wants a fix | Delegate to librarian (Fix) |
+| User asks about library internals | Delegate to librarian (Explain) |
+
+#### Analyst Prompt Update (delegation table addition)
+
+```markdown
+| Question type | Route to |
+|---|---|
+| ... existing delegation rules ... |
+| Implementation question ("how does X work?") | **Librarian** (explain mode) |
+| Error you can't diagnose from docstrings | **Librarian** (diagnose mode) |
+| Confirmed library bug | **Librarian** (fix mode) |
+```
+
+#### User-Facing Discovery
+
+Agents can proactively surface source-level capabilities:
+
+> "I notice you hit a QueryError. I can investigate the library source to understand exactly why this failed — want me to dig in?"
+
+For Mixpanel engineers:
+
+> "I found what looks like a bug in the retention parameter validation — bucket_sizes allows [0] but the API rejects it. Want me to create a fix PR?"
+
+---
+
+## Summary of Changes
+
+| Component | Files Changed | New Files |
+|---|---|---|
+| Source awareness (prompts) | `skills/mixpanelyst/SKILL.md`, 5 agent `.md` files | None |
+| help.py source subcommand | `skills/mixpanelyst/scripts/help.py` | None |
+| Librarian agent | None | `agents/librarian.md` |
+| Integration (delegation) | `agents/analyst.md`, `agents/diagnostician.md` | None |
+
+## Path Verification
+
+Confirmed on 2026-04-13 that the relative path mechanics work:
+
+```
+${CLAUDE_PLUGIN_ROOT} = mixpanel-plugin/
+${CLAUDE_PLUGIN_ROOT}/../src/mixpanel_data/  → full library source
+${CLAUDE_PLUGIN_ROOT}/../tests/              → full test suite
+${CLAUDE_PLUGIN_ROOT}/../context/            → design documents
+${CLAUDE_PLUGIN_ROOT}/../CLAUDE.md           → project standards
+```
+
+Package structure at time of design:
+
+```
+src/mixpanel_data/
+├── workspace.py
+├── types.py
+├── exceptions.py
+├── auth.py
+├── _internal/
+│   ├── api_client.py
+│   ├── auth_credential.py
+│   ├── bookmark_builders.py
+│   ├── bookmark_enums.py
+│   ├── config.py
+│   ├── expressions.py
+│   ├── me.py
+│   ├── pagination.py
+│   ├── segfilter.py
+│   ├── transforms.py
+│   ├── validation.py
+│   ├── auth/
+│   │   ├── bridge.py
+│   │   ├── callback_server.py
+│   │   ├── client_registration.py
+│   │   ├── flow.py
+│   │   ├── pkce.py
+│   │   ├── storage.py
+│   │   └── token.py
+│   └── services/
+│       ├── discovery.py
+│       └── live_query.py
+└── cli/
+    └── commands/
+```
+
+## Open Questions
+
+- **Staleness**: The marketplace clone is pinned to whatever commit was last fetched. Source may lag behind the latest `main`. Should the librarian detect and warn about this?
+- **Dependencies in clone**: The marketplace clone may not have `mixpanel_data` installed in a venv. The `help.py source` subcommand needs the package importable. Should we fall back to raw file reads with `ast` parsing?
+- **Scope of fix mode**: Should the librarian only fix bugs, or also implement missing features? Suggest limiting to bug fixes initially.

--- a/context/unified-query-engine-audit-report.md
+++ b/context/unified-query-engine-audit-report.md
@@ -1,0 +1,661 @@
+# Mixpanel Query API Capability Audit Report
+
+## Executive Summary
+
+A systematic, exhaustive audit of Mixpanel's query API capabilities across three codebases — the mixpanel_data Python library, the Mixpanel analytics server source, and mixpanel-power-tools — reveals **29 confirmed gaps** where capabilities the Mixpanel platform supports are either missing from or suboptimally exposed in the mixpanel_data unified query engine.
+
+| Category | Audited | No Gap | Partial | Confirmed Gap |
+|----------|---------|--------|---------|---------------|
+| Math types (Insights) | 21 | 14 | 0 | **7** |
+| Math types (Funnels) | 14 | 13 | 0 | **1** |
+| Math types (Retention) | 4 | 2 | 0 | **2** |
+| Per-user aggregation | 6 | 5 | 0 | **1** |
+| Segment method | 1 | 0 | 0 | **1** |
+| Filter operators | 35 | 22 | 0 | **6 actionable** |
+| Behavioral cohorts | 6 | 0 | 0 | **6** |
+| Funnel advanced modes | 1 | 0 | 0 | **1** |
+| Retention advanced modes | 2 | 0 | 0 | **2** |
+| Frequency analysis | 3 | 0 | 0 | **3** |
+| Time comparison | 1 | 0 | 0 | **1** |
+| Flows advanced features | 5 | 0 | 0 | **5** |
+| Group analytics scoping | 1 | 0 | 0 | **1** |
+| Custom property formulas | 1 | 1 | 0 | 0 |
+| Lookup table joins | 1 | 1 | 0 | 0 |
+| Multiple breakdowns | 1 | 1 | 0 | 0 |
+| Display options | 6 | 6 | 0 | 0 |
+
+**Confirmed non-gaps**: Custom property formulas (server-evaluated), lookup table joins (server-resolved), multiple breakdowns (already supported via `list[GroupBy]`), display options (data-affecting options already exposed; UI-only options intentionally excluded).
+
+---
+
+## Gap Priority Matrix
+
+| # | Gap | Engine | Severity | Effort | Agent Value |
+|---|-----|--------|----------|--------|-------------|
+| 1 | Expand `MathType` Literal (7 missing) | Insights | CRITICAL | SMALL | HIGH — unlocks cumulative_unique, sessions, unique_values, most_frequent, first_value, multi_attribution, numeric_summary |
+| 2 | Add `segment_method` to `Metric` class | Insights/Funnels/Retention | CRITICAL | SMALL | HIGH — controls first-touch vs all-touch attribution |
+| 3 | Add `funnelReentryMode` parameter | Funnels | HIGH | SMALL | HIGH — fundamentally changes funnel calculation |
+| 4 | Add `retentionUnboundedMode` parameter | Retention | HIGH | SMALL | HIGH — carry_back/carry_forward/consecutive_forward |
+| 5 | Add `retentionCumulative` parameter | Retention | HIGH | TRIVIAL | HIGH — cumulative vs period-over-period retention |
+| 6 | Expand `RetentionMathType` (2 missing) | Retention | HIGH | TRIVIAL | MEDIUM — adds total and average math for retention |
+| 7 | Add time comparison support | Insights/Funnels/Retention | HIGH | MEDIUM | HIGH — period-over-period overlay analysis |
+| 8 | Add bookmark-level frequency analysis | Insights | HIGH | MEDIUM | HIGH — frequency breakdown, frequency filter |
+| 9 | Behavioral cohort aggregation operators | All (via cohort filters) | HIGH | MEDIUM | HIGH — "users whose avg purchase > $50" vs just count |
+| 10 | Add missing `Filter` factory methods | All | MEDIUM | SMALL | MEDIUM — not_between, starts_with, ends_with, numeric aliases, date operators |
+| 11 | Add `FunnelMathType` histogram | Funnels | MEDIUM | TRIVIAL | LOW — niche use case |
+| 12 | Add `data_group_id` to query engines | All | MEDIUM | SMALL | MEDIUM — group analytics scoping |
+| 13 | Flow breakdowns/segments | Flows | MEDIUM | MEDIUM | MEDIUM — segment flow paths by property |
+| 14 | Flow exclusions | Flows | MEDIUM | SMALL | MEDIUM — exclude events between flow steps |
+| 15 | Flow session events | Flows | MEDIUM | SMALL | MEDIUM — $session_start/$session_end as flow anchors |
+| 16 | Flow global property filters | Flows | MEDIUM | SMALL | MEDIUM — filter_by_event in addition to filter_by_cohort |
+| 17 | Add `PerUserAggregation` session_replay_id_value | Insights | LOW | TRIVIAL | LOW — niche session replay use case |
+
+---
+
+## Detailed Findings
+
+### Tier 1: Critical Gaps — Type Expansions and Core Parameters
+
+#### 1.1 Expand `MathType` Literal (7 missing types)
+
+The `MathType` Literal in `_literal_types.py` exposes 15 values, but `VALID_MATH_INSIGHTS` in `bookmark_enums.py` accepts 21. Seven server-supported math types are invisible to type-checking:
+
+| Missing Math Type | What It Does | Requires Property? |
+|-------------------|-------------|-------------------|
+| `cumulative_unique` | Running total of unique users over time | No |
+| `sessions` | Count of sessions (not users or events) | No |
+| `unique_values` | Count of distinct property values | Yes |
+| `most_frequent` | Most common property value | Yes |
+| `first_value` | First property value seen per user | Yes |
+| `multi_attribution` | Multi-touch attribution across events | Yes |
+| `numeric_summary` | Count/mean/variance/sum_of_squares in one call | Yes |
+
+**Implementation**: Add these 7 values to the `MathType` Literal type. Update the docstring table. No builder changes needed — `bookmark_enums.py` already accepts them; only the public type annotation is too restrictive.
+
+**Files to modify**:
+- `src/mixpanel_data/_literal_types.py:46-62` — Expand `MathType` Literal
+- `src/mixpanel_data/_internal/bookmark_enums.py:128-142` — Update `MATH_REQUIRING_PROPERTY` if needed (verify `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary` all require property)
+
+#### 1.2 Add `segment_method` to `Metric` Class
+
+The `Metric` class has no `segment_method` field. The Mixpanel server validates `segment_method` with exactly two values:
+
+```python
+# From analytics/backend/arb/params.py
+def _validate_segment_method(self, segment_method):
+    if segment_method not in ("first", "all"):
+        raise ValidationError("invalid segment_method: %s" % segment_method)
+```
+
+| Value | Meaning |
+|-------|---------|
+| `"all"` | Count all qualifying events per user (default) |
+| `"first"` | Count only the first qualifying event per user |
+
+**Context restriction**: Only valid for retention, addiction (frequency), and funnel query types — NOT insights.
+
+**Note**: Power-tools incorrectly accepts `"last"` — this is a bug. Server rejects it.
+
+**Bookmark JSON position**: `sections.show[N].measurement.segmentMethod`
+
+**Implementation**:
+- Add `segment_method: Literal["all", "first"] | None = None` to `Metric` class
+- Add `SegmentMethod = Literal["all", "first"]` to `_literal_types.py`
+- Thread through bookmark builders into `measurement` block
+- Add validation: reject segment_method for insights-only queries
+
+**Files to modify**:
+- `src/mixpanel_data/_literal_types.py` — Add `SegmentMethod` Literal
+- `src/mixpanel_data/types.py` — Add field to `Metric` dataclass
+- `src/mixpanel_data/_internal/bookmark_builders.py` — Thread to measurement block
+
+#### 1.3 Add `funnelReentryMode` Parameter
+
+Funnel reentry mode controls how users re-entering a funnel are counted. Completely absent from mixpanel_data.
+
+**Field name**: `funnelReentryMode`
+**Bookmark JSON position**: `sections.show[0].behavior.funnelReentryMode`
+
+| Value | Meaning |
+|-------|---------|
+| `"default"` | Server-default reentry behavior |
+| `"basic"` | Users can re-enter funnel at steps after the first |
+| `"aggressive"` | Users re-entering generate additional conversion counts |
+| `"optimized"` | Server-optimized reentry calculation |
+
+**Server source**: `FunnelReentryModeType` enum in `analytics/lib/common/mxpnl/report/bookmarks/insights/show.py:42-46`
+
+**Default**: If absent, server assumes `"default"`.
+
+**Power-tools validation rule**: `F6_BAD_REENTRY` — enum validation
+
+**Implementation**:
+- Add `FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]` to `_literal_types.py`
+- Add `reentry_mode: FunnelReentryMode | None = None` parameter to `query_funnel()` and `build_funnel_params()`
+- Thread through `_build_funnel_params()` → behavior block in bookmark JSON
+- Add enum constant `VALID_FUNNEL_REENTRY_MODES` to `bookmark_enums.py`
+
+**Files to modify**:
+- `src/mixpanel_data/_literal_types.py` — Add Literal type
+- `src/mixpanel_data/workspace.py` — Add parameter to query_funnel/build_funnel_params
+- `src/mixpanel_data/_internal/bookmark_builders.py` — Thread to behavior block
+- `src/mixpanel_data/_internal/bookmark_enums.py` — Add enum constant
+- `src/mixpanel_data/_internal/validation.py` — Add validation rule
+
+#### 1.4 Add `retentionUnboundedMode` Parameter
+
+Controls how users are counted across retention buckets. Completely absent from mixpanel_data.
+
+**Field name**: `retentionUnboundedMode`
+**Bookmark JSON position**: `sections.show[0].behavior.retentionUnboundedMode`
+
+| Value | Meaning |
+|-------|---------|
+| `"none"` | Standard retention — only count users active in specific bucket (default) |
+| `"carry_back"` | Include users who became active before the birth period |
+| `"carry_forward"` | Count users who return after gaps as retained in all intermediate buckets |
+| `"consecutive_forward"` | Count users only on consecutive return events |
+
+**Server source**: `RetentionUnboundedModeType` enum in `analytics/lib/common/mxpnl/report/bookmarks/insights/show.py:66-70`
+
+**Default**: `"none"` (explicitly — see `analytics/mixpanel_mcp/mcp_server/utils/reports/retention.py`)
+
+**Power-tools validation rule**: `R8B_BAD_UNBOUNDED` — enum validation
+
+**Implementation**: Same pattern as funnelReentryMode.
+
+**Files to modify**: Same set as 1.3.
+
+#### 1.5 Add `retentionCumulative` Parameter
+
+Boolean flag controlling cumulative vs period-over-period retention display. Completely absent.
+
+**Field name**: `retentionCumulative`
+**Bookmark JSON position**: `sections.show[0].measurement.retentionCumulative` (NOTE: in `measurement`, NOT `behavior`)
+
+| Value | Meaning |
+|-------|---------|
+| `true` | Cumulative retention — retain users across all prior periods |
+| `false` | Period-over-period retention (default) |
+
+**Server source**: `BehaviorMeasurement.retentionCumulative` in `show.py:295`
+
+**Implementation**: Add `cumulative: bool = False` parameter to `query_retention()` and `build_retention_params()`. Thread to measurement block.
+
+#### 1.6 Expand `RetentionMathType` (2 missing types)
+
+`RetentionMathType` Literal has `retention_rate` and `unique`, but `VALID_MATH_RETENTION` accepts `total` and `average` too.
+
+| Missing Type | What It Does |
+|-------------|-------------|
+| `"total"` | Raw total event count per retention bucket |
+| `"average"` | Mean of a numeric property per retention bucket |
+
+**Implementation**: Add to `RetentionMathType` Literal. No builder changes needed.
+
+---
+
+### Tier 2: High-Value New Features
+
+#### 2.1 Time Comparison (Period-Over-Period)
+
+Time comparison overlays a second time period on the same query for comparison. Supported in insights, funnels, and retention (NOT flows). Completely absent from mixpanel_data.
+
+**Bookmark JSON position**: `params.timeComparison` (top-level, alongside `sections`)
+
+**Discriminated union with 3 types**:
+
+```python
+# Type 1: Relative (previous N periods)
+{"type": "relative", "unit": "day"}  # or "week", "month", "quarter", "year"
+
+# Type 2: Absolute start date
+{"type": "absolute-start", "date": "2024-01-15"}
+
+# Type 3: Absolute end date
+{"type": "absolute-end", "date": "2024-06-30"}
+```
+
+**Valid `type` values**: `"relative"`, `"absolute-start"`, `"absolute-end"`
+**Valid `unit` values** (when type=relative): `"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`
+**Date format** (when type=absolute-*): `YYYY-MM-DD`
+
+**Semantics**:
+- `sections.time[]` defines the primary period
+- `timeComparison` defines an overlay period
+- `type: "relative"` offsets backward from primary period start
+- `type: "absolute-start"` uses that date as comparison start (end inferred from primary period length)
+- `type: "absolute-end"` uses that date as comparison end (start inferred backward)
+
+**Power-tools validation rules** (bookmark-validator.js:761-790):
+- `B5D_TC_NOT_OBJECT`: must be an object
+- `B5D_BAD_TC_TYPE`: type must be valid
+- `B5D_TC_MISSING_UNIT` / `B5D_BAD_TC_UNIT`: relative requires valid unit
+- `B5D_TC_MISSING_DATE` / `B5D_TC_BAD_DATE`: absolute types require YYYY-MM-DD date
+
+**Implementation**:
+- Add `TimeComparison` type (frozen dataclass or union) to `types.py`
+- Add `time_comparison: TimeComparison | None = None` to `query()`, `query_funnel()`, `query_retention()`, and their `build_*_params()` counterparts
+- Add builder to serialize to bookmark JSON
+- Add validation rules
+
+**Files to modify**:
+- `src/mixpanel_data/types.py` — Add `TimeComparison`, `RelativeTimeComparison`, `AbsoluteTimeComparison`
+- `src/mixpanel_data/workspace.py` — Add parameter to 3 query methods + 3 build_params methods
+- `src/mixpanel_data/_internal/bookmark_builders.py` — Add time comparison serialization
+- `src/mixpanel_data/_internal/validation.py` — Add validation rules
+- `src/mixpanel_data/_literal_types.py` — Add `TimeComparisonType` and `TimeComparisonUnit` Literals
+
+#### 2.2 Bookmark-Level Frequency Analysis
+
+Frequency analysis (addiction analysis) measures how many times users perform events. mixpanel_data has a legacy `frequency()` method calling the old `/retention/addiction` endpoint, but does NOT support frequency as a bookmark-level query capability. This means agents cannot:
+- Break down any insights query by event frequency
+- Filter any query to users who performed events N times
+- Build frequency metrics in the bookmark query system
+
+**Three components needed**:
+
+##### 2.2.1 Frequency as Breakdown (`FrequencyBreakdown`)
+
+Goes into `sections.group[]`:
+
+```json
+{
+  "dataset": "$mixpanel",
+  "behavior": {
+    "aggregationOperator": "total",
+    "event": {"label": "SIGNUP", "value": "SIGNUP"},
+    "filters": [],
+    "filtersOperator": "and",
+    "dateRange": null,
+    "behaviorType": "$frequency"
+  },
+  "value": "SIGNUP Frequency",
+  "resourceType": "people",
+  "propertyType": "number",
+  "dataGroupId": null,
+  "customBucket": {
+    "bucketSize": 1,
+    "min": 0,
+    "max": 10,
+    "disabled": false
+  }
+}
+```
+
+Key constraints:
+- `resourceType` MUST be `"people"` (not events)
+- `behaviorType` MUST be `"$frequency"` (sentinel value)
+- `aggregationOperator` is always `"total"`
+
+##### 2.2.2 Frequency as Filter (`FrequencyFilter`)
+
+Goes into `sections.filter[]`:
+
+```json
+{
+  "dataset": "$mixpanel",
+  "value": "LOGIN Frequency",
+  "resourceType": "people",
+  "customProperty": {
+    "name": "LOGIN Frequency",
+    "behavior": {
+      "aggregationOperator": "total",
+      "event": {"label": "LOGIN", "value": "LOGIN"},
+      "filters": [],
+      "filtersOperator": "and",
+      "dateRange": null,
+      "behaviorType": "$frequency"
+    },
+    "propertyType": "number",
+    "resourceType": "people"
+  },
+  "customPropertyId": "$temp-<random-id>",
+  "filterType": "number",
+  "filterOperator": "is at least",
+  "filterValue": 5,
+  "dataGroupId": null
+}
+```
+
+Valid filter operators for frequency: `"is at least"`, `"is at most"`, `"is greater than"`, `"is less than"`, `"is equal to"`, `"is between"`
+
+##### 2.2.3 Frequency Show Clause
+
+Uses `type: "addiction"` behavior block in `sections.show[]`.
+
+**Implementation**:
+- Add `FrequencyBreakdown` dataclass to `types.py`
+- Add `FrequencyFilter` dataclass (or extend `Filter` class) to `types.py`
+- Accept `FrequencyBreakdown` in `group_by` parameter
+- Accept `FrequencyFilter` in `where` parameter
+- Add builders to `bookmark_builders.py`
+- Add validation rules
+
+#### 2.3 Behavioral Cohort Aggregation Operators
+
+`CohortCriteria.did_event()` currently only supports count-based frequency thresholds (`at_least`/`at_most`/`exactly`). The server supports aggregation operators that enable property-value-based behavioral cohorts:
+
+| Aggregation | What It Enables |
+|-------------|----------------|
+| `"total"` | "Users whose total purchase amount > $100" |
+| `"unique"` | "Users with 3+ unique product categories" |
+| `"average"` | "Users whose average session duration > 5 min" |
+| `"min"` | "Users whose minimum order value > $20" |
+| `"max"` | "Users whose maximum cart size > 10" |
+| `"median"` | "Users whose median purchase value > $50" |
+
+The power-tools' `buildRawCohort()` function accepts an `aggregation` parameter that sets `customProperty.behavior.aggregationOperator`. This field is completely absent from `CohortCriteria.did_event()`.
+
+**Implementation**:
+- Add `aggregation: Literal["total", "unique", "average", "min", "max", "median"] | None = None` to `CohortCriteria.did_event()`
+- Add `aggregation_property: str | None = None` for the property to aggregate on
+- Update serialization to emit `aggregationOperator` in the behavioral condition
+
+---
+
+### Tier 3: Medium-Value Completeness
+
+#### 3.1 Missing Filter Factory Methods
+
+Of ~35 operators in `VALID_FILTER_OPERATORS`, the `Filter` class covers ~22 via factory methods. The actionable gaps (excluding legacy date aliases and numeric aliases for existing methods):
+
+| Missing Operator | Recommended Method | Notes |
+|-----------------|-------------------|-------|
+| `"not between"` | `Filter.not_between(prop, min, max)` | Numeric negation of between |
+| `"starts with"` | `Filter.starts_with(prop, prefix)` | String prefix matching — in power-tools `VALID_FILTER_OPERATORS_BY_TYPE` |
+| `"ends with"` | `Filter.ends_with(prop, suffix)` | String suffix matching — same source |
+| `"was not between"` | `Filter.date_not_between(prop, start, end)` | Date range negation |
+| `"was in the next"` | `Filter.in_the_next(prop, value, unit)` | Future relative date |
+| `"is at least"` / `"is at most"` | `Filter.at_least(prop, val)` / `Filter.at_most(prop, val)` | Inclusive numeric bounds (>=, <=) |
+
+**Lower priority** (mostly aliases for existing methods):
+- `"is equal to"` — alias for `"equals"` with numeric semantics
+- `"is greater than or equal to"` — alias for `"is at least"`
+- `"is less than or equal to"` — alias for `"is at most"`
+- `"was less than"` — relative date operator
+- `"before the last"` — relative date operator
+
+**Implementation**: Add factory methods to `Filter` class. Each is ~10 lines following existing patterns.
+
+#### 3.2 Expand `FunnelMathType` (1 missing)
+
+Add `"histogram"` to `FunnelMathType` Literal. Already in `VALID_MATH_FUNNELS`.
+
+#### 3.3 Add `data_group_id` to Query Engines
+
+`dataGroupId` is hardcoded to `None` in 6 locations across `bookmark_builders.py` and `workspace.py`. Group analytics customers cannot scope queries to specific data groups (companies, accounts).
+
+**Where data_group_id IS used**: `list_cohorts_full()`, `list_lookup_tables()`, `upload_lookup_table()`, `update_lookup_table()`, `delete_lookup_tables()`
+
+**Where data_group_id is NOT used**: `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and all `build_*_params()` methods
+
+**Implementation**: Add `data_group_id: int | None = None` parameter to all query/build methods. Thread through to bookmark builders to replace hardcoded `None`.
+
+#### 3.4 Flow Breakdowns/Segments
+
+Power-tools' `buildFlowsReport` supports a `segments` array for breaking down flow paths by property. mixpanel_data does not expose this.
+
+#### 3.5 Flow Exclusions
+
+Power-tools supports `exclusions` array in flows for excluding events between specific steps. mixpanel_data does not expose this.
+
+#### 3.6 Flow Session Events
+
+Power-tools maps `$session_start` → `session_event: "start"` and `$session_end` → `session_event: "end"` via `SESSION_EVENT_MAP`. mixpanel_data's `FlowStep` only accepts event names, not session event types.
+
+#### 3.7 Flow Global Property Filters
+
+Power-tools supports `filter_by_event` for global property filters on flows. mixpanel_data only supports cohort filters via the `where` parameter (enforced by `build_flow_cohort_filter()`).
+
+---
+
+### Tier 4: Confirmed Non-Gaps (No Action Needed)
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| Custom property formulas (IFS, string ops) | NO GAP | Formula string passed as-is; server evaluates. Both codebases produce identical `displayFormula` + `composedProperties` JSON. |
+| Lookup table joins in queries | NO GAP | Joins are server-resolved via `get_rollup_dataset_joins()` based on show clause metadata. Client never constructs joins. |
+| Multiple/nested breakdowns | NO GAP | `build_group_section()` already accepts `list[str \| GroupBy \| CohortBreakdown]` and produces one entry per item in `sections.group[]`. |
+| Display options (plotStyle, yAxisOptions, valueMode) | NO GAP (for agents) | These are purely UI rendering options. Data-affecting options (analysis, rollingWindowSize) are already exposed via `rolling` and `cumulative` parameters. |
+
+---
+
+## Implementation Sequencing
+
+### Phase A: Type Expansions and Parameter Additions (Tier 1)
+
+*Estimated effort: 2-3 days. Low risk — expanding existing patterns.*
+
+| Step | What | Files | Effort |
+|------|------|-------|--------|
+| A1 | Expand `MathType` Literal (+7 values) | `_literal_types.py` | TRIVIAL |
+| A2 | Expand `RetentionMathType` Literal (+2 values) | `_literal_types.py` | TRIVIAL |
+| A3 | Expand `FunnelMathType` Literal (+1 value) | `_literal_types.py` | TRIVIAL |
+| A4 | Add `SegmentMethod` Literal + field to `Metric` | `_literal_types.py`, `types.py`, `bookmark_builders.py` | SMALL |
+| A5 | Add `FunnelReentryMode` Literal + parameter | `_literal_types.py`, `workspace.py`, `bookmark_builders.py`, `bookmark_enums.py`, `validation.py` | SMALL |
+| A6 | Add `RetentionUnboundedMode` Literal + parameter | Same files as A5 | SMALL |
+| A7 | Add `retentionCumulative` parameter | `workspace.py`, `bookmark_builders.py` | TRIVIAL |
+| A8 | Add missing `Filter` factory methods (6 methods) | `types.py` | SMALL |
+
+### Phase B: New Feature Types (Tier 2)
+
+*Estimated effort: 3-5 days. Medium risk — new types and builders.*
+
+| Step | What | Files | Effort |
+|------|------|-------|--------|
+| B1 | Add `TimeComparison` types + parameter | `types.py`, `_literal_types.py`, `workspace.py`, `bookmark_builders.py`, `validation.py` | MEDIUM |
+| B2 | Add `FrequencyBreakdown` type + builder | `types.py`, `bookmark_builders.py`, `workspace.py` | MEDIUM |
+| B3 | Add `FrequencyFilter` type + builder | `types.py`, `bookmark_builders.py` | MEDIUM |
+| B4 | Add aggregation operators to `CohortCriteria.did_event()` | `types.py` | MEDIUM |
+
+### Phase C: Completeness (Tier 3)
+
+*Estimated effort: 2-3 days. Low-medium risk.*
+
+| Step | What | Files | Effort |
+|------|------|-------|--------|
+| C1 | Add `data_group_id` to all query engines | `workspace.py`, `bookmark_builders.py` | SMALL |
+| C2 | Add flow breakdowns/segments | `workspace.py`, `bookmark_builders.py`, `types.py` | MEDIUM |
+| C3 | Add flow exclusions | `workspace.py`, `types.py` | SMALL |
+| C4 | Add flow session events | `types.py`, `workspace.py` | SMALL |
+| C5 | Add flow global property filters | `workspace.py`, `bookmark_builders.py` | SMALL |
+
+---
+
+## Appendix A: Complete Insights Math Type Matrix
+
+| Math Type | In `MathType` Literal | In `VALID_MATH_INSIGHTS` | In power-tools | Requires Property | No Per-User | Gap |
+|-----------|:---------------------:|:------------------------:|:--------------:|:-----------------:|:-----------:|:---:|
+| total | YES | YES | YES | Optional | No | - |
+| unique | YES | YES | YES | No | Yes | - |
+| cumulative_unique | **NO** | YES | YES | No | - | **GAP** |
+| sessions | **NO** | YES | YES | No | - | **GAP** |
+| dau | YES | YES | YES | No | Yes | - |
+| wau | YES | YES | YES | No | Yes | - |
+| mau | YES | YES | YES | No | Yes | - |
+| average | YES | YES | YES | Yes | No | - |
+| median | YES | YES | YES | Yes | No | - |
+| min | YES | YES | YES | Yes | No | - |
+| max | YES | YES | YES | Yes | No | - |
+| p25 | YES | YES | YES | Yes | No | - |
+| p75 | YES | YES | YES | Yes | No | - |
+| p90 | YES | YES | YES | Yes | No | - |
+| p99 | YES | YES | YES | Yes | No | - |
+| percentile | YES (maps to custom_percentile) | YES (as custom_percentile) | YES | Yes | No | - |
+| histogram | YES | YES | YES | Yes | No | - |
+| unique_values | **NO** | YES | YES | Yes | No | **GAP** |
+| most_frequent | **NO** | YES | YES | Yes | - | **GAP** |
+| first_value | **NO** | YES | YES | Yes | - | **GAP** |
+| multi_attribution | **NO** | YES | YES | Yes | - | **GAP** |
+| numeric_summary | **NO** | YES | YES | Yes | No | **GAP** |
+
+## Appendix B: Complete Filter Operator Matrix
+
+| Operator | Property Types | Filter Method | Gap |
+|----------|---------------|---------------|-----|
+| `equals` | string | `Filter.equals()` | - |
+| `does not equal` | string | `Filter.not_equals()` | - |
+| `is equal to` | number | (none) | Alias gap |
+| `contains` | string | `Filter.contains()` | - |
+| `does not contain` | string | `Filter.not_contains()` | - |
+| `is set` | all | `Filter.is_set()` | - |
+| `is not set` | all | `Filter.is_not_set()` | - |
+| `is at least` | number | (none) | **GAP** |
+| `is at most` | number | (none) | **GAP** |
+| `is between` | number | `Filter.between()` | - |
+| `between` | number | (covered by `Filter.between()`) | - |
+| `not between` | number | (none) | **GAP** |
+| `is greater than` | number | `Filter.greater_than()` | - |
+| `is less than` | number | `Filter.less_than()` | - |
+| `is greater than or equal to` | number | (none) | Alias for is at least |
+| `is less than or equal to` | number | (none) | Alias for is at most |
+| `true` | boolean | `Filter.is_true()` | - |
+| `false` | boolean | `Filter.is_false()` | - |
+| `was on` | datetime | `Filter.on()` | - |
+| `was not on` | datetime | `Filter.not_on()` | - |
+| `was in the` | datetime | `Filter.in_the_last()` | - |
+| `was not in the` | datetime | `Filter.not_in_the_last()` | - |
+| `was between` | datetime | `Filter.date_between()` | - |
+| `was not between` | datetime | (none) | **GAP** |
+| `was less than` | datetime | (none) | Minor gap |
+| `was before` | datetime | `Filter.before()` | - |
+| `was since` | datetime | `Filter.since()` | - |
+| `was in the next` | datetime | (none) | **GAP** |
+| `on` | datetime (legacy) | (covered by `was on`) | - |
+| `not on` | datetime (legacy) | (covered by `was not on`) | - |
+| `in the last` | datetime (legacy) | (covered by `was in the`) | - |
+| `not in the last` | datetime (legacy) | (covered by `was not in the`) | - |
+| `before the last` | datetime (legacy) | (none) | Minor gap |
+| `before` | datetime (legacy) | (covered by `was before`) | - |
+| `in the next` | datetime (legacy) | (covered by `was in the next`) | - |
+| `since` | datetime (legacy) | (covered by `was since`) | - |
+| `starts with` | string (in power-tools OPERATORS_BY_TYPE) | (none) | **GAP** |
+| `ends with` | string (in power-tools OPERATORS_BY_TYPE) | (none) | **GAP** |
+
+## Appendix C: Behavioral Cohort Feature Matrix
+
+| Feature | power-tools `buildRawCohort` | `CohortCriteria` | Gap |
+|---------|:---------------------------:|:-----------------:|:---:|
+| Count-based frequency (at_least/at_most/exactly) | YES | YES | - |
+| Aggregation: total | YES | **NO** | **GAP** |
+| Aggregation: unique | YES | **NO** | **GAP** |
+| Aggregation: average | YES | **NO** | **GAP** |
+| Aggregation: min | YES | **NO** | **GAP** |
+| Aggregation: max | YES | **NO** | **GAP** |
+| Aggregation: median | YES | **NO** | **GAP** |
+| Event property filters | YES | YES (via `where=`) | - |
+| Time scoping (within_days/weeks/months) | YES | YES | - |
+| Absolute date range (from_date/to_date) | NO | YES | - |
+| Negation (did_not_do_event) | YES | YES | - |
+| Cohort references (in_cohort/not_in_cohort) | NO | YES | - |
+| AND/OR composition (all_of/any_of) | NO | YES | - |
+| Property criteria (has_property) | NO | YES | - |
+
+## Appendix D: Bookmark JSON Examples for Key New Capabilities
+
+### D1: Funnel Reentry Mode
+
+```json
+{
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "funnel",
+        "funnelReentryMode": "aggressive",
+        "behaviors": [
+          {"type": "event", "name": "View Product"},
+          {"type": "event", "name": "Add to Cart"},
+          {"type": "event", "name": "Purchase"}
+        ]
+      }
+    }]
+  }
+}
+```
+
+### D2: Retention Unbounded + Cumulative
+
+```json
+{
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {
+        "type": "retention",
+        "retentionUnboundedMode": "carry_forward",
+        "retentionUnit": "week",
+        "behaviors": [
+          {"type": "event", "name": "Signup"},
+          {"type": "event", "name": "Login"}
+        ]
+      },
+      "measurement": {
+        "math": "retention_rate",
+        "retentionCumulative": true
+      }
+    }]
+  }
+}
+```
+
+### D3: Time Comparison (Relative)
+
+```json
+{
+  "sections": {
+    "time": [{"dateRangeType": "in the last", "window": {"value": 30, "unit": "day"}, "unit": "day"}],
+    "show": [{"type": "metric", "behavior": {"type": "event", "name": "Signup"}}]
+  },
+  "timeComparison": {
+    "type": "relative",
+    "unit": "month"
+  }
+}
+```
+
+### D4: Frequency Breakdown
+
+```json
+{
+  "sections": {
+    "group": [{
+      "dataset": "$mixpanel",
+      "behavior": {
+        "aggregationOperator": "total",
+        "event": {"label": "Purchase", "value": "Purchase"},
+        "behaviorType": "$frequency",
+        "filters": [],
+        "filtersOperator": "and",
+        "dateRange": null
+      },
+      "value": "Purchase Frequency",
+      "resourceType": "people",
+      "propertyType": "number",
+      "customBucket": {"bucketSize": 1, "min": 0, "max": 10}
+    }]
+  }
+}
+```
+
+### D5: Segment Method
+
+```json
+{
+  "sections": {
+    "show": [{
+      "type": "metric",
+      "behavior": {"type": "event", "name": "Purchase"},
+      "measurement": {
+        "math": "total",
+        "segmentMethod": "first"
+      }
+    }]
+  }
+}
+```
+
+---
+
+*Audit completed April 14, 2026. Sources: mixpanel_data (Python), mixpanel-power-tools (JavaScript), mixpanel_headless/analytics (Mixpanel server).*

--- a/context/unified-query-system-brief.md
+++ b/context/unified-query-system-brief.md
@@ -1,0 +1,110 @@
+# The Agentic Analytics Gap — and How `mixpanel_data` Closes It
+
+**Author:** Jared McFarland | **Date:** April 2026 | **Audience:** Anant Gupta, Engineering & Product Leadership
+
+---
+
+## The Problem Every Analytics Platform Shares
+
+AI agents are rewriting how teams interact with product data. But there's a structural problem across the entire analytics industry: **no product analytics vendor ships a query library for agents to use.**
+
+- **Mixpanel's** Python SDK is write-only. JQL is deprecated. The MCP server is in beta with ~12 tools.
+- **PostHog's** Python SDK is write-only. Querying requires hand-rolling HTTP requests against HogQL and parsing raw JSON.
+- **Amplitude's** Python SDK is write-only. Their SQL access requires a Snowflake add-on.
+
+Every platform has the same gap: agents can *send* data in, but they cannot *reason about* it programmatically. The official answer from every vendor, including Mixpanel, is either "use the UI" or "export to a warehouse and write SQL."
+
+That's the gap `mixpanel_data` closes — from the client side.
+
+---
+
+## What the Unified Query System Actually Is
+
+Four Python methods. One typed vocabulary. Every query validated before it touches the network.
+
+```python
+import mixpanel_data as mp
+ws = mp.Workspace()
+
+# Insights: "How many daily active users, by platform, last 90 days?"
+result = ws.query("Login", math="dau", group_by="platform", last=90)
+
+# Funnels: "What's the 7-day signup-to-purchase conversion?"
+result = ws.query_funnel(["Signup", "Purchase"], conversion_window=7)
+
+# Retention: "Do users come back weekly after onboarding?"
+result = ws.query_retention("Onboard", "Login", retention_unit="week")
+
+# Flows: "What do users do after hitting a paywall?"
+result = ws.query_flow("Paywall Shown", forward=5, mode="sankey")
+```
+
+Each method returns a typed result with a **native pandas DataFrame** (`result.df`), the generated **bookmark params** (`result.params`) for debugging or persistence, and **computed metadata**. Filters, breakdowns, formulas, cohorts, custom properties, time ranges — all shared across engines, all strongly typed, all validated before execution.
+
+Under the hood, these methods construct the same declarative JSON bookmark params that powers Mixpanel's UI reports, then POST them inline. **No temporary entities, no UI round-trips, no raw JSON construction.** The agent writes Python; the library handles the rest.
+
+---
+
+## Why This Is a Competitive Advantage
+
+### No competitor has this. Period.
+
+| Capability | mixpanel\_data | PostHog | Amplitude | Warehouses |
+|---|:---:|:---:|:---:|:---:|
+| Typed Python query library | **Yes** | No | No | No |
+| Native DataFrame returns | **Yes** | No | No | Via connector |
+| Analytics primitives as code objects | **Yes** | No | No | No |
+| Pre-execution validation | **Yes** | No | No | No |
+| Inline cohorts & custom properties | **Yes** | N/A | N/A | N/A |
+
+PostHog offers HogQL (raw SQL over ClickHouse). Amplitude offers Snowflake-native SQL access. Both force agents to **reconstruct analytics concepts from raw tables on every query** — writing complex window functions for funnels, manual cohort bucketing for retention, recursive CTEs for path analysis. These are hard problems. Getting funnel SQL right at scale is notoriously error-prone, and every agent invocation is a fresh attempt.
+
+`mixpanel_data` inverts this: the agent doesn't build analytics from primitives — **it starts from analytics primitives and reasons downward.** A funnel isn't a JOIN; it's `query_funnel(["Signup", "Purchase"])`. Retention isn't a self-join with date arithmetic; it's `query_retention("Signup", "Login")`. The agent stands on the shoulders of Mixpanel's purpose-built product analytics engine and sees further.
+
+### Code-first unlocks what MCP tool-calling cannot
+
+MCP servers — including Mixpanel's own — operate in a request-response loop: one tool call, one result, back to the LLM for the next decision. This is inherently serial and context-heavy.
+
+`mixpanel_data` operates natively inside Python. That means agents can:
+
+- **Run 4 engines in parallel** via `ThreadPoolExecutor` — Insights, Funnels, Retention, and Flows simultaneously
+- **Chain queries programmatically** — find the worst funnel step, then trace what users do instead via Flows, then check if that behavior predicts churn via Retention
+- **Join results with pandas** — merge DataFrames across engines on date, segment, or cohort
+- **Apply statistical testing** — scipy for significance, NetworkX for path graph analysis, all without leaving the runtime
+- **Iterate hypotheses in a loop** — segment a metric drop by 6 dimensions in parallel, identify the anomaly, drill deeper, all in one execution
+
+This is the difference between an agent that asks a question and waits, and an agent that *investigates.* The compound effect of parallelization, composition, and iteration is a step change in analytical capability.
+
+---
+
+## What This Unlocks for Mixpanel
+
+### 1. Internal agent capabilities
+
+Mixpanel's own AI agents — whether powering Spark, internal tools, or customer-facing copilots — can use `mixpanel_data` as their query substrate. Instead of building and maintaining internal query-building code, every agent gets typed, validated, DataFrame-native access to all four report types through a single library.
+
+### 2. A better foundation than building a new Query API
+
+The company is planning a new Query API infrastructure built on a stripped-down bookmark language. `mixpanel_data` already parameterizes the *full* bookmark language with strong types and two-layer validation. The library could inform — or even become — the reference implementation for that API. Client-side solutions are arguably *better* for agents than server-side APIs: agents write Python, not cURL.
+
+### 3. Rapid prototyping of new analytical workflows
+
+Because queries are just Python, teams can prototype complex multi-stage analyses — "find churning power users, trace their last 5 sessions, compare their funnel conversion to retained users" — in minutes, not sprints. These prototypes can ship as saved reports, dashboards, or agent capabilities without building new UI.
+
+### 4. Enhancing the MCP server
+
+The existing MCP server's ~12 tools could be backed by `mixpanel_data` instead of raw API calls, immediately gaining validation, richer parameterization, and DataFrame-native results. New tools become trivial to add.
+
+---
+
+## The Bottom Line
+
+The analytics industry is converging on a future where AI agents are the primary interface to product data. Every vendor is racing to build this. But today:
+
+- PostHog gives agents SQL and says "figure it out."
+- Amplitude gives agents SQL (via Snowflake) and says "figure it out."
+- Mixpanel, without `mixpanel_data`, gives agents a beta MCP server and says "we're working on it."
+
+`mixpanel_data` gives agents **typed analytics primitives, native DataFrames, validated queries, and the full power of Python's ecosystem** — all running on top of a database purpose-built for exactly these questions. Funnels, retention, flows, and segmentation aren't reconstructed from raw data on every query. They're first-class objects an agent can reason about, compose, parallelize, and iterate on.
+
+No other product analytics platform offers anything like this. Not as an official product, not as a community library, not as a roadmap item. This is a genuine competitive moat — and it's ready now.

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Turn Claude into a senior data analyst and Mixpanel product analytics expert. CodeMode-first: Claude writes Python using mixpanel_data's 5 typed query engines (insights, funnels, retention, flows, users) plus pandas, networkx, and anytree for sophisticated multi-engine analysis.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mixpanel-data:setup
-description: This skill installs mixpanel_data, pandas, numpy, matplotlib, seaborn, networkx, anytree, and scipy, then verifies Mixpanel credentials. It should be invoked when setting up a new environment for Mixpanel data analysis, when dependencies are missing, or when configuring service account or OAuth credentials for the first time.
+description: This skill installs mixpanel_data, pandas, pyarrow, numpy, matplotlib, seaborn, networkx, anytree, and scipy, then verifies Mixpanel credentials. It should be invoked when setting up a new environment for Mixpanel data analysis, when dependencies are missing, or when configuring service account or OAuth credentials for the first time.
 disable-model-invocation: true
 allowed-tools: Bash
 ---
@@ -17,8 +17,8 @@ bash ${CLAUDE_SKILL_DIR}/scripts/setup.sh
 
 This will:
 1. Verify Python 3.10+ is available
-2. Install `mixpanel_data`, `pandas`, `numpy`, `matplotlib`, `seaborn`, `networkx>=3.0`, `anytree>=2.8.0`, and `scipy` (tries uv, pip in order)
-3. Verify all packages import successfully (including networkx, anytree, and scipy)
+2. Install `mixpanel_data`, `pandas`, `pyarrow`, `numpy`, `matplotlib`, `seaborn`, `networkx>=3.0`, `anytree>=2.8.0`, and `scipy` (tries uv, pip in order)
+3. Verify all packages import successfully (including pyarrow, networkx, anytree, and scipy)
 4. Check for configured Mixpanel credentials (supports both v1 and v2 config schemas)
 
 ## Check Credentials

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mixpanel-data:setup
-description: This skill installs mixpanel_data, pandas, pyarrow, numpy, matplotlib, seaborn, networkx, anytree, and scipy, then verifies Mixpanel credentials. It should be invoked when setting up a new environment for Mixpanel data analysis, when dependencies are missing, or when configuring service account or OAuth credentials for the first time.
+description: This skill installs mixpanel_data, pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy (and pyarrow on Python 3.11+), then verifies Mixpanel credentials. It should be invoked when setting up a new environment for Mixpanel data analysis, when dependencies are missing, or when configuring service account or OAuth credentials for the first time.
 disable-model-invocation: true
 allowed-tools: Bash
 ---
@@ -17,8 +17,8 @@ bash ${CLAUDE_SKILL_DIR}/scripts/setup.sh
 
 This will:
 1. Verify Python 3.10+ is available
-2. Install `mixpanel_data`, `pandas`, `pyarrow`, `numpy`, `matplotlib`, `seaborn`, `networkx>=3.0`, `anytree>=2.8.0`, and `scipy` (tries uv, pip in order)
-3. Verify all packages import successfully (including pyarrow, networkx, anytree, and scipy)
+2. Install `mixpanel_data`, `pandas`, `numpy`, `matplotlib`, `seaborn`, `networkx>=3.0`, `anytree>=2.8.0`, `scipy`, and `pyarrow>=17.0` on Python 3.11+ (tries uv, pip in order)
+3. Verify all packages import successfully (including pyarrow on 3.11+, networkx, anytree, and scipy)
 4. Check for configured Mixpanel credentials (supports both v1 and v2 config schemas)
 
 ## Check Credentials

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -30,13 +30,13 @@ fi
 # mixpanel_data is not on PyPI — install from GitHub
 MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git"
 echo ""
-echo "Installing mixpanel_data (from GitHub), pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy..."
+echo "Installing mixpanel_data (from GitHub), pandas, pyarrow, numpy, matplotlib, seaborn, networkx, anytree, scipy..."
 if command -v uv &>/dev/null; then
   echo "  (using uv)"
-  uv pip install --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy || { echo "  ⚠ Virtualenv install failed, trying system install..."; uv pip install --system --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy; }
+  uv pip install --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy || { echo "  ⚠ Virtualenv install failed, trying system install..."; uv pip install --system --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy; }
 elif "$python_cmd" -m pip --version &>/dev/null; then
   echo "  (using pip via $python_cmd)"
-  "$python_cmd" -m pip install "$MIXPANEL_DATA_PKG" pandas numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy
+  "$python_cmd" -m pip install "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy
 else
   echo "✗ No package manager found. Install pip or uv."
   echo "  Recommended: https://docs.astral.sh/uv/"
@@ -49,6 +49,7 @@ echo "Verifying installation..."
 "$python_cmd" -c "
 import mixpanel_data as mp
 import pandas as pd
+import pyarrow as pa
 import numpy as np
 import matplotlib
 import seaborn as sns
@@ -57,6 +58,7 @@ import anytree
 import scipy
 print(f'✓ mixpanel_data installed')
 print(f'✓ pandas {pd.__version__}')
+print(f'✓ pyarrow {pa.__version__}')
 print(f'✓ numpy {np.__version__}')
 print(f'✓ matplotlib {matplotlib.__version__}')
 print(f'✓ seaborn {sns.__version__}')

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -29,14 +29,21 @@ fi
 # Install packages
 # mixpanel_data is not on PyPI — install from GitHub
 MIXPANEL_DATA_PKG="git+https://github.com/jaredmcfarland/mixpanel_data.git"
+DEPS=(pandas numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy)
+
+# pyarrow is only needed on Python 3.11+ (for pandas 3.x Arrow-backed dtypes)
+if [ "$minor" -ge 11 ]; then
+  DEPS+=('pyarrow>=17.0')
+fi
+
 echo ""
-echo "Installing mixpanel_data (from GitHub), pandas, pyarrow, numpy, matplotlib, seaborn, networkx, anytree, scipy..."
+echo "Installing mixpanel_data (from GitHub) and dependencies..."
 if command -v uv &>/dev/null; then
   echo "  (using uv)"
-  uv pip install --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy || { echo "  ⚠ Virtualenv install failed, trying system install..."; uv pip install --system --python "$python_cmd" "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy; }
+  uv pip install --python "$python_cmd" "$MIXPANEL_DATA_PKG" "${DEPS[@]}" || { echo "  ⚠ Virtualenv install failed, trying system install..."; uv pip install --system --python "$python_cmd" "$MIXPANEL_DATA_PKG" "${DEPS[@]}"; }
 elif "$python_cmd" -m pip --version &>/dev/null; then
   echo "  (using pip via $python_cmd)"
-  "$python_cmd" -m pip install "$MIXPANEL_DATA_PKG" pandas pyarrow numpy matplotlib seaborn 'networkx>=3.0' 'anytree>=2.8.0' scipy
+  "$python_cmd" -m pip install "$MIXPANEL_DATA_PKG" "${DEPS[@]}"
 else
   echo "✗ No package manager found. Install pip or uv."
   echo "  Recommended: https://docs.astral.sh/uv/"
@@ -47,9 +54,9 @@ fi
 echo ""
 echo "Verifying installation..."
 "$python_cmd" -c "
+import sys
 import mixpanel_data as mp
 import pandas as pd
-import pyarrow as pa
 import numpy as np
 import matplotlib
 import seaborn as sns
@@ -58,7 +65,9 @@ import anytree
 import scipy
 print(f'✓ mixpanel_data installed')
 print(f'✓ pandas {pd.__version__}')
-print(f'✓ pyarrow {pa.__version__}')
+if sys.version_info >= (3, 11):
+    import pyarrow as pa
+    print(f'✓ pyarrow {pa.__version__}')
 print(f'✓ numpy {np.__version__}')
 print(f'✓ matplotlib {matplotlib.__version__}')
 print(f'✓ seaborn {sns.__version__}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "tomli>=2.0; python_version < '3.11'",
     "tomli-w>=1.0",
     "pandas>=2.0",
+    "pyarrow>=17.0; python_version >= '3.11'",
     "httpx>=0.27",
     "typer>=0.12",
     "rich>=13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,18 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
@@ -714,10 +722,18 @@ name = "ipython"
 version = "9.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1214,7 +1230,9 @@ dependencies = [
     { name = "jq" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow", marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1271,6 +1289,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.0" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "pyarrow", marker = "python_full_version >= '3.11'", specifier = ">=17.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -1551,10 +1570,18 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -1640,10 +1667,18 @@ name = "numpy"
 version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/65/21b3bc86aac7b8f2862db1e808f1ea22b028e30a225a34a5ede9bf8678f2/numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0", size = 20584950, upload-time = "2025-11-16T22:52:42.067Z" }
 wheels = [
@@ -1744,12 +1779,14 @@ wheels = [
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1803,6 +1840,80 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
 name = "pandas-stubs"
 version = "2.3.3.251219"
 source = { registry = "https://pypi.org/simple" }
@@ -1839,7 +1950,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1936,6 +2047,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/a8/24e5dc6855f50a62936ceb004e6e9645e4219a8065f304145d7fb8a79d5d/pyarrow-23.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3fab8f82571844eb3c460f90a75583801d14ca0cc32b1acc8c361650e006fd56", size = 34307390, upload-time = "2026-02-16T10:08:08.654Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8e/4be5617b4aaae0287f621ad31c6036e5f63118cfca0dc57d42121ff49b51/pyarrow-23.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3f91c038b95f71ddfc865f11d5876c42f343b4495535bd262c7b321b0b94507c", size = 35853761, upload-time = "2026-02-16T10:08:17.811Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/08/3e56a18819462210432ae37d10f5c8eed3828be1d6c751b6e6a2e93c286a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d0744403adabef53c985a7f8a082b502a368510c40d184df349a0a8754533258", size = 44493116, upload-time = "2026-02-16T10:08:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/c40b68001dbec8a3faa4c08cd8c200798ac732d2854537c5449dc859f55a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c33b5bf406284fd0bba436ed6f6c3ebe8e311722b441d89397c54f871c6863a2", size = 47564532, upload-time = "2026-02-16T10:08:34.27Z" },
+    { url = "https://files.pythonhosted.org/packages/20/bc/73f611989116b6f53347581b02177f9f620efdf3cd3f405d0e83cdf53a83/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ddf743e82f69dcd6dbbcb63628895d7161e04e56794ef80550ac6f3315eeb1d5", size = 48183685, upload-time = "2026-02-16T10:08:42.889Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/6c6b3ecdae2a8c3aced99956187e8302fc954cc2cca2a37cf2111dad16ce/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e052a211c5ac9848ae15d5ec875ed0943c0221e2fcfe69eee80b604b4e703222", size = 50605582, upload-time = "2026-02-16T10:08:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/94/d359e708672878d7638a04a0448edf7c707f9e5606cee11e15aaa5c7535a/pyarrow-23.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:5abde149bb3ce524782d838eb67ac095cd3fd6090eba051130589793f1a7f76d", size = 27521148, upload-time = "2026-02-16T10:08:58.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050, upload-time = "2026-02-16T10:09:11.877Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918, upload-time = "2026-02-16T10:09:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811, upload-time = "2026-02-16T10:09:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766, upload-time = "2026-02-16T10:09:34.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669, upload-time = "2026-02-16T10:09:44.153Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698, upload-time = "2026-02-16T10:09:50.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `pyarrow>=17.0` as a dependency for Python 3.11+ to support pandas 3.x Arrow-backed dtypes
- Update plugin setup skill to install and verify pyarrow during `/mixpanel-data:setup`
- Bump plugin version from 3.2.0 to 3.2.1
- Add design context documents for upcoming work (backport plan, unified query engine audit, validation refactor, source-aware plugin design, cowork bundling feasibility, unified query system brief)
- Add `.specify/feature.json` config

## Test plan
- [ ] Verify `just check` passes (lint, typecheck, tests)
- [ ] Verify `pyarrow` imports successfully on Python 3.11+
- [ ] Verify plugin setup skill installs pyarrow via `/mixpanel-data:setup`