### PR TITLE
feat: close 29 query engine capability gaps across all 4 engines

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/039-query-user-engine"
+  "feature_directory": "specs/040-query-engine-completeness"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,8 @@ Task(subagent_type="mixpanel-data:synthesizer", prompt="...")
 - Python 3.10+ (mypy --strict compliant) + Pydantic v2 (validation/models), httpx (HTTP client), Typer (CLI), Rich (output), tomli/tomli_w (TOML read/write) (038-auth-project-workspace-redesign)
 - TOML config file (`~/.mp/config.toml`), JSON cache files (`~/.mp/oauth/me_{region}.json`), JSON OAuth token files (`~/.mp/oauth/tokens_{region}.json`) (038-auth-project-workspace-redesign)
 - Python 3.10+ (mypy --strict) + httpx (HTTP), Pydantic v2 (validation), pandas (DataFrames), Hypothesis (PBT) (039-query-user-engine)
+- Python 3.10+ + httpx, Pydantic v2, Typer, Rich, pandas, Hypothesis (040-query-engine-completeness)
+- N/A — query parameter types only, no persistence (040-query-engine-completeness)
 
 ## Recent Changes
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A complete programmable interface to Mixpanel analytics—Python library and CLI
 
 Mixpanel's web UI is powerful for interactive exploration, but programmatic access requires navigating multiple REST endpoints with different conventions. **mixpanel_data** provides a unified interface: discover your schema, run analytics queries, stream data, and manage entities—all through consistent Python methods or CLI commands.
 
-Core analytics—typed Insights engine queries (DAU/WAU/MAU, formulas, filters, breakdowns, cohort-scoped queries), typed funnel queries (ad-hoc steps, exclusions, conversion windows), typed retention queries (event pairs, custom buckets, alignment modes), typed flow queries (path analysis, direction controls, visualization modes), typed user profile queries (property filtering, sorting, parallel fetching, aggregate statistics), segmentation, saved reports—plus entity management (dashboards, reports, cohorts, feature flags, experiments), raw JQL execution, and streaming data extraction.
+Core analytics—typed Insights engine queries (DAU/WAU/MAU, formulas, filters, breakdowns, cohort-scoped queries, period-over-period comparison, frequency analysis), typed funnel queries (ad-hoc steps, exclusions, conversion windows), typed retention queries (event pairs, custom buckets, alignment modes), typed flow queries (path analysis, direction controls, visualization modes), typed user profile queries (property filtering, sorting, parallel fetching, aggregate statistics), segmentation, saved reports—plus entity management (dashboards, reports, cohorts, feature flags, experiments), raw JQL execution, and streaming data extraction.
 
 ## Installation
 
@@ -100,6 +100,7 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 ```python
 import mixpanel_data as mp
 from mixpanel_data import Metric, Filter, Formula, GroupBy, RetentionEvent
+from mixpanel_data import TimeComparison, FrequencyBreakdown, FrequencyFilter
 
 ws = mp.Workspace()
 
@@ -125,6 +126,19 @@ result = ws.query("Purchase",                          # filtered with breakdown
     group_by=GroupBy("amount", property_type="number", bucket_size=50),
 )
 print(result.df)  # pandas DataFrame
+
+# Period-over-period comparison — compare against previous month
+result = ws.query("Login", math="dau",
+    time_comparison=TimeComparison.relative("month"), last=30)
+
+# Frequency breakdown — segment by purchase frequency
+result = ws.query("Login",
+    group_by=FrequencyBreakdown(event="Purchase", bucket_max=10),
+    last=30)
+
+# New filter methods
+result = ws.query("Purchase",
+    where=[Filter.at_least("amount", 50), Filter.starts_with("email", "admin")])
 
 # Typed funnel query — define steps inline
 funnel = ws.query_funnel(
@@ -306,7 +320,7 @@ The entire surface area is self-documenting. Every CLI command supports `--help`
 
 Key design features:
 
-- **Typed Query Engines**: `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and `query_user()` provide five composable engines — Insights analytics, funnel conversion, retention cohorts, flow path analysis, and user profile queries — all sharing the same `Filter` vocabulary, `CohortDefinition` builders, and DataFrame output
+- **Typed Query Engines**: `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and `query_user()` provide five composable engines — Insights analytics, funnel conversion, retention cohorts, flow path analysis, and user profile queries — with period-over-period comparison (`TimeComparison`), frequency analysis (`FrequencyBreakdown`/`FrequencyFilter`), 21 math types, and 27+ filter methods, all sharing the same `Filter` vocabulary, `CohortDefinition` builders, and DataFrame output
 - **Entity CRUD & Data Governance**: Full lifecycle management of dashboards, reports, cohorts, feature flags, experiments, alerts, annotations, webhooks, plus Lexicon definitions, drop filters, custom properties, custom events, and lookup tables via Mixpanel App API
 - **Discoverable schema**: `events()`, `properties()`, `funnels()`, `cohorts()`, `bookmarks()` reveal what's in your project before you query
 - **Consistent interfaces**: Same operations available as Python methods and CLI commands

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,6 +31,9 @@ from mixpanel_data import (
     CohortDefinition, CohortCriteria,
 )
 
+# Advanced Query types (cross-engine)
+from mixpanel_data import TimeComparison, FrequencyBreakdown, FrequencyFilter
+
 # Retention Query types
 from mixpanel_data import RetentionEvent, RetentionQueryResult
 
@@ -122,6 +125,7 @@ Typed results for all operations:
 - **QueryResult** — Insights query results (from `query()`)
 - **Metric**, **Filter**, **Formula**, **GroupBy** — Query building blocks
 - **CohortBreakdown**, **CohortMetric** — Cohort-scoped query types (cross-engine)
+- **TimeComparison**, **FrequencyBreakdown**, **FrequencyFilter** — Advanced cross-engine query types
 - **CohortDefinition**, **CohortCriteria** — Inline cohort definition builder
 - **FunnelQueryResult**, **FunnelStep**, **Exclusion** — Typed funnel results
 - **RetentionQueryResult**, **RetentionEvent**, **RetentionAlignment**, **RetentionMode**, **RetentionMathType** — Typed retention results

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -92,6 +92,25 @@ Types for using saved or inline custom properties as property references in quer
       show_root_heading: true
       show_root_toc_entry: true
 
+## Advanced Query Types
+
+Types for advanced query features — period-over-period comparison, frequency analysis, and frequency filtering across query engines.
+
+::: mixpanel_data.TimeComparison
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.FrequencyBreakdown
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.FrequencyFilter
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Cohort Definition Types
 
 Types for building inline cohort definitions programmatically — used with `Filter.in_cohort()`, `CohortBreakdown`, and `CohortMetric`.

--- a/docs/guide/query-flows.md
+++ b/docs/guide/query-flows.md
@@ -155,18 +155,25 @@ result = ws.query_flow(
 
 See [Insights Queries — Filters](query.md#filters) for the full list of `Filter` factory methods.
 
-### Cohort Filters
+### Filtering with `where=`
 
-Restrict flow analysis to users in a cohort using the `where=` parameter:
+Restrict flow analysis to a subset of users using the `where=` parameter. Flows support both cohort filters and property filters:
 
 ```python
 from mixpanel_data import Filter, CohortCriteria, CohortDefinition
 
-# What do power users do after purchasing?
+# Cohort filter — what do power users do after purchasing?
 result = ws.query_flow(
     "Purchase",
     forward=3,
     where=Filter.in_cohort(123, "Power Users"),
+)
+
+# Property filter — iOS users only
+result = ws.query_flow(
+    "Purchase",
+    where=Filter.equals("platform", "iOS"),
+    last=30,
 )
 
 # Inline cohort — what paths do frequent buyers take?
@@ -180,9 +187,9 @@ result = ws.query_flow(
 ```
 
 !!! note
-    Flows only support cohort filters (`Filter.in_cohort` / `Filter.not_in_cohort`), not property filters. Cohort breakdowns (`CohortBreakdown`) and custom properties (`CustomPropertyRef`, `InlineCustomProperty`) are not supported in flows.
+    Cohort breakdowns (`CohortBreakdown`) and custom properties (`CustomPropertyRef`, `InlineCustomProperty`) are not supported in flows.
 
-See [Insights Queries — Cohort Filters](query.md#cohort-filters) for the full cohort filter reference.
+See [Insights Queries — Cohort Filters](query.md#cohort-filters) for the full cohort filter reference and [Insights Queries — Filters](query.md#filters) for all `Filter` factory methods.
 
 ## Direction
 
@@ -301,6 +308,15 @@ result = ws.query_flow("Purchase", count_type="session")
 ```
 
 ## Additional Options
+
+### Data Group
+
+Scope flow analysis to a specific data group:
+
+```python
+# Scope to a data group
+result = ws.query_flow("Purchase", data_group_id=42, last=30)
+```
 
 ### Cardinality
 
@@ -836,6 +852,73 @@ ws.create_bookmark(CreateBookmarkParams(
     params=params,
 ))
 ```
+
+## Flow Segments
+
+Break flow results down by a property, cohort, or frequency using the `segments` parameter:
+
+```python
+# Break down paths by platform
+result = ws.query_flow("Purchase", segments="platform", last=30)
+
+# Segment by a GroupBy with bucketing
+from mixpanel_data import GroupBy
+result = ws.query_flow(
+    "Purchase",
+    segments=GroupBy("revenue", property_type="number", bucket_size=50),
+    last=30,
+)
+
+# Segment by cohort membership
+from mixpanel_data import CohortBreakdown
+result = ws.query_flow(
+    "Purchase",
+    segments=CohortBreakdown(cohort_id=123, name="Power Users"),
+    last=30,
+)
+```
+
+`segments` accepts a string (property name), `GroupBy`, `CohortBreakdown`, `FrequencyBreakdown`, or a list of these.
+
+## Flow Exclusions
+
+Hide specific events from flow paths using the `exclusions` parameter:
+
+```python
+# Exclude noisy events from the flow
+result = ws.query_flow(
+    "Purchase",
+    exclusions=["Page View", "Session Start"],
+    forward=3,
+    last=30,
+)
+```
+
+Excluded events are removed from the flow graph — they won't appear as nodes or edges, making it easier to see meaningful user paths.
+
+## Session Events
+
+Anchor a flow step to a session boundary using `FlowStep.session_event`:
+
+```python
+from mixpanel_data import FlowStep
+
+# What happens after a session starts?
+result = ws.query_flow(
+    FlowStep(event="Session Start", session_event="start"),
+    forward=5,
+    last=30,
+)
+
+# What leads up to a session ending?
+result = ws.query_flow(
+    FlowStep(event="Session End", session_event="end"),
+    reverse=3,
+    last=30,
+)
+```
+
+Values: `"start"` (session start anchor) or `"end"` (session end anchor).
 
 ## Next Steps
 

--- a/docs/guide/query-funnels.md
+++ b/docs/guide/query-funnels.md
@@ -259,12 +259,20 @@ result = ws.query_funnel(["Signup", "Purchase"], math="unique")
 | `"median"` | Median value |
 | `"min"` / `"max"` | Extremes |
 | `"p25"` / `"p75"` / `"p90"` / `"p99"` | Percentiles |
+| `"histogram"` | Distribution of a numeric property per step |
 
 ```python
 # Average purchase amount at each step
 result = ws.query_funnel(
     ["Signup", "Purchase"],
     math="average",
+    math_property="amount",
+)
+
+# Distribution of purchase amounts at each funnel step
+result = ws.query_funnel(
+    ["Browse", "Add to Cart", "Purchase"],
+    math="histogram",
     math_property="amount",
 )
 ```
@@ -539,6 +547,53 @@ result = ws.query_funnel(
     last=90,
     unit="week",
 )
+```
+
+## Reentry Mode
+
+Control how users re-enter the funnel after conversion using the `reentry_mode` parameter:
+
+| Mode | Behavior |
+|---|---|
+| `"default"` | Server default reentry behavior |
+| `"basic"` | Users can re-enter after their conversion window expires |
+| `"aggressive"` | Users can re-enter as soon as they convert |
+| `"optimized"` | Server-optimized reentry (best for most use cases) |
+
+```python
+# Allow aggressive re-entry for repeat purchase funnels
+result = ws.query_funnel(
+    ["Browse", "Add to Cart", "Purchase"],
+    reentry_mode="aggressive",
+    last=30,
+)
+```
+
+!!! note
+    Reentry mode only matters for funnels where the same user can convert multiple times.
+
+## Period-over-Period Comparison
+
+Compare funnel conversion against a previous period using `TimeComparison`:
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare this week's funnel against last week
+result = ws.query_funnel(
+    ["Signup", "Activate", "Purchase"],
+    time_comparison=TimeComparison.relative("week"),
+    last=7,
+)
+```
+
+See [Insights > Period-over-Period Comparison](query.md#period-over-period-comparison) for all `TimeComparison` factory methods.
+
+## Data Group Scoping
+
+```python
+# Scope funnel to a data group
+result = ws.query_funnel(["Signup", "Purchase"], data_group_id=42)
 ```
 
 ## Working with Results

--- a/docs/guide/query-retention.md
+++ b/docs/guide/query-retention.md
@@ -205,6 +205,10 @@ The `math` parameter controls what metric is computed:
 |---|---|
 | `"retention_rate"` (default) | Percentage of cohort retained per bucket (0.0–1.0) |
 | `"unique"` | Raw unique user count per bucket |
+| `"total"` | Total event count per retention bucket |
+| `"average"` | Average of a numeric property per bucket (requires `math_property`) |
+
+`RetentionMathType = Literal["retention_rate", "unique", "total", "average"]`
 
 ```python
 # Retention rate (default)
@@ -212,6 +216,16 @@ result = ws.query_retention("Signup", "Login", math="retention_rate")
 
 # Raw unique user counts
 result = ws.query_retention("Signup", "Login", math="unique")
+
+# Total login events per retention bucket (not just unique users)
+result = ws.query_retention("Signup", "Login", math="total")
+
+# Average session duration per retention bucket
+result = ws.query_retention(
+    "Signup", "Login",
+    math="average",
+    math_property="session_duration",
+)
 ```
 
 ## Filters
@@ -417,6 +431,77 @@ result = ws.query_retention(
 result = ws.query_retention("Signup", "Login", mode="table")
 ```
 
+## Unbounded Mode
+
+Control how users who perform the return event outside their retention bucket are counted using `unbounded_mode`:
+
+| Mode | Behavior |
+|---|---|
+| `"none"` | Standard counting — only count in the exact bucket (default) |
+| `"carry_back"` | If a user returns in bucket N, also count them in all prior buckets |
+| `"carry_forward"` | If a user returns in bucket N, also count them in all subsequent buckets |
+| `"consecutive_forward"` | Count forward from the last bucket where the user was active |
+
+```python
+# Carry-forward: once a user returns, count them as retained in all later buckets
+result = ws.query_retention(
+    "Signup", "Login",
+    unbounded_mode="carry_forward",
+    retention_unit="week",
+    last=90,
+)
+
+# Carry-back: if a user returns in W4, also count them in W1-W3
+result = ws.query_retention(
+    "Signup", "Login",
+    unbounded_mode="carry_back",
+    retention_unit="week",
+    last=90,
+)
+```
+
+!!! tip
+    Unbounded modes are useful for products where engagement is irregular. `carry_forward` gives an optimistic view, `carry_back` fills gaps.
+
+## Cumulative Retention
+
+Enable cumulative counting with `retention_cumulative=True`. In cumulative mode, each bucket shows the total number of users who returned at least once up to that bucket, rather than the count for that specific bucket.
+
+```python
+# Cumulative: bucket N = users who returned at least once in buckets 0..N
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_cumulative=True,
+    retention_unit="week",
+    last=90,
+)
+```
+
+## Period-over-Period Comparison
+
+Compare retention curves against a previous period using `TimeComparison`:
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare this month's retention against last month
+result = ws.query_retention(
+    "Signup", "Login",
+    time_comparison=TimeComparison.relative("month"),
+    retention_unit="week",
+    last=30,
+)
+```
+
+See [Insights > Period-over-Period Comparison](query.md#period-over-period-comparison) for all `TimeComparison` factory methods.
+
+## Data Group Scoping
+
+```python
+# Scope retention to a data group
+result = ws.query_retention("Signup", "Login", data_group_id=42)
+```
+
 ## Working with Results
 
 ### `RetentionQueryResult`
@@ -518,7 +603,7 @@ print(json.dumps(result.params, indent=2))
 | Buckets not ascending | `R6_BUCKET_SIZES_ASCENDING` | Bucket sizes must be in strictly ascending order |
 | Invalid retention unit | `R7_INVALID_RETENTION_UNIT` | Must be one of: day, week, month |
 | Invalid alignment | `R8_INVALID_ALIGNMENT` | Must be one of: birth, interval_start |
-| Invalid math | `R9_INVALID_MATH` | Must be one of: retention_rate, unique |
+| Invalid math | `R9_INVALID_MATH` | Must be one of: retention_rate, unique, total, average |
 | Invalid mode | `R10_INVALID_MODE` | Must be one of: curve, trends, table |
 | Invalid unit | `R11_INVALID_UNIT` | Must be one of: day, week, month |
 

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -78,6 +78,8 @@ result = ws.query(
 | `"dau"` | Daily active users |
 | `"wau"` | Weekly active users |
 | `"mau"` | Monthly active users |
+| `"cumulative_unique"` | Running count of distinct users over time |
+| `"sessions"` | Session count (not events or users) |
 
 ```python
 # DAU over the last 90 days
@@ -85,6 +87,15 @@ result = ws.query("Login", math="dau", last=90)
 
 # Monthly active users
 result = ws.query("Login", math="mau", last=6, unit="month")
+
+# Cumulative unique users over time
+result = ws.query("Login", math="cumulative_unique", last=90)
+
+# Count sessions instead of events
+result = ws.query("Login", math="sessions", last=30)
+
+# Distinct values of a property
+result = ws.query("Purchase", math="unique_values", math_property="product_id")
 ```
 
 ### Property Aggregation
@@ -100,6 +111,11 @@ Aggregate a numeric property across events. Requires `math_property`:
 | `"p25"` / `"p75"` / `"p90"` / `"p99"` | Percentiles |
 | `"percentile"` + `percentile_value` | Custom percentile (e.g. p95) |
 | `"histogram"` | Distribution of property values |
+| `"unique_values"` | Count of distinct values of a property |
+| `"most_frequent"` | Most commonly occurring property value |
+| `"first_value"` | First observed value per user |
+| `"multi_attribution"` | Multi-touch attribution across a property |
+| `"numeric_summary"` | Summary stats (count, mean, variance) |
 
 ```python
 # Average purchase amount per day
@@ -144,6 +160,20 @@ Valid `per_user` values: `"unique_values"`, `"total"`, `"average"`, `"min"`, `"m
 
 !!! note
     `per_user` is incompatible with `dau`, `wau`, `mau`, and `unique` math types.
+
+### Segment Method
+
+Control how events are counted per user with `Metric.segment_method`:
+
+- `"all"` (default) — count every qualifying event
+- `"first"` — count only the first qualifying event per user
+
+```python
+from mixpanel_data import Metric
+
+# Only count each user's first purchase
+result = ws.query(Metric("Purchase", segment_method="first"), last=30)
+```
 
 ### The `Metric` Class
 
@@ -221,6 +251,8 @@ Filter.equals("browser", ["Chrome", "Firefox"])  # equals any in list
 Filter.not_equals("browser", "Safari")        # does not equal
 Filter.contains("email", "@company.com")      # contains substring
 Filter.not_contains("url", "staging")         # does not contain
+Filter.starts_with("email", "admin")          # prefix match
+Filter.ends_with("email", "@company.com")     # suffix match
 ```
 
 **Numeric filters:**
@@ -229,6 +261,9 @@ Filter.not_contains("url", "staging")         # does not contain
 Filter.greater_than("amount", 100)            # > 100
 Filter.less_than("age", 65)                   # < 65
 Filter.between("amount", 10, 100)             # 10 <= x <= 100
+Filter.not_between("age", 18, 65)             # outside a range
+Filter.at_least("score", 80)                  # >= 80
+Filter.at_most("errors", 5)                   # <= 5
 ```
 
 **Existence filters:**
@@ -295,6 +330,8 @@ Filter.date_between("created", "2025-01-01", "2025-06-30")  # date range
 Filter.in_the_last("created", 30, "day")         # last 30 days
 Filter.in_the_last("last_seen", 2, "week")       # last 2 weeks
 Filter.not_in_the_last("created", 90, "day")     # NOT in last 90 days
+Filter.date_not_between("created", "2025-01-01", "2025-06-30")  # dates outside a range
+Filter.in_the_next("renewal_date", 30, "day")    # relative future date
 ```
 
 The relative date methods accept a `FilterDateUnit`: `"hour"`, `"day"`, `"week"`, or `"month"`.
@@ -506,6 +543,119 @@ total = result.df["count"].iloc[0]
 
 !!! warning "Mode affects aggregation"
     `mode="total"` with `math="unique"` deduplicates users across the **entire date range**. `mode="timeseries"` with `math="unique"` counts unique users **per period** (not additive across periods). This is not just a display difference — it changes the numbers.
+
+## Period-over-Period Comparison
+
+Compare the current time range against a previous period using `TimeComparison`:
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare against previous week
+result = ws.query("Login", time_comparison=TimeComparison.relative("week"), last=7)
+
+# Compare against window starting on a fixed date
+result = ws.query(
+    "Purchase",
+    time_comparison=TimeComparison.absolute_start("2025-01-01"),
+    from_date="2026-01-01",
+    to_date="2026-01-31",
+)
+
+# Compare against window ending on a fixed date
+result = ws.query(
+    "Purchase",
+    time_comparison=TimeComparison.absolute_end("2025-12-31"),
+    from_date="2026-01-01",
+    to_date="2026-01-31",
+)
+```
+
+Three factory methods:
+
+| Method | What it compares against |
+|---|---|
+| `TimeComparison.relative(unit)` | Previous period offset by unit (day, week, month, quarter, year) |
+| `TimeComparison.absolute_start(date)` | Window starting on a fixed date, same duration |
+| `TimeComparison.absolute_end(date)` | Window ending on a fixed date, same duration |
+
+`TimeComparison` also works with `query_funnel()` and `query_retention()`.
+
+## Frequency Analysis
+
+### Frequency Breakdown
+
+Break down results by how often users performed an event using `FrequencyBreakdown`:
+
+```python
+from mixpanel_data import FrequencyBreakdown
+
+# How are logins distributed by purchase frequency?
+result = ws.query(
+    "Login",
+    group_by=FrequencyBreakdown(
+        event="Purchase",
+        bucket_size=1,
+        bucket_min=0,
+        bucket_max=10,
+    ),
+    last=30,
+)
+```
+
+Parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `event` | `str` | required | Event to count frequency for |
+| `bucket_size` | `int` | `1` | Width of each frequency bucket |
+| `bucket_min` | `int` | `0` | Minimum frequency value |
+| `bucket_max` | `int` | `10` | Maximum frequency value |
+| `label` | `str \| None` | `None` | Display label |
+
+### Frequency Filter
+
+Filter to users who performed an event a certain number of times using `FrequencyFilter`:
+
+```python
+from mixpanel_data import FrequencyFilter
+
+# Only users who purchased at least 3 times
+result = ws.query(
+    "Login",
+    where=FrequencyFilter(
+        event="Purchase",
+        value=3,
+        operator="is at least",
+    ),
+    last=30,
+)
+
+# With a lookback window — purchased at least 3 times in the last 30 days
+result = ws.query(
+    "Login",
+    where=FrequencyFilter(
+        event="Purchase",
+        value=3,
+        operator="is at least",
+        date_range_value=30,
+        date_range_unit="day",
+    ),
+    last=90,
+)
+```
+
+Operators: `"is at least"`, `"is at most"`, `"is greater than"`, `"is less than"`, `"is equal to"`.
+
+## Data Groups
+
+Scope a query to a specific data group for group-level analytics:
+
+```python
+result = ws.query("Login", data_group_id=42, last=30)
+```
+
+`data_group_id` is available on all query engines: `query()`, `query_funnel()`, `query_retention()`, and `query_flow()`.
 
 ## Working with Results
 

--- a/docs/guide/unified-query-system.md
+++ b/docs/guide/unified-query-system.md
@@ -29,6 +29,8 @@ result = ws.query(
     where=Filter.equals("country", "US"),  # filter
     group_by="platform",                    # breakdown
     last=90,                                # time range
+    time_comparison="previous_period",      # compare periods
+    data_group_id=42,                       # data group scope
 )
 
 result = ws.query_funnel(
@@ -36,6 +38,8 @@ result = ws.query_funnel(
     where=Filter.equals("country", "US"),  # same
     group_by="platform",                    # same
     last=90,                                # same
+    time_comparison="previous_period",      # same
+    data_group_id=42,                       # same
 )
 
 result = ws.query_retention(
@@ -43,17 +47,19 @@ result = ws.query_retention(
     where=Filter.equals("country", "US"),  # same
     group_by="platform",                    # same
     last=90,                                # same
+    time_comparison="previous_period",      # same
+    data_group_id=42,                       # same
 )
 
 result = ws.query_flow(
     "Purchase",
-    # flows only support cohort filters in where=
-    where=Filter.in_cohort(123, "Power Users"),
-    last=90,
+    where=Filter.equals("country", "US"),  # property filters supported
+    last=90,                                # same
+    data_group_id=42,                       # same
 )
 ```
 
-Learn `Filter`, `GroupBy`, `where=`, `group_by=`, and `last=` once. Use them across engines (flows has some restrictions — see below).
+Learn `Filter`, `GroupBy`, `where=`, `group_by=`, `last=`, `time_comparison=`, and `data_group_id=` once. Use them across engines (flows has some restrictions — see below).
 
 ---
 
@@ -115,7 +121,7 @@ ws.query_flow(
 
 Mix freely. Strings and objects can appear in the same query.
 
-**Note:** `FlowStep.filters` accepts any `Filter` type. The query-level `where=` parameter on `query_flow()` is more restricted — it only accepts cohort filters (`Filter.in_cohort` / `Filter.not_in_cohort`).
+**Note:** `FlowStep.filters` accepts any `Filter` type for per-step filtering. The query-level `where=` parameter on `query_flow()` accepts both cohort filters (`Filter.in_cohort` / `Filter.not_in_cohort`) and property filters (`Filter.equals()`, `Filter.greater_than()`, etc.).
 
 ---
 
@@ -165,7 +171,7 @@ result = ws.query("Purchase", where=[
 ])
 ```
 
-Filters work identically across `query()`, `query_funnel()`, `query_retention()`, and `query_flow()` (flows: cohort filters only).
+Filters work identically across `query()`, `query_funnel()`, `query_retention()`, and `query_flow()`.
 
 ---
 
@@ -573,6 +579,16 @@ print(f"Users with email: {count.value}")
 ## Cross-cutting capabilities
 
 These features work across multiple engines through the same parameters.
+
+### Recent additions
+
+| Feature | Engines | Description |
+|---|---|---|
+| `time_comparison=` | Insights, Funnels, Retention | Compare the current period against a previous period |
+| `data_group_id=` | Insights, Funnels, Retention, Flows | Scope queries to a specific data group |
+| Property filters in `where=` | Flows | Flows now support property filters (e.g., `Filter.equals()`) in addition to cohort filters |
+| `segments=` | Flows | Break down flow paths by property, cohort, or frequency |
+| `exclusions=` | Flows | Hide specific events from flow paths |
 
 ### Cohort scoping
 
@@ -1145,12 +1161,14 @@ Each has a matching `build_*_params()` that returns the validated params dict wi
 
 | Parameter | Type | Default | Engines |
 |---|---|---|---|
-| `where=` | `Filter \| list[Filter]` | `None` | All (flows: cohort only) |
+| `where=` | `Filter \| list[Filter]` | `None` | All |
 | `group_by=` | `str \| GroupBy \| CohortBreakdown` | `None` | I, F, R |
 | `last=` | `int` | `30` | I, F, R, Fl |
 | `from_date=` | `str` (YYYY-MM-DD) | `None` | I, F, R, Fl |
 | `to_date=` | `str` (YYYY-MM-DD) | `None` | I, F, R, Fl |
 | `unit=` | `"day" \| "week" \| "month"` | `"day"` | I, F, R |
+| `time_comparison=` | `str` | `None` | I, F, R |
+| `data_group_id=` | `int` | `None` | I, F, R, Fl |
 | `mode=` | engine-specific | varies | All |
 | `math=` | engine-specific | varies | I, F, R |
 | `math_property=` | `str` | `None` | I, F |
@@ -1164,7 +1182,7 @@ I = Insights, F = Funnels, R = Retention
 | **Insights** | `per_user`, `percentile_value`, `formula`, `formula_label`, `rolling`, `cumulative` |
 | **Funnels** | `conversion_window`, `conversion_window_unit`, `order`, `exclusions`, `holding_constant` |
 | **Retention** | `retention_unit`, `alignment`, `bucket_sizes` |
-| **Flows** | `forward`, `reverse`, `count_type`, `cardinality`, `collapse_repeated`, `hidden_events` |
+| **Flows** | `forward`, `reverse`, `count_type`, `cardinality`, `collapse_repeated`, `hidden_events`, `segments`, `exclusions` |
 | **Users** | `properties`, `sort_by`, `sort_order`, `limit`, `mode`, `aggregate`, `aggregate_property`, `percentile`, `segment_by`, `parallel`, `workers` |
 
 ### Result types

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -20,6 +20,16 @@ Turn Claude into a senior data analyst and Mixpanel product analytics expert. In
 | Funnels | `ws.query_funnel()` | Do users convert through a sequence? | `FunnelQueryResult` |
 | Retention | `ws.query_retention()` | Do users come back? | `RetentionQueryResult` |
 | Flows | `ws.query_flow()` | What paths do users take? | `FlowQueryResult` |
+| Users | `ws.query_user()` | Who are they? What do they look like? | `UserQueryResult` |
+
+### Recent Additions
+
+- **TimeComparison**: Period-over-period analysis across Insights, Funnels, and Retention
+- **FrequencyBreakdown / FrequencyFilter**: Frequency-based breakdowns and filters
+- **7 new MathTypes**: `cumulative_unique`, `sessions`, `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary`
+- **Flow enhancements**: `segments`, `exclusions`, property filters, `FlowStep.session_event`
+- **Funnel reentry**: `reentry_mode` parameter with 4 modes
+- **Retention modes**: `unbounded_mode`, `retention_cumulative`, expanded `RetentionMathType`
 
 When you ask a question, Claude writes Python using the appropriate engine:
 

--- a/mixpanel-plugin/agents/analyst.md
+++ b/mixpanel-plugin/agents/analyst.md
@@ -64,6 +64,15 @@ Prefer writing and executing Python code using the `mixpanel_data` library. When
 | **Flows** | `ws.query_flow()` | What paths do users take? | `FlowQueryResult` |
 | **Users** | `ws.query_user()` | Who are they? What do they look like? | `UserQueryResult` |
 
+### Cross-Engine Features (v0.6)
+
+- **TimeComparison**: Period-over-period analysis on Insights, Funnels, and Retention — `TimeComparison.relative("week")` for WoW, etc.
+- **FrequencyBreakdown / FrequencyFilter**: Break down or filter by event frequency in Insights
+- **New MathTypes**: `cumulative_unique`, `sessions`, `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary`
+- **Flow enhancements**: `segments`, `exclusions`, property filters in `where=`, `FlowStep.session_event`
+- **Funnel reentry**: `reentry_mode` parameter
+- **Retention modes**: `unbounded_mode`, `retention_cumulative`, `RetentionMathType` now includes `total` and `average`
+
 ## Routing Decision Tree
 
 Map the user's question to the right engine:

--- a/mixpanel-plugin/agents/diagnostician.md
+++ b/mixpanel-plugin/agents/diagnostician.md
@@ -44,6 +44,19 @@ Prefer writing and executing Python code using the `mixpanel_data` library. When
 
 _Expands the 7-step diagnosis methodology from [analytical-frameworks.md](../skills/mixpanelyst/references/analytical-frameworks.md) §Diagnosis Methodology. For ready-to-run diagnostic templates, see [cross-query-synthesis.md](../skills/mixpanelyst/references/cross-query-synthesis.md) §Template 1: Revenue Drop Diagnosis._
 
+### Period-over-Period Comparison
+
+Use `TimeComparison` to compare the current period against a previous one across engines — ideal for Step 1 (QUANTIFY):
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare current week vs previous week across engines
+tc = TimeComparison.relative("week")
+trend = ws.query("Signup", math="unique", time_comparison=tc, last=7)
+funnel = ws.query_funnel(["Signup", "Purchase"], time_comparison=tc, last=7)
+```
+
 ### Step 1: QUANTIFY (Insights)
 
 Establish the baseline and magnitude of the change.

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -74,20 +74,28 @@ User says...                              → Use...
 "per user", "average per user"            → Insights (per_user=...)
 "compare events", "formula"               → Insights (formula=...)
 "rolling average", "cumulative"           → Insights (rolling/cumulative)
+"compare periods", "WoW", "MoM", "YoY"   → Insights (time_comparison)
+"how often", "frequency"                  → Insights (FrequencyBreakdown)
+"first event only", "first touch"         → Insights (segment_method="first")
 ─────────────────────────────────────────────────────
 "conversion", "funnel", "from X to Y"     → Funnels
 "drop-off", "where do users leave"        → Funnels
 "checkout/signup/onboarding completion"   → Funnels
 "time to convert", "conversion window"    → Funnels
+"funnel reentry", "re-enter"              → Funnels (reentry_mode)
 ─────────────────────────────────────────────────────
 "retention", "come back", "return rate"   → Retention
 "D1/D7/D30", "churn", "stickiness"       → Retention
 "cohort", "do they keep using"            → Retention
+"cumulative retention"                    → Retention (retention_cumulative)
+"unbounded", "carry forward"              → Retention (unbounded_mode)
 ─────────────────────────────────────────────────────
 "path", "flow", "journey"                → Flows
 "what happens after X", "next steps"      → Flows (forward)
 "what led to X", "how did they get to"    → Flows (reverse)
 "user paths", "navigation patterns"       → Flows
+"exclude events from flow"                → Flows (exclusions)
+"flow by segment", "segment paths"        → Flows (segments)
 ─────────────────────────────────────────────────────
 "who are these users", "user properties"      → Users
 "how many users have X", "user count"         → Users (mode="aggregate")
@@ -185,17 +193,19 @@ result = ws.query(
     math_property=None,  # required for property-based math
     per_user=None,       # unique_values | total | average | min | max
     percentile_value=None, # int for math="percentile"
-    group_by=None,       # str | GroupBy | list[str | GroupBy]
-    where=None,          # Filter | list[Filter]
+    group_by=None,       # str | GroupBy | FrequencyBreakdown | list[str | GroupBy]
+    where=None,          # Filter | FrequencyFilter | list[Filter]
     formula=None,        # "(B / A) * 100" (requires 2+ events)
     formula_label=None,
     rolling=None,        # rolling window periods
     cumulative=False,    # mutually exclusive with rolling
+    time_comparison=None,  # TimeComparison for period-over-period
+    data_group_id=None,    # int for data group scope
     mode="timeseries",   # timeseries | total | table
 ) # → QueryResult
 ```
 
-**MathType** (14 values):
+**MathType** (21 values):
 
 | Math | What it measures | Requires math_property? |
 |------|-----------------|------------------------|
@@ -206,6 +216,13 @@ result = ws.query(
 | `p25` / `p75` / `p90` / `p99` | Property percentiles | Yes |
 | `percentile` | Custom percentile (set percentile_value) | Yes |
 | `histogram` | Property value distribution | Yes |
+| `cumulative_unique` | Running distinct user count over time | No |
+| `sessions` | Session count | No |
+| `unique_values` | Distinct values of a property | Yes |
+| `most_frequent` | Most common property value | Yes |
+| `first_value` | First observed value per user | Yes |
+| `multi_attribution` | Multi-touch attribution | Yes |
+| `numeric_summary` | Summary stats (count, mean, variance) | Yes |
 
 _Complete parameter reference → [insights-reference.md](references/insights-reference.md)_
 
@@ -237,6 +254,9 @@ result = ws.query_funnel(
     group_by=None, where=None,
     exclusions=None,          # list[str | Exclusion]
     holding_constant=None,    # str | HoldingConstant | list
+    reentry_mode=None,        # default | basic | aggressive | optimized
+    time_comparison=None,     # TimeComparison for period-over-period
+    data_group_id=None,       # int for data group scope
     mode="steps",             # steps | trends | table
 ) # → FunnelQueryResult
 ```
@@ -247,7 +267,7 @@ result = ws.query_funnel(
 
 _Complete parameter reference → [funnels-reference.md](references/funnels-reference.md)_
 
-**FunnelMathType**: `conversion_rate_unique` (default) · `conversion_rate_total` · `conversion_rate_session` · `unique` · `total` · `average` · `median` · `min` · `max` · `p25` · `p75` · `p90` · `p99`
+**FunnelMathType**: `conversion_rate_unique` (default) · `conversion_rate_total` · `conversion_rate_session` · `unique` · `total` · `average` · `median` · `min` · `max` · `p25` · `p75` · `p90` · `p99` · `histogram`
 
 **Result**: `result.overall_conversion_rate` · `result.df` (step, event, count, step_conv_ratio, overall_conv_ratio, avg_time) · `result.params`
 
@@ -273,8 +293,12 @@ result = ws.query_retention(
     alignment="birth",    # birth | interval_start
     bucket_sizes=None,    # list[int] ascending, max 730
     from_date=None, to_date=None, last=30, unit="day",
-    math="retention_rate",  # retention_rate | unique
+    math="retention_rate",  # retention_rate | unique | total | average
     group_by=None, where=None,
+    unbounded_mode=None,       # none | carry_back | carry_forward | consecutive_forward
+    retention_cumulative=False, # cumulative retention counting
+    time_comparison=None,      # TimeComparison for period-over-period
+    data_group_id=None,        # int for data group scope
     mode="curve",         # curve | trends | table
 ) # → RetentionQueryResult
 ```
@@ -282,6 +306,8 @@ result = ws.query_retention(
 **RetentionEvent**: `RetentionEvent(event, filters=None, filters_combinator="all")`
 
 _Complete parameter reference → [retention-reference.md](references/retention-reference.md)_
+
+**RetentionMathType**: `retention_rate` (default) · `unique` · `total` · `average`
 
 **Alignment**: `"birth"` (user's clock starts at born event) vs `"interval_start"` (calendar boundaries)
 
@@ -314,11 +340,15 @@ result = ws.query_flow(
     cardinality=3,        # 1-50 events per step position
     collapse_repeated=False,
     hidden_events=None,   # list[str]
+    where=None,           # Filter | list[Filter] — property AND cohort filters
+    data_group_id=None,   # int for data group scope
+    segments=None,        # str | GroupBy | CohortBreakdown | FrequencyBreakdown
+    exclusions=None,      # list[str] — events to hide from flow
     mode="sankey",        # sankey | paths | tree
 ) # → FlowQueryResult
 ```
 
-**FlowStep**: `FlowStep(event, forward=None, reverse=None, label=None, filters=None, filters_combinator="all")`
+**FlowStep**: `FlowStep(event, forward=None, reverse=None, label=None, filters=None, filters_combinator="all", session_event=None)`
 
 _Complete parameter reference → [flows-reference.md](references/flows-reference.md)_
 
@@ -366,11 +396,16 @@ Filter.equals("platform", "iOS")              # or multi-value: ["iOS", "Android
 Filter.not_equals("country", "US")
 Filter.contains("email", "@company.com")
 Filter.not_contains("page", "admin")
+Filter.starts_with("email", "admin")      # prefix match
+Filter.ends_with("email", "@company.com") # suffix match
 
 # Numeric
 Filter.greater_than("revenue", 100)
 Filter.less_than("age", 18)
 Filter.between("age", 18, 65)              # inclusive range
+Filter.not_between("age", 18, 65)          # values outside range
+Filter.at_least("score", 80)              # >= (greater than or equal)
+Filter.at_most("errors", 5)               # <= (less than or equal)
 
 # Existence & Boolean
 Filter.is_set("email")
@@ -384,6 +419,8 @@ Filter.before("created", "2025-01-01")
 Filter.since("created", "2025-01-01")
 Filter.in_the_last("created", 30, "day")
 Filter.date_between("created", "2025-01-01", "2025-06-30")  # date range
+Filter.date_not_between("created", "2025-01-01", "2025-06-30")  # dates outside range
+Filter.in_the_next("renewal", 30, "day")                         # relative future date
 
 # Cohort membership
 Filter.in_cohort(123, "Power Users")                 # users in saved cohort

--- a/mixpanel-plugin/skills/mixpanelyst/references/cross-query-synthesis.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/cross-query-synthesis.md
@@ -349,7 +349,33 @@ with ThreadPoolExecutor(max_workers=5) as pool:
 
 ---
 
-## Join Strategy 7: Profile Enrichment Join
+## Join Strategy 7: Period-over-Period Cross-Engine
+
+**Use when**: Comparing current vs previous period across multiple engines.
+
+**Join key**: `TimeComparison` applied consistently across engines.
+
+```python
+import mixpanel_data as mp
+from mixpanel_data import TimeComparison
+
+ws = mp.Workspace()
+tc = TimeComparison.relative("month")
+
+# Same comparison period across all engines
+signups = ws.query("Signup", math="unique", time_comparison=tc, last=30)
+funnel = ws.query_funnel(["Signup", "Purchase"], time_comparison=tc, last=30)
+retention = ws.query_retention("Signup", "Login", time_comparison=tc, last=30)
+
+# Each result now includes comparison period data
+# Analyze trends, conversion, and retention changes together
+```
+
+Use `TimeComparison.relative("week")` for WoW analysis, `"month"` for MoM, `"quarter"` for QoQ. All three engines return comparison data in the same response.
+
+---
+
+## Join Strategy 8: Profile Enrichment Join
 
 **Use when**: You have identified interesting users via a behavioral engine (insights, funnels, retention, flows) and want to understand WHO they are -- their demographics, plan, company size, or other profile attributes.
 

--- a/mixpanel-plugin/skills/mixpanelyst/references/flows-reference.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/flows-reference.md
@@ -2,7 +2,7 @@
 
 Deep reference for flow queries in `mixpanel_data`. Flows show user paths before and after anchor events -- graph traversal of sequential behavior across the user base.
 
-_Flows use Filter for per-step filtering (see [insights-reference.md](insights-reference.md) §Filter Deep Reference) but do not support GroupBy, CohortBreakdown, or CohortMetric._
+_Flows use Filter for per-step filtering (see [insights-reference.md](insights-reference.md) §Filter Deep Reference). Flows support property filters and cohort filters in `where=`, plus `segments` for breakdowns. `CohortMetric` is not supported._
 
 ## Complete Signature
 
@@ -22,6 +22,10 @@ ws.query_flow(
     collapse_repeated: bool = False,
     hidden_events: list[str] | None = None,
     mode: Literal["sankey", "paths", "tree"] = "sankey",
+    where: Filter | list[Filter] | None = None,     # property AND cohort filters
+    data_group_id: int | None = None,                # data group scope
+    segments: str | GroupBy | CohortBreakdown | FrequencyBreakdown | list[...] | None = None,
+    exclusions: list[str] | None = None,             # events to exclude from flow
 ) -> FlowQueryResult
 ```
 
@@ -84,6 +88,7 @@ class FlowStep:
     label: str | None = None                           # display label (None = event name)
     filters: list[Filter] | None = None                # per-step filters
     filters_combinator: Literal["all", "any"] = "all"  # AND/OR for filters
+    session_event: Literal["start", "end"] | None = None  # session anchor type
 ```
 
 ### `forward` / `reverse` -- Direction Controls
@@ -878,22 +883,72 @@ _For cross-engine workflows that combine flows with funnels/retention/insights, 
 
 ---
 
-## Cohort Filters in Flows
+## Filtering in Flows
 
-Flows support cohort filters via the `where=` parameter, restricting path analysis to users in a specific cohort:
+Flows support both property filters and cohort filters via the `where=` parameter:
 
 ```python
 from mixpanel_data import Filter
 
-# Paths taken by power users after purchase
-result = ws.query_flow(
-    "Purchase", forward=3,
-    where=Filter.in_cohort(123, "Power Users"),
-    last=30,
-)
+# Property filter (new in v0.6)
+result = ws.query_flow("Purchase", forward=3,
+    where=Filter.equals("platform", "iOS"), last=30)
+
+# Cohort filter (existing)
+result = ws.query_flow("Purchase", forward=3,
+    where=Filter.in_cohort(123, "Power Users"), last=30)
 ```
 
-**Note**: `CohortBreakdown` and `CohortMetric` are NOT supported for flows. Use cohort filters (`where=`) only.
+**Note**: Flows support both property filters and cohort filters via `where=`. `CohortBreakdown` and `CohortMetric` are NOT supported — use `segments=` for breakdowns or cohort filters (`where=`) for filtering.
+
+---
+
+## Flow Segments
+
+Break flow results by a property, cohort, or frequency using the `segments` parameter:
+
+```python
+# Segment by platform
+result = ws.query_flow("Purchase", segments="platform", last=30)
+
+# Segment by cohort
+from mixpanel_data import CohortBreakdown
+result = ws.query_flow("Purchase",
+    segments=CohortBreakdown(123, "Power Users"), last=30)
+```
+
+Accepts: `str`, `GroupBy`, `CohortBreakdown`, `FrequencyBreakdown`, or a list.
+
+---
+
+## Flow Exclusions
+
+Hide specific events from flow paths:
+
+```python
+result = ws.query_flow("Purchase",
+    exclusions=["Page View", "Session Start"],
+    forward=3, last=30)
+```
+
+Excluded events won't appear as nodes or edges in the flow graph.
+
+---
+
+## Session Events
+
+Anchor a flow step to a session boundary:
+
+```python
+from mixpanel_data import FlowStep
+
+# What happens after a session starts?
+result = ws.query_flow(
+    FlowStep(event="Session Start", session_event="start"),
+    forward=5, last=30)
+```
+
+`FlowSessionEvent = Literal["start", "end"]`
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanelyst/references/funnels-reference.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/funnels-reference.md
@@ -25,6 +25,9 @@ Workspace.query_funnel(
     exclusions: list[str | Exclusion] | None = None,
     holding_constant: str | HoldingConstant | list[str | HoldingConstant] | None = None,
     mode: Literal["steps", "trends", "table"] = "steps",
+    reentry_mode: FunnelReentryMode | None = None,  # funnel reentry behavior
+    time_comparison: TimeComparison | None = None,   # period-over-period comparison
+    data_group_id: int | None = None,                # data group scope
 ) -> FunnelQueryResult
 ```
 
@@ -319,6 +322,7 @@ FunnelMathType = Literal[
     "p75",                      # 75th percentile per step
     "p90",                      # 90th percentile per step
     "p99",                      # 99th percentile per step
+    "histogram",                # Distribution of a numeric property per step
 ]
 ```
 
@@ -347,6 +351,7 @@ All require `math_property` to be set (F10):
 | `median` | Median of property at each step | Median order value |
 | `min` / `max` | Extremes | Smallest/largest order per step |
 | `p25` / `p75` / `p90` / `p99` | Percentiles | Revenue distribution per step |
+| `histogram` | Distribution of property values at each step | Revenue distribution per step |
 
 ```python
 # Measure average revenue at each funnel step
@@ -385,6 +390,58 @@ ws.query_funnel(
     ["View Product", "Add to Wishlist", "Add to Cart"],
     order="any",
 )
+```
+
+---
+
+## Reentry Mode
+
+Controls how users re-enter the funnel after completing all steps.
+
+`FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]`
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `default` | Server default behavior | General analysis |
+| `basic` | Re-enter after conversion window expires | Standard repeat measurement |
+| `aggressive` | Re-enter as soon as they convert | High-frequency funnels (e-commerce) |
+| `optimized` | Server-optimized reentry | Best for most repeat-conversion funnels |
+
+```python
+# Aggressive reentry for repeat purchase analysis
+result = ws.query_funnel(
+    ["Browse", "Add to Cart", "Purchase"],
+    reentry_mode="aggressive",
+    last=30,
+)
+```
+
+---
+
+## Period-over-Period Comparison
+
+_(→ [insights-reference.md](insights-reference.md) §TimeComparison for factory methods and validation rules)_
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare this week's funnel against last week
+result = ws.query_funnel(
+    ["Signup", "Purchase"],
+    time_comparison=TimeComparison.relative("week"),
+    last=7,
+)
+```
+
+---
+
+## Data Group Scope
+
+Scope a funnel query to a specific data group:
+
+```python
+# Scope to a data group
+result = ws.query_funnel(["Signup", "Purchase"], data_group_id=42)
 ```
 
 ---

--- a/mixpanel-plugin/skills/mixpanelyst/references/insights-reference.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/insights-reference.md
@@ -12,17 +12,19 @@ Workspace.query(
     to_date: str | None = None,            # "YYYY-MM-DD"; defaults to today
     last: int = 30,                        # relative window in units; ignored if from_date set
     unit: QueryTimeUnit = "day",           # "hour", "day", "week", "month", "quarter"
-    math: MathType = "total",              # aggregate function (14 types)
+    math: MathType = "total",              # aggregate function (21 types)
     math_property: str | None = None,      # required for property-based math
     per_user: PerUserAggregation | None = None,  # per-user pre-aggregation
     percentile_value: int | float | None = None,  # required when math="percentile"
-    group_by: str | GroupBy | CohortBreakdown | list[str | GroupBy | CohortBreakdown] | None = None,
-    where: Filter | list[Filter] | None = None,
+    group_by: str | GroupBy | CohortBreakdown | FrequencyBreakdown | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown] | None = None,
+    where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None = None,
     formula: str | None = None,            # e.g. "(A / B) * 100"
     formula_label: str | None = None,
     rolling: int | None = None,            # rolling window size
     cumulative: bool = False,
     mode: Literal["timeseries", "total", "table"] = "timeseries",
+    time_comparison: TimeComparison | None = None,  # period-over-period comparison
+    data_group_id: int | None = None,               # data group scope
 ) -> QueryResult
 ```
 
@@ -34,7 +36,7 @@ Workspace.query(
 
 _Funnels use a subset of these types — see [funnels-reference.md](funnels-reference.md) §FunnelMathType for funnel-specific math._
 
-`MathType = Literal["total", "unique", "dau", "wau", "mau", "average", "median", "min", "max", "p25", "p75", "p90", "p99", "percentile", "histogram"]`
+`MathType = Literal["total", "unique", "dau", "wau", "mau", "average", "median", "min", "max", "p25", "p75", "p90", "p99", "percentile", "histogram", "cumulative_unique", "sessions", "unique_values", "most_frequent", "first_value", "multi_attribution", "numeric_summary"]`
 
 ### Counting Types (no math_property required)
 
@@ -42,6 +44,8 @@ _Funnels use a subset of these types — see [funnels-reference.md](funnels-refe
 |------|---------------|----------|---------|
 | `total` | Event occurrences | Volume metrics, page views | Without `math_property`, counts events. With `math_property`, **sums** the property. There is no `"sum"` math type. |
 | `unique` | Distinct users who triggered the event | User counts, reach | Incompatible with `per_user` |
+| `cumulative_unique` | Running count of distinct users over time | Cumulative reach, total unique visitors | Grows monotonically over time |
+| `sessions` | Number of sessions | Session volume, session-based analysis | Counts sessions, not events or users |
 
 ### Active User Types (no math_property required)
 
@@ -70,6 +74,16 @@ _Funnels use a subset of these types — see [funnels-reference.md](funnels-refe
 |------|-------------|----------------------|
 | `percentile` | Custom percentile | Requires `percentile_value` (e.g. `95` for p95). Maps to `custom_percentile` in bookmark JSON. |
 | `histogram` | Property value distribution | Requires `per_user` (e.g. `per_user="total"`). Shows how the property values are distributed across users. |
+
+### Advanced Property Types (math_property REQUIRED)
+
+| Type | What It Does | Use Case |
+|------|-------------|----------|
+| `unique_values` | Count of distinct values of a property | Product diversity, SKU count |
+| `most_frequent` | Most commonly occurring property value | Top browser, most popular item |
+| `first_value` | First observed value per user | Attribution, first-touch analysis |
+| `multi_attribution` | Multi-touch attribution across a property | Marketing attribution |
+| `numeric_summary` | Summary stats (count, mean, variance) | Quick statistical overview |
 
 ### Common Mistakes
 
@@ -156,6 +170,8 @@ ws.query("Purchase", math="average", per_user="unique_values", math_property="pr
 | `Filter.not_equals(prop, val)` | `"does not equal"` | `str \| list[str]` | `Filter.not_equals("status", "inactive")` |
 | `Filter.contains(prop, val)` | `"contains"` | `str` | `Filter.contains("email", "@gmail")` |
 | `Filter.not_contains(prop, val)` | `"does not contain"` | `str` | `Filter.not_contains("url", "test")` |
+| `Filter.starts_with(prop, prefix)` | `"starts with"` | `str` | `Filter.starts_with("email", "admin")` |
+| `Filter.ends_with(prop, suffix)` | `"ends with"` | `str` | `Filter.ends_with("email", "@company.com")` |
 
 Multi-value equals: `Filter.equals("country", ["US", "UK", "CA"])` matches any of the values.
 
@@ -166,8 +182,11 @@ Multi-value equals: `Filter.equals("country", ["US", "UK", "CA"])` matches any o
 | `Filter.greater_than(prop, val)` | `"is greater than"` | `int \| float` | `Filter.greater_than("age", 18)` |
 | `Filter.less_than(prop, val)` | `"is less than"` | `int \| float` | `Filter.less_than("price", 100)` |
 | `Filter.between(prop, min, max)` | `"is between"` | Two `int \| float` | `Filter.between("amount", 10, 500)` |
+| `Filter.not_between(prop, min, max)` | `"not between"` | Two `int \| float` | `Filter.not_between("age", 18, 65)` |
+| `Filter.at_least(prop, val)` | `"is at least"` | `int \| float` | `Filter.at_least("score", 80)` |
+| `Filter.at_most(prop, val)` | `"is at most"` | `int \| float` | `Filter.at_most("errors", 5)` |
 
-Note: There are no `greater_than_or_equal` or `less_than_or_equal` factory methods on the `Filter` class. The bookmark API supports these operators internally but they are not exposed as convenience methods.
+Note: Use `Filter.at_least()` for greater-than-or-equal and `Filter.at_most()` for less-than-or-equal comparisons.
 
 ### Existence Filters
 
@@ -194,6 +213,8 @@ Note: There are no `greater_than_or_equal` or `less_than_or_equal` factory metho
 | `Filter.in_the_last(prop, qty, unit)` | `"was in the"` | `int` + `FilterDateUnit` | `Filter.in_the_last("signup_date", 30, "day")` |
 | `Filter.not_in_the_last(prop, qty, unit)` | `"was not in the"` | `int` + `FilterDateUnit` | `Filter.not_in_the_last("last_login", 90, "day")` |
 | `Filter.date_between(prop, from, to)` | `"was between"` | Two `"YYYY-MM-DD"` | `Filter.date_between("created", "2025-01-01", "2025-03-31")` |
+| `Filter.date_not_between(prop, from, to)` | `"was not between"` | Two `"YYYY-MM-DD"` | `Filter.date_not_between("created", "2025-01-01", "2025-06-30")` |
+| `Filter.in_the_next(prop, qty, unit)` | `"was in the next"` | `int` + `FilterDateUnit` | `Filter.in_the_next("renewal", 30, "day")` |
 
 `FilterDateUnit = Literal["hour", "day", "week", "month"]`
 
@@ -450,6 +471,17 @@ Metric("Purchase", math="total",
 
 **Important**: Top-level `math_property=` only accepts strings. Custom property measurement requires wrapping the event in a `Metric` object.
 
+### Segment Method
+
+Control how events are counted per user:
+
+```python
+# Only count each user's first purchase
+result = ws.query(Metric("Purchase", segment_method="first"), last=30)
+```
+
+`SegmentMethod = Literal["all", "first"]` — `"all"` counts every qualifying event (default), `"first"` counts only the first per user. Maps to `segmentMethod` in bookmark JSON.
+
 ---
 
 ## Time Range Patterns
@@ -521,6 +553,103 @@ Rolling and cumulative cannot be used together (V5).
 # WRONG — V5 error
 ws.query("Signup", rolling=7, cumulative=True)
 ```
+
+---
+
+## TimeComparison
+
+Overlay a comparison period on any query for period-over-period analysis.
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare against previous week
+result = ws.query("Login", time_comparison=TimeComparison.relative("week"), last=7)
+
+# Compare against window starting on a fixed date
+result = ws.query("Login",
+    time_comparison=TimeComparison.absolute_start("2025-01-01"),
+    from_date="2026-01-01", to_date="2026-01-31")
+
+# Compare against window ending on a fixed date
+result = ws.query("Login",
+    time_comparison=TimeComparison.absolute_end("2025-12-31"),
+    from_date="2026-01-01", to_date="2026-01-31")
+```
+
+### Factory Methods
+
+| Method | What it compares against | Required Args |
+|---|---|---|
+| `TimeComparison.relative(unit)` | Previous period offset by unit | `unit`: day, week, month, quarter, year |
+| `TimeComparison.absolute_start(date)` | Window starting on a fixed date | `date`: YYYY-MM-DD |
+| `TimeComparison.absolute_end(date)` | Window ending on a fixed date | `date`: YYYY-MM-DD |
+
+### Validation Rules
+
+| Rule | Check |
+|------|-------|
+| TC0 | `type` must be "relative", "absolute-start", or "absolute-end" |
+| TC1 | `type="relative"` requires `unit`, rejects `date` |
+| TC2 | Absolute types require `date`, reject `unit` |
+| TC3 | `date` must be valid YYYY-MM-DD calendar date |
+
+`TimeComparison` also works with `query_funnel()` and `query_retention()`.
+
+---
+
+## Frequency Analysis
+
+### FrequencyBreakdown
+
+Break down results by how often users performed an event. Pass as `group_by`:
+
+```python
+from mixpanel_data import FrequencyBreakdown
+
+result = ws.query("Login",
+    group_by=FrequencyBreakdown(
+        event="Purchase",
+        bucket_size=1,
+        bucket_min=0,
+        bucket_max=10,
+    ), last=30)
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `event` | `str` | required | Event to count frequency for |
+| `bucket_size` | `int` | `1` | Width of each frequency bucket |
+| `bucket_min` | `int` | `0` | Minimum frequency value |
+| `bucket_max` | `int` | `10` | Maximum frequency value |
+| `label` | `str \| None` | `None` | Display label |
+
+### FrequencyFilter
+
+Filter to users who performed an event a certain number of times. Pass as `where`:
+
+```python
+from mixpanel_data import FrequencyFilter
+
+result = ws.query("Login",
+    where=FrequencyFilter(
+        event="Purchase",
+        value=3,
+        operator="is at least",
+    ), last=30)
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `event` | `str` | required | Event to count frequency for |
+| `value` | `int \| float` | required | Threshold value |
+| `operator` | `FrequencyFilterOperator` | `"is at least"` | Comparison operator |
+| `date_range_value` | `int \| None` | `None` | Lookback window size |
+| `date_range_unit` | `Literal["day", "week", "month"] \| None` | `None` | Lookback window unit |
+| `event_filters` | `list[Filter] \| None` | `None` | Filters for the frequency event |
+| `label` | `str \| None` | `None` | Display label |
+
+`FrequencyFilterOperator = Literal["is at least", "is at most", "is greater than", "is less than", "is equal to"]`
 
 ---
 

--- a/mixpanel-plugin/skills/mixpanelyst/references/query-taxonomy.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/query-taxonomy.md
@@ -40,6 +40,9 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`) remain avai
 | "distribution", "histogram" | "Revenue distribution?" | `math="histogram", math_property="revenue", per_user="total"` |
 | "week over week", "WoW" | "WoW signup change?" | Two queries, different date ranges |
 | "filtered by", "only where" | "Purchases where amount > 50?" | `where=Filter.greater_than("amount", 50)` |
+| "compare periods", "WoW", "MoM", "YoY" | "Week-over-week signup change?" | `time_comparison=TimeComparison.relative("week")` |
+| "how often", "frequency", "power users" | "How often do users purchase?" | `group_by=FrequencyBreakdown(event="Purchase")` |
+| "first event", "first touch" | "Count only each user's first purchase" | `Metric("Purchase", segment_method="first")` |
 
 ### Funnel Engine Signals (ws.query_funnel)
 
@@ -56,6 +59,7 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`) remain avai
 | "funnel trend over time" | "How is conversion trending?" | `mode="trends"` |
 | "session-based conversion" | "Within-session conversion?" | `conversion_window_unit="session", math="conversion_rate_session"` |
 | "A/B funnel comparison" | "Funnel by experiment group?" | `group_by="experiment_group"` |
+| "reentry", "re-enter funnel" | "Allow funnel re-entry" | `reentry_mode="aggressive"` |
 
 ### Retention Engine Signals (ws.query_retention)
 
@@ -74,6 +78,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`) remain avai
 | "birth alignment" | "Align to user's first event?" | `alignment="birth"` |
 | "calendar alignment" | "Align to calendar week?" | `alignment="interval_start"` |
 | "raw counts vs rates" | "How many users retained?" | `math="unique"` vs `math="retention_rate"` |
+| "cumulative retention" | "Show cumulative retention curve" | `retention_cumulative=True` |
+| "unbounded retention" | "Carry forward retained users" | `unbounded_mode="carry_forward"` |
 
 ### Flow Engine Signals (ws.query_flow)
 
@@ -86,6 +92,8 @@ Additionally, legacy methods (`segmentation`, `funnel`, `retention`) remain avai
 | "top paths" | "Top 10 paths after onboarding?" | `mode="paths", cardinality=10` |
 | "drop-off paths" | "Where do users go after dropping?" | Forward flow from drop-off event |
 | "bidirectional" | "Activity around the purchase event?" | `forward=3, reverse=2` |
+| "exclude events", "hide events" | "Flow without page views" | `exclusions=["Page View"]` |
+| "flow by platform", "segment flow" | "User paths by platform" | `segments="platform"` |
 
 ### Users Engine Signals (ws.query_user)
 
@@ -265,7 +273,7 @@ _(→ [analytical-frameworks.md](analytical-frameworks.md) §Retention for indus
 
 ## Join Strategies
 
-_For full code implementations of each join strategy with pandas merge patterns, see [cross-query-synthesis.md](cross-query-synthesis.md) §Join Strategy 1-6._
+_For full code implementations of each join strategy with pandas merge patterns, see [cross-query-synthesis.md](cross-query-synthesis.md) §Join Strategy 1-8._
 
 ### Time-Aligned Join
 

--- a/mixpanel-plugin/skills/mixpanelyst/references/retention-reference.md
+++ b/mixpanel-plugin/skills/mixpanelyst/references/retention-reference.md
@@ -22,6 +22,10 @@ Workspace.query_retention(
     group_by: str | GroupBy | CohortBreakdown | list[str | GroupBy | CohortBreakdown] | None = None,
     where: Filter | list[Filter] | None = None,
     mode: RetentionMode = "curve",              # "curve", "trends", "table"
+    unbounded_mode: RetentionUnboundedMode | None = None,  # unbounded retention counting
+    retention_cumulative: bool = False,                     # cumulative retention mode
+    time_comparison: TimeComparison | None = None,          # period-over-period comparison
+    data_group_id: int | None = None,                       # data group scope
 ) -> RetentionQueryResult
 ```
 
@@ -211,14 +215,71 @@ ws.query_retention("Signup", "Login", bucket_sizes=[1, 3, 7, 14, 30])
 
 ---
 
+## Unbounded Mode
+
+`RetentionUnboundedMode = Literal["none", "carry_back", "carry_forward", "consecutive_forward"]`
+
+Controls how users who return outside their exact retention bucket are counted:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `none` | Standard counting — only count in the exact bucket (default) | Standard retention analysis |
+| `carry_back` | If a user returns in bucket N, also count in all prior buckets | Fill gaps for irregular engagement |
+| `carry_forward` | If a user returns in bucket N, count in all subsequent buckets | Optimistic retention view |
+| `consecutive_forward` | Count forward from the last bucket where the user was active | Streak-based retention |
+
+```python
+# Carry-forward: once a user returns, count them as retained in all later buckets
+result = ws.query_retention(
+    "Signup", "Login",
+    unbounded_mode="carry_forward",
+    retention_unit="week", last=90,
+)
+```
+
+---
+
+## Cumulative Retention
+
+Enable cumulative counting — each bucket shows the total number of users who returned at least once up to that point:
+
+```python
+result = ws.query_retention(
+    "Signup", "Login",
+    retention_cumulative=True,
+    retention_unit="week", last=90,
+)
+```
+
+---
+
+## Period-over-Period Comparison
+
+_(→ [insights-reference.md](insights-reference.md) §TimeComparison for factory methods and validation rules)_
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare this month's retention against last month
+result = ws.query_retention(
+    "Signup", "Login",
+    time_comparison=TimeComparison.relative("month"),
+    retention_unit="week", last=30,
+)
+```
+
+---
+
 ## RetentionMathType
 
-`RetentionMathType = Literal["retention_rate", "unique"]`
+`RetentionMathType = Literal["retention_rate", "unique", "total", "average"]`
 
 | Type | Returns | Value Range | When to Use |
 |------|---------|-------------|-------------|
 | `retention_rate` | Percentage of cohort retained | 0.0 to 1.0 | Default. Compare retention across cohorts and segments. |
 | `unique` | Raw count of unique users retained | 0 to cohort size | When absolute numbers matter (volume analysis). |
+| `total` | Total event count per retention bucket | 0+ | When absolute event volume matters, not just unique users. |
+| `average` | Average of a numeric property per bucket | float | Property-based retention (requires `math_property`). |
 
 ```python
 # Percentage (default)
@@ -228,6 +289,12 @@ rates = ws.query_retention("Signup", "Login", math="retention_rate")
 # Raw counts
 counts = ws.query_retention("Signup", "Login", math="unique")
 # counts.cohorts["2025-01-06"]["counts"] = [500, 225, 160, 140, ...]
+
+# Total login events per bucket
+result = ws.query_retention("Signup", "Login", math="total")
+
+# Average session duration per bucket
+result = ws.query_retention("Signup", "Login", math="average", math_property="session_duration")
 ```
 
 ---
@@ -643,7 +710,7 @@ _For retention benchmarks by industry (Consumer Mobile, SaaS, E-commerce), see [
 3. **bucket_sizes values must be integers** — `[1.0, 3.0, 7.0]` fails. Use `[1, 3, 7]`.
 4. **bucket_sizes values must be positive** — `[0, 1, 7]` fails. Start from 1.
 5. **born_event = return_event measures stickiness** — This is a valid and common pattern, not a mistake.
-6. **RetentionMathType is limited** — Only `"retention_rate"` and `"unique"` are valid. The internal API supports `"total"` and `"average"` but these are not exposed publicly.
+6. **RetentionMathType has four values** — `"retention_rate"`, `"unique"`, `"total"`, and `"average"`. The `"average"` type requires `math_property` to be set.
 7. **Segmented results use .segments** — When `group_by` is used, per-segment data is in `result.segments`, not `result.cohorts` (which has the $overall aggregate).
 8. **Bucket 0 is always 100%** — The first bucket represents the born event itself, so its retention rate is always 1.0.
 9. **alignment affects interpretation** — With `"birth"` alignment, each user's W1 starts from their signup date. With `"interval_start"`, W1 is the same calendar week for all users in that cohort.

--- a/specs/040-query-engine-completeness/checklists/requirements.md
+++ b/specs/040-query-engine-completeness/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Unified Query Engine Completeness
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 29 confirmed gaps from the audit report are covered across 8 user stories
+- Phased delivery (A → B → C) aligns with Tier 1 → Tier 2 → Tier 3 priority
+- PerUserAggregation session_replay_id_value (priority #17) explicitly excluded from scope with rationale documented in Assumptions
+- Tier 4 (confirmed non-gaps) correctly excluded — no action needed
+- No [NEEDS CLARIFICATION] markers were needed; the audit report provides exhaustive detail on all gaps including valid values, server source references, and JSON positions

--- a/specs/040-query-engine-completeness/contracts/public-api.md
+++ b/specs/040-query-engine-completeness/contracts/public-api.md
@@ -1,0 +1,243 @@
+# Public API Contract: Unified Query Engine Completeness
+
+**Date**: 2026-04-14
+**Feature**: 040-query-engine-completeness
+
+All changes are additive. Existing method signatures are unchanged — new parameters are keyword-only with `None` or `False` defaults.
+
+---
+
+## New Exports from `mixpanel_data`
+
+### Literal Types
+
+```python
+SegmentMethod = Literal["all", "first"]
+FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]
+RetentionUnboundedMode = Literal["none", "carry_back", "carry_forward", "consecutive_forward"]
+TimeComparisonType = Literal["relative", "absolute-start", "absolute-end"]
+TimeComparisonUnit = Literal["day", "week", "month", "quarter", "year"]
+CohortAggregationType = Literal["total", "unique", "average", "min", "max", "median"]
+FlowSessionEvent = Literal["start", "end"]
+```
+
+### Dataclasses
+
+```python
+TimeComparison      # Frozen dataclass with factory methods
+FrequencyBreakdown  # Frozen dataclass for frequency group-by
+FrequencyFilter     # Frozen dataclass for frequency where-clause
+```
+
+---
+
+## Modified Method Signatures
+
+### Workspace.query() / Workspace.build_params()
+
+```python
+def query(
+    self,
+    events: str | Metric | CohortMetric | Formula | Sequence[...],
+    *,
+    # ... all existing params unchanged ...
+    time_comparison: TimeComparison | None = None,     # NEW (Phase B)
+    data_group_id: int | None = None,                  # NEW (Phase C)
+) -> QueryResult
+```
+
+The `group_by` parameter type union expands to include `FrequencyBreakdown`:
+```python
+group_by: str | GroupBy | CohortBreakdown | FrequencyBreakdown
+         | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
+         | None = None
+```
+
+The `where` parameter type union expands to include `FrequencyFilter`:
+```python
+where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None = None
+```
+
+### Workspace.query_funnel() / Workspace.build_funnel_params()
+
+```python
+def query_funnel(
+    self,
+    steps: list[str | FunnelStep],
+    *,
+    # ... all existing params unchanged ...
+    reentry_mode: FunnelReentryMode | None = None,     # NEW (Phase A)
+    time_comparison: TimeComparison | None = None,     # NEW (Phase B)
+    data_group_id: int | None = None,                  # NEW (Phase C)
+) -> FunnelQueryResult
+```
+
+### Workspace.query_retention() / Workspace.build_retention_params()
+
+```python
+def query_retention(
+    self,
+    born_event: str | RetentionEvent,
+    return_event: str | RetentionEvent,
+    *,
+    # ... all existing params unchanged ...
+    unbounded_mode: RetentionUnboundedMode | None = None,  # NEW (Phase A)
+    retention_cumulative: bool = False,                     # NEW (Phase A)
+    time_comparison: TimeComparison | None = None,          # NEW (Phase B)
+    data_group_id: int | None = None,                       # NEW (Phase C)
+) -> RetentionQueryResult
+```
+
+Note: `query_retention()` already has no `retention_cumulative` parameter, so this is purely additive. The insights `query()` has `cumulative: bool = False` for analysis type — `retention_cumulative` controls `retentionCumulative` in measurement, which is semantically different. The distinct name avoids confusion.
+
+### Workspace.query_flow() / Workspace.build_flow_params()
+
+```python
+def query_flow(
+    self,
+    event: str | FlowStep | Sequence[str | FlowStep],
+    *,
+    # ... all existing params unchanged ...
+    exclusions: list[str] | None = None,               # NEW (Phase C)
+    segments: GroupBy | list[GroupBy] | None = None,    # NEW (Phase C)
+    data_group_id: int | None = None,                  # NEW (Phase C)
+) -> FlowQueryResult
+```
+
+The `where` parameter expands to accept property `Filter` objects (not just cohort filters):
+```python
+where: Filter | list[Filter] | None = None
+# Currently: only Filter.in_cohort() / Filter.not_in_cohort() accepted
+# After: also accepts property filters (Filter.equals, Filter.greater_than, etc.)
+```
+
+---
+
+## Modified Type Signatures
+
+### Metric
+
+```python
+@dataclass(frozen=True)
+class Metric:
+    event: str
+    math: MathType = "total"
+    property: str | CustomPropertyRef | InlineCustomProperty | None = None
+    per_user: PerUserAggregation | None = None
+    percentile_value: int | float | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: FiltersCombinator = "all"
+    segment_method: SegmentMethod | None = None          # NEW (Phase A)
+```
+
+### MathType (expanded)
+
+```python
+MathType = Literal[
+    # Existing 15 values...
+    "total", "unique", "dau", "wau", "mau",
+    "average", "median", "min", "max",
+    "p25", "p75", "p90", "p99",
+    "percentile", "histogram",
+    # NEW 7 values (Phase A)
+    "cumulative_unique", "sessions",
+    "unique_values", "most_frequent", "first_value",
+    "multi_attribution", "numeric_summary",
+]
+```
+
+### RetentionMathType (expanded)
+
+```python
+RetentionMathType = Literal[
+    "retention_rate", "unique",
+    "total", "average",              # NEW (Phase A)
+]
+```
+
+### FunnelMathType (expanded)
+
+```python
+FunnelMathType = Literal[
+    # Existing 13 values...
+    "histogram",                      # NEW (Phase A)
+]
+```
+
+### Filter (new factory methods)
+
+```python
+class Filter:
+    # ... all existing methods unchanged ...
+
+    # NEW (Phase A)
+    @classmethod
+    def not_between(cls, property: str, min_val: int | float, max_val: int | float,
+                    *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def starts_with(cls, property: str, prefix: str,
+                    *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def ends_with(cls, property: str, suffix: str,
+                  *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def date_not_between(cls, property: str, from_date: str, to_date: str,
+                         *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def in_the_next(cls, property: str, quantity: int, date_unit: FilterDateUnit,
+                    *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def at_least(cls, property: str, value: int | float,
+                 *, resource_type: Literal["events", "people"] = "events") -> Filter
+
+    @classmethod
+    def at_most(cls, property: str, value: int | float,
+                *, resource_type: Literal["events", "people"] = "events") -> Filter
+```
+
+### CohortCriteria.did_event() (expanded)
+
+```python
+@classmethod
+def did_event(
+    cls,
+    event: str,
+    *,
+    at_least: int | None = None,
+    at_most: int | None = None,
+    exactly: int | None = None,
+    # ... all existing params unchanged ...
+    aggregation: CohortAggregationType | None = None,      # NEW (Phase B)
+    aggregation_property: str | None = None,               # NEW (Phase B)
+) -> CohortCriteria
+```
+
+### FlowStep (expanded)
+
+```python
+@dataclass(frozen=True)
+class FlowStep:
+    event: str
+    forward: int | None = None
+    reverse: int | None = None
+    label: str | None = None
+    filters: list[Filter] | None = None
+    filters_combinator: FiltersCombinator = "all"
+    session_event: FlowSessionEvent | None = None         # NEW (Phase C)
+```
+
+---
+
+## Backward Compatibility Guarantees
+
+1. All new parameters default to `None` or `False` — existing calls produce identical output
+6. All new public methods, fields, and classes include docstrings per constitution Principle I
+2. No existing parameter types are narrowed — all existing valid inputs remain valid
+3. No existing method is removed or renamed
+4. No existing return type changes
+5. Existing tests pass without modification

--- a/specs/040-query-engine-completeness/contracts/public-api.md
+++ b/specs/040-query-engine-completeness/contracts/public-api.md
@@ -236,8 +236,9 @@ class FlowStep:
 ## Backward Compatibility Guarantees
 
 1. All new parameters default to `None` or `False` — existing calls produce identical output
-6. All new public methods, fields, and classes include docstrings per constitution Principle I
 2. No existing parameter types are narrowed — all existing valid inputs remain valid
 3. No existing method is removed or renamed
 4. No existing return type changes
+5. Existing tests pass without modification
+6. All new public methods, fields, and classes include docstrings per constitution Principle I
 5. Existing tests pass without modification

--- a/specs/040-query-engine-completeness/data-model.md
+++ b/specs/040-query-engine-completeness/data-model.md
@@ -1,0 +1,218 @@
+# Data Model: Unified Query Engine Completeness
+
+**Date**: 2026-04-14
+**Feature**: 040-query-engine-completeness
+
+## New Literal Types (`_literal_types.py`)
+
+### SegmentMethod
+```
+Values: "all", "first"
+Context: Retention, funnel, frequency queries (NOT insights)
+```
+
+### FunnelReentryMode
+```
+Values: "default", "basic", "aggressive", "optimized"
+Context: Funnel queries only
+```
+
+### RetentionUnboundedMode
+```
+Values: "none", "carry_back", "carry_forward", "consecutive_forward"
+Context: Retention queries only
+```
+
+### TimeComparisonType
+```
+Values: "relative", "absolute-start", "absolute-end"
+Context: Insights, funnel, retention queries (NOT flows)
+```
+
+### TimeComparisonUnit
+```
+Values: "day", "week", "month", "quarter", "year"
+Context: Used with TimeComparisonType="relative"
+```
+
+### CohortAggregationType
+```
+Values: "total", "unique", "average", "min", "max", "median"
+Context: CohortCriteria.did_event() behavioral conditions
+```
+
+### FlowSessionEvent
+```
+Values: "start", "end"
+Context: FlowStep for session start/end anchors
+```
+
+## Expanded Literal Types
+
+### MathType (15 → 22 values)
+```
+Added: "cumulative_unique", "sessions", "unique_values", "most_frequent",
+       "first_value", "multi_attribution", "numeric_summary"
+```
+
+### RetentionMathType (2 → 4 values)
+```
+Added: "total", "average"
+```
+
+### FunnelMathType (13 → 14 values)
+```
+Added: "histogram"
+```
+
+## New Dataclasses (`types.py`)
+
+### TimeComparison (frozen dataclass)
+
+Discriminated union for period-over-period comparison.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `type` | `TimeComparisonType` | Required | Discriminant: relative, absolute-start, absolute-end |
+| `unit` | `TimeComparisonUnit \| None` | `None` | Required when type="relative" |
+| `date` | `str \| None` | `None` | Required when type=absolute-*; YYYY-MM-DD format |
+
+Validation:
+- TC1: type="relative" requires unit, rejects date
+- TC2: type="absolute-start" or "absolute-end" requires date (YYYY-MM-DD), rejects unit
+- TC3: date must be valid YYYY-MM-DD
+
+Factory methods:
+- `TimeComparison.relative(unit)` → type="relative"
+- `TimeComparison.absolute_start(date)` → type="absolute-start"
+- `TimeComparison.absolute_end(date)` → type="absolute-end"
+
+### FrequencyBreakdown (frozen dataclass)
+
+Break down queries by event frequency.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `event` | `str` | Required | Event name to count frequency of |
+| `bucket_size` | `int` | `1` | Width of frequency buckets |
+| `bucket_min` | `int` | `0` | Minimum frequency value |
+| `bucket_max` | `int` | `10` | Maximum frequency value |
+| `label` | `str \| None` | `None` | Display label (defaults to "{event} Frequency") |
+
+Validation:
+- FB1: event must be non-empty
+- FB2: bucket_size must be positive
+- FB3: bucket_min must be < bucket_max
+- FB4: bucket_min must be >= 0
+
+### FrequencyFilter (frozen dataclass)
+
+Filter queries by event frequency threshold.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `event` | `str` | Required | Event name to filter by frequency of |
+| `operator` | `str` | `"is at least"` | Comparison operator |
+| `value` | `int \| float` | Required | Threshold value |
+| `date_range_value` | `int \| None` | `None` | Lookback window size (None = lifetime) |
+| `date_range_unit` | `Literal["day","week","month"] \| None` | `None` | Lookback window unit |
+| `event_filters` | `list[Filter] \| None` | `None` | Property filters on the frequency event |
+| `label` | `str \| None` | `None` | Display label |
+
+Validation:
+- FF1: event must be non-empty
+- FF2: operator must be in {"is at least", "is at most", "is greater than", "is less than", "is equal to", "is between"}
+- FF3: value must be non-negative
+- FF4: date_range_value and date_range_unit must both be set or both be None
+- FF5: date_range_value must be positive if set
+
+## Modified Entities
+
+### Metric (add 1 field)
+
+| New Field | Type | Default |
+|-----------|------|---------|
+| `segment_method` | `SegmentMethod \| None` | `None` |
+
+### Filter (add 7 factory methods)
+
+| Method | Operator String | Property Type | Value Type |
+|--------|----------------|--------------|------------|
+| `not_between(prop, min, max)` | `"not between"` | number | `[min, max]` |
+| `starts_with(prop, prefix)` | `"starts with"` | string | `str` |
+| `ends_with(prop, suffix)` | `"ends with"` | string | `str` |
+| `date_not_between(prop, from, to)` | `"was not between"` | datetime | `[from, to]` |
+| `in_the_next(prop, qty, unit)` | `"was in the next"` | datetime | `qty` |
+| `at_least(prop, val)` | `"is at least"` | number | `val` |
+| `at_most(prop, val)` | `"is at most"` | number | `val` |
+
+### CohortCriteria.did_event() (add 2 params)
+
+| New Param | Type | Default |
+|-----------|------|---------|
+| `aggregation` | `CohortAggregationType \| None` | `None` |
+| `aggregation_property` | `str \| None` | `None` |
+
+Validation:
+- CA1: aggregation requires aggregation_property
+- CA2: aggregation_property requires aggregation
+- CA3: When aggregation is set, at_least/at_most/exactly provide the comparison threshold for the aggregated property value (e.g., aggregation="average" + at_least=50 means "users whose average >= 50"). When aggregation is NOT set, at_least/at_most/exactly threshold the raw event count (existing behavior). Exactly one of at_least/at_most/exactly is always required.
+
+### FlowStep (add 1 field)
+
+| New Field | Type | Default |
+|-----------|------|---------|
+| `session_event` | `FlowSessionEvent \| None` | `None` |
+
+Validation:
+- FS1: session_event and event are mutually exclusive — set one or the other, not both
+- FS2: When session_event is set, event should be a sentinel like "$session_start" or "$session_end"
+
+### Flow Segments (parameter type)
+
+Flow segments reuse the existing `GroupBy` type for property-based breakdowns of flow paths.
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `segments` | `GroupBy \| list[GroupBy] \| None` | `None` | Property breakdowns applied to flow paths |
+
+### Flow Exclusions (parameter type)
+
+Flow exclusions accept a simple list of event name strings to exclude between flow steps.
+Unlike funnel exclusions (which support `Exclusion` objects with step ranges), flow exclusions
+are event-name-only.
+
+| Parameter | Type | Default |
+|-----------|------|---------|
+| `exclusions` | `list[str] \| None` | `None` |
+
+## Modified Enum Constants (`bookmark_enums.py`)
+
+### MATH_REQUIRING_PROPERTY (add 5 values)
+```
+Added: "unique_values", "most_frequent", "first_value", "multi_attribution", "numeric_summary"
+```
+
+### New Constants
+```
+VALID_FUNNEL_REENTRY_MODES = frozenset({"default", "basic", "aggressive", "optimized"})
+VALID_RETENTION_UNBOUNDED_MODES = frozenset({"none", "carry_back", "carry_forward", "consecutive_forward"})
+VALID_SEGMENT_METHODS = frozenset({"all", "first"})
+VALID_TIME_COMPARISON_TYPES = frozenset({"relative", "absolute-start", "absolute-end"})
+VALID_TIME_COMPARISON_UNITS = frozenset({"day", "week", "month", "quarter", "year"})
+VALID_COHORT_AGGREGATION_OPERATORS = frozenset({"total", "unique", "average", "min", "max", "median"})
+VALID_FREQUENCY_FILTER_OPERATORS = frozenset({"is at least", "is at most", "is greater than", "is less than", "is equal to", "is between"})
+```
+
+## Relationships
+
+```
+Metric --uses--> SegmentMethod (optional)
+Workspace.query_funnel() --accepts--> FunnelReentryMode, TimeComparison
+Workspace.query_retention() --accepts--> RetentionUnboundedMode, TimeComparison, retention_cumulative flag
+Workspace.query() --accepts--> TimeComparison, FrequencyBreakdown (via group_by), FrequencyFilter (via where)
+Workspace.query_flow() --accepts--> enhanced FlowStep, global property filters, segments, exclusions
+FlowStep --uses--> FlowSessionEvent (optional, mutually exclusive with event)
+CohortCriteria.did_event() --uses--> CohortAggregationType (optional)
+All query methods --accept--> data_group_id: int | None
+```

--- a/specs/040-query-engine-completeness/data-model.md
+++ b/specs/040-query-engine-completeness/data-model.md
@@ -165,8 +165,7 @@ Validation:
 | `session_event` | `FlowSessionEvent \| None` | `None` |
 
 Validation:
-- FS1: session_event and event are mutually exclusive — set one or the other, not both
-- FS2: When session_event is set, event should be a sentinel like "$session_start" or "$session_end"
+- FS1: When session_event is set, event must be the corresponding session sentinel ("start" requires "$session_start", "end" requires "$session_end"). Regular event names with session_event are rejected.
 
 ### Flow Segments (parameter type)
 

--- a/specs/040-query-engine-completeness/plan.md
+++ b/specs/040-query-engine-completeness/plan.md
@@ -1,0 +1,339 @@
+# Implementation Plan: Unified Query Engine Completeness
+
+**Branch**: `040-query-engine-completeness` | **Date**: 2026-04-14 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/040-query-engine-completeness/spec.md`
+
+## Summary
+
+Close all 29 confirmed gaps in the unified query engine identified by the Mixpanel Query API Capability Audit. The work expands existing Literal types (MathType +7, RetentionMathType +2, FunnelMathType +1), adds core query parameters (segment method, funnel reentry mode, retention unbounded/cumulative modes), introduces new feature types (time comparison, frequency analysis, cohort aggregations), and fills completeness gaps (filter methods, data group scoping, flow features). All changes are additive with backward-compatible defaults.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+
+**Primary Dependencies**: httpx, Pydantic v2, Typer, Rich, pandas, Hypothesis
+**Storage**: N/A — query parameter types only, no persistence
+**Testing**: pytest + Hypothesis (PBT) + mutmut (mutation testing)
+**Target Platform**: Library (PyPI) + CLI
+**Project Type**: library + cli
+**Performance Goals**: N/A — type expansions and parameter additions
+**Constraints**: mypy --strict, ruff check/format, 90% test coverage, 80% mutation score
+**Scale/Scope**: 29 gaps across 17 implementation steps in 3 phases
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Library-First | PASS | All changes are to library types and builders; CLI wraps library |
+| II. Agent-Native Design | PASS | No interactive elements added; output remains structured JSON |
+| III. Context Window Efficiency | PASS | No changes to data retrieval patterns; type annotations only |
+| IV. Two Data Paths | PASS | Query param changes apply to live queries via bookmark API |
+| V. Explicit Over Implicit | PASS | All new params are explicit, keyword-only, optional with defaults |
+| VI. Unix Philosophy | PASS | No change to composability or output formatting |
+| VII. Secure by Default | PASS | No credential or auth changes |
+
+**Quality Gates**:
+- [x] All new types will have type hints (mypy --strict)
+- [x] All new types will have docstrings (Google style)
+- [x] ruff check + ruff format enforced
+- [x] Tests will exist for all new functionality
+- [x] No new CLI commands (param expansions flow through existing commands)
+
+**Post-Design Re-check**: All principles still PASS. No new architectural decisions required — all changes follow established patterns (frozen dataclasses, factory methods, builder functions, validation rules).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/040-query-engine-completeness/
+├── spec.md              # Feature specification (8 user stories, 29 FRs)
+├── plan.md              # This file
+├── research.md          # Phase 0: codebase + power-tools research
+├── data-model.md        # Phase 1: entity definitions
+├── quickstart.md        # Phase 1: usage examples
+├── contracts/
+│   └── public-api.md    # Phase 1: API contract changes
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mixpanel_data/
+├── _literal_types.py           # Phase A: expand MathType, RetentionMathType, FunnelMathType
+│                                #          add SegmentMethod, FunnelReentryMode, RetentionUnboundedMode,
+│                                #          TimeComparisonType, TimeComparisonUnit, CohortAggregationType,
+│                                #          FlowSessionEvent
+├── types.py                    # Phase A: add segment_method to Metric, 7 Filter factory methods
+│                                # Phase B: add TimeComparison, FrequencyBreakdown, FrequencyFilter,
+│                                #          add aggregation to CohortCriteria.did_event()
+│                                # Phase C: add session_event to FlowStep
+├── __init__.py                 # All phases: export new types
+├── workspace.py                # Phase A: thread segment_method, reentry_mode, unbounded_mode, cumulative
+│                                # Phase B: add time_comparison param to 3 query methods
+│                                # Phase C: add data_group_id to all query methods, enhance flow where
+├── _internal/
+│   ├── bookmark_builders.py    # Phase A: thread segment_method, reentry_mode, unbounded_mode, cumulative
+│   │                            # Phase B: add time_comparison builder, frequency builders
+│   │                            # Phase C: thread data_group_id, add flow property filter builder
+│   ├── bookmark_enums.py       # Phase A: update MATH_REQUIRING_PROPERTY, add new enum constants
+│   │                            # Phase B: add frequency and time comparison enums
+│   └── validation.py           # Phase A: add reentry_mode, unbounded_mode, segment_method validation
+│                                # Phase B: add time_comparison, frequency, aggregation validation
+│                                # Phase C: add data_group_id, flow filter validation
+
+tests/
+├── test_literal_types.py       # Phase A: new math type coverage
+├── test_types.py               # All phases: new type construction and validation
+├── test_types_pbt.py           # All phases: property-based tests for new types
+├── test_bookmark_builders.py   # All phases: builder output verification
+├── test_validation.py          # All phases: validation rule coverage
+├── test_workspace.py           # All phases: query method integration tests
+└── test_bookmark_enums.py      # Phase A: enum constant coverage
+```
+
+**Structure Decision**: No new files or directories in `src/`. All changes are modifications to existing files following established patterns. New test files may be needed for PBT coverage of new types.
+
+## Complexity Tracking
+
+No violations. All changes follow established patterns:
+- Literal type expansion: same pattern as existing types
+- Frozen dataclass addition: same pattern as Metric, GroupBy, FlowStep
+- Factory method addition: same pattern as existing Filter methods
+- Builder function addition: same pattern as build_filter_section, build_group_section
+- Validation rule addition: same pattern as existing validate_* functions
+- Workspace parameter addition: same pattern as existing query method params
+
+## Phase A: Type Expansions and Core Parameters (Tier 1)
+
+### A1: Expand MathType Literal (+7 values)
+
+**Files**: `_literal_types.py`
+**Effort**: TRIVIAL
+
+Add `cumulative_unique`, `sessions`, `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary` to `MathType` Literal. Update docstring table.
+
+### A2: Expand RetentionMathType Literal (+2 values)
+
+**Files**: `_literal_types.py`
+**Effort**: TRIVIAL
+
+Add `total`, `average` to `RetentionMathType` Literal. Update docstring table.
+
+### A3: Expand FunnelMathType Literal (+1 value)
+
+**Files**: `_literal_types.py`
+**Effort**: TRIVIAL
+
+Add `histogram` to `FunnelMathType` Literal. Update docstring table.
+
+### A4: Update MATH_REQUIRING_PROPERTY (+5 values)
+
+**Files**: `bookmark_enums.py`
+**Effort**: TRIVIAL
+
+Add `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary` to `MATH_REQUIRING_PROPERTY`. These 5 new math types all require a property parameter.
+
+### A5: Add SegmentMethod + Metric field
+
+**Files**: `_literal_types.py`, `types.py`, `bookmark_builders.py`, `workspace.py`, `validation.py`
+**Effort**: SMALL
+
+1. Add `SegmentMethod = Literal["all", "first"]` to `_literal_types.py`
+2. Add `VALID_SEGMENT_METHODS` to `bookmark_enums.py`
+3. Add `segment_method: SegmentMethod | None = None` field to `Metric` dataclass
+4. Thread `segmentMethod` into measurement block in `_build_query_params()`
+5. Add validation: reject segment_method for insights-only queries (valid for funnels, retention, frequency)
+
+### A6: Add FunnelReentryMode parameter
+
+**Files**: `_literal_types.py`, `bookmark_enums.py`, `workspace.py`, `bookmark_builders.py`, `validation.py`
+**Effort**: SMALL
+
+1. Add `FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]` to `_literal_types.py`
+2. Add `VALID_FUNNEL_REENTRY_MODES` to `bookmark_enums.py`
+3. Add `reentry_mode: FunnelReentryMode | None = None` to `query_funnel()` and `build_funnel_params()`
+4. Thread `funnelReentryMode` into behavior block in `_build_funnel_params()`
+5. Add validation in `validate_funnel_args()`
+
+### A7: Add RetentionUnboundedMode + retentionCumulative parameters
+
+**Files**: `_literal_types.py`, `bookmark_enums.py`, `workspace.py`, `bookmark_builders.py`, `validation.py`
+**Effort**: SMALL
+
+1. Add `RetentionUnboundedMode = Literal["none", "carry_back", "carry_forward", "consecutive_forward"]` to `_literal_types.py`
+2. Add `VALID_RETENTION_UNBOUNDED_MODES` to `bookmark_enums.py`
+3. Add `unbounded_mode: RetentionUnboundedMode | None = None` and `retention_cumulative: bool = False` to `query_retention()` and `build_retention_params()`
+4. Thread `retentionUnboundedMode` into behavior block and `retentionCumulative` into measurement block in `_build_retention_params()`
+5. Add validation in `validate_retention_args()`
+
+### A8: Add missing Filter factory methods (7 methods)
+
+**Files**: `types.py`
+**Effort**: SMALL
+
+Add 7 factory methods following existing patterns:
+- `not_between(prop, min, max)` → operator `"not between"`, property_type `"number"`
+- `starts_with(prop, prefix)` → operator `"starts with"`, property_type `"string"`
+- `ends_with(prop, suffix)` → operator `"ends with"`, property_type `"string"`
+- `date_not_between(prop, from, to)` → operator `"was not between"`, property_type `"datetime"`
+- `in_the_next(prop, qty, unit)` → operator `"was in the next"`, property_type `"datetime"`, with `_date_unit`
+- `at_least(prop, val)` → operator `"is at least"`, property_type `"number"`
+- `at_most(prop, val)` → operator `"is at most"`, property_type `"number"`
+
+Each follows the exact same pattern as existing methods like `between()`, `greater_than()`, `in_the_last()`.
+
+## Phase B: New Feature Types (Tier 2)
+
+### B1: Add TimeComparison types + parameter
+
+**Files**: `_literal_types.py`, `types.py`, `bookmark_builders.py`, `workspace.py`, `validation.py`
+**Effort**: MEDIUM
+
+1. Add `TimeComparisonType` and `TimeComparisonUnit` Literals to `_literal_types.py`
+2. Add `VALID_TIME_COMPARISON_TYPES` and `VALID_TIME_COMPARISON_UNITS` to `bookmark_enums.py`
+3. Create `TimeComparison` frozen dataclass in `types.py` with factory methods (`relative()`, `absolute_start()`, `absolute_end()`)
+4. Add `build_time_comparison()` builder to `bookmark_builders.py` — serializes to `displayOptions.timeComparison`
+5. Add `time_comparison: TimeComparison | None = None` to `query()`, `query_funnel()`, `query_retention()` and their `build_*` variants
+6. Add validation: reject for flows, validate unit/date based on type
+7. Thread into `displayOptions` block in all 3 `_build_*_params()` methods
+
+### B2: Add FrequencyBreakdown type + builder
+
+**Files**: `types.py`, `bookmark_builders.py`, `workspace.py`
+**Effort**: MEDIUM
+
+1. Create `FrequencyBreakdown` frozen dataclass in `types.py`
+2. Add `build_frequency_group_entry()` to `bookmark_builders.py` — produces `sections.group[]` entry with `behaviorType: "$frequency"`, `resourceType: "people"`
+3. Update `build_group_section()` to accept `FrequencyBreakdown` in type union
+4. Update `group_by` parameter type annotations on `query()` and `build_params()`
+5. Add validation for frequency breakdown fields
+
+### B3: Add FrequencyFilter type + builder
+
+**Files**: `types.py`, `bookmark_builders.py`, `workspace.py`
+**Effort**: MEDIUM
+
+1. Create `FrequencyFilter` frozen dataclass in `types.py`
+2. Add `build_frequency_filter_entry()` to `bookmark_builders.py` — produces `sections.filter[]` entry with `customProperty.behavior` containing frequency definition
+3. Update `build_filter_section()` to accept `FrequencyFilter` in type union
+4. Update `where` parameter type annotations on `query()` and `build_params()`
+5. Add validation: operator must be in `VALID_FREQUENCY_FILTER_OPERATORS`
+
+### B4: Add aggregation operators to CohortCriteria.did_event()
+
+**Files**: `types.py`, `bookmark_enums.py`
+**Effort**: MEDIUM
+
+1. Add `CohortAggregationType = Literal[...]` to `_literal_types.py`
+2. Add `VALID_COHORT_AGGREGATION_OPERATORS` to `bookmark_enums.py`
+3. Add `aggregation: CohortAggregationType | None = None` and `aggregation_property: str | None = None` to `did_event()`
+4. Add validation: aggregation requires aggregation_property and vice versa
+5. Update behavior serialization to include `aggregationOperator` in the behavioral condition
+6. Update selector structure for aggregation-based criteria
+
+## Phase C: Completeness (Tier 3)
+
+### C1: Add data_group_id to all query engines
+
+**Files**: `workspace.py`, `bookmark_builders.py`
+**Effort**: SMALL
+
+1. Add `data_group_id: int | None = None` to `query()`, `query_funnel()`, `query_retention()`, `query_flow()` and their `build_*` variants
+2. Thread through to all `_build_*_params()` methods
+3. Replace 5 hardcoded `dataGroupId: None` / `data_group_id: None` in `bookmark_builders.py` with the parameter value
+4. Add validation: must be positive integer if provided
+
+### C2: Add flow breakdowns/segments
+
+**Files**: `workspace.py`, `bookmark_builders.py`, `types.py`
+**Effort**: MEDIUM
+
+1. Add `segments` parameter to `query_flow()` and `build_flow_params()` — accepts property-based breakdown spec
+2. Add `build_flow_segments()` builder to `bookmark_builders.py`
+3. Thread into `_build_flow_params()` → adds `segments` array to flow params
+
+### C3: Add flow exclusions (enhanced)
+
+**Files**: `workspace.py`
+**Effort**: SMALL
+
+Flow exclusions are already partially supported (the `exclusions` key exists in `_build_flow_params()` as empty list). Add parameter to accept exclusion events and thread them through.
+
+### C4: Add FlowStep session_event support
+
+**Files**: `types.py`, `workspace.py`
+**Effort**: SMALL
+
+1. Add `FlowSessionEvent = Literal["start", "end"]` to `_literal_types.py`
+2. Add `session_event: FlowSessionEvent | None = None` to `FlowStep` dataclass
+3. Add validation: session_event and event are mutually exclusive
+4. Update `_build_flow_params()` to emit `session_event` field when set
+
+### C5: Add flow global property filters
+
+**Files**: `workspace.py`, `bookmark_builders.py`
+**Effort**: SMALL
+
+1. Update flow `where` parameter to accept property filters (currently only cohort filters)
+2. Add `build_flow_property_filter()` builder for `filter_by_event` structure
+3. Update `_build_flow_params()` to check filter type and route to `filter_by_cohort` or `filter_by_event`
+
+## Implementation Dependencies
+
+```
+Phase A (can be parallelized within phase):
+  A1, A2, A3, A4: Independent — just literal/enum expansions
+  A5: Depends on A1 (new MathType values affect validation)
+  A6: Independent
+  A7: Depends on A2 (new RetentionMathType values)
+  A8: Independent
+
+Phase B (requires Phase A complete):
+  B1: Independent
+  B2: Independent
+  B3: Independent
+  B4: Independent
+  (All B items are independent of each other)
+
+Phase C (requires Phase B complete for full validation):
+  C1: Independent
+  C2: Independent
+  C3: Independent  
+  C4: Independent
+  C5: Independent
+  (All C items are independent of each other)
+```
+
+## Testing Strategy
+
+### Unit Tests (per step)
+
+Each implementation step includes tests for:
+1. **Happy path**: New type/parameter accepted, produces correct output
+2. **Validation**: Invalid values rejected with clear error messages
+3. **Backward compatibility**: Omitting new param produces identical output to pre-change behavior
+4. **Edge cases**: Boundary values, mutually exclusive params, type combinations
+
+### Property-Based Tests (Hypothesis)
+
+New PBT tests for:
+- `TimeComparison` construction: arbitrary valid/invalid type+unit+date combinations
+- `FrequencyBreakdown` construction: arbitrary bucket configurations
+- `FrequencyFilter` construction: arbitrary operator+value combinations
+- Expanded `MathType` values: all 22 values accepted by builder
+- New `Filter` factory methods: operator string correctness
+
+### Integration Tests
+
+- End-to-end: `Workspace.build_*_params()` with new parameters → validate against `validate_bookmark()`
+- Roundtrip: Build params with new features → validate structure matches power-tools reference JSON
+
+### Mutation Testing
+
+- Target 80%+ mutation score on new code
+- Focus on validation logic (where mutations are most dangerous)

--- a/specs/040-query-engine-completeness/quickstart.md
+++ b/specs/040-query-engine-completeness/quickstart.md
@@ -1,0 +1,235 @@
+# Quickstart: Unified Query Engine Completeness
+
+**Date**: 2026-04-14
+**Feature**: 040-query-engine-completeness
+
+## Phase A: Type Expansions and Core Parameters
+
+### Expanded Math Types (Insights)
+
+```python
+from mixpanel_data import Workspace, Metric
+
+ws = Workspace()
+
+# Cumulative unique users over time
+result = ws.query("Signup", math="cumulative_unique", last=30)
+
+# Count sessions (not events or users)
+result = ws.query("Login", math="sessions", last=30)
+
+# Most frequent value of a property
+result = ws.query("Purchase", math="most_frequent", math_property="category", last=30)
+
+# Numeric summary (count, mean, variance, sum_of_squares)
+result = ws.query("Purchase", math="numeric_summary", math_property="amount", last=30)
+
+# Metric object with new math types
+m = Metric("Purchase", math="unique_values", property="product_id")
+result = ws.query(m, last=30)
+```
+
+### Expanded Math Types (Retention and Funnels)
+
+```python
+# Retention with total event count per bucket
+result = ws.query_retention("Signup", "Purchase", math="total", last=90)
+
+# Retention with average property value per bucket
+result = ws.query_retention("Signup", "Purchase", math="average", last=90)
+
+# Funnel with histogram math
+result = ws.query_funnel(["View", "Cart", "Purchase"], math="histogram", math_property="amount")
+```
+
+### Segment Method
+
+```python
+# First-touch attribution (count only first qualifying event per user)
+m = Metric("Purchase", segment_method="first")
+result = ws.query_funnel(["View", "Purchase"], math="total")
+
+# All-touch attribution (count all qualifying events, default)
+m = Metric("Purchase", segment_method="all")
+```
+
+### Funnel Reentry Mode
+
+```python
+# Aggressive reentry — each re-entry generates additional conversion
+result = ws.query_funnel(
+    ["View Product", "Add to Cart", "Purchase"],
+    reentry_mode="aggressive",
+    last=30,
+)
+
+# Basic reentry — users can re-enter at steps after the first
+result = ws.query_funnel(steps, reentry_mode="basic")
+```
+
+### Retention Unbounded and Cumulative Modes
+
+```python
+# Carry forward — count returning users in all intermediate buckets
+result = ws.query_retention(
+    "Signup", "Login",
+    unbounded_mode="carry_forward",
+    retention_unit="week",
+    last=90,
+)
+
+# Cumulative retention view
+result = ws.query_retention("Signup", "Login", retention_cumulative=True, last=90)
+
+# Combined: cumulative with carry_forward
+result = ws.query_retention(
+    "Signup", "Login",
+    unbounded_mode="carry_forward",
+    retention_cumulative=True,
+    last=90,
+)
+```
+
+### New Filter Methods
+
+```python
+from mixpanel_data import Filter
+
+# Numeric range negation
+f = Filter.not_between("age", 18, 25)
+
+# String prefix/suffix matching
+f = Filter.starts_with("email", "admin")
+f = Filter.ends_with("domain", ".edu")
+
+# Date range negation
+f = Filter.date_not_between("created", "2025-01-01", "2025-06-30")
+
+# Future relative date
+f = Filter.in_the_next("trial_end", 7, "day")
+
+# Inclusive numeric bounds
+f = Filter.at_least("purchase_count", 5)
+f = Filter.at_most("age", 65)
+```
+
+## Phase B: New Feature Types
+
+### Time Comparison
+
+```python
+from mixpanel_data import TimeComparison
+
+# Compare last 30 days vs previous month
+result = ws.query(
+    "Signup",
+    last=30,
+    time_comparison=TimeComparison.relative("month"),
+)
+
+# Compare against a specific start date
+result = ws.query(
+    "Signup",
+    from_date="2026-03-01",
+    to_date="2026-03-31",
+    time_comparison=TimeComparison.absolute_start("2026-02-01"),
+)
+
+# Works with funnels and retention too
+result = ws.query_funnel(
+    ["View", "Purchase"],
+    last=30,
+    time_comparison=TimeComparison.relative("week"),
+)
+```
+
+### Frequency Analysis
+
+```python
+from mixpanel_data import FrequencyBreakdown, FrequencyFilter
+
+# Break down by how many times users purchased
+result = ws.query(
+    "Signup",
+    group_by=FrequencyBreakdown("Purchase", bucket_size=1, bucket_min=0, bucket_max=10),
+    last=30,
+)
+
+# Filter to users who logged in at least 5 times
+result = ws.query(
+    "Purchase",
+    where=FrequencyFilter("Login", operator="is at least", value=5),
+    last=30,
+)
+
+# Frequency filter with time window
+result = ws.query(
+    "Purchase",
+    where=FrequencyFilter(
+        "Login",
+        operator="is at least",
+        value=3,
+        date_range_value=7,
+        date_range_unit="day",
+    ),
+    last=30,
+)
+```
+
+### Enhanced Behavioral Cohorts
+
+```python
+from mixpanel_data import CohortCriteria, CohortDefinition
+
+# Users whose average purchase value > $50
+criteria = CohortCriteria.did_event(
+    "Purchase",
+    aggregation="average",
+    aggregation_property="amount",
+    at_least=50,
+    within_days=30,
+)
+
+cohort = CohortDefinition(criteria)
+ws.create_cohort(name="High-Value Buyers", definition=cohort)
+
+# Users with 3+ unique product categories
+criteria = CohortCriteria.did_event(
+    "Purchase",
+    aggregation="unique",
+    aggregation_property="category",
+    at_least=3,
+    within_days=30,
+)
+```
+
+## Phase C: Completeness
+
+### Group Analytics Scoping
+
+```python
+# Scope query to a specific data group (e.g., companies)
+result = ws.query("Feature Used", math="unique", data_group_id=5, last=30)
+
+# Works across all query types
+result = ws.query_funnel(["Trial", "Paid"], data_group_id=5, last=30)
+result = ws.query_retention("Signup", "Login", data_group_id=5, last=90)
+result = ws.query_flow("Login", data_group_id=5, last=30)
+```
+
+### Advanced Flow Features
+
+```python
+from mixpanel_data import FlowStep, Filter
+
+# Session start/end as flow anchors
+step = FlowStep(event="$session_start", session_event="start", forward=5)
+result = ws.query_flow(step, last=30)
+
+# Global property filter on flows
+result = ws.query_flow(
+    "Login",
+    where=Filter.equals("country", "US"),
+    last=30,
+)
+```

--- a/specs/040-query-engine-completeness/research.md
+++ b/specs/040-query-engine-completeness/research.md
@@ -1,0 +1,114 @@
+# Research: Unified Query Engine Completeness
+
+**Date**: 2026-04-14
+**Feature**: 040-query-engine-completeness
+
+## Summary
+
+All NEEDS CLARIFICATION items are resolved. Codebase exploration and power-tools reference analysis confirm all 29 gaps and their implementations. One discrepancy found and resolved.
+
+---
+
+## Decision Log
+
+### D1: TimeComparison JSON Location
+
+**Decision**: Place in `displayOptions.timeComparison`
+**Rationale**: Power-tools (`bookmark-validator.js:761-790`, `mixpanel-bookmark-typedefs.d.ts:62-77`) consistently places `timeComparison` inside `displayOptions`. The audit report states "params.timeComparison (top-level, alongside sections)" which may reflect an older or alternative server parsing path. The power-tools implementation is the canonical, battle-tested reference.
+**Alternatives considered**: Top-level `params.timeComparison` per audit report. Rejected because power-tools' validator tests confirm `displayOptions` location.
+**Action**: Implement in `displayOptions`. Add a test that verifies the server accepts it.
+
+### D2: Segment Method Values
+
+**Decision**: Support only `"all"` and `"first"` (2 values)
+**Rationale**: Server-side `_validate_segment_method()` in `analytics/backend/arb/params.py` explicitly rejects any value other than "first" and "all". Power-tools incorrectly accepts "last" — this is a confirmed bug in power-tools, not a feature.
+**Alternatives considered**: Including "last" for power-tools compatibility. Rejected because the server rejects it.
+
+### D3: FunnelReentryMode Default
+
+**Decision**: Default to `None` (omit from JSON) rather than `"basic"` or `"default"`
+**Rationale**: Power-tools builders default to `"basic"`, but the server documentation indicates that if the field is absent, server assumes `"default"` behavior. Using `None` preserves backward compatibility — existing queries produce identical JSON. Users explicitly opt in.
+**Alternatives considered**: Default to `"basic"` (power-tools pattern). Rejected to maintain backward compatibility per FR-029.
+
+### D4: MATH_REQUIRING_PROPERTY Updates
+
+**Decision**: Add `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary` to `MATH_REQUIRING_PROPERTY`
+**Rationale**: Audit report confirms all 5 require a property. The existing `MATH_REQUIRING_PROPERTY` set in `bookmark_enums.py` is missing these because the MathType Literal didn't include them — expanding the Literal means the validation set must also expand.
+**Alternatives considered**: None. This is a factual correctness update.
+
+### D5: FrequencyBreakdown vs Extending GroupBy
+
+**Decision**: Create a dedicated `FrequencyBreakdown` frozen dataclass rather than extending `GroupBy`
+**Rationale**: Frequency breakdowns have fundamentally different semantics from property breakdowns: they require an event name (not a property name), use `behaviorType: "$frequency"`, force `resourceType: "people"`, and have a different JSON structure. Extending GroupBy would conflate two distinct concepts.
+**Alternatives considered**: Adding `behavior_type` field to `GroupBy`. Rejected because it would weaken the type's semantics and require complex conditional validation.
+
+### D6: FrequencyFilter vs Extending Filter
+
+**Decision**: Create a dedicated `FrequencyFilter` frozen dataclass rather than extending `Filter`
+**Rationale**: Frequency filters have a `customProperty` block with behavioral semantics that doesn't map to Filter's property-operator-value model. The JSON structure is significantly different (nested `customProperty.behavior` with event, aggregation, date range). A dedicated type keeps the Filter class focused.
+**Alternatives considered**: Adding frequency-specific factory methods to Filter. Rejected because the internal structure diverges too much from Filter's model.
+
+### D7: FlowStep Session Events
+
+**Decision**: Add a `session_event` field to `FlowStep` as `Literal["start", "end"] | None`
+**Rationale**: Power-tools uses `SESSION_EVENT_MAP` to translate `$session_start` → `"start"` and `$session_end` → `"end"`, setting `session_event` instead of `event`. The two fields are mutually exclusive. Adding a dedicated field keeps the type explicit.
+**Alternatives considered**: Auto-detecting `$session_start`/`$session_end` event names and mapping them. Rejected because implicit magic violates Constitution Principle V (Explicit Over Implicit).
+
+### D8: Flow Global Property Filters Implementation
+
+**Decision**: Accept property filters in `where` parameter alongside cohort filters for flows, using `filter_by_event` key in params
+**Rationale**: Currently `where` on flows only accepts cohort filters (via `build_flow_cohort_filter()`). Power-tools supports both `filter_by_cohort` and `filter_by_event`. Property filters use a different structure: `{"operator": "and", "children": [...]}`.
+**Alternatives considered**: Separate `property_filter` parameter. Rejected to keep the API surface consistent — `where` already serves as the filter parameter.
+
+### D9: CohortCriteria Aggregation Property Type
+
+**Decision**: `aggregation_property: str` (plain property name)
+**Rationale**: Power-tools' `buildRawCohort()` uses a plain event property name string in the `behavior.property` field. Custom property references are not supported in cohort behavioral conditions.
+**Alternatives considered**: Supporting `CustomPropertyRef` for aggregation property. Rejected because cohort behavioral conditions don't support custom properties on the server.
+
+---
+
+## Codebase Findings
+
+### Current State of Key Files
+
+| File | Current State | Changes Needed |
+|------|--------------|---------------|
+| `_literal_types.py` | MathType: 15 values, RetentionMathType: 2, FunnelMathType: 13 | +7 to MathType, +2 to RetentionMathType, +1 to FunnelMathType, +5 new Literal types |
+| `types.py` | Metric (7 fields), Filter (22 factory methods), CohortCriteria.did_event (13 params), FlowStep (6 fields) | +1 Metric field, +7 Filter methods, +2 CohortCriteria params, +1 FlowStep field, +3 new dataclasses |
+| `workspace.py` | query (20 params), query_funnel (16 params), query_retention (13 params), query_flow (15 params) | +1-3 params per method, same for build_* variants |
+| `bookmark_builders.py` | 5 dataGroupId=None hardcodings, no time comparison, no frequency builders | Thread data_group_id, add time comparison builder, add frequency builders |
+| `bookmark_enums.py` | MATH_REQUIRING_PROPERTY missing 5 values, no reentry/unbounded enums | Update MATH_REQUIRING_PROPERTY, add new enum sets |
+| `validation.py` | validate_query_args, validate_funnel_args, validate_retention_args, validate_flow_args | Add validation for new params in each function |
+
+### Power-Tools Reference Summary
+
+| Feature | JSON Path | Valid Values | Default |
+|---------|-----------|-------------|---------|
+| Funnel reentry mode | `show[0].behavior.funnelReentryMode` | default, basic, aggressive, optimized | None (server assumes default) |
+| Retention unbounded mode | `show[0].behavior.retentionUnboundedMode` | none, carry_back, carry_forward, consecutive_forward | None (server assumes none) |
+| Retention cumulative | `show[0].measurement.retentionCumulative` | true, false | false |
+| Segment method | `show[0].measurement.segmentMethod` | all, first | None (server assumes all) |
+| Time comparison | `displayOptions.timeComparison` | Discriminated union (3 types) | None (no comparison) |
+| Frequency breakdown | `group[].behavior.behaviorType` | "$frequency" sentinel | N/A (new type) |
+| Frequency filter | `filter[].customProperty.behavior` | Behavioral filter structure | N/A (new type) |
+| Flow session event | `steps[].session_event` | start, end | N/A (use event field) |
+| Cohort aggregation | `behavior.aggregationOperator` | total, unique, average, min, max, median | total |
+
+---
+
+## Dependency Analysis
+
+### No External Dependencies Required
+
+All changes are type expansions, parameter additions, and builder updates. No new pip dependencies needed.
+
+### Internal Dependencies (Build Order)
+
+```
+Phase A: _literal_types.py → bookmark_enums.py → types.py → bookmark_builders.py → validation.py → workspace.py
+Phase B: types.py (new classes) → bookmark_builders.py (new builders) → validation.py → workspace.py  
+Phase C: bookmark_builders.py (threading) → workspace.py (threading)
+```
+
+Within each phase, the dependency chain is: Literal types → Enum constants → Dataclasses/types → Builders → Validators → Workspace methods.

--- a/specs/040-query-engine-completeness/spec.md
+++ b/specs/040-query-engine-completeness/spec.md
@@ -1,0 +1,256 @@
+# Feature Specification: Unified Query Engine Completeness
+
+**Feature Branch**: `040-query-engine-completeness`
+**Created**: 2026-04-14
+**Status**: Draft
+**Input**: User description: "All phases and tiers of unified-query-engine-audit-report.md"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Complete Math Type Coverage (Priority: P1)
+
+A developer building an insights query needs to measure cumulative unique users over time, count sessions, find the most frequent property value, or get a numeric summary of a property. Currently, the library's type system prevents them from specifying these 7 valid math types even though the Mixpanel server accepts them.
+
+Similarly, a developer building a retention query needs to measure total event counts or average property values per retention bucket, but the retention math type only exposes 2 of the 4 server-supported values. A developer building a funnel query cannot use histogram math.
+
+**Why this priority**: Math types are the foundation of every analytics query. Missing types mean entire categories of analysis are impossible through the library, forcing developers to use raw API calls or untyped workarounds.
+
+**Independent Test**: Can be tested by constructing queries with each newly supported math type and verifying the library accepts them without type errors and produces valid query parameters.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building an insights query, **When** they specify `cumulative_unique` as the math type, **Then** the library accepts the value and produces valid query parameters
+2. **Given** a developer building an insights query, **When** they specify any of `sessions`, `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, or `numeric_summary`, **Then** the library accepts the value and produces valid query parameters
+3. **Given** a developer using a math type that requires a property (e.g. `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, `numeric_summary`), **When** they omit the property, **Then** the library raises ValueError during Metric construction
+4. **Given** a developer building a retention query, **When** they specify `total` or `average` as the math type, **Then** the library accepts the value and produces valid query parameters
+5. **Given** a developer building a funnel query, **When** they specify `histogram` as the math type, **Then** the library accepts the value and produces valid query parameters
+
+---
+
+### User Story 2 - Advanced Funnel and Retention Modes (Priority: P1)
+
+A developer building a funnel query needs to control how users re-entering the funnel are counted — for example, counting each re-entry as a separate conversion ("aggressive") versus only counting the first completion ("default"). Currently there is no way to specify funnel reentry mode.
+
+A developer building a retention query needs to control how users are counted across retention buckets — for example, carrying forward users who return after gaps as retained in intermediate buckets. They also need to switch between cumulative and period-over-period retention views. Neither retention unbounded mode nor cumulative mode is currently exposed.
+
+A developer also needs to control attribution method (first-touch vs all-touch) via segment method for retention and funnel queries.
+
+**Why this priority**: These parameters fundamentally change how queries are calculated. Without them, developers cannot reproduce analyses that are possible in the Mixpanel UI, making the library incomplete for serious analytics work.
+
+**Independent Test**: Can be tested by constructing funnel and retention queries with each mode value and verifying the parameters appear correctly in the generated query output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building a funnel query, **When** they specify a reentry mode of "default", "basic", "aggressive", or "optimized", **Then** the query output includes the correct reentry mode setting
+2. **Given** a developer building a funnel query, **When** they specify an invalid reentry mode, **Then** the library raises ValueError listing valid reentry modes
+3. **Given** a developer building a retention query, **When** they specify an unbounded mode of "none", "carry_back", "carry_forward", or "consecutive_forward", **Then** the query output includes the correct unbounded mode setting
+4. **Given** a developer building a retention query, **When** they set cumulative mode to true, **Then** the query output reflects cumulative retention rather than period-over-period
+5. **Given** a developer building a retention or funnel query, **When** they specify a segment method of "first" or "all", **Then** the query output includes the correct attribution setting
+6. **Given** a developer specifying segment method for an insights-only query, **When** they submit the query, **Then** the library raises ValueError explaining segment method is only valid for funnels, retention, and frequency queries
+
+---
+
+### User Story 3 - Period-Over-Period Time Comparison (Priority: P2)
+
+A developer wants to compare current metrics against a previous period — such as this month's signups versus last month's, or this week's revenue versus the same week last year. Time comparison overlays a second time window on any insights, funnel, or retention query, enabling trend analysis and anomaly detection without running multiple queries.
+
+**Why this priority**: Period-over-period comparison is one of the most common analytics workflows. Without it, developers must run two separate queries and manually align the results, a tedious and error-prone process.
+
+**Independent Test**: Can be tested by adding a time comparison parameter to an insights query and verifying the generated query output contains the correct comparison configuration alongside the primary time range.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building an insights query, **When** they add a relative time comparison with a unit such as "month", **Then** the query output includes a comparison configuration specifying the relative offset
+2. **Given** a developer building a funnel or retention query, **When** they add a time comparison, **Then** the query output includes the same comparison structure
+3. **Given** a developer specifying an absolute-start time comparison with a date, **When** they submit the query, **Then** the comparison period begins at the specified date with its end inferred from the primary period length
+4. **Given** a developer specifying an absolute-end time comparison with a date, **When** they submit the query, **Then** the comparison period ends at the specified date with its start inferred backward
+5. **Given** a developer building a flow query, **When** they attempt to add a time comparison, **Then** the library raises ValueError explaining flows do not support time comparison
+6. **Given** a developer specifying a relative time comparison, **When** they omit the unit, **Then** the library raises ValueError during TimeComparison construction
+7. **Given** a developer specifying an absolute time comparison, **When** they provide an invalid date format, **Then** the library raises ValueError during TimeComparison construction
+
+---
+
+### User Story 4 - Frequency Analysis in Bookmark Queries (Priority: P2)
+
+A developer wants to understand how often users perform events — for example, breaking down a signup funnel by how many times users viewed a product, or filtering to users who performed a specific action at least 5 times. The library has a legacy frequency method but does not support frequency as a first-class concept in the modern query system, meaning it cannot be composed with other query features like breakdowns, filters, and time comparisons.
+
+**Why this priority**: Frequency analysis answers "how often" questions that are fundamental to engagement and habit-formation analysis. The legacy method is isolated from the modern query engine and cannot benefit from its composability.
+
+**Independent Test**: Can be tested by adding a frequency breakdown or frequency filter to an insights query and verifying the generated query output contains the correct frequency-specific structures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building a query, **When** they add a frequency breakdown for an event, **Then** the query output includes a group entry with frequency-specific behavior type and people-scoped resource type
+2. **Given** a developer building a query, **When** they add a frequency filter (e.g., "Login frequency is at least 5"), **Then** the query output includes a filter entry with the frequency behavior and numeric threshold
+3. **Given** a developer specifying a frequency breakdown, **When** they configure custom bucket boundaries (min, max, bucket size), **Then** the query output includes the bucket configuration
+4. **Given** a developer using a frequency filter, **When** they use any valid frequency filter operator ("is at least", "is at most", "is greater than", "is less than", "is equal to", "is between"), **Then** the library accepts it and produces correct query output
+
+---
+
+### User Story 5 - Enhanced Behavioral Cohorts with Property Aggregations (Priority: P2)
+
+A developer creating a behavioral cohort wants to define criteria based on property aggregations — for example, "users whose average purchase value exceeds $50" or "users whose maximum session duration exceeds 30 minutes." Currently, cohort behavioral criteria only support count-based thresholds (at least N, at most N, exactly N events), which limits the expressiveness of cohort definitions.
+
+**Why this priority**: Property-based behavioral segmentation is essential for identifying high-value, at-risk, or power-user segments. Count-only cohorts miss behavioral quality signals that distinguish user segments.
+
+**Independent Test**: Can be tested by creating a cohort criterion with an aggregation operator and property, and verifying the serialized cohort definition includes the aggregation operator and target property.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building a cohort criterion, **When** they specify an aggregation of "average" with a target property and threshold, **Then** the criterion serializes with the correct aggregation operator and property reference
+2. **Given** a developer, **When** they use any of the 6 aggregation operators (total, unique, average, min, max, median), **Then** the library accepts and correctly serializes each
+3. **Given** a developer specifying an aggregation operator, **When** they omit the aggregation property, **Then** the library raises ValueError during CohortCriteria construction
+4. **Given** a developer using count-based frequency without aggregation, **When** they build the criterion as before, **Then** existing behavior is preserved with no regressions
+
+---
+
+### User Story 6 - Complete Filter Operator Coverage (Priority: P3)
+
+A developer building query filters needs operators that are currently missing from the filter builder — such as `not_between` for numeric range negation, `starts_with` and `ends_with` for string matching, `date_not_between` for date exclusion, `in_the_next` for future-relative dates, and inclusive numeric bounds (`at_least`, `at_most`). They must currently construct raw filter dictionaries to use these operators, which is error-prone and breaks the fluent API pattern.
+
+**Why this priority**: While workarounds exist, missing filter methods break the fluent API pattern, increase the chance of typos in hand-constructed filter dictionaries, and make queries harder to read and maintain.
+
+**Independent Test**: Can be tested by calling each new filter method and verifying it produces the correct operator string and value structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer, **When** they create a `not_between` filter with min and max values, **Then** the filter produces the "not between" operator with the correct value structure
+2. **Given** a developer, **When** they create a `starts_with` filter with a prefix, **Then** the filter produces the "starts with" operator
+3. **Given** a developer, **When** they create an `ends_with` filter with a suffix, **Then** the filter produces the "ends with" operator
+4. **Given** a developer, **When** they create a `date_not_between` filter with start and end dates, **Then** the filter produces the "was not between" operator
+5. **Given** a developer, **When** they create an `in_the_next` filter with a value and unit, **Then** the filter produces the "was in the next" operator
+6. **Given** a developer, **When** they create `at_least` or `at_most` filters with a value, **Then** the filters produce "is at least" and "is at most" operators respectively
+
+---
+
+### User Story 7 - Group Analytics Scoping (Priority: P3)
+
+A developer using Mixpanel's group analytics feature needs to scope queries to a specific data group (e.g., companies, accounts, workspaces) so that metrics are calculated at the group level rather than the user level. Currently, the data group identifier is hardcoded to null in all query engines, making group-level analysis impossible through the library.
+
+**Why this priority**: Group analytics is a paid Mixpanel feature used by B2B companies. Without scoping support, these customers cannot use the library for their primary analytics use case.
+
+**Independent Test**: Can be tested by passing a data group identifier to a query method and verifying it appears in the generated query output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer with a group analytics project, **When** they specify a data group identifier on an insights query, **Then** the generated query output includes the group identifier in the appropriate locations
+2. **Given** a developer, **When** they specify a data group identifier on funnel, retention, and flow queries, **Then** each engine threads the value through to the query output
+3. **Given** a developer, **When** they omit the data group identifier, **Then** existing behavior is preserved (defaults to user-level analytics)
+
+---
+
+### User Story 8 - Advanced Flow Features (Priority: P3)
+
+A developer building flow analyses needs capabilities beyond basic step sequencing: breaking down flow paths by a user property (e.g., "show flows segmented by country"), excluding specific events between steps, using session start/end as flow anchors, and applying global property filters to flow queries.
+
+**Why this priority**: Flow analysis without segmentation or filtering produces overly broad results. These features are needed to answer targeted "how do users navigate" questions for specific user populations.
+
+**Independent Test**: Can be tested by adding segments, exclusions, session events, or global filters to a flow query and verifying the generated parameters include the correct structures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer building a flow query, **When** they add a breakdown by a user property, **Then** the generated parameters include the segments array with the property specification
+2. **Given** a developer building a flow query, **When** they specify events to exclude between steps, **Then** the generated parameters include the exclusions array
+3. **Given** a developer building a flow query, **When** they use session start or session end as a flow step, **Then** the library maps these to the correct session event format expected by the server
+4. **Given** a developer building a flow query, **When** they add a global property filter, **Then** the generated parameters include the property filter alongside any cohort filters
+
+---
+
+### Edge Cases
+
+- Math types requiring a property must validate that the property is provided; math types that do not accept a property must reject it if provided
+- Segment method must be rejected for insights-only queries but accepted for funnels, retention, and frequency queries
+- Time comparison must be rejected for flow queries with a clear engine-specific error message
+- Frequency breakdowns must enforce people-scoped resource type and frequency-specific behavior type
+- Frequency filter operators must be restricted to the 6 valid numeric operators; non-numeric operators must be rejected
+- Aggregation-based cohort criteria must require an aggregation property; count-based criteria must reject aggregation properties
+- Date-based filter values must validate format where applicable (e.g., in_the_next requires a positive integer and valid unit)
+- Flow session events must map session start/end sentinel values to the server's session event format rather than treating them as regular event names
+- All new parameters must be optional with backward-compatible defaults so existing code is unaffected
+- Existing tests must continue to pass without modification (strict backward compatibility)
+- Invalid enum values must produce clear error messages listing all valid options
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Phase A — Type Expansions and Core Parameters (Tier 1)**
+
+- **FR-001**: System MUST accept `cumulative_unique`, `sessions`, `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, and `numeric_summary` as valid insights math types
+- **FR-002**: System MUST enforce that `unique_values`, `most_frequent`, `first_value`, `multi_attribution`, and `numeric_summary` require a property parameter
+- **FR-003**: System MUST accept `total` and `average` as valid retention math types in addition to existing `retention_rate` and `unique`
+- **FR-004**: System MUST accept `histogram` as a valid funnel math type in addition to existing funnel math types
+- **FR-005**: System MUST accept a segment method parameter on metrics with values "all" (default) or "first"
+- **FR-006**: System MUST reject segment method on insights-only queries and accept it on funnel, retention, and frequency queries
+- **FR-007**: System MUST accept a reentry mode parameter on funnel queries with values "default", "basic", "aggressive", or "optimized"
+- **FR-008**: System MUST accept a retention unbounded mode parameter on retention queries with values "none" (default), "carry_back", "carry_forward", or "consecutive_forward"
+- **FR-009**: System MUST accept a cumulative boolean parameter on retention queries defaulting to false
+- **FR-010**: System MUST provide 7 additional filter factory methods: `not_between`, `starts_with`, `ends_with`, `date_not_between`, `in_the_next`, `at_least`, and `at_most`
+
+**Phase B — New Feature Types (Tier 2)**
+
+- **FR-011**: System MUST accept a time comparison parameter on insights, funnel, and retention queries
+- **FR-012**: System MUST support 3 time comparison modes: relative (with unit: day, week, month, quarter, year), absolute-start (with date), and absolute-end (with date)
+- **FR-013**: System MUST reject time comparison on flow queries
+- **FR-014**: System MUST validate time comparison parameters: relative requires a valid unit; absolute modes require a valid date
+- **FR-015**: System MUST accept a frequency breakdown in the group-by parameter, producing query output with frequency-specific behavior type and people-scoped resource type
+- **FR-016**: System MUST accept configurable bucket boundaries (min, max, bucket size) on frequency breakdowns
+- **FR-017**: System MUST accept a frequency filter in the where parameter, supporting numeric filter operators ("is at least", "is at most", "is greater than", "is less than", "is equal to", "is between")
+- **FR-018**: System MUST accept an aggregation parameter on behavioral cohort criteria with values "total", "unique", "average", "min", "max", or "median"
+- **FR-019**: System MUST require an aggregation property when an aggregation operator is specified on a cohort criterion
+- **FR-020**: System MUST serialize aggregation-based cohort criteria with the aggregation operator in the behavioral condition output
+
+**Phase C — Completeness (Tier 3)**
+
+- **FR-021**: System MUST accept a data group identifier parameter on all query methods (insights, funnel, retention, flow) and include it in the generated query output
+- **FR-022**: System MUST accept a segments/breakdowns parameter on flow queries for property-based flow path segmentation
+- **FR-023**: System MUST accept an exclusions parameter on flow queries for excluding events between specific steps
+- **FR-024**: System MUST map session start and session end sentinel values to the server's session event format when used as flow steps
+- **FR-025**: System MUST accept global property filters on flow queries in addition to existing cohort filters
+
+**Cross-Cutting**
+
+- **FR-026**: All new parameters MUST be optional with backward-compatible defaults
+- **FR-027**: All new parameter values MUST be validated against server-accepted values before query submission, with clear error messages listing valid options
+- **FR-028**: All new types MUST be fully typed and pass strict type checking
+- **FR-029**: Existing queries without new parameters MUST continue to produce identical output (backward compatibility)
+
+### Key Entities
+
+- **MathType**: Constrained set of valid mathematical operations for insights queries, expanded to include cumulative_unique, sessions, unique_values, most_frequent, first_value, multi_attribution, and numeric_summary
+- **RetentionMathType**: Constrained set of valid math operations for retention queries, expanded to include total and average
+- **FunnelMathType**: Constrained set of valid math operations for funnel queries, expanded to include histogram
+- **SegmentMethod**: Attribution control specifying first-touch ("first") or all-touch ("all") event counting, applicable to funnels, retention, and frequency queries
+- **FunnelReentryMode**: Controls how funnel re-entries are counted, with 4 modes: default, basic, aggressive, optimized
+- **RetentionUnboundedMode**: Controls how users are counted across retention time buckets, with 4 modes: none, carry_back, carry_forward, consecutive_forward
+- **TimeComparison**: Discriminated union of 3 comparison types (relative, absolute-start, absolute-end) for period-over-period overlay analysis
+- **FrequencyBreakdown**: Frequency-based group-by concept that segments queries by how many times users perform a specified event, with configurable bucketing
+- **FrequencyFilter**: Filter concept that restricts queries to users based on event frequency thresholds using numeric comparison operators
+- **CohortAggregation**: Extended cohort criterion concept supporting property aggregation operators (total, unique, average, min, max, median) beyond count-based thresholds
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can specify all server-supported insights math types without type errors or raw dictionary workarounds — 7 previously inaccessible math types (cumulative_unique, sessions, unique_values, most_frequent, first_value, multi_attribution, numeric_summary) become available
+- **SC-002**: Developers can configure funnel reentry mode, retention unbounded mode, retention cumulative mode, and segment method using named parameters — 4 previously impossible query configurations become available
+- **SC-003**: Developers can overlay a comparison time period on any insights, funnel, or retention query in a single call — period-over-period analysis that previously required 2 queries and manual alignment becomes a single operation
+- **SC-004**: Developers can break down and filter queries by event frequency using the modern query system — frequency analysis joins the composable query engine rather than being isolated in a legacy method
+- **SC-005**: Developers can create behavioral cohorts using property aggregations (total, unique, average, min, max, median) — 6 aggregation operators expand cohort definitions beyond count-only thresholds
+- **SC-006**: Developers can use all server-supported filter operators through the fluent filter builder — 7 previously missing filter methods become available
+- **SC-007**: Developers can scope any query to a specific data group for group-level analytics — B2B group analytics customers can use the library for their primary use case
+- **SC-008**: Developers can segment, exclude, filter, and configure flow queries with breakdowns, exclusions, session events, and global property filters — 4 flow capabilities reach parity with the Mixpanel UI
+- **SC-009**: All existing queries continue to work identically — zero regressions in generated output
+- **SC-010**: All 29 confirmed gaps from the capability audit are closed, verified by query acceptance tests covering every new parameter and type value
+
+## Assumptions
+
+- The Mixpanel server's accepted values for these capabilities are stable and will not change during implementation
+- The existing query builder architecture is extensible enough to accommodate all new parameters without structural refactoring
+- Developers using the library have access to Mixpanel project configurations that support the features they invoke (e.g., group analytics requires a paid plan; session replay requires the feature to be enabled)
+- The legacy `frequency()` method will be preserved for backward compatibility; the new frequency capability in the modern query engine is additive
+- The `PerUserAggregation` session_replay_id_value gap (priority matrix item #17) is excluded from this scope due to its niche use case and low agent value; it can be addressed in a future iteration if needed
+- All parameter names follow the library's existing naming conventions, mapped to the server's expected format by the query builders
+- Validation errors provide clear, actionable messages identifying the invalid parameter and listing all valid options
+- The implementation is phased (A → B → C) to allow incremental delivery and testing, but all phases are in scope for this feature
+- The frequency show clause (audit section 2.2.3 — `type: "addiction"` behavior in `sections.show[]`) is excluded from scope; the existing legacy `frequency()` method covers standalone frequency metrics. This feature adds frequency as a composable breakdown (group_by) and filter (where) in the modern query engine, not as a standalone metric type.

--- a/specs/040-query-engine-completeness/tasks.md
+++ b/specs/040-query-engine-completeness/tasks.md
@@ -1,0 +1,338 @@
+# Tasks: Unified Query Engine Completeness
+
+**Input**: Design documents from `/specs/040-query-engine-completeness/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/public-api.md, quickstart.md
+
+**Tests**: Included — this project enforces strict TDD per CLAUDE.md.
+
+**Organization**: Tasks grouped by user story. Each story is independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Exact file paths included in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — all changes modify existing files.
+
+_(No tasks — existing project structure is sufficient)_
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Expand Literal types and enum constants that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T001 Expand MathType (+7: cumulative_unique, sessions, unique_values, most_frequent, first_value, multi_attribution, numeric_summary), RetentionMathType (+2: total, average), FunnelMathType (+1: histogram), and add 7 new Literal type aliases (SegmentMethod, FunnelReentryMode, RetentionUnboundedMode, TimeComparisonType, TimeComparisonUnit, CohortAggregationType, FlowSessionEvent) with docstring tables in src/mixpanel_data/_literal_types.py
+- [x] T002 [P] Update MATH_REQUIRING_PROPERTY (+5: unique_values, most_frequent, first_value, multi_attribution, numeric_summary) and add VALID_FUNNEL_REENTRY_MODES, VALID_RETENTION_UNBOUNDED_MODES, VALID_SEGMENT_METHODS, VALID_TIME_COMPARISON_TYPES, VALID_TIME_COMPARISON_UNITS, VALID_COHORT_AGGREGATION_OPERATORS, VALID_FREQUENCY_FILTER_OPERATORS frozenset constants in src/mixpanel_data/_internal/bookmark_enums.py
+- [x] T003 Export new Literal types (SegmentMethod, FunnelReentryMode, RetentionUnboundedMode, TimeComparisonType, TimeComparisonUnit, CohortAggregationType, FlowSessionEvent) and update __all__ in src/mixpanel_data/__init__.py
+
+**Checkpoint**: Foundation ready — all types and enums available for user story implementation
+
+---
+
+## Phase 3: User Story 1 - Complete Math Type Coverage (Priority: P1) MVP
+
+**Goal**: Developers can specify all 22 insights math types, 4 retention math types, and 14 funnel math types without type errors
+
+**Independent Test**: Construct Metric objects with each new math type, call build_params() and build_retention_params()/build_funnel_params(), verify acceptance and correct output
+
+### Tests for User Story 1
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T004 [P] [US1] Write tests for Metric construction with 7 new math types: verify acceptance, verify property-required math types (unique_values, most_frequent, first_value, multi_attribution, numeric_summary) reject missing property, verify property-optional types (cumulative_unique, sessions) accept without property in tests/test_types.py
+- [x] T005 [P] [US1] Write tests for build_params() with new math types producing correct measurement.math, build_retention_params() accepting total/average, build_funnel_params() accepting histogram in tests/test_workspace.py
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Update _MATH_REQUIRING_PROPERTY frozenset in Metric.__post_init__() to include unique_values, most_frequent, first_value, multi_attribution, numeric_summary in src/mixpanel_data/types.py
+- [x] T007 [P] [US1] Verify validate_query_args(), validate_funnel_args(), validate_retention_args() correctly accept expanded math types via the VALID_MATH_* enum sets — update any hardcoded checks in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: All 22 insights, 4 retention, and 14 funnel math types accepted and produce correct output
+
+---
+
+## Phase 4: User Story 2 - Advanced Funnel and Retention Modes (Priority: P1)
+
+**Goal**: Developers can configure funnel reentry mode, retention unbounded mode, retention cumulative mode, and segment method
+
+**Independent Test**: Call build_funnel_params() with reentry_mode="aggressive", build_retention_params() with unbounded_mode="carry_forward" and retention_cumulative=True, verify correct JSON structure
+
+### Tests for User Story 2
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T008 [P] [US2] Write tests for Metric with segment_method="first" and segment_method="all" construction, verify None default in tests/test_types.py
+- [x] T009 [P] [US2] Write tests for build_funnel_params() with reentry_mode producing behavior.funnelReentryMode, build_retention_params() with unbounded_mode producing behavior.retentionUnboundedMode and retention_cumulative producing measurement.retentionCumulative, and segmentMethod in measurement block in tests/test_workspace.py
+- [x] T010 [P] [US2] Write tests for validate_funnel_args() rejecting invalid reentry_mode, validate_retention_args() rejecting invalid unbounded_mode, and segment_method rejection for insights-only queries in tests/test_validation.py
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Add segment_method: SegmentMethod | None = None field to Metric dataclass with docstring in src/mixpanel_data/types.py
+- [x] T012 [US2] Add reentry_mode: FunnelReentryMode | None = None to query_funnel()/build_funnel_params(), add unbounded_mode: RetentionUnboundedMode | None = None and retention_cumulative: bool = False to query_retention()/build_retention_params(), thread reentry_mode to _build_funnel_params() behavior block as funnelReentryMode, thread unbounded_mode to _build_retention_params() behavior block as retentionUnboundedMode, thread retention_cumulative to measurement block as retentionCumulative, thread segment_method to measurement block as segmentMethod in src/mixpanel_data/workspace.py
+- [x] T013 [P] [US2] Add reentry_mode enum validation in validate_funnel_args(), unbounded_mode enum validation in validate_retention_args(), segment_method context validation (reject for insights-only) in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: Funnel reentry, retention unbounded, retention cumulative, and segment method all configurable with validation
+
+---
+
+## Phase 5: User Story 3 - Period-Over-Period Time Comparison (Priority: P2)
+
+**Goal**: Developers can overlay a comparison time period on insights, funnel, and retention queries
+
+**Independent Test**: Call build_params() with time_comparison=TimeComparison.relative("month"), verify displayOptions.timeComparison in output
+
+### Tests for User Story 3
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T014 [P] [US3] Write tests for TimeComparison dataclass: factory methods (relative, absolute_start, absolute_end), validation (relative requires unit, absolute requires date, date must be YYYY-MM-DD) in tests/test_types.py
+- [x] T015 [P] [US3] Write tests for build_time_comparison() producing correct dict for all 3 types in tests/test_bookmark_builders.py
+- [x] T016 [P] [US3] Write tests for time_comparison rejection on query_flow, acceptance on query/query_funnel/query_retention in tests/test_validation.py
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] Create TimeComparison frozen dataclass with type/unit/date fields, factory methods (relative, absolute_start, absolute_end), __post_init__ validation (TC1-TC3) in src/mixpanel_data/types.py
+- [x] T018 [P] [US3] Add build_time_comparison(tc: TimeComparison) -> dict builder function in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T019 [US3] Add time_comparison: TimeComparison | None = None to query()/build_params(), query_funnel()/build_funnel_params(), query_retention()/build_retention_params(), thread to displayOptions via build_time_comparison() in src/mixpanel_data/workspace.py; export TimeComparison from src/mixpanel_data/__init__.py
+- [x] T020 [P] [US3] Add time_comparison validation: reject for flows in validate_flow_args(), validate discriminated fields in validate_query_args()/validate_funnel_args()/validate_retention_args() in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: Time comparison works on insights, funnels, and retention; rejected for flows
+
+---
+
+## Phase 6: User Story 4 - Frequency Analysis (Priority: P2)
+
+**Goal**: Developers can break down and filter queries by event frequency using the modern query engine
+
+**Independent Test**: Call build_params() with group_by=FrequencyBreakdown("Purchase") and where=FrequencyFilter("Login", value=5), verify correct sections.group and sections.filter output
+
+### Tests for User Story 4
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T021 [P] [US4] Write tests for FrequencyBreakdown and FrequencyFilter dataclass construction, validation (FB1-FB4, FF1-FF5), and defaults in tests/test_types.py
+- [x] T022 [P] [US4] Write tests for build_frequency_group_entry() producing behaviorType="$frequency" + resourceType="people", and build_frequency_filter_entry() producing customProperty.behavior structure with correct operators in tests/test_bookmark_builders.py
+- [x] T023 [P] [US4] Write tests for build_params() accepting FrequencyBreakdown in group_by and FrequencyFilter in where in tests/test_workspace.py
+
+### Implementation for User Story 4
+
+- [x] T024 [US4] Create FrequencyBreakdown and FrequencyFilter frozen dataclasses with validation in src/mixpanel_data/types.py; export both from src/mixpanel_data/__init__.py
+- [x] T025 [US4] Add build_frequency_group_entry() and build_frequency_filter_entry() functions, update build_group_section() type union to accept FrequencyBreakdown, update build_filter_section() type union to accept FrequencyFilter in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T026 [US4] Update group_by parameter type annotation to include FrequencyBreakdown and where parameter to include FrequencyFilter on query()/build_params() in src/mixpanel_data/workspace.py
+
+**Checkpoint**: Frequency breakdown and frequency filter produce correct bookmark JSON
+
+---
+
+## Phase 7: User Story 5 - Enhanced Behavioral Cohorts (Priority: P2)
+
+**Goal**: Developers can create behavioral cohorts using property aggregation operators beyond count-based thresholds
+
+**Independent Test**: Call CohortCriteria.did_event("Purchase", aggregation="average", aggregation_property="amount", at_least=50, within_days=30), verify serialized output includes aggregationOperator
+
+### Tests for User Story 5
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T027 [P] [US5] Write tests for CohortCriteria.did_event() with aggregation and aggregation_property: all 6 operators accepted, mutual requirement enforced (CA1-CA2), correct serialization of aggregationOperator in behavior dict in tests/test_types.py
+
+### Implementation for User Story 5
+
+- [x] T028 [US5] Add aggregation: CohortAggregationType | None = None and aggregation_property: str | None = None to CohortCriteria.did_event(), add validation (aggregation requires aggregation_property, vice versa), update behavior dict serialization to include aggregationOperator and property in src/mixpanel_data/types.py
+
+**Checkpoint**: Cohort criteria support 6 aggregation operators with property-based thresholds
+
+---
+
+## Phase 8: User Story 6 - Complete Filter Operator Coverage (Priority: P3)
+
+**Goal**: Developers can use all server-supported filter operators through fluent factory methods
+
+**Independent Test**: Call each new Filter factory method, verify operator string and value structure
+
+### Tests for User Story 6
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T029 [P] [US6] Write tests for 7 new Filter factory methods: not_between produces "not between" with [min, max], starts_with produces "starts with", ends_with produces "ends with", date_not_between produces "was not between" with [from, to], in_the_next produces "was in the next" with date_unit, at_least produces "is at least", at_most produces "is at most" in tests/test_types.py
+- [x] T030 [P] [US6] Write tests for new filter operators in build_filter_entry() output in tests/test_bookmark_builders.py
+
+### Implementation for User Story 6
+
+- [x] T031 [US6] Add 7 Filter factory methods (not_between, starts_with, ends_with, date_not_between, in_the_next, at_least, at_most) following existing patterns (property, operator, value, property_type, resource_type) in src/mixpanel_data/types.py
+
+**Checkpoint**: All 7 new filter factory methods produce correct operator strings and value structures
+
+---
+
+## Phase 9: User Story 7 - Group Analytics Scoping (Priority: P3)
+
+**Goal**: Developers can scope any query to a specific data group for group-level analytics
+
+**Independent Test**: Call build_params() with data_group_id=5, verify dataGroupId appears in output instead of None
+
+### Tests for User Story 7
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T032 [P] [US7] Write tests for data_group_id parameter on build_params(), build_funnel_params(), build_retention_params(), build_flow_params() — verify dataGroupId/data_group_id in output in tests/test_workspace.py
+- [x] T033 [P] [US7] Write tests for data_group_id threading through build_group_section() and _build_cohort_group_entry() replacing hardcoded None in tests/test_bookmark_builders.py
+
+### Implementation for User Story 7
+
+- [x] T034 [US7] Add data_group_id: int | None = None parameter to query()/build_params(), query_funnel()/build_funnel_params(), query_retention()/build_retention_params(), query_flow()/build_flow_params() and thread through all _resolve_and_build_* and _build_* methods in src/mixpanel_data/workspace.py
+- [x] T035 [P] [US7] Add data_group_id parameter to build_group_section(), _build_cohort_group_entry(), and replace 5 hardcoded dataGroupId: None / data_group_id: None with parameter value in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T036 [P] [US7] Add data_group_id validation (must be positive integer if provided) in validate_query_args(), validate_funnel_args(), validate_retention_args(), validate_flow_args() in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: data_group_id threads through all query engines, replacing hardcoded None
+
+---
+
+## Phase 10: User Story 8 - Advanced Flow Features (Priority: P3)
+
+**Goal**: Developers can segment, exclude, anchor on sessions, and apply property filters in flow queries
+
+**Independent Test**: Call build_flow_params() with FlowStep(event="$session_start", session_event="start"), verify session_event in output; call with where=Filter.equals("country", "US"), verify filter_by_event in output
+
+### Tests for User Story 8
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T037 [P] [US8] Write tests for FlowStep with session_event field: construction, mutual exclusivity with event name (FS1), session_event mapping in tests/test_types.py
+- [x] T038 [P] [US8] Write tests for flow with segments parameter, exclusion events, session_event mapping in step output, and property filter producing filter_by_event structure in tests/test_workspace.py
+- [x] T039 [P] [US8] Write tests for build_flow_property_filter() output structure in tests/test_bookmark_builders.py
+
+### Implementation for User Story 8
+
+- [x] T040 [US8] Add session_event: FlowSessionEvent | None = None to FlowStep dataclass, add validation (FS1: session_event mutually exclusive with regular event name) in src/mixpanel_data/types.py
+- [x] T041 [P] [US8] Add build_flow_property_filter() builder for filter_by_event structure in src/mixpanel_data/_internal/bookmark_builders.py
+- [x] T042 [US8] Update query_flow()/build_flow_params(): emit session_event in step dict when set, expand where parameter to accept property Filter objects (route to filter_by_event vs filter_by_cohort based on filter type), add segments parameter support in src/mixpanel_data/workspace.py
+- [x] T043 [P] [US8] Add flow validation for session_event on steps, property filter validation, segments validation in validate_flow_args() in src/mixpanel_data/_internal/validation.py
+
+**Checkpoint**: Flow queries support segments, exclusions, session events, and global property filters
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality assurance across all stories
+
+- [x] T044 [P] Write PBT tests for TimeComparison, FrequencyBreakdown, FrequencyFilter, expanded MathType using Hypothesis strategies in tests/test_types_pbt.py
+- [x] T045 [P] Verify all new types (Literal aliases, dataclasses) are exported in __all__ and importable from mixpanel_data in src/mixpanel_data/__init__.py
+- [x] T046 Run just check (ruff check + ruff format + mypy --strict + pytest) and fix any issues
+- [x] T047 Run just test-cov and verify 90% coverage threshold is met — add targeted tests for any uncovered branches
+- [x] T048 Validate quickstart.md examples by running representative code snippets against build_*_params() methods
+- [x] T049 Run just mutate-check and verify 80% mutation score — SKIPPED (macOS grep -P incompatibility; mutation testing deferred)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — can start immediately. BLOCKS all user stories.
+- **US1 (Phase 3)**: Depends on Foundational only
+- **US2 (Phase 4)**: Depends on Foundational only (segment_method on Metric is independent of math type expansion)
+- **US3 (Phase 5)**: Depends on Foundational only
+- **US4 (Phase 6)**: Depends on Foundational only
+- **US5 (Phase 7)**: Depends on Foundational only
+- **US6 (Phase 8)**: Depends on Foundational only
+- **US7 (Phase 9)**: Depends on Foundational only
+- **US8 (Phase 10)**: Depends on Foundational only
+- **Polish (Phase 11)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+All 8 user stories are **independent** of each other. After the Foundational phase completes, any story can be implemented without waiting for others.
+
+The only cross-story concern is that multiple stories modify the same files (workspace.py, validation.py, types.py). When implementing sequentially, later stories build on earlier changes. When implementing in parallel, merge conflicts in these files must be resolved.
+
+### Within Each User Story
+
+1. Test tasks MUST be written and FAIL before implementation
+2. types.py changes before workspace.py changes
+3. bookmark_builders.py [P] with validation.py (independent files)
+4. workspace.py changes last (imports types, calls builders, calls validation)
+
+### Parallel Opportunities
+
+**Within Foundational**: T001 and T002 are [P] (different files: _literal_types.py vs bookmark_enums.py)
+
+**Within each story**: Test tasks marked [P] can run in parallel. Implementation tasks on different files marked [P] can run in parallel.
+
+**Across stories**: After Foundational, all stories CAN run in parallel if handled by separate developers with merge coordination on shared files.
+
+---
+
+## Parallel Example: User Story 3 (Time Comparison)
+
+```text
+# Launch all tests in parallel (3 different files):
+T014: TimeComparison dataclass tests in tests/test_types.py
+T015: build_time_comparison() tests in tests/test_bookmark_builders.py
+T016: Time comparison validation tests in tests/test_validation.py
+
+# Then implementation — types first, then parallel builder + validation:
+T017: Create TimeComparison in src/mixpanel_data/types.py
+  Then in parallel:
+    T018: Add builder in src/mixpanel_data/_internal/bookmark_builders.py
+    T020: Add validation in src/mixpanel_data/_internal/validation.py
+  Then:
+    T019: Thread param through workspace methods in src/mixpanel_data/workspace.py
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (expand types and enums)
+2. Complete Phase 3: US1 - Math Type Coverage
+3. **STOP and VALIDATE**: Run `just check` — all 22 math types accepted
+4. Commit and verify
+
+### Incremental Delivery (Recommended)
+
+1. Foundational → US1 (math types) → US2 (advanced modes) → **P1 complete**
+2. US3 (time comparison) → US4 (frequency) → US5 (cohorts) → **P2 complete**
+3. US6 (filters) → US7 (data groups) → US8 (flows) → **P3 complete**
+4. Polish → **All 29 gaps closed**
+
+Each story adds independent value and can be validated separately.
+
+### Parallel Team Strategy
+
+With 3 developers after Foundational:
+- Developer A: US1 → US3 → US6 (math → time comparison → filters)
+- Developer B: US2 → US4 → US7 (modes → frequency → data groups)
+- Developer C: US5 → US8 → Polish (cohorts → flows → quality)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks in the same phase
+- [Story] label maps to user stories from spec.md (US1-US8)
+- TDD is enforced: test tasks must complete and fail before implementation
+- The project validates bookmark JSON with validate_bookmark() — builder output must pass Layer 2 validation
+- All new params default to None/False for backward compatibility (FR-026, FR-029)
+- Commit after each completed story checkpoint
+- Run `just check` after each story to catch regressions early
+
+### Documentation Requirements (Constitution Mandate)
+
+Per Constitution Principle I, ALL new public methods, fields, classes, and Literal types MUST include:
+- Type hints (enforced by mypy --strict)
+- Docstrings with: summary, Args, Returns, Raises, Example (where behavior isn't obvious)
+- Docstring tables for Literal types (see existing MathType docstring as reference)
+
+This applies to every implementation task — docstrings are part of the task, not a separate step.

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -13,6 +13,7 @@ from mixpanel_data._internal.auth_credential import (
 )
 from mixpanel_data._internal.validation import validate_bookmark
 from mixpanel_data._literal_types import (
+    CohortAggregationType,
     ConversionWindowUnit,
     CountType,
     FilterDateUnit,
@@ -23,9 +24,11 @@ from mixpanel_data._literal_types import (
     FlowConversionWindowUnit,
     FlowCountType,
     FlowNodeType,
+    FlowSessionEvent,
     FunnelMathType,
     FunnelMode,
     FunnelOrder,
+    FunnelReentryMode,
     HourDayUnit,
     InsightsMode,
     MathType,
@@ -34,6 +37,10 @@ from mixpanel_data._literal_types import (
     RetentionAlignment,
     RetentionMathType,
     RetentionMode,
+    RetentionUnboundedMode,
+    SegmentMethod,
+    TimeComparisonType,
+    TimeComparisonUnit,
     TimeUnit,
 )
 from mixpanel_data.exceptions import (
@@ -160,6 +167,9 @@ from mixpanel_data.types import (
     FlowStepNode,
     FlowTreeNode,
     Formula,
+    # Frequency Analysis types (Phase 040 US4)
+    FrequencyBreakdown,
+    FrequencyFilter,
     FrequencyResult,
     FunnelInfo,
     FunnelQueryResult,
@@ -215,6 +225,7 @@ from mixpanel_data.types import (
     SegmentationResult,
     ServingMethod,
     SetTestUsersParams,
+    TimeComparison,
     TopEvent,
     UpdateAlertParams,
     UpdateAnnotationParams,
@@ -287,6 +298,14 @@ __all__ = [
     "FilterPropertyType",
     "FilterDateUnit",
     "FiltersCombinator",
+    # Type aliases — advanced query types
+    "SegmentMethod",
+    "FunnelReentryMode",
+    "RetentionUnboundedMode",
+    "TimeComparisonType",
+    "TimeComparisonUnit",
+    "CohortAggregationType",
+    "FlowSessionEvent",
     # Result structure TypedDicts
     "QueryMeta",
     "FunnelStepData",
@@ -519,4 +538,9 @@ __all__ = [
     "FlowQueryResult",
     # User query types (Phase 039)
     "UserQueryResult",
+    # Time Comparison (Phase 040)
+    "TimeComparison",
+    # Frequency Analysis types (Phase 040 US4)
+    "FrequencyBreakdown",
+    "FrequencyFilter",
 ]

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -25,6 +25,7 @@ from mixpanel_data._literal_types import (
     FlowCountType,
     FlowNodeType,
     FlowSessionEvent,
+    FrequencyFilterOperator,
     FunnelMathType,
     FunnelMode,
     FunnelOrder,
@@ -305,6 +306,7 @@ __all__ = [
     "TimeComparisonUnit",
     "CohortAggregationType",
     "FlowSessionEvent",
+    "FrequencyFilterOperator",
     # Result structure TypedDicts
     "QueryMeta",
     "FunnelStepData",

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -167,7 +167,6 @@ from mixpanel_data.types import (
     FlowStepNode,
     FlowTreeNode,
     Formula,
-    # Frequency Analysis types (Phase 040 US4)
     FrequencyBreakdown,
     FrequencyFilter,
     FrequencyResult,
@@ -538,9 +537,7 @@ __all__ = [
     "FlowQueryResult",
     # User query types (Phase 039)
     "UserQueryResult",
-    # Time Comparison (Phase 040)
     "TimeComparison",
-    # Frequency Analysis types (Phase 040 US4)
     "FrequencyBreakdown",
     "FrequencyFilter",
 ]

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -9,6 +9,7 @@ These are internal helpers — import from ``mixpanel_data._internal.bookmark_bu
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import date
 from typing import Any
 
@@ -17,9 +18,12 @@ from mixpanel_data.types import (
     CohortBreakdown,
     CustomPropertyRef,
     Filter,
+    FrequencyBreakdown,
+    FrequencyFilter,
     GroupBy,
     InlineCustomProperty,
     PropertyInput,
+    TimeComparison,
     _sanitize_raw_cohort,
 )
 
@@ -166,17 +170,18 @@ def build_date_range(
 
 
 def build_filter_section(
-    where: Filter | list[Filter] | None,
+    where: Filter | FrequencyFilter | Sequence[Filter | FrequencyFilter] | None,
 ) -> list[dict[str, Any]]:
     """Build the ``sections.filter`` array for bookmark params.
 
-    Converts ``None``, a single ``Filter``, or a list of ``Filter`` objects
-    into the list-of-dicts format expected by the Mixpanel bookmark API.
+    Converts ``None``, a single ``Filter`` or ``FrequencyFilter``, or a
+    list of ``Filter`` / ``FrequencyFilter`` objects into the list-of-dicts
+    format expected by the Mixpanel bookmark API.
 
     Args:
         where: Filter specification. ``None`` means no filters,
-            a single ``Filter`` is wrapped in a list, a list is
-            processed element-by-element.
+            a single ``Filter`` or ``FrequencyFilter`` is wrapped in a
+            list, a list is processed element-by-element.
 
     Returns:
         List of filter entry dicts (may be empty).
@@ -190,7 +195,13 @@ def build_filter_section(
     if where is None:
         return []
     filters_list = where if isinstance(where, list) else [where]
-    return [build_filter_entry(f) for f in filters_list]
+    result: list[dict[str, Any]] = []
+    for f in filters_list:
+        if isinstance(f, FrequencyFilter):
+            result.append(build_frequency_filter_entry(f))
+        else:
+            result.append(build_filter_entry(f))
+    return result
 
 
 def patch_custom_property_filters_for_transform(
@@ -231,29 +242,38 @@ def build_group_section(
     group_by: str
     | GroupBy
     | CohortBreakdown
-    | list[str | GroupBy | CohortBreakdown]
+    | FrequencyBreakdown
+    | Sequence[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
     | None,
+    *,
+    data_group_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """Build the ``sections.group`` array for bookmark params.
 
     Converts group-by specifications into the list-of-dicts format
     expected by the Mixpanel bookmark API. Supports strings (simple
     property name), ``GroupBy`` objects (with optional bucketing),
-    ``CohortBreakdown`` objects (cohort-based segmentation), and
-    lists mixing all three.
+    ``CohortBreakdown`` objects (cohort-based segmentation),
+    ``FrequencyBreakdown`` objects (event frequency segmentation),
+    and lists mixing all four.
 
     Args:
         group_by: Group-by specification. ``None`` means no grouping.
             Strings produce default string-typed entries. ``GroupBy``
             objects allow custom property types and numeric bucketing.
             ``CohortBreakdown`` objects produce cohort group entries.
+            ``FrequencyBreakdown`` objects produce frequency group entries.
+        data_group_id: Optional data group ID for group-level analytics.
+            Threads into ``dataGroupId`` fields within group entries
+            that support it (custom property refs, inline custom
+            properties, cohort breakdowns). Default: ``None``.
 
     Returns:
         List of group entry dicts (may be empty).
 
     Raises:
-        TypeError: If any element is not ``str``, ``GroupBy``, or
-            ``CohortBreakdown``.
+        TypeError: If any element is not ``str``, ``GroupBy``,
+            ``CohortBreakdown``, or ``FrequencyBreakdown``.
 
     Example:
         ```python
@@ -279,6 +299,8 @@ def build_group_section(
                     "propertyDefaultType": "string",
                 }
             )
+        elif isinstance(g, FrequencyBreakdown):
+            group_section.append(build_frequency_group_entry(g))
         elif isinstance(g, GroupBy):
             prop = g.property
             if isinstance(prop, CustomPropertyRef):
@@ -288,7 +310,7 @@ def build_group_section(
                     "resourceType": "events",
                     "profileType": None,
                     "search": "",
-                    "dataGroupId": None,
+                    "dataGroupId": data_group_id,
                     "dataset": "$mixpanel",
                     "propertyType": g.property_type,
                     "typeCast": None,
@@ -315,7 +337,7 @@ def build_group_section(
                     "resourceType": prop.resource_type,
                     "profileType": None,
                     "search": "",
-                    "dataGroupId": None,
+                    "dataGroupId": data_group_id,
                     "dataset": "$mixpanel",
                     "propertyType": effective_type,
                     "typeCast": None,
@@ -340,17 +362,23 @@ def build_group_section(
                     group_entry["customBucket"]["max"] = g.bucket_max
             group_section.append(group_entry)
         elif isinstance(g, CohortBreakdown):
-            group_section.append(_build_cohort_group_entry(g))
+            group_section.append(
+                _build_cohort_group_entry(g, data_group_id=data_group_id)
+            )
         else:
             raise TypeError(
-                f"group_by elements must be str, GroupBy, or CohortBreakdown, "
-                f"got {type(g).__name__}: {g!r}"
+                f"group_by elements must be str, GroupBy, CohortBreakdown, "
+                f"or FrequencyBreakdown, got {type(g).__name__}: {g!r}"
             )
 
     return group_section
 
 
-def _build_cohort_group_entry(cb: CohortBreakdown) -> dict[str, Any]:
+def _build_cohort_group_entry(
+    cb: CohortBreakdown,
+    *,
+    data_group_id: int | None = None,
+) -> dict[str, Any]:
     """Build a single cohort group entry for sections.group[].
 
     Produces the cohort-specific group dict with ``cohorts`` array
@@ -359,6 +387,10 @@ def _build_cohort_group_entry(cb: CohortBreakdown) -> dict[str, Any]:
 
     Args:
         cb: CohortBreakdown specification.
+        data_group_id: Optional data group ID for group-level analytics.
+            Threads into ``data_group_id`` in cohort entries and
+            ``dataGroupId`` in the top-level group entry.
+            Default: ``None``.
 
     Returns:
         Group entry dict with ``cohorts`` array.
@@ -377,7 +409,7 @@ def _build_cohort_group_entry(cb: CohortBreakdown) -> dict[str, Any]:
     base_cohort: dict[str, Any] = {
         "name": name,
         "negated": False,
-        "data_group_id": None,
+        "data_group_id": data_group_id,
     }
     if isinstance(cb.cohort, int):
         base_cohort["id"] = cb.cohort
@@ -397,7 +429,7 @@ def _build_cohort_group_entry(cb: CohortBreakdown) -> dict[str, Any]:
         "resourceType": "events",
         "profileType": None,
         "search": "",
-        "dataGroupId": None,
+        "dataGroupId": data_group_id,
         "propertyType": None,
         "typeCast": None,
         "cohorts": cohorts,
@@ -465,6 +497,53 @@ def build_filter_entry(f: Filter) -> dict[str, Any]:
     if f._date_unit is not None:
         entry["filterDateUnit"] = f._date_unit
     return entry
+
+
+def build_flow_property_filter(
+    filters: list[Filter],
+) -> dict[str, Any]:
+    """Build the ``filter_by_event`` dict for flow bookmark params.
+
+    Flows accept global property filters via a ``filter_by_event``
+    top-level key containing an ``operator`` (always ``"and"``) and
+    a ``children`` array of filter entries. Each child is produced
+    by :func:`build_filter_entry` with an added ``propertyName`` key.
+
+    Args:
+        filters: List of property ``Filter`` objects. Must not be
+            empty — caller should check before calling.
+
+    Returns:
+        Dict with ``operator`` and ``children`` keys suitable for
+        the ``filter_by_event`` bookmark key.
+
+    Example:
+        ```python
+        fbe = build_flow_property_filter([Filter.equals("country", "US")])
+        # {"operator": "and", "children": [
+        #   {"filterOperator": "equals", "filterType": "string",
+        #    "propertyName": "country", "filterValue": ["US"],
+        #    "resourceType": "events"}
+        # ]}
+        ```
+    """
+    children: list[dict[str, Any]] = []
+    for f in filters:
+        entry = build_filter_entry(f)
+        # Add propertyName from the entry's value key (the property name)
+        prop = f._property
+        if isinstance(prop, str):
+            entry["propertyName"] = prop
+        # Remove the "value" key since flow filters use propertyName instead
+        entry.pop("value", None)
+        # Remove defaultType — flow filters don't use it
+        entry.pop("defaultType", None)
+        children.append(entry)
+
+    return {
+        "operator": "and",
+        "children": children,
+    }
 
 
 def build_flow_cohort_filter(
@@ -545,3 +624,139 @@ def build_flow_cohort_filter(
     if "raw_cohort" in cohort_data:
         result["raw_cohort"] = cohort_data["raw_cohort"]
     return result
+
+
+def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
+    """Build a single frequency group entry for sections.group[].
+
+    Produces the frequency-specific group dict with ``behaviorType``
+    set to ``"$frequency"`` and ``resourceType`` set to ``"people"``.
+
+    Args:
+        fb: FrequencyBreakdown specification.
+
+    Returns:
+        Group entry dict with ``behavior`` sub-dict containing the
+        frequency event and bucket configuration.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        entry = build_frequency_group_entry(FrequencyBreakdown("Purchase"))
+        # {"resourceType": "people", "behaviorType": "$frequency",
+        #  "behavior": {"event": "Purchase", ...}}
+        ```
+    """
+    entry: dict[str, Any] = {
+        "resourceType": "people",
+        "behaviorType": "$frequency",
+        "behavior": {
+            "event": fb.event,
+            "bucket_size": fb.bucket_size,
+            "bucket_min": fb.bucket_min,
+            "bucket_max": fb.bucket_max,
+        },
+    }
+    if fb.label is not None:
+        entry["label"] = fb.label
+    return entry
+
+
+def build_frequency_filter_entry(ff: FrequencyFilter) -> dict[str, Any]:
+    """Build a single frequency filter entry for sections.filter[].
+
+    Produces the frequency-specific filter dict with ``behaviorType``
+    set to ``"$frequency"`` and ``resourceType`` set to ``"people"``.
+
+    Args:
+        ff: FrequencyFilter specification.
+
+    Returns:
+        Filter entry dict with ``customProperty.behavior`` sub-dict
+        containing the frequency event, operator, and threshold.
+        Optionally includes ``dateRange`` and ``eventFilters``.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        entry = build_frequency_filter_entry(
+            FrequencyFilter("Login", value=5)
+        )
+        # {"resourceType": "people", "behaviorType": "$frequency",
+        #  "customProperty": {"behavior": {"event": "Login", ...}}}
+        ```
+    """
+    behavior: dict[str, Any] = {
+        "event": ff.event,
+        "aggregation": "total",
+        "filterOperator": ff.operator,
+        "filterValue": ff.value,
+    }
+    if ff.date_range_value is not None and ff.date_range_unit is not None:
+        behavior["dateRange"] = {
+            "value": ff.date_range_value,
+            "unit": ff.date_range_unit,
+        }
+    if ff.event_filters is not None:
+        behavior["eventFilters"] = [build_filter_entry(f) for f in ff.event_filters]
+    entry: dict[str, Any] = {
+        "resourceType": "people",
+        "behaviorType": "$frequency",
+        "customProperty": {
+            "behavior": behavior,
+        },
+    }
+    if ff.label is not None:
+        entry["label"] = ff.label
+    return entry
+
+
+def build_time_comparison(tc: TimeComparison) -> dict[str, str]:
+    """Build the ``timeComparison`` dict for ``displayOptions``.
+
+    Converts a ``TimeComparison`` dataclass into the JSON dict format
+    expected by the Mixpanel bookmark API inside
+    ``displayOptions.timeComparison``.
+
+    The output format is ``{"type": <type>, "value": <unit_or_date>}``:
+
+    - For ``type="relative"``: value is the comparison unit
+      (day, week, month, quarter, year).
+    - For ``type="absolute-start"`` or ``"absolute-end"``: value is
+      the ISO date string (YYYY-MM-DD).
+
+    Args:
+        tc: A validated ``TimeComparison`` dataclass instance.
+
+    Returns:
+        Dict with ``type`` and ``value`` keys, both strings.
+
+    Example:
+        ```python
+        from mixpanel_data._internal.bookmark_builders import (
+            build_time_comparison,
+        )
+        from mixpanel_data.types import TimeComparison
+
+        result = build_time_comparison(TimeComparison.relative("month"))
+        # {"type": "relative", "value": "month"}
+        ```
+    """
+    value: str
+    if tc.type == "relative":
+        # tc.unit is guaranteed non-None by TimeComparison.__post_init__
+        assert tc.unit is not None  # for mypy
+        value = tc.unit
+    else:
+        # tc.date is guaranteed non-None by TimeComparison.__post_init__
+        assert tc.date is not None  # for mypy
+        value = tc.date
+    return {"type": tc.type, "value": value}

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -527,6 +527,11 @@ def build_flow_property_filter(
         # ]}
         ```
     """
+    if not filters:
+        raise ValueError(
+            "build_flow_property_filter requires at least one filter; "
+            "caller should check before calling"
+        )
     children: list[dict[str, Any]] = []
     for f in filters:
         entry = build_filter_entry(f)
@@ -588,8 +593,9 @@ def build_flow_cohort_filter(
     for f in filters:
         if f._property != "$cohorts":
             raise ValueError(
-                "query_flow where= only accepts cohort filters "
-                "(Filter.in_cohort/not_in_cohort)"
+                "build_flow_cohort_filter only accepts cohort filters "
+                "(Filter.in_cohort/not_in_cohort); property filters should "
+                "use build_flow_property_filter instead"
             )
 
     if len(filters) > 1:

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -530,10 +530,16 @@ def build_flow_property_filter(
     children: list[dict[str, Any]] = []
     for f in filters:
         entry = build_filter_entry(f)
-        # Add propertyName from the entry's value key (the property name)
+        # Add propertyName — flow filters only support string property names
         prop = f._property
         if isinstance(prop, str):
             entry["propertyName"] = prop
+        else:
+            raise TypeError(
+                f"build_flow_property_filter only supports string property "
+                f"filters; got {type(prop).__name__} — custom property refs "
+                f"are not supported in flow filters"
+            )
         # Remove the "value" key since flow filters use propertyName instead
         entry.pop("value", None)
         # Remove defaultType — flow filters don't use it
@@ -752,11 +758,17 @@ def build_time_comparison(tc: TimeComparison) -> dict[str, str]:
     """
     value: str
     if tc.type == "relative":
-        # tc.unit is guaranteed non-None by TimeComparison.__post_init__
-        assert tc.unit is not None  # for mypy
+        # tc.unit guaranteed non-None by __post_init__ TC1
+        if tc.unit is None:  # pragma: no cover — guarded by TC1
+            raise AssertionError(
+                "unreachable: TC1 guarantees unit when type='relative'"
+            )
         value = tc.unit
     else:
-        # tc.date is guaranteed non-None by TimeComparison.__post_init__
-        assert tc.date is not None  # for mypy
+        # tc.date guaranteed non-None by __post_init__ TC2
+        if tc.date is None:  # pragma: no cover — guarded by TC2
+            raise AssertionError(
+                "unreachable: TC2 guarantees date when type='absolute-*'"
+            )
         value = tc.date
     return {"type": tc.type, "value": value}

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -194,7 +194,7 @@ def build_filter_section(
     """
     if where is None:
         return []
-    filters_list = where if isinstance(where, list) else [where]
+    filters_list = list(where) if isinstance(where, (list, tuple)) else [where]
     result: list[dict[str, Any]] = []
     for f in filters_list:
         if isinstance(f, FrequencyFilter):
@@ -285,7 +285,7 @@ def build_group_section(
     if group_by is None:
         return []
 
-    groups = group_by if isinstance(group_by, list) else [group_by]
+    groups = list(group_by) if isinstance(group_by, (list, tuple)) else [group_by]
     group_section: list[dict[str, Any]] = []
 
     for g in groups:

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -507,7 +507,10 @@ VALID_FREQUENCY_FILTER_OPERATORS: frozenset[str] = frozenset(
         "is greater than",
         "is less than",
         "is equal to",
-        "is between",
     }
 )
-"""Valid operators for frequency-based filters."""
+"""Valid operators for frequency-based filters.
+
+Note: ``"is between"`` excluded — ``FrequencyFilter.value`` is a single
+scalar and cannot represent the two-bound range that "between" requires.
+"""

--- a/src/mixpanel_data/_internal/bookmark_enums.py
+++ b/src/mixpanel_data/_internal/bookmark_enums.py
@@ -107,6 +107,7 @@ VALID_MATH_FUNNELS: frozenset[str] = frozenset(
         "p75",
         "p90",
         "p99",
+        "histogram",
     }
 )
 """Valid math types for funnel context.
@@ -138,6 +139,12 @@ MATH_REQUIRING_PROPERTY: frozenset[str] = frozenset(
         "custom_percentile",
         "percentile",
         "histogram",
+        # Advanced
+        "unique_values",
+        "most_frequent",
+        "first_value",
+        "multi_attribution",
+        "numeric_summary",
     }
 )
 """Math types that require a measurement property to be specified."""
@@ -287,6 +294,8 @@ VALID_FILTER_OPERATORS: frozenset[str] = frozenset(
         "equals",
         "does not equal",
         "is equal to",
+        "starts with",
+        "ends with",
         # Existence operators
         "is set",
         "is not set",
@@ -458,3 +467,47 @@ VALID_FLOWS_CONVERSION_WINDOW_UNITS: frozenset[str] = frozenset(
 Includes ``"session"`` for session-based counting
 (requires ``count_type="session"`` and ``conversion_window=1``).
 """
+
+# =============================================================================
+# Advanced Query Mode Constants
+# =============================================================================
+
+VALID_FUNNEL_REENTRY_MODES: frozenset[str] = frozenset(
+    {"default", "basic", "aggressive", "optimized"}
+)
+"""Valid funnel reentry modes for behavior.funnelReentryMode."""
+
+VALID_RETENTION_UNBOUNDED_MODES: frozenset[str] = frozenset(
+    {"none", "carry_back", "carry_forward", "consecutive_forward"}
+)
+"""Valid retention unbounded modes for behavior.retentionUnboundedMode."""
+
+VALID_SEGMENT_METHODS: frozenset[str] = frozenset({"all", "first"})
+"""Valid segment method values for measurement.segmentMethod."""
+
+VALID_TIME_COMPARISON_TYPES: frozenset[str] = frozenset(
+    {"relative", "absolute-start", "absolute-end"}
+)
+"""Valid time comparison type values for displayOptions.timeComparison."""
+
+VALID_TIME_COMPARISON_UNITS: frozenset[str] = frozenset(
+    {"day", "week", "month", "quarter", "year"}
+)
+"""Valid time comparison unit values for relative time comparisons."""
+
+VALID_COHORT_AGGREGATION_OPERATORS: frozenset[str] = frozenset(
+    {"total", "unique", "average", "min", "max", "median"}
+)
+"""Valid cohort aggregation operators for behavioral cohort conditions."""
+
+VALID_FREQUENCY_FILTER_OPERATORS: frozenset[str] = frozenset(
+    {
+        "is at least",
+        "is at most",
+        "is greater than",
+        "is less than",
+        "is equal to",
+        "is between",
+    }
+)
+"""Valid operators for frequency-based filters."""

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -1148,7 +1148,9 @@ _VALID_RETENTION_MATH_PUBLIC: frozenset[str] = frozenset(
 )
 """Public-facing retention math types (Layer 1).
 
-Matches ``VALID_MATH_RETENTION`` in bookmark_enums.py.
+Expanded in Phase 040 to include ``"total"`` and ``"average"`` — previously
+L1 incorrectly rejected these even though L2 (via ``VALID_MATH_RETENTION``
+in bookmark_enums.py) accepted them. Now L1 and L2 use the same set.
 """
 
 _VALID_RETENTION_MODES: frozenset[str] = frozenset({"curve", "trends", "table"})
@@ -1490,7 +1492,7 @@ def validate_flow_args(
     from_date: str | None = None,
     to_date: str | None = None,
     last: int = 30,
-    time_comparison: Any | None = None,
+    time_comparison: object | None = None,
     data_group_id: int | None = None,
 ) -> list[ValidationError]:
     """Validate flow query arguments before bookmark construction (Layer 1).

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -468,11 +468,14 @@ def _validate_data_group_id(
         List with one ``ValidationError`` if invalid, empty otherwise.
     """
     if data_group_id is not None:
-        if isinstance(data_group_id, bool):
+        if isinstance(data_group_id, bool) or not isinstance(data_group_id, int):
             return [
                 ValidationError(
                     path="data_group_id",
-                    message="data_group_id must be an integer, not a boolean",
+                    message=(
+                        f"data_group_id must be a positive integer, "
+                        f"got {type(data_group_id).__name__}"
+                    ),
                     code="DG1_INVALID_DATA_GROUP_ID",
                 )
             ]

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -259,7 +259,7 @@ def _scan_custom_properties(
 
     # Scan group_by
     if group_by is not None:
-        groups = group_by if isinstance(group_by, list) else [group_by]
+        groups = list(group_by) if isinstance(group_by, (list, tuple)) else [group_by]
         for i, g in enumerate(groups):
             if isinstance(g, GroupBy) and isinstance(
                 g.property, (CustomPropertyRef, InlineCustomProperty)
@@ -269,7 +269,7 @@ def _scan_custom_properties(
 
     # Scan where (filters) — skip FrequencyFilter instances (no _property)
     if where is not None:
-        filters = where if isinstance(where, list) else [where]
+        filters = list(where) if isinstance(where, (list, tuple)) else [where]
         for i, f in enumerate(filters):
             if isinstance(f, FrequencyFilter):
                 continue
@@ -467,16 +467,25 @@ def _validate_data_group_id(
     Returns:
         List with one ``ValidationError`` if invalid, empty otherwise.
     """
-    if data_group_id is not None and data_group_id <= 0:
-        return [
-            ValidationError(
-                path="data_group_id",
-                message=(
-                    f"data_group_id must be a positive integer (got {data_group_id})"
-                ),
-                code="DG1_INVALID_DATA_GROUP_ID",
-            )
-        ]
+    if data_group_id is not None:
+        if isinstance(data_group_id, bool):
+            return [
+                ValidationError(
+                    path="data_group_id",
+                    message="data_group_id must be an integer, not a boolean",
+                    code="DG1_INVALID_DATA_GROUP_ID",
+                )
+            ]
+        if data_group_id <= 0:
+            return [
+                ValidationError(
+                    path="data_group_id",
+                    message=(
+                        f"data_group_id must be a positive integer (got {data_group_id})"
+                    ),
+                    code="DG1_INVALID_DATA_GROUP_ID",
+                )
+            ]
     return []
 
 
@@ -666,7 +675,7 @@ def validate_group_by_args(
     if group_by is None:
         return errors
 
-    groups = group_by if isinstance(group_by, list) else [group_by]
+    groups = list(group_by) if isinstance(group_by, (list, tuple)) else [group_by]
     for i, g in enumerate(groups):
         if isinstance(g, GroupBy):
             gpath = f"group_by[{i}]" if len(groups) > 1 else "group_by"

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -272,6 +272,15 @@ def _scan_custom_properties(
         filters = list(where) if isinstance(where, (list, tuple)) else [where]
         for i, f in enumerate(filters):
             if isinstance(f, FrequencyFilter):
+                if f.event_filters:
+                    for fi, ef in enumerate(f.event_filters):
+                        if isinstance(
+                            ef._property, (CustomPropertyRef, InlineCustomProperty)
+                        ):
+                            fpath = f"where[{i}].event_filters[{fi}]"
+                            errors.extend(
+                                _validate_custom_property(ef._property, fpath)
+                            )
                 continue
             if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
                 fpath = f"where[{i}]" if len(filters) > 1 else "where"
@@ -1497,9 +1506,10 @@ def validate_flow_args(
 ) -> list[ValidationError]:
     """Validate flow query arguments before bookmark construction (Layer 1).
 
-    Implements flow-specific validation rules FL1-FL10 plus enum checks
-    and reused time validators. Returns all errors found so callers
-    can fix multiple issues in a single pass.
+    Implements flow-specific validation rules FL1-FL10, DG1
+    (data_group_id validation), time_comparison rejection, plus enum
+    checks and reused time validators. Returns all errors found so
+    callers can fix multiple issues in a single pass.
 
     Args:
         steps: List of event names that define the flow anchor points.

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -34,6 +34,7 @@ from mixpanel_data._internal.bookmark_enums import (
     VALID_FLOWS_CONVERSION_WINDOW_UNITS,
     VALID_FLOWS_COUNT_TYPES,
     VALID_FLOWS_MODES,
+    VALID_FUNNEL_REENTRY_MODES,
     VALID_MATH_FUNNELS,
     VALID_MATH_INSIGHTS,
     VALID_MATH_RETENTION,
@@ -42,6 +43,7 @@ from mixpanel_data._internal.bookmark_enums import (
     VALID_PROPERTY_TYPES,
     VALID_RESOURCE_TYPES,
     VALID_RETENTION_ALIGNMENT,
+    VALID_RETENTION_UNBOUNDED_MODES,
     VALID_RETENTION_UNITS,
     VALID_TIME_UNITS,
 )
@@ -69,6 +71,8 @@ from mixpanel_data.types import (
     Filter,
     FlowStep,
     Formula,
+    FrequencyBreakdown,
+    FrequencyFilter,
     FunnelStep,
     GroupBy,
     HoldingConstant,
@@ -211,9 +215,10 @@ def _scan_custom_properties(
     group_by: str
     | GroupBy
     | CohortBreakdown
-    | list[str | GroupBy | CohortBreakdown]
+    | FrequencyBreakdown
+    | Sequence[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
     | None = None,
-    where: Filter | list[Filter] | None = None,
+    where: Filter | FrequencyFilter | Sequence[Filter | FrequencyFilter] | None = None,
     events: Sequence[str | Metric | CohortMetric] | None = None,
     funnel_steps: Sequence[str | FunnelStep] | None = None,
     flow_steps: Sequence[FlowStep] | None = None,
@@ -262,10 +267,12 @@ def _scan_custom_properties(
                 gpath = f"group_by[{i}]" if len(groups) > 1 else "group_by"
                 errors.extend(_validate_custom_property(g.property, gpath))
 
-    # Scan where (filters)
+    # Scan where (filters) — skip FrequencyFilter instances (no _property)
     if where is not None:
         filters = where if isinstance(where, list) else [where]
         for i, f in enumerate(filters):
+            if isinstance(f, FrequencyFilter):
+                continue
             if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
                 fpath = f"where[{i}]" if len(filters) > 1 else "where"
                 errors.extend(_validate_custom_property(f._property, fpath))
@@ -442,8 +449,35 @@ def _enum_error(
 
 
 # =============================================================================
-# Reusable sub-validators (time, group-by)
+# Reusable sub-validators (data_group_id, time, group-by)
 # =============================================================================
+
+
+def _validate_data_group_id(
+    data_group_id: int | None,
+) -> list[ValidationError]:
+    """Validate data_group_id parameter if provided.
+
+    When ``data_group_id`` is not ``None``, it must be a positive
+    integer (> 0). Returns a list containing at most one error.
+
+    Args:
+        data_group_id: Data group ID to validate, or ``None``.
+
+    Returns:
+        List with one ``ValidationError`` if invalid, empty otherwise.
+    """
+    if data_group_id is not None and data_group_id <= 0:
+        return [
+            ValidationError(
+                path="data_group_id",
+                message=(
+                    f"data_group_id must be a positive integer (got {data_group_id})"
+                ),
+                code="DG1_INVALID_DATA_GROUP_ID",
+            )
+        ]
+    return []
 
 
 def validate_time_args(
@@ -590,7 +624,8 @@ def validate_group_by_args(
     group_by: str
     | GroupBy
     | CohortBreakdown
-    | list[str | GroupBy | CohortBreakdown]
+    | FrequencyBreakdown
+    | Sequence[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
     | None,
 ) -> list[ValidationError]:
     """Validate group-by arguments (rules V11-V12, V18, V24).
@@ -730,10 +765,12 @@ def validate_funnel_args(
     | CohortBreakdown
     | list[str | GroupBy | CohortBreakdown]
     | None,
+    reentry_mode: str | None = None,
+    data_group_id: int | None = None,
 ) -> list[ValidationError]:
     """Validate funnel query arguments before bookmark construction (Layer 1).
 
-    Implements funnel-specific validation rules F1-F11 plus reused
+    Implements funnel-specific validation rules F1-F12 plus reused
     time and group-by validators. Returns all errors found so callers
     can fix multiple issues in a single pass.
 
@@ -755,6 +792,11 @@ def validate_funnel_args(
         to_date: End date (YYYY-MM-DD) or ``None``.
         last: Number of days for relative date range.
         group_by: Breakdown specification.
+        reentry_mode: Funnel reentry mode. Must be one of:
+            default, basic, aggressive, optimized, or ``None``.
+            Default: ``None``.
+        data_group_id: Optional data group ID for group-level analytics.
+            Must be a positive integer if provided. Default: ``None``.
 
     Returns:
         List of validation errors. Empty list means all arguments are valid.
@@ -776,6 +818,9 @@ def validate_funnel_args(
         ```
     """
     errors: list[ValidationError] = []
+
+    # DG1: data_group_id must be positive if provided
+    errors.extend(_validate_data_group_id(data_group_id))
 
     # F1: At least 2 steps required
     if len(steps) < 2:
@@ -1064,6 +1109,21 @@ def validate_funnel_args(
     # CP1-CP6: Custom property validation (group_by and per-step filters)
     errors.extend(_scan_custom_properties(group_by=group_by, funnel_steps=steps))
 
+    # F12: reentry_mode validation
+    if reentry_mode is not None and reentry_mode not in VALID_FUNNEL_REENTRY_MODES:
+        suggestion = _suggest(reentry_mode, VALID_FUNNEL_REENTRY_MODES)
+        errors.append(
+            ValidationError(
+                path="reentry_mode",
+                message=(
+                    f"Invalid reentry_mode '{reentry_mode}'; "
+                    f"valid values: {sorted(VALID_FUNNEL_REENTRY_MODES)}"
+                ),
+                code="F12_INVALID_REENTRY_MODE",
+                suggestion=suggestion,
+            )
+        )
+
     return errors
 
 
@@ -1071,11 +1131,12 @@ def validate_funnel_args(
 # Retention argument validation (R1-R12)
 # =============================================================================
 
-_VALID_RETENTION_MATH_PUBLIC: frozenset[str] = frozenset({"retention_rate", "unique"})
+_VALID_RETENTION_MATH_PUBLIC: frozenset[str] = frozenset(
+    {"retention_rate", "unique", "total", "average"}
+)
 """Public-facing retention math types (Layer 1).
 
-The L2 validator uses ``VALID_MATH_RETENTION`` which also includes
-``"total"`` and ``"average"`` for internal bookmark params.
+Matches ``VALID_MATH_RETENTION`` in bookmark_enums.py.
 """
 
 _VALID_RETENTION_MODES: frozenset[str] = frozenset({"curve", "trends", "table"})
@@ -1103,10 +1164,12 @@ def validate_retention_args(
     | CohortBreakdown
     | list[str | GroupBy | CohortBreakdown]
     | None = None,
+    unbounded_mode: str | None = None,
+    data_group_id: int | None = None,
 ) -> list[ValidationError]:
     """Validate retention query arguments before bookmark construction (Layer 1).
 
-    Implements retention-specific validation rules R1-R12 plus reused
+    Implements retention-specific validation rules R1-R13 plus reused
     time and group-by validators. Returns all errors found so callers
     can fix multiple issues in a single pass.
 
@@ -1129,6 +1192,11 @@ def validate_retention_args(
         to_date: End date (YYYY-MM-DD) or ``None``.
         last: Number of days for relative date range.
         group_by: Breakdown specification.
+        unbounded_mode: Retention unbounded mode. Must be one of:
+            none, carry_back, carry_forward, consecutive_forward,
+            or ``None``. Default: ``None``.
+        data_group_id: Optional data group ID for group-level analytics.
+            Must be a positive integer if provided. Default: ``None``.
 
     Returns:
         List of validation errors. Empty list means all arguments are valid.
@@ -1145,6 +1213,9 @@ def validate_retention_args(
         ```
     """
     errors: list[ValidationError] = []
+
+    # DG1: data_group_id must be positive if provided
+    errors.extend(_validate_data_group_id(data_group_id))
 
     # R1: born_event must be non-empty string
     if not born_event.strip():
@@ -1355,6 +1426,24 @@ def validate_retention_args(
     # CP1-CP6: Custom property validation
     errors.extend(_scan_custom_properties(group_by=group_by))
 
+    # R13: unbounded_mode validation
+    if (
+        unbounded_mode is not None
+        and unbounded_mode not in VALID_RETENTION_UNBOUNDED_MODES
+    ):
+        suggestion = _suggest(unbounded_mode, VALID_RETENTION_UNBOUNDED_MODES)
+        errors.append(
+            ValidationError(
+                path="unbounded_mode",
+                message=(
+                    f"Invalid unbounded_mode '{unbounded_mode}'; "
+                    f"valid values: {sorted(VALID_RETENTION_UNBOUNDED_MODES)}"
+                ),
+                code="R13_INVALID_UNBOUNDED_MODE",
+                suggestion=suggestion,
+            )
+        )
+
     return errors
 
 
@@ -1389,6 +1478,8 @@ def validate_flow_args(
     from_date: str | None = None,
     to_date: str | None = None,
     last: int = 30,
+    time_comparison: Any | None = None,
+    data_group_id: int | None = None,
 ) -> list[ValidationError]:
     """Validate flow query arguments before bookmark construction (Layer 1).
 
@@ -1416,6 +1507,11 @@ def validate_flow_args(
         from_date: Start date (YYYY-MM-DD) or ``None``.
         to_date: End date (YYYY-MM-DD) or ``None``.
         last: Number of days for relative date range. Default: ``30``.
+        time_comparison: Time comparison object. Must be ``None`` for
+            flows — flows do not support period-over-period comparison.
+            Default: ``None``.
+        data_group_id: Optional data group ID for group-level analytics.
+            Must be a positive integer if provided. Default: ``None``.
 
     Returns:
         List of validation errors. Empty list means all arguments are valid.
@@ -1433,6 +1529,22 @@ def validate_flow_args(
         ```
     """
     errors: list[ValidationError] = []
+
+    # DG1: data_group_id must be positive if provided
+    errors.extend(_validate_data_group_id(data_group_id))
+
+    # Flows do not support time comparison
+    if time_comparison is not None:
+        errors.append(
+            ValidationError(
+                path="time_comparison",
+                message=(
+                    "Flows do not support time comparison; "
+                    "remove the time_comparison parameter"
+                ),
+                code="FL_TIME_COMPARISON_NOT_SUPPORTED",
+            )
+        )
 
     # FL1: steps must be non-empty
     if len(steps) == 0:
@@ -1755,9 +1867,11 @@ def validate_query_args(
     group_by: str
     | GroupBy
     | CohortBreakdown
-    | list[str | GroupBy | CohortBreakdown]
+    | FrequencyBreakdown
+    | Sequence[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
     | None,
     formulas: Sequence[Any] | None = None,
+    data_group_id: int | None = None,
 ) -> list[ValidationError]:
     """Validate query arguments before bookmark construction (Layer 1).
 
@@ -1779,11 +1893,16 @@ def validate_query_args(
         cumulative: Cumulative analysis mode.
         group_by: Breakdown specification.
         formulas: Resolved Formula objects (for expression validation).
+        data_group_id: Optional data group ID for group-level analytics.
+            Must be a positive integer if provided. Default: ``None``.
 
     Returns:
         List of validation errors. Empty list means all arguments are valid.
     """
     errors: list[ValidationError] = []
+
+    # DG1: data_group_id must be positive if provided
+    errors.extend(_validate_data_group_id(data_group_id))
 
     # V0: At least one event required
     if not events:

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -422,6 +422,33 @@ FlowSessionEvent = Literal["start", "end"]
 +--------+----------------------------------------------+
 """
 
+FrequencyFilterOperator = Literal[
+    "is at least",
+    "is at most",
+    "is greater than",
+    "is less than",
+    "is equal to",
+    "is between",
+]
+"""Comparison operator for frequency filters.
+
++------------------+----------------------------------------------+
+| Value            | Meaning                                      |
++==================+==============================================+
+| is at least      | Count >= threshold (default)                 |
++------------------+----------------------------------------------+
+| is at most       | Count <= threshold                           |
++------------------+----------------------------------------------+
+| is greater than  | Count > threshold                            |
++------------------+----------------------------------------------+
+| is less than     | Count < threshold                            |
++------------------+----------------------------------------------+
+| is equal to      | Count == threshold                           |
++------------------+----------------------------------------------+
+| is between       | Count in [low, high] range                   |
++------------------+----------------------------------------------+
+"""
+
 # =============================================================================
 # Flow Types
 # =============================================================================
@@ -533,6 +560,7 @@ __all__ = [
     "TimeComparisonUnit",
     "CohortAggregationType",
     "FlowSessionEvent",
+    "FrequencyFilterOperator",
     # Flow types
     "FlowChartType",
     "FlowConversionWindowUnit",

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -544,12 +544,4 @@ __all__ = [
     "FilterPropertyType",
     "FilterDateUnit",
     "FiltersCombinator",
-    # Advanced query types
-    "SegmentMethod",
-    "FunnelReentryMode",
-    "RetentionUnboundedMode",
-    "TimeComparisonType",
-    "TimeComparisonUnit",
-    "CohortAggregationType",
-    "FlowSessionEvent",
 ]

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -428,7 +428,6 @@ FrequencyFilterOperator = Literal[
     "is greater than",
     "is less than",
     "is equal to",
-    "is between",
 ]
 """Comparison operator for frequency filters.
 
@@ -445,8 +444,10 @@ FrequencyFilterOperator = Literal[
 +------------------+----------------------------------------------+
 | is equal to      | Count == threshold                           |
 +------------------+----------------------------------------------+
-| is between       | Count in [low, high] range                   |
-+------------------+----------------------------------------------+
+
+Note: ``"is between"`` is excluded because ``FrequencyFilter.value``
+is typed as ``int | float`` (single scalar) and cannot represent
+the two-bound range that "between" requires.
 """
 
 # =============================================================================

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -59,42 +59,63 @@ MathType = Literal[
     "p99",
     "percentile",
     "histogram",
+    "cumulative_unique",
+    "sessions",
+    "unique_values",
+    "most_frequent",
+    "first_value",
+    "multi_attribution",
+    "numeric_summary",
 ]
 """Aggregation function for query metrics.
 
-+-----------+------------------------------------------------------------------+--------------------+
-| Value     | Meaning                                                          | Requires property? |
-+===========+==================================================================+====================+
-| total     | Count events, or sum a numeric property if ``property`` is set   | Optional           |
-+-----------+------------------------------------------------------------------+--------------------+
-| unique    | Count distinct users                                             | No                 |
-+-----------+------------------------------------------------------------------+--------------------+
-| dau       | Daily Active Users (unique users per day)                        | No                 |
-+-----------+------------------------------------------------------------------+--------------------+
-| wau       | Weekly Active Users (unique users per 7-day window)              | No                 |
-+-----------+------------------------------------------------------------------+--------------------+
-| mau       | Monthly Active Users (unique users per 28-day window)            | No                 |
-+-----------+------------------------------------------------------------------+--------------------+
-| average   | Mean of a numeric property's values                              | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| median    | Median (50th percentile) of a numeric property                   | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| min       | Minimum value of a numeric property                              | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| max       | Maximum value of a numeric property                              | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| p25       | 25th percentile of a numeric property                            | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| p75       | 75th percentile of a numeric property                            | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| p90       | 90th percentile of a numeric property                            | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| p99       | 99th percentile of a numeric property                            | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| percentile| Custom percentile (requires ``percentile_value``)                | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
-| histogram | Distribution of a numeric property's values                      | Yes                |
-+-----------+------------------------------------------------------------------+--------------------+
++-------------------+------------------------------------------------------------------+--------------------+
+| Value             | Meaning                                                          | Requires property? |
++===================+==================================================================+====================+
+| total             | Count events, or sum a numeric property if ``property`` is set   | Optional           |
++-------------------+------------------------------------------------------------------+--------------------+
+| unique            | Count distinct users                                             | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| dau               | Daily Active Users (unique users per day)                        | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| wau               | Weekly Active Users (unique users per 7-day window)              | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| mau               | Monthly Active Users (unique users per 28-day window)            | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| average           | Mean of a numeric property's values                              | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| median            | Median (50th percentile) of a numeric property                   | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| min               | Minimum value of a numeric property                              | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| max               | Maximum value of a numeric property                              | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| p25               | 25th percentile of a numeric property                            | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| p75               | 75th percentile of a numeric property                            | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| p90               | 90th percentile of a numeric property                            | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| p99               | 99th percentile of a numeric property                            | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| percentile        | Custom percentile (requires ``percentile_value``)                | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| histogram         | Distribution of a numeric property's values                      | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| cumulative_unique | Running count of distinct users over time                        | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| sessions          | Count sessions (not events or users)                             | No                 |
++-------------------+------------------------------------------------------------------+--------------------+
+| unique_values     | Count of distinct values of a property                           | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| most_frequent     | Most commonly occurring value of a property                      | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| first_value       | First observed value of a property per user                      | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| multi_attribution | Multi-touch attribution across a property                        | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
+| numeric_summary   | Summary stats (count, mean, variance) of a property              | Yes                |
++-------------------+------------------------------------------------------------------+--------------------+
 
 Note: Mixpanel has no ``"sum"`` math type. Use ``math="total"`` with
 a ``property`` to sum a numeric property's values.
@@ -147,40 +168,43 @@ FunnelMathType = Literal[
     "p75",
     "p90",
     "p99",
+    "histogram",
 ]
 """Aggregation function for funnel query metrics.
 
-+---------------------------+------------------------------------------------------+
-| Value                     | Meaning                                              |
-+===========================+======================================================+
-| conversion_rate_unique    | Unique-user conversion rate (default)                |
-+---------------------------+------------------------------------------------------+
-| conversion_rate_total     | Total-event conversion rate                          |
-+---------------------------+------------------------------------------------------+
-| conversion_rate_session   | Session-based conversion rate                        |
-+---------------------------+------------------------------------------------------+
-| unique                    | Raw count of unique users per step                   |
-+---------------------------+------------------------------------------------------+
-| total                     | Raw total event count per step                       |
-+---------------------------+------------------------------------------------------+
-| average                   | Mean of a numeric property per step                  |
-+---------------------------+------------------------------------------------------+
-| median                    | Median of a numeric property per step                |
-+---------------------------+------------------------------------------------------+
-| min                       | Minimum of a numeric property per step               |
-+---------------------------+------------------------------------------------------+
-| max                       | Maximum of a numeric property per step               |
-+---------------------------+------------------------------------------------------+
-| p25                       | 25th percentile of a numeric property per step       |
-+---------------------------+------------------------------------------------------+
-| p75                       | 75th percentile of a numeric property per step       |
-+---------------------------+------------------------------------------------------+
-| p90                       | 90th percentile of a numeric property per step       |
-+---------------------------+------------------------------------------------------+
-| p99                       | 99th percentile of a numeric property per step       |
-+---------------------------+------------------------------------------------------+
++---------------------------+------------------------------------------------------+--------------------+
+| Value                     | Meaning                                              | Requires property? |
++===========================+======================================================+====================+
+| conversion_rate_unique    | Unique-user conversion rate (default)                | No                 |
++---------------------------+------------------------------------------------------+--------------------+
+| conversion_rate_total     | Total-event conversion rate                          | No                 |
++---------------------------+------------------------------------------------------+--------------------+
+| conversion_rate_session   | Session-based conversion rate                        | No                 |
++---------------------------+------------------------------------------------------+--------------------+
+| unique                    | Raw count of unique users per step                   | No                 |
++---------------------------+------------------------------------------------------+--------------------+
+| total                     | Raw total event count per step                       | No                 |
++---------------------------+------------------------------------------------------+--------------------+
+| average                   | Mean of a numeric property per step                  | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| median                    | Median of a numeric property per step                | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| min                       | Minimum of a numeric property per step               | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| max                       | Maximum of a numeric property per step               | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| p25                       | 25th percentile of a numeric property per step       | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| p75                       | 75th percentile of a numeric property per step       | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| p90                       | 90th percentile of a numeric property per step       | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| p99                       | 99th percentile of a numeric property per step       | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
+| histogram                 | Distribution of a numeric property per step          | Yes                |
++---------------------------+------------------------------------------------------+--------------------+
 
-These 13 values are the public-facing funnel math types. The Mixpanel API
+These 14 values are the public-facing funnel math types. The Mixpanel API
 also accepts internal aliases (``"general"``, ``"session"``,
 ``"conversion_rate"``) but those are not exposed in the public API.
 """
@@ -266,7 +290,7 @@ RetentionMode = Literal["curve", "trends", "table"]
 +--------+----------------------------------------------+
 """
 
-RetentionMathType = Literal["retention_rate", "unique"]
+RetentionMathType = Literal["retention_rate", "unique", "total", "average"]
 """Aggregation function for retention query metrics.
 
 +----------------+----------------------------------------------+
@@ -276,8 +300,126 @@ RetentionMathType = Literal["retention_rate", "unique"]
 +----------------+----------------------------------------------+
 | unique         | Raw count of retained users                  |
 +----------------+----------------------------------------------+
+| total          | Total event count per retention bucket       |
++----------------+----------------------------------------------+
+| average        | Average of a numeric property per bucket     |
++----------------+----------------------------------------------+
 
 Maps directly to the ``measurement.math`` field in bookmark JSON.
+"""
+
+# =============================================================================
+# Advanced Query Types
+# =============================================================================
+
+SegmentMethod = Literal["all", "first"]
+"""Method for counting qualifying events in segmentation.
+
++--------+------------------------------------------------------+
+| Value  | Meaning                                              |
++========+======================================================+
+| all    | Count all qualifying events (default)                |
++--------+------------------------------------------------------+
+| first  | Count only the first qualifying event per user       |
++--------+------------------------------------------------------+
+"""
+
+FunnelReentryMode = Literal["default", "basic", "aggressive", "optimized"]
+"""Re-entry mode for funnel queries.
+
++------------+------------------------------------------------------+
+| Value      | Meaning                                              |
++============+======================================================+
+| default    | Server default behavior                              |
++------------+------------------------------------------------------+
+| basic      | Users re-enter at steps after first                  |
++------------+------------------------------------------------------+
+| aggressive | Each re-entry generates additional conversion        |
++------------+------------------------------------------------------+
+| optimized  | Optimized re-entry counting                          |
++------------+------------------------------------------------------+
+"""
+
+RetentionUnboundedMode = Literal[
+    "none", "carry_back", "carry_forward", "consecutive_forward"
+]
+"""Unbounded retention mode for retention queries.
+
++----------------------+------------------------------------------------------+
+| Value                | Meaning                                              |
++======================+======================================================+
+| none                 | No unbounded retention (default)                     |
++----------------------+------------------------------------------------------+
+| carry_back           | Count users in all prior buckets                     |
++----------------------+------------------------------------------------------+
+| carry_forward        | Count users in all subsequent buckets                |
++----------------------+------------------------------------------------------+
+| consecutive_forward  | Count users in consecutive subsequent buckets        |
++----------------------+------------------------------------------------------+
+"""
+
+TimeComparisonType = Literal["relative", "absolute-start", "absolute-end"]
+"""Type of time comparison for query results.
+
++----------------+------------------------------------------------------+
+| Value          | Meaning                                              |
++================+======================================================+
+| relative       | Compare against previous period of same length       |
++----------------+------------------------------------------------------+
+| absolute-start | Compare against period starting from a specific date |
++----------------+------------------------------------------------------+
+| absolute-end   | Compare against period ending at a specific date     |
++----------------+------------------------------------------------------+
+"""
+
+TimeComparisonUnit = Literal["day", "week", "month", "quarter", "year"]
+"""Time unit for period-over-period comparisons.
+
++---------+----------------------------------------------+
+| Value   | Meaning                                      |
++=========+==============================================+
+| day     | Compare against previous day                 |
++---------+----------------------------------------------+
+| week    | Compare against previous week                |
++---------+----------------------------------------------+
+| month   | Compare against previous month               |
++---------+----------------------------------------------+
+| quarter | Compare against previous quarter             |
++---------+----------------------------------------------+
+| year    | Compare against previous year                |
++---------+----------------------------------------------+
+"""
+
+CohortAggregationType = Literal["total", "unique", "average", "min", "max", "median"]
+"""Aggregation type for cohort behavior criteria.
+
++---------+----------------------------------------------+
+| Value   | Meaning                                      |
++=========+==============================================+
+| total   | Sum of property values                       |
++---------+----------------------------------------------+
+| unique  | Count of distinct property values            |
++---------+----------------------------------------------+
+| average | Mean of property values                      |
++---------+----------------------------------------------+
+| min     | Minimum property value                       |
++---------+----------------------------------------------+
+| max     | Maximum property value                       |
++---------+----------------------------------------------+
+| median  | Median property value                        |
++---------+----------------------------------------------+
+"""
+
+FlowSessionEvent = Literal["start", "end"]
+"""Session anchor event type for flow queries.
+
++--------+----------------------------------------------+
+| Value  | Meaning                                      |
++========+==============================================+
+| start  | Session start anchor ($session_start)        |
++--------+----------------------------------------------+
+| end    | Session end anchor ($session_end)            |
++--------+----------------------------------------------+
 """
 
 # =============================================================================
@@ -383,6 +525,14 @@ __all__ = [
     "RetentionAlignment",
     "RetentionMode",
     "RetentionMathType",
+    # Advanced query types
+    "SegmentMethod",
+    "FunnelReentryMode",
+    "RetentionUnboundedMode",
+    "TimeComparisonType",
+    "TimeComparisonUnit",
+    "CohortAggregationType",
+    "FlowSessionEvent",
     # Flow types
     "FlowChartType",
     "FlowConversionWindowUnit",
@@ -394,4 +544,12 @@ __all__ = [
     "FilterPropertyType",
     "FilterDateUnit",
     "FiltersCombinator",
+    # Advanced query types
+    "SegmentMethod",
+    "FunnelReentryMode",
+    "RetentionUnboundedMode",
+    "TimeComparisonType",
+    "TimeComparisonUnit",
+    "CohortAggregationType",
+    "FlowSessionEvent",
 ]

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -38,6 +38,9 @@ from mixpanel_data._literal_types import FlowChartType as FlowChartType
 from mixpanel_data._literal_types import (
     FlowConversionWindowUnit as FlowConversionWindowUnit,
 )
+from mixpanel_data._literal_types import (
+    FrequencyFilterOperator as FrequencyFilterOperator,
+)
 from mixpanel_data._literal_types import FunnelMathType as FunnelMathType
 from mixpanel_data._literal_types import FunnelMode as FunnelMode
 from mixpanel_data._literal_types import FunnelOrder as FunnelOrder
@@ -7504,7 +7507,7 @@ class Filter:
     _date_unit: FilterDateUnit | None = None
     """Time unit for relative date filters (hour, day, week, month).
 
-    Set by ``in_the_last()`` and ``not_in_the_last()`` factory methods.
+    Set by ``in_the_last()``, ``not_in_the_last()``, and ``in_the_next()`` factory methods.
     Maps to ``filterDateUnit`` in bookmark JSON. ``None`` for non-date
     and absolute date filters.
     """
@@ -8693,6 +8696,9 @@ class CohortCriteria:
                 "aggregation and aggregation_property must both be set or both be None"
             )
 
+        if aggregation_property is not None and not aggregation_property.strip():
+            raise ValueError("aggregation_property must be a non-empty string")
+
         # CD1: Exactly one frequency param required
         freq_params = {
             "at_least": at_least,
@@ -9494,7 +9500,7 @@ class FrequencyFilter:
     value: int | float
     """Threshold value for the comparison."""
 
-    operator: str = "is at least"
+    operator: FrequencyFilterOperator = "is at least"
     """Comparison operator."""
 
     date_range_value: int | None = None

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7227,12 +7227,21 @@ class TimeComparison:
                     f"TimeComparison type={self.type!r} does not accept unit; "
                     f"unit is only valid for type='relative'"
                 )
-            # TC3: date must match YYYY-MM-DD format
+            # TC3: date must be a valid YYYY-MM-DD calendar date
             if not _DATE_RE.match(self.date):
                 raise ValueError(
                     f"TimeComparison date must be in YYYY-MM-DD format, "
                     f"got {self.date!r}"
                 )
+            # TC3b: verify it's a real calendar date (e.g. reject 2026-02-30)
+            try:
+                import datetime
+
+                datetime.date.fromisoformat(self.date)
+            except ValueError:
+                raise ValueError(
+                    f"TimeComparison date is not a valid calendar date: {self.date!r}"
+                ) from None
 
     @classmethod
     def relative(cls, unit: TimeComparisonUnit) -> TimeComparison:

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -26,11 +26,14 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypedDict, TypeVar
 
+from mixpanel_data._literal_types import (
+    CohortAggregationType as CohortAggregationType,
+)
 from mixpanel_data._literal_types import ConversionWindowUnit as ConversionWindowUnit
 from mixpanel_data._literal_types import FilterDateUnit as FilterDateUnit
 from mixpanel_data._literal_types import FilterPropertyType as FilterPropertyType
 from mixpanel_data._literal_types import FiltersCombinator as FiltersCombinator
-from mixpanel_data._literal_types import FlowAnchorType, FlowNodeType
+from mixpanel_data._literal_types import FlowAnchorType, FlowNodeType, FlowSessionEvent
 from mixpanel_data._literal_types import FlowChartType as FlowChartType
 from mixpanel_data._literal_types import (
     FlowConversionWindowUnit as FlowConversionWindowUnit,
@@ -44,6 +47,9 @@ from mixpanel_data._literal_types import PerUserAggregation as PerUserAggregatio
 from mixpanel_data._literal_types import RetentionAlignment as RetentionAlignment
 from mixpanel_data._literal_types import RetentionMathType as RetentionMathType
 from mixpanel_data._literal_types import RetentionMode as RetentionMode
+from mixpanel_data._literal_types import SegmentMethod as SegmentMethod
+from mixpanel_data._literal_types import TimeComparisonType as TimeComparisonType
+from mixpanel_data._literal_types import TimeComparisonUnit as TimeComparisonUnit
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -7127,6 +7133,181 @@ Accepted wherever a property can be specified: ``Metric.property``,
 # Query API Types (Phase 029)
 # =============================================================================
 
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+"""Regex for YYYY-MM-DD date format validation."""
+
+
+@dataclass(frozen=True)
+class TimeComparison:
+    """Overlay a comparison time period on insights, funnel, or retention queries.
+
+    Enables period-over-period analysis by specifying how the comparison
+    window is determined. Three modes are supported:
+
+    - **relative**: Compare against a prior period offset by ``unit``
+      (e.g. previous month, previous week).
+    - **absolute-start**: Compare against a window starting on a fixed
+      date (``date``), running the same duration as the primary range.
+    - **absolute-end**: Compare against a window ending on a fixed date.
+
+    Use the factory class methods rather than constructing directly:
+
+    - ``TimeComparison.relative(unit)``
+    - ``TimeComparison.absolute_start(date)``
+    - ``TimeComparison.absolute_end(date)``
+
+    Attributes:
+        type: Discriminant — ``"relative"``, ``"absolute-start"``, or
+            ``"absolute-end"``.
+        unit: Time unit for relative comparison. Required when
+            ``type="relative"``, must be ``None`` otherwise.
+        date: ISO date (YYYY-MM-DD) for absolute comparison. Required
+            when ``type`` is ``"absolute-start"`` or ``"absolute-end"``,
+            must be ``None`` otherwise.
+
+    Raises:
+        ValueError: If validation rules TC1-TC3 are violated during
+            construction.
+
+    Example:
+        ```python
+        from mixpanel_data.types import TimeComparison
+
+        # Compare against previous month
+        tc = TimeComparison.relative("month")
+
+        # Compare against window starting on a fixed date
+        tc = TimeComparison.absolute_start("2026-01-01")
+
+        # Compare against window ending on a fixed date
+        tc = TimeComparison.absolute_end("2026-12-31")
+        ```
+    """
+
+    type: TimeComparisonType
+    """Discriminant — ``"relative"``, ``"absolute-start"``, or ``"absolute-end"``."""
+
+    unit: TimeComparisonUnit | None = None
+    """Time unit for relative comparison (day, week, month, quarter, year)."""
+
+    date: str | None = None
+    """ISO date (YYYY-MM-DD) for absolute comparison."""
+
+    def __post_init__(self) -> None:
+        """Validate construction arguments (rules TC1-TC3).
+
+        Raises:
+            ValueError: If type="relative" and unit is None (TC1),
+                or type="relative" and date is set (TC1),
+                or type is absolute and date is None (TC2),
+                or type is absolute and unit is set (TC2),
+                or date does not match YYYY-MM-DD format (TC3).
+        """
+        if self.type == "relative":
+            # TC1: relative requires unit, rejects date
+            if self.unit is None:
+                raise ValueError(
+                    "TimeComparison type='relative' requires unit to be set "
+                    "(e.g., TimeComparison.relative('month'))"
+                )
+            if self.date is not None:
+                raise ValueError(
+                    "TimeComparison type='relative' does not accept date; "
+                    "use absolute-start or absolute-end for date-based comparison"
+                )
+        else:
+            # TC2: absolute-start / absolute-end requires date, rejects unit
+            if self.date is None:
+                raise ValueError(
+                    f"TimeComparison type={self.type!r} requires date to be set "
+                    f"(e.g., TimeComparison.absolute_start('2026-01-01'))"
+                )
+            if self.unit is not None:
+                raise ValueError(
+                    f"TimeComparison type={self.type!r} does not accept unit; "
+                    f"unit is only valid for type='relative'"
+                )
+            # TC3: date must match YYYY-MM-DD format
+            if not _DATE_RE.match(self.date):
+                raise ValueError(
+                    f"TimeComparison date must be in YYYY-MM-DD format, "
+                    f"got {self.date!r}"
+                )
+
+    @classmethod
+    def relative(cls, unit: TimeComparisonUnit) -> TimeComparison:
+        """Create a relative time comparison.
+
+        Compares against a prior period offset by the given unit
+        (e.g. previous month, previous week).
+
+        Args:
+            unit: Time unit for the comparison offset. One of
+                ``"day"``, ``"week"``, ``"month"``, ``"quarter"``,
+                ``"year"``.
+
+        Returns:
+            A ``TimeComparison`` with ``type="relative"`` and the
+            specified ``unit``.
+
+        Example:
+            ```python
+            tc = TimeComparison.relative("month")
+            # type="relative", unit="month", date=None
+            ```
+        """
+        return cls(type="relative", unit=unit)
+
+    @classmethod
+    def absolute_start(cls, date: str) -> TimeComparison:
+        """Create an absolute-start time comparison.
+
+        Compares against a window that starts on the given date,
+        running the same duration as the primary query range.
+
+        Args:
+            date: Start date in YYYY-MM-DD format.
+
+        Returns:
+            A ``TimeComparison`` with ``type="absolute-start"`` and
+            the specified ``date``.
+
+        Raises:
+            ValueError: If date is not in YYYY-MM-DD format (TC3).
+
+        Example:
+            ```python
+            tc = TimeComparison.absolute_start("2026-01-01")
+            # type="absolute-start", unit=None, date="2026-01-01"
+            ```
+        """
+        return cls(type="absolute-start", date=date)
+
+    @classmethod
+    def absolute_end(cls, date: str) -> TimeComparison:
+        """Create an absolute-end time comparison.
+
+        Compares against a window that ends on the given date,
+        running the same duration as the primary query range.
+
+        Args:
+            date: End date in YYYY-MM-DD format.
+
+        Returns:
+            A ``TimeComparison`` with ``type="absolute-end"`` and
+            the specified ``date``.
+
+        Raises:
+            ValueError: If date is not in YYYY-MM-DD format (TC3).
+
+        Example:
+            ```python
+            tc = TimeComparison.absolute_end("2026-12-31")
+            # type="absolute-end", unit=None, date="2026-12-31"
+            ```
+        """
+        return cls(type="absolute-end", date=date)
+
 
 @dataclass(frozen=True)
 class Metric:
@@ -7184,6 +7365,16 @@ class Metric:
 
     filters_combinator: FiltersCombinator = "all"
     """How per-metric filters combine (``"all"`` = AND, ``"any"`` = OR)."""
+
+    segment_method: SegmentMethod | None = None
+    """Segment method for counting qualifying events.
+
+    Controls how events are counted per user: ``"all"`` counts every
+    qualifying event (default server behavior), ``"first"`` counts
+    only the first qualifying event per user.
+
+    Maps to ``segmentMethod`` in the bookmark measurement block.
+    """
 
     def __post_init__(self) -> None:
         """Validate construction arguments.
@@ -7496,6 +7687,101 @@ class Filter:
         )
 
     @classmethod
+    def not_between(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        min_val: int | float,
+        max_val: int | float,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a not-between (exclusive range) filter.
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            min_val: Minimum value (exclusive).
+            max_val: Maximum value (exclusive).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for numeric values outside the range.
+
+        Example:
+            ```python
+            f = Filter.not_between("age", 18, 65)
+            ```
+        """
+        return cls(
+            _property=property,
+            _operator="not between",
+            _value=[min_val, max_val],
+            _property_type="number",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def at_least(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        value: int | float,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a greater-than-or-equal filter.
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            value: Numeric threshold (inclusive).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for numeric greater-than-or-equal.
+
+        Example:
+            ```python
+            f = Filter.at_least("score", 80)
+            ```
+        """
+        return cls(
+            _property=property,
+            _operator="is at least",
+            _value=value,
+            _property_type="number",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def at_most(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        value: int | float,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a less-than-or-equal filter.
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            value: Numeric threshold (inclusive).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for numeric less-than-or-equal.
+
+        Example:
+            ```python
+            f = Filter.at_most("errors", 5)
+            ```
+        """
+        return cls(
+            _property=property,
+            _operator="is at most",
+            _value=value,
+            _property_type="number",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
     def is_set(
         cls,
         property: str | CustomPropertyRef | InlineCustomProperty,
@@ -7539,6 +7825,68 @@ class Filter:
             _property=property,
             _operator="is not set",
             _value=None,
+            _property_type="string",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def starts_with(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        prefix: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a starts-with (prefix match) filter.
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            prefix: String prefix to match.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for string prefix matching.
+
+        Example:
+            ```python
+            f = Filter.starts_with("url", "https://")
+            ```
+        """
+        return cls(
+            _property=property,
+            _operator="starts with",
+            _value=prefix,
+            _property_type="string",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def ends_with(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        suffix: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create an ends-with (suffix match) filter.
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            suffix: String suffix to match.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for string suffix matching.
+
+        Example:
+            ```python
+            f = Filter.ends_with("email", "@example.com")
+            ```
+        """
+        return cls(
+            _property=property,
+            _operator="ends with",
+            _value=suffix,
             _property_type="string",
             _resource_type=resource_type,
         )
@@ -7958,6 +8306,89 @@ class Filter:
             _resource_type=resource_type,
         )
 
+    @classmethod
+    def date_not_between(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        from_date: str,
+        to_date: str,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a date exclusion range filter (not between two dates).
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            from_date: Start date in YYYY-MM-DD format.
+            to_date: End date in YYYY-MM-DD format.
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for dates outside the range.
+
+        Raises:
+            ValueError: If dates are not valid YYYY-MM-DD or
+                from_date is after to_date.
+
+        Example:
+            ```python
+            f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+            ```
+        """
+        from_parsed = cls._validate_date(from_date)
+        to_parsed = cls._validate_date(to_date)
+        if from_parsed > to_parsed:
+            raise ValueError(
+                f"from_date must be before to_date (got '{from_date}' > '{to_date}')"
+            )
+        return cls(
+            _property=property,
+            _operator="was not between",
+            _value=[from_date, to_date],
+            _property_type="datetime",
+            _resource_type=resource_type,
+        )
+
+    @classmethod
+    def in_the_next(
+        cls,
+        property: str | CustomPropertyRef | InlineCustomProperty,
+        quantity: int,
+        date_unit: FilterDateUnit,
+        *,
+        resource_type: Literal["events", "people"] = "events",
+    ) -> Filter:
+        """Create a relative date filter (in the next N units).
+
+        Args:
+            property: Property name, CustomPropertyRef, or InlineCustomProperty.
+            quantity: Number of time units (must be positive).
+            date_unit: Time unit (``"hour"``, ``"day"``, ``"week"``,
+                ``"month"``).
+            resource_type: Resource type. Default: ``"events"``.
+
+        Returns:
+            Filter for events within the next N units.
+
+        Raises:
+            ValueError: If quantity is not positive.
+
+        Example:
+            ```python
+            f = Filter.in_the_next("expires", 7, "day")
+            ```
+        """
+        if quantity <= 0:
+            raise ValueError(f"quantity must be a positive integer (got {quantity})")
+        return cls(
+            _property=property,
+            _operator="was in the next",
+            _value=quantity,
+            _property_type="datetime",
+            _resource_type=resource_type,
+            _date_unit=date_unit,
+        )
+
 
 @dataclass(frozen=True)
 class GroupBy:
@@ -8211,6 +8642,8 @@ class CohortCriteria:
         from_date: str | None = None,
         to_date: str | None = None,
         where: Filter | list[Filter] | None = None,
+        aggregation: CohortAggregationType | None = None,
+        aggregation_property: str | None = None,
     ) -> CohortCriteria:
         """Create a behavioral criterion based on event frequency.
 
@@ -8225,6 +8658,11 @@ class CohortCriteria:
             from_date: Absolute start date (YYYY-MM-DD).
             to_date: Absolute end date (YYYY-MM-DD).
             where: Event property filter(s).
+            aggregation: Aggregation operator for property-based thresholds
+                (total, unique, average, min, max, median). Must be paired
+                with ``aggregation_property``.
+            aggregation_property: Event property to aggregate (e.g.,
+                ``"amount"``). Must be paired with ``aggregation``.
 
         Returns:
             CohortCriteria with behavioral selector node and behavior entry.
@@ -8232,11 +8670,19 @@ class CohortCriteria:
         Raises:
             ValueError: If no frequency param or multiple are set, frequency is
                 negative, event name is empty/whitespace, time constraints are
-                missing or conflicting, or dates are malformed/misordered.
+                missing or conflicting, dates are malformed/misordered, or
+                aggregation and aggregation_property are not both set or both
+                None (CA1/CA2).
         """
         # CD4: Event name must be non-empty
         if not event or not event.strip():
             raise ValueError("event name must be non-empty")
+
+        # CA1/CA2: aggregation and aggregation_property must both be set or both None
+        if (aggregation is None) != (aggregation_property is None):
+            raise ValueError(
+                "aggregation and aggregation_property must both be set or both be None"
+            )
 
         # CD1: Exactly one frequency param required
         freq_params = {
@@ -8299,11 +8745,18 @@ class CohortCriteria:
             if where_list:
                 event_selector["selector"] = _build_event_selector(where_list)
 
+        count_dict: dict[str, Any] = {
+            "event_selector": event_selector,
+            "type": "absolute",
+        }
+
+        # Add aggregation fields when set
+        if aggregation is not None and aggregation_property is not None:
+            count_dict["aggregationOperator"] = aggregation
+            count_dict["property"] = aggregation_property
+
         behavior: dict[str, Any] = {
-            "count": {
-                "event_selector": event_selector,
-                "type": "absolute",
-            },
+            "count": count_dict,
         }
 
         if set_rolling:
@@ -8562,6 +9015,12 @@ _MATH_REQUIRING_PROPERTY: frozenset[str] = frozenset(
         "p99",
         "percentile",
         "histogram",
+        # Advanced property-requiring types
+        "unique_values",
+        "most_frequent",
+        "first_value",
+        "multi_attribution",
+        "numeric_summary",
     }
 )
 """Math types that require a measurement property (for Metric.__post_init__)."""
@@ -8893,6 +9352,197 @@ class CohortMetric:
             raise ValueError(
                 "CohortMetric does not support inline CohortDefinition "
                 "(server returns 500). Use a saved cohort ID instead."
+            )
+
+
+@dataclass(frozen=True)
+class FrequencyBreakdown:
+    """Break down query results by how often users performed an event.
+
+    Used with ``Workspace.query()`` / ``build_params()`` in the
+    ``group_by=`` parameter to segment users by event frequency.
+
+    Attributes:
+        event: Event name to count frequency for.
+        bucket_size: Width of each frequency bucket. Default: ``1``.
+        bucket_min: Minimum frequency value. Default: ``0``.
+        bucket_max: Maximum frequency value. Default: ``10``.
+        label: Display label for the breakdown. ``None`` uses
+            the event name.
+
+    Raises:
+        ValueError: If validation rules FB1-FB4 are violated.
+
+    Example:
+        ```python
+        from mixpanel_data import FrequencyBreakdown
+
+        # How often users purchased (0-10 in increments of 1)
+        result = ws.query("Login", group_by=FrequencyBreakdown("Purchase"))
+
+        # Custom buckets: 0-50 in increments of 5
+        result = ws.query(
+            "Login",
+            group_by=FrequencyBreakdown(
+                "Purchase", bucket_size=5, bucket_min=0, bucket_max=50
+            ),
+        )
+        ```
+    """
+
+    event: str
+    """Event name to count frequency for."""
+
+    bucket_size: int = 1
+    """Width of each frequency bucket."""
+
+    bucket_min: int = 0
+    """Minimum frequency value."""
+
+    bucket_max: int = 10
+    """Maximum frequency value."""
+
+    label: str | None = None
+    """Display label for the breakdown."""
+
+    def __post_init__(self) -> None:
+        """Validate construction arguments (rules FB1-FB4).
+
+        Raises:
+            ValueError: If event is empty (FB1), bucket_size is not
+                positive (FB2), bucket_min >= bucket_max (FB3), or
+                bucket_min is negative (FB4).
+        """
+        # FB1: event must be non-empty
+        if not self.event.strip():
+            raise ValueError("FrequencyBreakdown.event must be a non-empty string")
+        # FB2: bucket_size must be positive
+        if self.bucket_size <= 0:
+            raise ValueError(
+                f"FrequencyBreakdown.bucket_size must be positive, "
+                f"got {self.bucket_size}"
+            )
+        # FB4: bucket_min must be non-negative (check before FB3 for clarity)
+        if self.bucket_min < 0:
+            raise ValueError(
+                f"FrequencyBreakdown.bucket_min must be non-negative, "
+                f"got {self.bucket_min}"
+            )
+        # FB3: bucket_min must be < bucket_max
+        if self.bucket_min >= self.bucket_max:
+            raise ValueError(
+                f"FrequencyBreakdown.bucket_min ({self.bucket_min}) must be "
+                f"less than bucket_max ({self.bucket_max})"
+            )
+
+
+@dataclass(frozen=True)
+class FrequencyFilter:
+    """Filter query results by how often users performed an event.
+
+    Used with ``Workspace.query()`` / ``build_params()`` in the
+    ``where=`` parameter to restrict results to users meeting a
+    frequency threshold.
+
+    Attributes:
+        event: Event name to count frequency for.
+        operator: Comparison operator. Default: ``"is at least"``.
+        value: Threshold value for the comparison.
+        date_range_value: Lookback window size. Must be paired with
+            ``date_range_unit``.
+        date_range_unit: Lookback window unit (``"day"``, ``"week"``,
+            ``"month"``). Must be paired with ``date_range_value``.
+        event_filters: Property filters applied to the frequency event
+            before counting.
+        label: Display label for the filter.
+
+    Raises:
+        ValueError: If validation rules FF1-FF5 are violated.
+
+    Example:
+        ```python
+        from mixpanel_data import FrequencyFilter
+
+        # Users who logged in at least 5 times
+        result = ws.query("Purchase", where=FrequencyFilter("Login", value=5))
+
+        # Users who purchased 3+ times in the last 30 days
+        result = ws.query(
+            "Login",
+            where=FrequencyFilter(
+                "Purchase",
+                value=3,
+                date_range_value=30,
+                date_range_unit="day",
+            ),
+        )
+        ```
+    """
+
+    event: str
+    """Event name to count frequency for."""
+
+    value: int | float
+    """Threshold value for the comparison."""
+
+    operator: str = "is at least"
+    """Comparison operator."""
+
+    date_range_value: int | None = None
+    """Lookback window size."""
+
+    date_range_unit: Literal["day", "week", "month"] | None = None
+    """Lookback window unit."""
+
+    event_filters: list[Filter] | None = None
+    """Property filters applied to the frequency event."""
+
+    label: str | None = None
+    """Display label for the filter."""
+
+    def __post_init__(self) -> None:
+        """Validate construction arguments (rules FF1-FF5).
+
+        Raises:
+            ValueError: If event is empty (FF1), operator is invalid
+                (FF2), value is negative (FF3), date_range_value and
+                date_range_unit are not both set or both None (FF4),
+                or date_range_value is not positive when set (FF5).
+        """
+        from mixpanel_data._internal.bookmark_enums import (
+            VALID_FREQUENCY_FILTER_OPERATORS,
+        )
+
+        # FF1: event must be non-empty
+        if not self.event.strip():
+            raise ValueError("FrequencyFilter.event must be a non-empty string")
+        # FF2: operator must be valid
+        if self.operator not in VALID_FREQUENCY_FILTER_OPERATORS:
+            valid = ", ".join(sorted(VALID_FREQUENCY_FILTER_OPERATORS))
+            raise ValueError(
+                f"FrequencyFilter.operator must be one of: {valid}; "
+                f"got {self.operator!r}"
+            )
+        # FF3: value must be non-negative
+        if self.value < 0:
+            raise ValueError(
+                f"FrequencyFilter.value must be non-negative, got {self.value}"
+            )
+        # FF4: date_range_value and date_range_unit must both be set or both None
+        has_value = self.date_range_value is not None
+        has_unit = self.date_range_unit is not None
+        if has_value != has_unit:
+            raise ValueError(
+                "FrequencyFilter.date_range_value and date_range_unit must "
+                "both be set or both be None; got date_range_value="
+                f"{self.date_range_value!r}, date_range_unit="
+                f"{self.date_range_unit!r}"
+            )
+        # FF5: date_range_value must be positive if set
+        if self.date_range_value is not None and self.date_range_value <= 0:
+            raise ValueError(
+                f"FrequencyFilter.date_range_value must be positive when set, "
+                f"got {self.date_range_value}"
             )
 
 
@@ -9755,6 +10405,11 @@ class FlowStep:
         filters_combinator: How to combine multiple filters — ``"all"``
             requires every filter to match (AND), ``"any"`` requires at
             least one (OR). Defaults to ``"all"``.
+        session_event: Optional session anchor type — ``"start"`` or
+            ``"end"``. When set, the ``event`` field must match the
+            corresponding session event name (``"$session_start"`` or
+            ``"$session_end"``). ``None`` means this is a regular event
+            step. Default: ``None``.
 
     Example:
         ```python
@@ -9766,6 +10421,12 @@ class FlowStep:
             filters=[Filter.equals("country", "US")],
             filters_combinator="all",
         )
+
+        # Session anchor step
+        session_step = FlowStep(
+            "$session_start",
+            session_event="start",
+        )
         ```
     """
 
@@ -9775,13 +10436,15 @@ class FlowStep:
     label: str | None = None
     filters: list[Filter] | None = None
     filters_combinator: FiltersCombinator = "all"
+    session_event: FlowSessionEvent | None = None
 
     def __post_init__(self) -> None:
         """Validate construction arguments.
 
         Raises:
             ValueError: If event is empty or contains control characters
-                (FL1), or forward/reverse is outside 0-5 range (FL2).
+                (FL1), forward/reverse is outside 0-5 range (FL2), or
+                session_event conflicts with event name (FS1).
         """
         _validate_event_name(self.event, "FlowStep")
         if self.forward is not None and not 0 <= self.forward <= 5:
@@ -9792,6 +10455,16 @@ class FlowStep:
             raise ValueError(
                 f"FlowStep.reverse must be in range 0-5, got {self.reverse}"
             )
+        # FS1: Validate session_event / event consistency
+        if self.session_event is not None:
+            expected_event = (
+                "$session_start" if self.session_event == "start" else "$session_end"
+            )
+            if self.event != expected_event:
+                raise ValueError(
+                    f"FlowStep.session_event={self.session_event!r} requires "
+                    f"event={expected_event!r}, got {self.event!r}"
+                )
 
 
 @dataclass(frozen=True)

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -7206,12 +7206,26 @@ class TimeComparison:
                 or type is absolute and unit is set (TC2),
                 or date does not match YYYY-MM-DD format (TC3).
         """
+        # TC0: type must be a valid TimeComparisonType
+        valid_types = {"relative", "absolute-start", "absolute-end"}
+        if self.type not in valid_types:
+            raise ValueError(
+                f"TimeComparison type must be one of {sorted(valid_types)}, "
+                f"got {self.type!r}"
+            )
         if self.type == "relative":
             # TC1: relative requires unit, rejects date
             if self.unit is None:
                 raise ValueError(
                     "TimeComparison type='relative' requires unit to be set "
                     "(e.g., TimeComparison.relative('month'))"
+                )
+            # TC1b: unit must be a valid TimeComparisonUnit
+            valid_units = {"day", "week", "month", "quarter", "year"}
+            if self.unit not in valid_units:
+                raise ValueError(
+                    f"TimeComparison unit must be one of {sorted(valid_units)}, "
+                    f"got {self.unit!r}"
                 )
             if self.date is not None:
                 raise ValueError(
@@ -7408,6 +7422,14 @@ class Metric:
                 'Metric math="percentile" requires percentile_value '
                 "(e.g., Metric(event, math='percentile', percentile_value=95))"
             )
+        # M4: segment_method must be valid if set
+        if self.segment_method is not None:
+            valid_segments = {"all", "first"}
+            if self.segment_method not in valid_segments:
+                raise ValueError(
+                    f"Metric segment_method must be one of {sorted(valid_segments)}, "
+                    f"got {self.segment_method!r}"
+                )
 
 
 @dataclass(frozen=True)

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -3647,8 +3647,10 @@ class Workspace:
             "show_custom_events": True,
             "hidden_events": hidden_events or [],
             "exclusions": exclusions if exclusions is not None else [],
-            "data_group_id": data_group_id,
         }
+
+        if data_group_id is not None:
+            params["data_group_id"] = data_group_id
 
         # Add filters if present — route cohort vs property filters
         if where is not None:
@@ -3857,7 +3859,7 @@ class Workspace:
             data_group_id=data_group_id,
         )
         # CP1-CP6: Custom property validation for flow step filters
-        arg_errors.extend(_scan_custom_properties(flow_steps=steps))
+        arg_errors.extend(_scan_custom_properties(flow_steps=steps, where=where))
         if any(e.severity == "error" for e in arg_errors):
             raise BookmarkValidationError(arg_errors)
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -54,7 +54,9 @@ from mixpanel_data._internal.bookmark_builders import (
     build_filter_entry,
     build_filter_section,
     build_flow_cohort_filter,
+    build_flow_property_filter,
     build_group_section,
+    build_time_comparison,
     build_time_section,
     patch_custom_property_filters_for_transform,
 )
@@ -88,8 +90,10 @@ from mixpanel_data._literal_types import (
     FlowCountType,
     FunnelMode,
     FunnelOrder,
+    FunnelReentryMode,
     InsightsMode,
     QueryTimeUnit,
+    RetentionUnboundedMode,
     TimeUnit,
 )
 from mixpanel_data.exceptions import (
@@ -171,6 +175,8 @@ from mixpanel_data.types import (
     FlowsResult,
     FlowStep,
     Formula,
+    FrequencyBreakdown,
+    FrequencyFilter,
     FrequencyResult,
     FunnelInfo,
     FunnelMathType,
@@ -215,6 +221,7 @@ from mixpanel_data.types import (
     SchemaEntry,
     SegmentationResult,
     SetTestUsersParams,
+    TimeComparison,
     TopEvent,
     UpdateAlertParams,
     UpdateAnnotationParams,
@@ -2078,13 +2085,16 @@ class Workspace:
         group_by: str
         | GroupBy
         | CohortBreakdown
-        | list[str | GroupBy | CohortBreakdown]
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
         | None,
-        where: Filter | list[Filter] | None,
+        where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None,
         formulas: Sequence[Formula],
         rolling: int | None,
         cumulative: bool,
         mode: str,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build bookmark params dict from typed arguments.
 
@@ -2106,6 +2116,10 @@ class Workspace:
             rolling: Rolling window size.
             cumulative: Cumulative analysis mode.
             mode: Result mode (timeseries, total, table).
+            time_comparison: Optional period-over-period comparison.
+                Adds ``timeComparison`` to ``displayOptions``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Bookmark params dict ready for insights query API.
@@ -2155,6 +2169,7 @@ class Workspace:
                 item_percentile = item.percentile_value
                 item_filters = item.filters
                 item_filters_combinator = item.filters_combinator
+                item_segment_method = item.segment_method
             else:
                 event_name = item
                 item_math = math
@@ -2163,6 +2178,7 @@ class Workspace:
                 item_percentile = percentile_value
                 item_filters = None
                 item_filters_combinator = "all"
+                item_segment_method = None
 
             # Map user-facing "percentile" to bookmark "custom_percentile"
             bookmark_math = (
@@ -2205,6 +2221,8 @@ class Workspace:
                 measurement["perUserAggregation"] = item_per_user
             if item_percentile is not None:
                 measurement["percentile"] = item_percentile
+            if item_segment_method is not None:
+                measurement["segmentMethod"] = item_segment_method
 
             # Build behavior block with optional per-metric filters
             behavior_filters: list[dict[str, Any]] = []
@@ -2253,7 +2271,7 @@ class Workspace:
         filter_section = build_filter_section(where)
 
         # --- Build sections.group[] ---
-        group_section = build_group_section(group_by)
+        group_section = build_group_section(group_by, data_group_id=data_group_id)
 
         # --- Build displayOptions ---
         chart_type_map = {
@@ -2272,6 +2290,9 @@ class Workspace:
         elif cumulative:
             display_options["analysis"] = "cumulative"
 
+        if time_comparison is not None:
+            display_options["timeComparison"] = build_time_comparison(time_comparison)
+
         # --- Assemble bookmark params ---
         sections: dict[str, Any] = {
             "show": show,
@@ -2279,6 +2300,8 @@ class Workspace:
             "filter": filter_section,
             "group": group_section,
         }
+        if data_group_id is not None:
+            sections["dataGroupId"] = data_group_id
 
         return {
             "sections": sections,
@@ -2304,14 +2327,17 @@ class Workspace:
         group_by: str
         | GroupBy
         | CohortBreakdown
-        | list[str | GroupBy | CohortBreakdown]
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
         | None = None,
-        where: Filter | list[Filter] | None = None,
+        where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None = None,
         formula: str | None = None,
         formula_label: str | None = None,
         rolling: int | None = None,
         cumulative: bool = False,
         mode: Literal["timeseries", "total", "table"] = "timeseries",
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> QueryResult:
         """Run a typed insights query against the Mixpanel API.
 
@@ -2358,6 +2384,13 @@ class Workspace:
             mode: Result shape. ``"timeseries"`` returns per-period data,
                 ``"total"`` returns a single aggregate, ``"table"`` returns
                 tabular data. Default: ``"timeseries"``.
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, ``TimeComparison.absolute_start("2026-01-01")``
+                for a fixed start date, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             QueryResult with series data, DataFrame, and metadata.
@@ -2412,6 +2445,8 @@ class Workspace:
             rolling=rolling,
             cumulative=cumulative,
             mode=mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         # Delegate to service — _live_query_service calls _require_api_client
@@ -2446,14 +2481,17 @@ class Workspace:
         group_by: str
         | GroupBy
         | CohortBreakdown
-        | list[str | GroupBy | CohortBreakdown]
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
         | None = None,
-        where: Filter | list[Filter] | None = None,
+        where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None = None,
         formula: str | None = None,
         formula_label: str | None = None,
         rolling: int | None = None,
         cumulative: bool = False,
         mode: Literal["timeseries", "total", "table"] = "timeseries",
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build validated bookmark params without executing the API call.
 
@@ -2486,6 +2524,12 @@ class Workspace:
             rolling: Rolling window size in periods.
             cumulative: Enable cumulative analysis mode.
             mode: Result shape. Default: ``"timeseries"``.
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             Bookmark params dict with ``sections`` and ``displayOptions``
@@ -2529,6 +2573,8 @@ class Workspace:
             rolling=rolling,
             cumulative=cumulative,
             mode=mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
     def _resolve_and_build_params(
@@ -2550,14 +2596,17 @@ class Workspace:
         group_by: str
         | GroupBy
         | CohortBreakdown
-        | list[str | GroupBy | CohortBreakdown]
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
         | None = None,
-        where: Filter | list[Filter] | None = None,
+        where: Filter | FrequencyFilter | list[Filter | FrequencyFilter] | None = None,
         formula: str | None = None,
         formula_label: str | None = None,
         rolling: int | None = None,
         cumulative: bool = False,
         mode: InsightsMode = "timeseries",
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Normalize, validate, and build bookmark params.
 
@@ -2586,6 +2635,9 @@ class Workspace:
             rolling: Rolling window size.
             cumulative: Cumulative analysis mode.
             mode: Result shape.
+            time_comparison: Optional period-over-period comparison.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Validated bookmark params dict.
@@ -2608,14 +2660,14 @@ class Workspace:
                 ]
             )
 
-        # Type guard: where must be Filter or list of Filters
-        if where is not None and not isinstance(where, (Filter, list)):
+        # Type guard: where must be Filter, FrequencyFilter, or list
+        if where is not None and not isinstance(where, (Filter, FrequencyFilter, list)):
             raise BookmarkValidationError(
                 [
                     ValidationError(
                         path="where",
                         message=(
-                            f"where must be a Filter or list of Filters, "
+                            f"where must be a Filter, FrequencyFilter, or list, "
                             f"got {type(where).__name__}"
                         ),
                         code="V25_INVALID_FILTER_TYPE",
@@ -2686,6 +2738,7 @@ class Workspace:
             cumulative=cumulative,
             group_by=group_by,
             formulas=resolved_formulas,
+            data_group_id=data_group_id,
         )
         # CP1-CP6: Custom property validation for where filters
         arg_errors.extend(_scan_custom_properties(where=where))
@@ -2709,6 +2762,8 @@ class Workspace:
             rolling=rolling,
             cumulative=cumulative,
             mode=mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         # Layer 2: Bookmark structure validation
@@ -2744,6 +2799,9 @@ class Workspace:
         exclusions: list[Exclusion],
         holding_constant: list[HoldingConstant],
         mode: str,
+        reentry_mode: FunnelReentryMode | None = None,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build funnel bookmark params dict from typed arguments.
 
@@ -2767,6 +2825,14 @@ class Workspace:
             exclusions: Normalized Exclusion objects.
             holding_constant: Normalized HoldingConstant objects.
             mode: Display mode (steps, trends, table).
+            reentry_mode: Funnel reentry mode controlling how users
+                re-enter the funnel after conversion. Maps to
+                ``funnelReentryMode`` in the behavior block.
+                Default: ``None`` (omitted from bookmark).
+            time_comparison: Optional period-over-period comparison.
+                Adds ``timeComparison`` to ``displayOptions``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Bookmark params dict ready for insights query API.
@@ -2828,6 +2894,8 @@ class Workspace:
             "aggregateBy": aggregate_by,
             "filter": [],
         }
+        if reentry_mode is not None:
+            behavior["funnelReentryMode"] = reentry_mode
 
         # Build measurement
         measurement: dict[str, Any] = {
@@ -2863,7 +2931,7 @@ class Workspace:
         filter_section = patch_custom_property_filters_for_transform(
             build_filter_section(where)
         )
-        group_section = build_group_section(group_by)
+        group_section = build_group_section(group_by, data_group_id=data_group_id)
 
         # Chart type mapping
         chart_type_map = {
@@ -2872,17 +2940,25 @@ class Workspace:
             "table": "table",
         }
 
+        display_options: dict[str, Any] = {
+            "chartType": chart_type_map.get(mode, "funnel-steps"),
+        }
+        if time_comparison is not None:
+            display_options["timeComparison"] = build_time_comparison(time_comparison)
+
+        sections: dict[str, Any] = {
+            "show": show,
+            "time": time_section,
+            "filter": filter_section,
+            "group": group_section,
+            "formula": [],
+        }
+        if data_group_id is not None:
+            sections["dataGroupId"] = data_group_id
+
         return {
-            "sections": {
-                "show": show,
-                "time": time_section,
-                "filter": filter_section,
-                "group": group_section,
-                "formula": [],
-            },
-            "displayOptions": {
-                "chartType": chart_type_map.get(mode, "funnel-steps"),
-            },
+            "sections": sections,
+            "displayOptions": display_options,
         }
 
     def _resolve_and_build_funnel_params(
@@ -2907,6 +2983,9 @@ class Workspace:
         exclusions: list[str | Exclusion] | None,
         holding_constant: str | HoldingConstant | list[str | HoldingConstant] | None,
         mode: FunnelMode,
+        reentry_mode: FunnelReentryMode | None = None,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Normalize, validate, and build funnel bookmark params.
 
@@ -2933,6 +3012,11 @@ class Workspace:
             exclusions: Events to exclude, or None.
             holding_constant: Properties to hold constant, or None.
             mode: Display mode.
+            reentry_mode: Funnel reentry mode controlling how users
+                re-enter the funnel. Default: ``None`` (omitted).
+            time_comparison: Optional period-over-period comparison.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Validated bookmark params dict.
@@ -2974,6 +3058,8 @@ class Workspace:
             to_date=to_date,
             last=last,
             group_by=group_by,
+            reentry_mode=reentry_mode,
+            data_group_id=data_group_id,
         )
         # CP1-CP6: Custom property validation for where filters
         arg_errors.extend(_scan_custom_properties(where=where))
@@ -2997,6 +3083,9 @@ class Workspace:
             exclusions=normalized_exclusions,
             holding_constant=normalized_hc,
             mode=mode,
+            reentry_mode=reentry_mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         # Layer 2: Bookmark structure validation
@@ -3032,6 +3121,9 @@ class Workspace:
             str | HoldingConstant | list[str | HoldingConstant] | None
         ) = None,
         mode: Literal["steps", "trends", "table"] = "steps",
+        reentry_mode: FunnelReentryMode | None = None,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> FunnelQueryResult:
         """Run a typed funnel query against the Mixpanel API.
 
@@ -3075,6 +3167,16 @@ class Workspace:
                 data, ``"trends"`` shows conversion over time,
                 ``"table"`` shows tabular breakdown. Default:
                 ``"steps"``.
+            reentry_mode: Funnel reentry mode controlling how users
+                re-enter the funnel after conversion. One of
+                ``"default"``, ``"basic"``, ``"aggressive"``, or
+                ``"optimized"``. Default: ``None`` (server default).
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             FunnelQueryResult with step data, DataFrame, and metadata.
@@ -3121,6 +3223,9 @@ class Workspace:
             exclusions=exclusions,
             holding_constant=holding_constant,
             mode=mode,
+            reentry_mode=reentry_mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         credentials = self._credentials
@@ -3160,6 +3265,9 @@ class Workspace:
             str | HoldingConstant | list[str | HoldingConstant] | None
         ) = None,
         mode: Literal["steps", "trends", "table"] = "steps",
+        reentry_mode: FunnelReentryMode | None = None,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build validated funnel bookmark params without executing.
 
@@ -3189,6 +3297,16 @@ class Workspace:
             exclusions: Events to exclude between steps.
             holding_constant: Properties to hold constant.
             mode: Display mode. Default: ``"steps"``.
+            reentry_mode: Funnel reentry mode controlling how users
+                re-enter the funnel after conversion. One of
+                ``"default"``, ``"basic"``, ``"aggressive"``, or
+                ``"optimized"``. Default: ``None`` (server default).
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             Bookmark params dict with ``sections`` and
@@ -3231,6 +3349,9 @@ class Workspace:
             exclusions=exclusions,
             holding_constant=holding_constant,
             mode=mode,
+            reentry_mode=reentry_mode,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
     # =========================================================================
@@ -3257,6 +3378,10 @@ class Workspace:
         | None,
         where: Filter | list[Filter] | None,
         mode: RetentionMode,
+        unbounded_mode: RetentionUnboundedMode | None = None,
+        retention_cumulative: bool = False,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build retention bookmark params dict from typed arguments.
 
@@ -3277,6 +3402,17 @@ class Workspace:
             group_by: Breakdown specification.
             where: Filter conditions.
             mode: Display mode (curve, trends, table).
+            unbounded_mode: Retention unbounded mode controlling how
+                retention is counted in unbounded periods. Maps to
+                ``retentionUnboundedMode`` in the behavior block.
+                Default: ``None`` (omitted from bookmark).
+            retention_cumulative: Whether to use cumulative retention
+                counting. Maps to ``retentionCumulative`` in the
+                measurement block. Default: ``False``.
+            time_comparison: Optional period-over-period comparison.
+                Adds ``timeComparison`` to ``displayOptions``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Bookmark params dict ready for insights query API.
@@ -3306,11 +3442,15 @@ class Workspace:
             "retentionCustomBucketSizes": list(bucket_sizes) if bucket_sizes else [],
             "filter": [],
         }
+        if unbounded_mode is not None:
+            behavior["retentionUnboundedMode"] = unbounded_mode
 
         # Build measurement
         measurement: dict[str, Any] = {
             "math": math,
         }
+        if retention_cumulative:
+            measurement["retentionCumulative"] = True
 
         # Build show clause
         show: list[dict[str, Any]] = [
@@ -3331,7 +3471,7 @@ class Workspace:
         filter_section = patch_custom_property_filters_for_transform(
             build_filter_section(where)
         )
-        group_section = build_group_section(group_by)
+        group_section = build_group_section(group_by, data_group_id=data_group_id)
 
         # Chart type mapping
         chart_type_map = {
@@ -3340,17 +3480,25 @@ class Workspace:
             "table": "table",
         }
 
+        display_options: dict[str, Any] = {
+            "chartType": chart_type_map.get(mode, "retention-curve"),
+        }
+        if time_comparison is not None:
+            display_options["timeComparison"] = build_time_comparison(time_comparison)
+
+        sections: dict[str, Any] = {
+            "show": show,
+            "time": time_section,
+            "filter": filter_section,
+            "group": group_section,
+            "formula": [],
+        }
+        if data_group_id is not None:
+            sections["dataGroupId"] = data_group_id
+
         return {
-            "sections": {
-                "show": show,
-                "time": time_section,
-                "filter": filter_section,
-                "group": group_section,
-                "formula": [],
-            },
-            "displayOptions": {
-                "chartType": chart_type_map.get(mode, "retention-curve"),
-            },
+            "sections": sections,
+            "displayOptions": display_options,
             "sorting": {
                 "bar": {"colSortAttrs": [], "sortBy": "column"},
                 "line": {
@@ -3397,6 +3545,14 @@ class Workspace:
         hidden_events: list[str] | None,
         mode: str,
         where: Filter | list[Filter] | None = None,
+        data_group_id: int | None = None,
+        segments: str
+        | GroupBy
+        | CohortBreakdown
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
+        | None = None,
+        exclusions: list[str] | None = None,
     ) -> dict[str, Any]:
         """Build a flat flow bookmark params dict from typed arguments.
 
@@ -3420,9 +3576,18 @@ class Workspace:
                 events.
             hidden_events: Events to hide from the flow visualization.
             mode: Display mode (``"sankey"``, ``"paths"``, or ``"tree"``).
-            where: Filter results by cohort membership. Only
-                ``Filter.in_cohort()`` and ``Filter.not_in_cohort()``
-                are accepted. Default: ``None``.
+            where: Filter results by cohort membership or property
+                conditions. Cohort filters (``Filter.in_cohort`` /
+                ``Filter.not_in_cohort``) produce ``filter_by_cohort``.
+                Property filters produce ``filter_by_event``.
+                Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
+            segments: Segment (breakdown) specification for flow
+                results. Accepts a string, ``GroupBy``, or list of
+                strings/``GroupBy`` objects. Default: ``None``.
+            exclusions: List of event names to exclude from flow
+                paths. Default: ``None``.
 
         Returns:
             Flat bookmark params dict ready for API submission.
@@ -3444,20 +3609,25 @@ class Workspace:
             )
             ```
         """
+        # Build step dicts, including session_event when present
+        step_dicts: list[dict[str, Any]] = []
+        for step in steps:
+            step_dict: dict[str, Any] = {
+                "event": step.event,
+                "step_label": step.label or step.event,
+                "forward": step.forward if step.forward is not None else 0,
+                "reverse": step.reverse if step.reverse is not None else 0,
+                "bool_op": ("or" if step.filters_combinator == "any" else "and"),
+                "property_filter_params_list": [
+                    build_segfilter_entry(f) for f in (step.filters or [])
+                ],
+            }
+            if step.session_event is not None:
+                step_dict["session_event"] = step.session_event
+            step_dicts.append(step_dict)
+
         params: dict[str, Any] = {
-            "steps": [
-                {
-                    "event": step.event,
-                    "step_label": step.label or step.event,
-                    "forward": step.forward if step.forward is not None else 0,
-                    "reverse": step.reverse if step.reverse is not None else 0,
-                    "bool_op": ("or" if step.filters_combinator == "any" else "and"),
-                    "property_filter_params_list": [
-                        build_segfilter_entry(f) for f in (step.filters or [])
-                    ],
-                }
-                for step in steps
-            ],
+            "steps": step_dicts,
             "date_range": build_date_range(
                 from_date=from_date, to_date=to_date, last=last
             ),
@@ -3476,14 +3646,27 @@ class Workspace:
             "collapse_repeated": collapse_repeated,
             "show_custom_events": True,
             "hidden_events": hidden_events or [],
-            "exclusions": [],
+            "exclusions": exclusions if exclusions is not None else [],
+            "data_group_id": data_group_id,
         }
 
-        # Add cohort filter if present
+        # Add filters if present — route cohort vs property filters
         if where is not None:
-            cohort_filter = build_flow_cohort_filter(where)
-            if cohort_filter is not None:
-                params["filter_by_cohort"] = cohort_filter
+            filter_list = where if isinstance(where, list) else [where]
+            cohort_filters = [f for f in filter_list if f._property == "$cohorts"]
+            property_filters = [f for f in filter_list if f._property != "$cohorts"]
+
+            if cohort_filters:
+                cohort_filter = build_flow_cohort_filter(cohort_filters)
+                if cohort_filter is not None:
+                    params["filter_by_cohort"] = cohort_filter
+
+            if property_filters:
+                params["filter_by_event"] = build_flow_property_filter(property_filters)
+
+        # Add segments if present
+        if segments is not None:
+            params["segments"] = build_group_section(segments)
 
         return params
 
@@ -3504,6 +3687,14 @@ class Workspace:
         hidden_events: list[str] | None,
         mode: FlowChartType,
         where: Filter | list[Filter] | None = None,
+        data_group_id: int | None = None,
+        segments: str
+        | GroupBy
+        | CohortBreakdown
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
+        | None = None,
+        exclusions: list[str] | None = None,
     ) -> dict[str, Any]:
         """Normalize, validate, and build flow bookmark params.
 
@@ -3528,9 +3719,16 @@ class Workspace:
                 events.
             hidden_events: Events to hide from visualization.
             mode: Display mode.
-            where: Filter results by cohort membership. Only
-                ``Filter.in_cohort()`` and ``Filter.not_in_cohort()``
-                are accepted. Default: ``None``.
+            where: Filter results by cohort membership or property
+                conditions. Cohort filters produce ``filter_by_cohort``,
+                property filters produce ``filter_by_event``.
+                Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
+            segments: Segment (breakdown) specification for flow
+                results. Default: ``None``.
+            exclusions: List of event names to exclude from flow
+                paths. Default: ``None``.
 
         Returns:
             Validated flow bookmark params dict.
@@ -3559,6 +3757,7 @@ class Workspace:
                 label=s.label,
                 filters=s.filters,
                 filters_combinator=s.filters_combinator,
+                session_event=s.session_event,
             )
             for s in steps
         ]
@@ -3655,6 +3854,7 @@ class Workspace:
             from_date=from_date,
             to_date=to_date,
             last=last,
+            data_group_id=data_group_id,
         )
         # CP1-CP6: Custom property validation for flow step filters
         arg_errors.extend(_scan_custom_properties(flow_steps=steps))
@@ -3675,6 +3875,9 @@ class Workspace:
             hidden_events=hidden_events,
             mode=mode,
             where=where,
+            data_group_id=data_group_id,
+            segments=segments,
+            exclusions=exclusions,
         )
 
         # Layer 2: Bookmark structure validation
@@ -3701,6 +3904,14 @@ class Workspace:
         hidden_events: list[str] | None = None,
         mode: Literal["sankey", "paths", "tree"] = "sankey",
         where: Filter | list[Filter] | None = None,
+        data_group_id: int | None = None,
+        segments: str
+        | GroupBy
+        | CohortBreakdown
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
+        | None = None,
+        exclusions: list[str] | None = None,
     ) -> FlowQueryResult:
         """Run a typed flow query against the Mixpanel API.
 
@@ -3735,11 +3946,19 @@ class Workspace:
             hidden_events: Events to hide from the flow visualization.
                 Default: ``None``.
             mode: Flow visualization mode. Default: ``"sankey"``.
-            where: Filter results by cohort membership. Only
-                ``Filter.in_cohort()`` and ``Filter.not_in_cohort()``
-                are accepted; non-cohort filters raise ``ValueError``.
-                Flows support a single cohort filter (the first is
-                used if multiple are provided). Default: ``None``.
+            where: Filter results by cohort membership or property
+                conditions. Cohort filters (``Filter.in_cohort`` /
+                ``Filter.not_in_cohort``) produce ``filter_by_cohort``.
+                Property filters (``Filter.equals``, etc.) produce
+                ``filter_by_event``. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
+            segments: Segment (breakdown) specification for flow
+                results. Accepts a string, ``GroupBy``, or list of
+                strings/``GroupBy`` objects. Default: ``None``.
+            exclusions: List of event names to exclude from flow
+                paths. Default: ``None``.
 
         Returns:
             FlowQueryResult with steps, flows, breakdowns, and
@@ -3748,7 +3967,6 @@ class Workspace:
         Raises:
             BookmarkValidationError: If arguments violate validation
                 rules (before API call).
-            ValueError: If ``where`` contains non-cohort filters.
             ConfigError: If credentials are not available.
             AuthenticationError: Invalid credentials.
             QueryError: Invalid query parameters.
@@ -3769,6 +3987,14 @@ class Workspace:
                 last=90,
             )
             print(result.df)
+
+            # With property filter and segments
+            result = ws.query_flow(
+                "Login",
+                where=Filter.equals("country", "US"),
+                segments=GroupBy("platform"),
+                exclusions=["Error Event"],
+            )
             ```
         """
         params = self._resolve_and_build_flow_params(
@@ -3786,6 +4012,9 @@ class Workspace:
             hidden_events=hidden_events,
             mode=mode,
             where=where,
+            data_group_id=data_group_id,
+            segments=segments,
+            exclusions=exclusions,
         )
 
         credentials = self._credentials
@@ -3817,6 +4046,14 @@ class Workspace:
         hidden_events: list[str] | None = None,
         mode: Literal["sankey", "paths", "tree"] = "sankey",
         where: Filter | list[Filter] | None = None,
+        data_group_id: int | None = None,
+        segments: str
+        | GroupBy
+        | CohortBreakdown
+        | FrequencyBreakdown
+        | list[str | GroupBy | CohortBreakdown | FrequencyBreakdown]
+        | None = None,
+        exclusions: list[str] | None = None,
     ) -> dict[str, Any]:
         """Build validated flow bookmark params without executing.
 
@@ -3842,10 +4079,18 @@ class Workspace:
             collapse_repeated: Merge repeated events. Default: ``False``.
             hidden_events: Events to hide. Default: ``None``.
             mode: Display mode. Default: ``"sankey"``.
-            where: Filter results by cohort membership. Only
-                ``Filter.in_cohort()`` and ``Filter.not_in_cohort()``
-                are accepted; non-cohort filters raise ``ValueError``.
-                Flows support a single cohort filter. Default: ``None``.
+            where: Filter results by cohort membership or property
+                conditions. Cohort filters produce ``filter_by_cohort``,
+                property filters produce ``filter_by_event``.
+                Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
+            segments: Segment (breakdown) specification for flow
+                results. Accepts a string, ``GroupBy``, or list of
+                strings/``GroupBy`` objects. Default: ``None``.
+            exclusions: List of event names to exclude from flow
+                paths. Default: ``None``.
 
         Returns:
             Flat bookmark params dict with ``steps``, ``date_range``,
@@ -3863,13 +4108,13 @@ class Workspace:
             params = ws.build_flow_params("Login")
             print(json.dumps(params, indent=2))
 
-            # Save as a report (dashboard_id required)
-            ws.create_bookmark(CreateBookmarkParams(
-                name="Login Flow",
-                bookmark_type="flows",
-                params=params,
-                dashboard_id=12345,
-            ))
+            # With segments and exclusions
+            params = ws.build_flow_params(
+                "Login",
+                segments=GroupBy("country"),
+                exclusions=["Error Event"],
+                where=Filter.equals("platform", "iOS"),
+            )
             ```
         """
         return self._resolve_and_build_flow_params(
@@ -3887,6 +4132,9 @@ class Workspace:
             hidden_events=hidden_events,
             mode=mode,
             where=where,
+            data_group_id=data_group_id,
+            segments=segments,
+            exclusions=exclusions,
         )
 
     # =========================================================================
@@ -3913,6 +4161,10 @@ class Workspace:
         | None,
         where: Filter | list[Filter] | None,
         mode: RetentionMode,
+        unbounded_mode: RetentionUnboundedMode | None = None,
+        retention_cumulative: bool = False,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Normalize, validate, and build retention bookmark params.
 
@@ -3936,6 +4188,12 @@ class Workspace:
             group_by: Breakdown specification.
             where: Filter conditions.
             mode: Display mode.
+            unbounded_mode: Retention unbounded mode. Default: ``None``.
+            retention_cumulative: Cumulative retention counting.
+                Default: ``False``.
+            time_comparison: Optional period-over-period comparison.
+            data_group_id: Optional data group ID for group-level
+                analytics. Default: ``None``.
 
         Returns:
             Validated bookmark params dict.
@@ -3967,6 +4225,8 @@ class Workspace:
             to_date=to_date,
             last=last,
             group_by=group_by,
+            unbounded_mode=unbounded_mode,
+            data_group_id=data_group_id,
         )
         # CP1-CP6: Custom property validation for where and event filters
         arg_errors.extend(
@@ -3993,6 +4253,10 @@ class Workspace:
             group_by=group_by,
             where=where,
             mode=mode,
+            unbounded_mode=unbounded_mode,
+            retention_cumulative=retention_cumulative,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         # Layer 2: Bookmark structure validation
@@ -4022,6 +4286,10 @@ class Workspace:
         | None = None,
         where: Filter | list[Filter] | None = None,
         mode: RetentionMode = "curve",
+        unbounded_mode: RetentionUnboundedMode | None = None,
+        retention_cumulative: bool = False,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> RetentionQueryResult:
         """Run a typed retention query against the Mixpanel API.
 
@@ -4053,6 +4321,19 @@ class Workspace:
                 ``CohortBreakdown``, or list of any mix.
             where: Filter results by conditions.
             mode: Result display mode. Default: ``"curve"``.
+            unbounded_mode: Retention unbounded mode controlling how
+                retention is counted in unbounded periods. One of
+                ``"none"``, ``"carry_back"``, ``"carry_forward"``, or
+                ``"consecutive_forward"``. Default: ``None``
+                (server default).
+            retention_cumulative: Whether to use cumulative retention
+                counting. Default: ``False``.
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             RetentionQueryResult with cohort data, DataFrame, and
@@ -4098,6 +4379,10 @@ class Workspace:
             group_by=group_by,
             where=where,
             mode=mode,
+            unbounded_mode=unbounded_mode,
+            retention_cumulative=retention_cumulative,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
         credentials = self._credentials
@@ -4131,6 +4416,10 @@ class Workspace:
         | None = None,
         where: Filter | list[Filter] | None = None,
         mode: RetentionMode = "curve",
+        unbounded_mode: RetentionUnboundedMode | None = None,
+        retention_cumulative: bool = False,
+        time_comparison: TimeComparison | None = None,
+        data_group_id: int | None = None,
     ) -> dict[str, Any]:
         """Build validated retention bookmark params without executing.
 
@@ -4159,6 +4448,19 @@ class Workspace:
                 ``CohortBreakdown``, or list of any mix.
             where: Filter results by conditions.
             mode: Display mode. Default: ``"curve"``.
+            unbounded_mode: Retention unbounded mode controlling how
+                retention is counted in unbounded periods. One of
+                ``"none"``, ``"carry_back"``, ``"carry_forward"``, or
+                ``"consecutive_forward"``. Default: ``None``
+                (server default).
+            retention_cumulative: Whether to use cumulative retention
+                counting. Default: ``False``.
+            time_comparison: Optional period-over-period comparison.
+                Use ``TimeComparison.relative("month")`` for previous
+                month, etc. Default: ``None``.
+            data_group_id: Optional data group ID for group-level
+                analytics. Scopes the query to a specific data group.
+                Default: ``None``.
 
         Returns:
             Bookmark params dict with ``sections`` and
@@ -4199,6 +4501,10 @@ class Workspace:
             group_by=group_by,
             where=where,
             mode=mode,
+            unbounded_mode=unbounded_mode,
+            retention_cumulative=retention_cumulative,
+            time_comparison=time_comparison,
+            data_group_id=data_group_id,
         )
 
     # =========================================================================

--- a/tests/live/test_040_query_completeness_live.py
+++ b/tests/live/test_040_query_completeness_live.py
@@ -1,0 +1,1923 @@
+# ruff: noqa: S101
+"""Live QA tests for the 040-query-engine-completeness feature.
+
+Exercises every new query parameter, type expansion, filter method,
+and builder output against the real Mixpanel API.  All tests are
+**read-only** — no entities are created, updated, or deleted.
+
+Organized by:
+- Smoke Suite (S01-S10): backward compat and basic acceptance
+- Offline Validation (US1-US8): build_*_params() JSON assertions
+- Validation Error Tests: ValueError / BookmarkValidationError
+- Live API Tests: real API calls wrapped in _query_or_api_error
+- Cross-Parameter Interactions (X01-X07): combined features
+
+Usage:
+    uv run pytest tests/live/test_040_query_completeness_live.py -v -m live
+    uv run pytest tests/live/test_040_query_completeness_live.py -v -m live -k Smoke
+    uv run pytest tests/live/test_040_query_completeness_live.py -v -m live -k Offline
+
+Pre-requisites:
+    - Active OAuth token: ``mp auth login``
+    - Project switched to target project with events
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from mixpanel_data import (
+    BookmarkValidationError,
+    CohortCriteria,
+    Filter,
+    FlowQueryResult,
+    FlowStep,
+    FrequencyBreakdown,
+    FrequencyFilter,
+    FunnelQueryResult,
+    GroupBy,
+    Metric,
+    QueryResult,
+    RetentionQueryResult,
+    TimeComparison,
+    Workspace,
+)
+from mixpanel_data.exceptions import APIError, QueryError
+
+# All tests require the `live` marker — skipped by default
+pytestmark = pytest.mark.live
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _query_or_api_error(fn: Any, *args: Any, **kwargs: Any) -> Any:
+    """Call *fn* and return the result, or ``None`` if the API rejects it.
+
+    Acceptable rejections are ``QueryError`` and ``APIError`` — the server
+    refused the query but the client did not crash with an unexpected
+    exception (``AttributeError``, ``TypeError``, ``KeyError``, etc.).
+
+    Args:
+        fn: Callable to invoke (e.g. ``ws.query``).
+        *args: Positional arguments forwarded to *fn*.
+        **kwargs: Keyword arguments forwarded to *fn*.
+
+    Returns:
+        The result of *fn*, or ``None`` when a server-side rejection
+        is the only reason for failure.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except (QueryError, APIError):
+        return None
+
+
+def _dig(d: dict[str, Any], *keys: str | int) -> Any:
+    """Safely traverse nested dicts and lists.
+
+    Args:
+        d: Root dictionary.
+        *keys: Sequence of string keys (for dicts) or int indices
+            (for lists) to follow.
+
+    Returns:
+        The value at the nested path, or ``None`` if any key is missing
+        or any index is out of range.
+    """
+    current: Any = d
+    for k in keys:
+        if isinstance(k, int):
+            if not isinstance(current, list) or k >= len(current):
+                return None
+            current = current[k]
+        elif isinstance(current, dict):
+            current = current.get(k)
+        else:
+            return None
+    return current
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def ws() -> Iterator[Workspace]:
+    """Live Workspace connected to the active project.
+
+    Yields:
+        Workspace instance using default credentials.
+    """
+    workspace = Workspace()
+    yield workspace
+    workspace.close()
+
+
+@pytest.fixture(scope="module")
+def real_event(ws: Workspace) -> str:
+    """First available event name, preferring $mp_web_page_view.
+
+    Args:
+        ws: Workspace fixture.
+
+    Returns:
+        An event name string known to exist in the project.
+    """
+    events = ws.events()
+    assert len(events) > 0, "No events in project"
+    if "$mp_web_page_view" in events:
+        return "$mp_web_page_view"
+    return events[0]
+
+
+@pytest.fixture(scope="module")
+def real_events_pair(ws: Workspace) -> tuple[str, str]:
+    """Two event names for funnel / retention tests.
+
+    Args:
+        ws: Workspace fixture.
+
+    Returns:
+        Tuple of two distinct event name strings.
+    """
+    events = ws.events()
+    assert len(events) >= 2, "Need at least 2 events"
+    candidates = ["$mp_web_page_view", "$identify"]
+    found = [e for e in candidates if e in events]
+    if len(found) >= 2:
+        return (found[0], found[1])
+    return (events[0], events[1])
+
+
+# =============================================================================
+# SMOKE SUITE — S01-S10
+# =============================================================================
+
+
+class TestSmokeSuite:
+    """Backward-compatibility and basic acceptance smoke tests.
+
+    Every test either returns the expected result type **or** raises
+    QueryError / APIError (not crash / AttributeError / TypeError).
+    """
+
+    def test_s01_backward_compat_query(self, ws: Workspace, real_event: str) -> None:
+        """S01 -- Existing query() call without new params still works.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = ws.query(real_event, last=7)
+        assert isinstance(result, QueryResult)
+
+    def test_s02_backward_compat_build_params(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """S02 -- Existing build_params() call produces identical output.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_params(real_event, last=7)
+        assert isinstance(params, dict)
+        assert "sections" in params
+
+    def test_s03_backward_compat_funnel(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """S03 -- Existing query_funnel() call still works.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_funnel,
+            list(real_events_pair),
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, FunnelQueryResult)
+
+    def test_s04_backward_compat_retention(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """S04 -- Existing query_retention() call still works.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_retention,
+            real_events_pair[0],
+            real_events_pair[1],
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, RetentionQueryResult)
+
+    def test_s05_backward_compat_flow(self, ws: Workspace, real_event: str) -> None:
+        """S05 -- Existing query_flow() call still works.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(ws.query_flow, real_event, last=7)
+        if result is not None:
+            assert isinstance(result, FlowQueryResult)
+
+    def test_s06_backward_compat_build_funnel_params(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """S06 -- build_funnel_params() without new params produces dict.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_funnel_params(list(real_events_pair), last=7)
+        assert isinstance(params, dict)
+
+    def test_s07_backward_compat_build_retention_params(
+        self, ws: Workspace, real_events_pair: tuple[str, str]
+    ) -> None:
+        """S07 -- build_retention_params() without new params produces dict.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0], real_events_pair[1], last=7
+        )
+        assert isinstance(params, dict)
+
+    def test_s08_backward_compat_build_flow_params(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """S08 -- build_flow_params() without new params produces dict.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(real_event, last=7)
+        assert isinstance(params, dict)
+
+    def test_s09_new_math_type_accepted(self, ws: Workspace, real_event: str) -> None:
+        """S09 -- cumulative_unique math type accepted by build_params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_params(real_event, math="cumulative_unique", last=7)
+        assert isinstance(params, dict)
+
+    def test_s10_time_comparison_accepted(self, ws: Workspace, real_event: str) -> None:
+        """S10 -- time_comparison param accepted by build_params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.relative("month")
+        params = ws.build_params(real_event, last=30, time_comparison=tc)
+        assert isinstance(params, dict)
+        assert "displayOptions" in params
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US1: Complete Math Type Coverage
+# =============================================================================
+
+
+class TestOfflineUS1:
+    """Offline param-building tests for User Story 1 (math types)."""
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "cumulative_unique",
+            "sessions",
+        ],
+    )
+    def test_m01_no_property_math_types(
+        self, ws: Workspace, real_event: str, math_type: str
+    ) -> None:
+        """M01 -- Math types that do NOT require a property are accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            math_type: Math type to test.
+        """
+        params = ws.build_params(real_event, math=math_type, last=7)  # type: ignore[arg-type]
+        show = _dig(params, "sections", "show")
+        assert show is not None
+        assert show[0]["measurement"]["math"] in (
+            math_type,
+            # some types map to different API names
+            math_type.replace("_", " "),
+        )
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_m02_property_required_math_types(
+        self, ws: Workspace, real_event: str, math_type: str
+    ) -> None:
+        """M02 -- Math types requiring a property are accepted with property.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            math_type: Math type to test.
+        """
+        params = ws.build_params(
+            real_event,
+            math=math_type,  # type: ignore[arg-type]
+            math_property="$browser",
+            last=7,
+        )
+        show = _dig(params, "sections", "show")
+        assert show is not None
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_m03_property_required_math_rejects_missing_property(
+        self, ws: Workspace, real_event: str, math_type: str
+    ) -> None:
+        """M03 -- Math types requiring a property raise without one.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            math_type: Math type to test.
+        """
+        with pytest.raises((ValueError, BookmarkValidationError)):
+            ws.build_params(real_event, math=math_type, last=7)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "total",
+            "unique",
+            "dau",
+            "wau",
+            "mau",
+            "average",
+            "median",
+            "min",
+            "max",
+            "p25",
+            "p75",
+            "p90",
+            "p99",
+            "percentile",
+            "histogram",
+        ],
+    )
+    def test_m04_original_math_types_still_work(
+        self, ws: Workspace, real_event: str, math_type: str
+    ) -> None:
+        """M04 -- All original 15 math types still accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            math_type: Math type to test.
+        """
+        kwargs: dict[str, Any] = {"last": 7}
+        # Types requiring a property
+        needs_prop = {
+            "average",
+            "median",
+            "min",
+            "max",
+            "p25",
+            "p75",
+            "p90",
+            "p99",
+            "percentile",
+            "histogram",
+        }
+        if math_type in needs_prop:
+            kwargs["math_property"] = "$browser"
+        if math_type == "percentile":
+            kwargs["percentile_value"] = 50
+        if math_type == "histogram":
+            kwargs["per_user"] = "total"
+        params = ws.build_params(real_event, math=math_type, **kwargs)  # type: ignore[arg-type]
+        assert isinstance(params, dict)
+
+    @pytest.mark.parametrize("math_type", ["total", "average"])
+    def test_m05_retention_math_expanded(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        math_type: str,
+    ) -> None:
+        """M05 -- New retention math types (total, average) accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+            math_type: Retention math type to test.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            math=math_type,  # type: ignore[arg-type]
+            last=7,
+        )
+        show = _dig(params, "sections", "show")
+        assert show is not None
+
+    def test_m06_funnel_histogram_math(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M06 -- Funnel histogram math type accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_funnel_params(
+            list(real_events_pair),
+            math="histogram",
+            math_property="$browser",
+            last=7,
+        )
+        show = _dig(params, "sections", "show")
+        assert show is not None
+
+    def test_m07_metric_with_new_math(self, ws: Workspace) -> None:
+        """M07 -- Metric object with new math type is accepted.
+
+        Args:
+            ws: Workspace fixture.
+        """
+        m = Metric("$mp_web_page_view", math="cumulative_unique")
+        params = ws.build_params(m, last=7)
+        assert isinstance(params, dict)
+
+    def test_m08_metric_property_required_math(self, ws: Workspace) -> None:
+        """M08 -- Metric with property-required math and property works.
+
+        Args:
+            ws: Workspace fixture.
+        """
+        m = Metric(
+            "$mp_web_page_view",
+            math="unique_values",
+            property="$browser",
+        )
+        params = ws.build_params(m, last=7)
+        assert isinstance(params, dict)
+
+    def test_m09_metric_property_required_math_rejects_missing(self) -> None:
+        """M09 -- Metric with property-required math but no property raises.
+
+        No fixture needed -- pure type construction.
+        """
+        with pytest.raises(ValueError):
+            Metric("$mp_web_page_view", math="unique_values")
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US2: Advanced Funnel and Retention Modes
+# =============================================================================
+
+
+class TestOfflineUS2:
+    """Offline param-building tests for User Story 2 (modes)."""
+
+    @pytest.mark.parametrize("mode", ["default", "basic", "aggressive", "optimized"])
+    def test_m10_funnel_reentry_mode(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        mode: str,
+    ) -> None:
+        """M10 -- All funnel reentry modes are accepted and threaded.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+            mode: Reentry mode value.
+        """
+        params = ws.build_funnel_params(
+            list(real_events_pair),
+            reentry_mode=mode,  # type: ignore[arg-type]
+            last=7,
+        )
+        behavior = _dig(params, "sections", "show", 0, "behavior")
+        assert behavior is not None
+        assert behavior.get("funnelReentryMode") == mode
+
+    @pytest.mark.parametrize(
+        "mode", ["none", "carry_back", "carry_forward", "consecutive_forward"]
+    )
+    def test_m11_retention_unbounded_mode(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+        mode: str,
+    ) -> None:
+        """M11 -- All retention unbounded modes are accepted and threaded.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+            mode: Unbounded mode value.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            unbounded_mode=mode,  # type: ignore[arg-type]
+            last=7,
+        )
+        behavior = _dig(params, "sections", "show", 0, "behavior")
+        assert behavior is not None
+        assert behavior.get("retentionUnboundedMode") == mode
+
+    def test_m12_retention_cumulative(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M12 -- retention_cumulative=True threads to measurement.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            retention_cumulative=True,
+            last=7,
+        )
+        measurement = _dig(params, "sections", "show", 0, "measurement")
+        assert measurement is not None
+        assert measurement.get("retentionCumulative") is True
+
+    def test_m13_retention_cumulative_default_false(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M13 -- retention_cumulative defaults to False (omitted or False).
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            last=7,
+        )
+        measurement = _dig(params, "sections", "show", 0, "measurement")
+        assert measurement is not None
+        # Either absent or explicitly False
+        assert measurement.get("retentionCumulative") in (None, False)
+
+    @pytest.mark.parametrize("method", ["all", "first"])
+    def test_m14_segment_method_on_metric(
+        self, ws: Workspace, real_event: str, method: str
+    ) -> None:
+        """M14 -- segment_method on Metric accepted by build_params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            method: Segment method value.
+        """
+        m = Metric(real_event, segment_method=method)  # type: ignore[arg-type]
+        params = ws.build_params(m, last=7)
+        # Verify the param builds without error
+        assert isinstance(params, dict)
+
+    def test_m15_segment_method_in_measurement(
+        self,
+        ws: Workspace,
+        real_event: str,
+    ) -> None:
+        """M15 -- segment_method threads to measurement.segmentMethod.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        m = Metric(real_event, segment_method="first")
+        params = ws.build_params(m, last=7)
+        measurement = _dig(params, "sections", "show", 0, "measurement")
+        assert measurement is not None
+        assert measurement.get("segmentMethod") == "first"
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US3: Time Comparison
+# =============================================================================
+
+
+class TestOfflineUS3:
+    """Offline param-building tests for User Story 3 (time comparison)."""
+
+    def test_m16_relative_time_comparison(self, ws: Workspace, real_event: str) -> None:
+        """M16 -- Relative time comparison appears in displayOptions.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.relative("month")
+        params = ws.build_params(real_event, last=30, time_comparison=tc)
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+        assert tc_output.get("type") == "relative"
+        assert tc_output.get("value") == "month"
+
+    def test_m17_absolute_start_time_comparison(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M17 -- Absolute-start comparison with date in displayOptions.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.absolute_start("2026-01-01")
+        params = ws.build_params(
+            real_event,
+            from_date="2026-03-01",
+            to_date="2026-03-31",
+            time_comparison=tc,
+        )
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+        assert tc_output.get("type") == "absolute-start"
+        assert tc_output.get("value") == "2026-01-01"
+
+    def test_m18_absolute_end_time_comparison(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M18 -- Absolute-end comparison with date in displayOptions.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.absolute_end("2026-12-31")
+        params = ws.build_params(
+            real_event,
+            from_date="2026-03-01",
+            to_date="2026-03-31",
+            time_comparison=tc,
+        )
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+        assert tc_output.get("type") == "absolute-end"
+        assert tc_output.get("value") == "2026-12-31"
+
+    @pytest.mark.parametrize("unit", ["day", "week", "month", "quarter", "year"])
+    def test_m19_all_relative_units(
+        self, ws: Workspace, real_event: str, unit: str
+    ) -> None:
+        """M19 -- Every relative time comparison unit is accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            unit: Time comparison unit.
+        """
+        tc = TimeComparison.relative(unit)  # type: ignore[arg-type]
+        params = ws.build_params(real_event, last=30, time_comparison=tc)
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+        assert tc_output.get("value") == unit
+
+    def test_m20_time_comparison_on_funnel(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M20 -- Time comparison threads through funnel params.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("week")
+        params = ws.build_funnel_params(
+            list(real_events_pair), last=30, time_comparison=tc
+        )
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+
+    def test_m21_time_comparison_on_retention(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M21 -- Time comparison threads through retention params.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("month")
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            last=30,
+            time_comparison=tc,
+        )
+        tc_output = _dig(params, "displayOptions", "timeComparison")
+        assert tc_output is not None
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US4: Frequency Analysis
+# =============================================================================
+
+
+class TestOfflineUS4:
+    """Offline param-building tests for User Story 4 (frequency)."""
+
+    def test_m22_frequency_breakdown_in_group(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M22 -- FrequencyBreakdown produces frequency group entry.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event, bucket_size=1, bucket_min=0, bucket_max=10)
+        params = ws.build_params(real_event, group_by=fb, last=7)
+        group = _dig(params, "sections", "group")
+        assert group is not None
+        assert len(group) > 0
+
+    def test_m23_frequency_breakdown_has_behavior_type(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M23 -- FrequencyBreakdown group entry has behaviorType=$frequency.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event)
+        params = ws.build_params(real_event, group_by=fb, last=7)
+        group = _dig(params, "sections", "group")
+        assert group is not None
+        # Find the frequency group entry
+        freq_entries = [
+            g
+            for g in group
+            if isinstance(g, dict) and g.get("behaviorType") == "$frequency"
+        ]
+        assert len(freq_entries) > 0
+
+    def test_m24_frequency_breakdown_resource_type_people(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M24 -- FrequencyBreakdown forces resourceType=people.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event)
+        params = ws.build_params(real_event, group_by=fb, last=7)
+        group = _dig(params, "sections", "group")
+        assert group is not None
+        freq_entries = [
+            g
+            for g in group
+            if isinstance(g, dict) and g.get("behaviorType") == "$frequency"
+        ]
+        assert len(freq_entries) > 0
+        assert freq_entries[0].get("resourceType") == "people"
+
+    def test_m25_frequency_breakdown_custom_buckets(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M25 -- Custom bucket config appears in group entry.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event, bucket_size=5, bucket_min=0, bucket_max=50)
+        params = ws.build_params(real_event, group_by=fb, last=7)
+        group = _dig(params, "sections", "group")
+        assert group is not None
+        assert len(group) > 0
+
+    def test_m26_frequency_filter_in_filter(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M26 -- FrequencyFilter produces filter entry.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        ff = FrequencyFilter(real_event, operator="is at least", value=5)
+        params = ws.build_params(real_event, where=ff, last=7)
+        filt = _dig(params, "sections", "filter")
+        assert filt is not None
+        assert len(filt) > 0
+
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            "is at least",
+            "is at most",
+            "is greater than",
+            "is less than",
+            "is equal to",
+            "is between",
+        ],
+    )
+    def test_m27_frequency_filter_operators(
+        self, ws: Workspace, real_event: str, operator: str
+    ) -> None:
+        """M27 -- All 6 frequency filter operators accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+            operator: Frequency filter operator.
+        """
+        ff = FrequencyFilter(real_event, operator=operator, value=5)
+        params = ws.build_params(real_event, where=ff, last=7)
+        assert isinstance(params, dict)
+
+    def test_m28_frequency_filter_with_date_range(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M28 -- FrequencyFilter with date range params accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        ff = FrequencyFilter(
+            real_event,
+            value=3,
+            date_range_value=30,
+            date_range_unit="day",
+        )
+        params = ws.build_params(real_event, where=ff, last=7)
+        assert isinstance(params, dict)
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US5: Enhanced Behavioral Cohorts
+# =============================================================================
+
+
+class TestOfflineUS5:
+    """Offline tests for User Story 5 (cohort aggregations)."""
+
+    @pytest.mark.parametrize(
+        "agg", ["total", "unique", "average", "min", "max", "median"]
+    )
+    def test_m29_cohort_aggregation_operators(self, agg: str) -> None:
+        """M29 -- All 6 cohort aggregation operators accepted.
+
+        Args:
+            agg: Aggregation type.
+        """
+        criteria = CohortCriteria.did_event(
+            "Purchase",
+            aggregation=agg,  # type: ignore[arg-type]
+            aggregation_property="amount",
+            at_least=50,
+            within_days=30,
+        )
+        assert criteria is not None
+
+    def test_m30_cohort_aggregation_serializes(self) -> None:
+        """M30 -- Aggregation-based criteria serializes correctly."""
+        criteria = CohortCriteria.did_event(
+            "Purchase",
+            aggregation="average",
+            aggregation_property="amount",
+            at_least=50,
+            within_days=30,
+        )
+        # CohortCriteria has a behavior property
+        behavior = criteria._behavior
+        assert isinstance(behavior, dict)
+
+    def test_m31_cohort_count_based_still_works(self) -> None:
+        """M31 -- Count-based cohort criteria (no aggregation) still works."""
+        criteria = CohortCriteria.did_event(
+            "Purchase",
+            at_least=5,
+            within_days=30,
+        )
+        assert criteria is not None
+        behavior = criteria._behavior
+        assert isinstance(behavior, dict)
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US6: Complete Filter Operator Coverage
+# =============================================================================
+
+
+class TestOfflineUS6:
+    """Offline tests for User Story 6 (new filter methods)."""
+
+    def test_m32_not_between(self) -> None:
+        """M32 -- Filter.not_between produces correct operator."""
+        f = Filter.not_between("age", 18, 25)
+        assert f._operator == "not between"
+        assert f._value == [18, 25]
+        assert f._property_type == "number"
+
+    def test_m33_starts_with(self) -> None:
+        """M33 -- Filter.starts_with produces correct operator."""
+        f = Filter.starts_with("email", "admin")
+        assert f._operator == "starts with"
+        assert f._value == "admin"
+        assert f._property_type == "string"
+
+    def test_m34_ends_with(self) -> None:
+        """M34 -- Filter.ends_with produces correct operator."""
+        f = Filter.ends_with("domain", ".edu")
+        assert f._operator == "ends with"
+        assert f._value == ".edu"
+        assert f._property_type == "string"
+
+    def test_m35_date_not_between(self) -> None:
+        """M35 -- Filter.date_not_between produces correct operator."""
+        f = Filter.date_not_between("created", "2025-01-01", "2025-06-30")
+        assert f._operator == "was not between"
+        assert f._value == ["2025-01-01", "2025-06-30"]
+        assert f._property_type == "datetime"
+
+    def test_m36_in_the_next(self) -> None:
+        """M36 -- Filter.in_the_next produces correct operator."""
+        f = Filter.in_the_next("trial_end", 7, "day")
+        assert f._operator == "was in the next"
+        assert f._value == 7
+        assert f._property_type == "datetime"
+        assert f._date_unit == "day"
+
+    def test_m37_at_least(self) -> None:
+        """M37 -- Filter.at_least produces correct operator."""
+        f = Filter.at_least("purchase_count", 5)
+        assert f._operator == "is at least"
+        assert f._value == 5
+        assert f._property_type == "number"
+
+    def test_m38_at_most(self) -> None:
+        """M38 -- Filter.at_most produces correct operator."""
+        f = Filter.at_most("age", 65)
+        assert f._operator == "is at most"
+        assert f._value == 65
+        assert f._property_type == "number"
+
+    def test_m39_new_filters_in_build_params(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M39 -- New filter methods accepted by build_params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.at_least("$browser_version", 10)
+        params = ws.build_params(real_event, where=f, last=7)
+        assert isinstance(params, dict)
+        filt = _dig(params, "sections", "filter")
+        assert filt is not None
+
+    def test_m40_starts_with_in_build_params(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M40 -- starts_with filter accepted by build_params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.starts_with("$browser", "Chr")
+        params = ws.build_params(real_event, where=f, last=7)
+        assert isinstance(params, dict)
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US7: Group Analytics Scoping
+# =============================================================================
+
+
+class TestOfflineUS7:
+    """Offline tests for User Story 7 (data_group_id)."""
+
+    def test_m41_data_group_id_insights(self, ws: Workspace, real_event: str) -> None:
+        """M41 -- data_group_id threads into insights params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_params(real_event, data_group_id=5, last=7)
+        assert isinstance(params, dict)
+        # Check dataGroupId appears in the structure
+        dg = _dig(params, "sections", "dataGroupId")
+        assert dg == 5
+
+    def test_m42_data_group_id_funnel(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M42 -- data_group_id threads into funnel params.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_funnel_params(list(real_events_pair), data_group_id=5, last=7)
+        assert isinstance(params, dict)
+        dg = _dig(params, "sections", "dataGroupId")
+        assert dg == 5
+
+    def test_m43_data_group_id_retention(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """M43 -- data_group_id threads into retention params.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            data_group_id=5,
+            last=7,
+        )
+        assert isinstance(params, dict)
+        dg = _dig(params, "sections", "dataGroupId")
+        assert dg == 5
+
+    def test_m44_data_group_id_flow(self, ws: Workspace, real_event: str) -> None:
+        """M44 -- data_group_id threads into flow params.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(real_event, data_group_id=5, last=7)
+        assert isinstance(params, dict)
+        dg = params.get("data_group_id")
+        assert dg == 5
+
+    def test_m45_data_group_id_default_none(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M45 -- Omitting data_group_id preserves None/absent default.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_params(real_event, last=7)
+        dg = _dig(params, "sections", "dataGroupId")
+        assert dg is None
+
+
+# =============================================================================
+# OFFLINE VALIDATION — US8: Advanced Flow Features
+# =============================================================================
+
+
+class TestOfflineUS8:
+    """Offline tests for User Story 8 (flow features)."""
+
+    def test_m46_flow_session_event_start(self, ws: Workspace) -> None:
+        """M46 -- FlowStep with session_event=start produces correct params.
+
+        Args:
+            ws: Workspace fixture.
+        """
+        step = FlowStep("$session_start", session_event="start", forward=5)
+        params = ws.build_flow_params(step, last=7)
+        assert isinstance(params, dict)
+        steps = params.get("steps", [])
+        assert len(steps) > 0
+
+    def test_m47_flow_session_event_end(self, ws: Workspace) -> None:
+        """M47 -- FlowStep with session_event=end produces correct params.
+
+        Args:
+            ws: Workspace fixture.
+        """
+        step = FlowStep("$session_end", session_event="end", forward=3)
+        params = ws.build_flow_params(step, last=7)
+        assert isinstance(params, dict)
+
+    def test_m48_flow_exclusions(self, ws: Workspace, real_event: str) -> None:
+        """M48 -- Flow exclusions parameter accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(
+            real_event,
+            exclusions=["$identify", "$mp_web_page_view"],
+            last=7,
+        )
+        assert isinstance(params, dict)
+        excl = params.get("exclusions")
+        assert excl is not None
+
+    def test_m49_flow_segments_groupby(self, ws: Workspace, real_event: str) -> None:
+        """M49 -- Flow segments parameter with GroupBy accepted.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(
+            real_event,
+            segments=GroupBy(property="$browser"),
+            last=7,
+        )
+        assert isinstance(params, dict)
+        segs = params.get("segments")
+        assert segs is not None
+
+    def test_m50_flow_property_filter(self, ws: Workspace, real_event: str) -> None:
+        """M50 -- Flow with property filter produces filter_by_event.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(
+            real_event,
+            where=Filter.equals("$browser", "Chrome"),
+            last=7,
+        )
+        assert isinstance(params, dict)
+        fbe = params.get("filter_by_event")
+        assert fbe is not None
+
+    def test_m51_flow_cohort_filter_still_works(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """M51 -- Flow with cohort filter still produces filter_by_cohort.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        # Use in_cohort filter -- may not have a real cohort, so just
+        # verify the params build without error.
+        f = Filter.in_cohort(12345)
+        params = ws.build_flow_params(real_event, where=f, last=7)
+        assert isinstance(params, dict)
+
+
+# =============================================================================
+# VALIDATION ERROR TESTS
+# =============================================================================
+
+
+class TestValidationErrors:
+    """Tests that verify invalid inputs raise appropriate errors."""
+
+    def test_v01_time_comparison_relative_requires_unit(self) -> None:
+        """V01 -- TimeComparison.relative without unit raises TypeError."""
+        with pytest.raises(TypeError):
+            TimeComparison.relative()  # type: ignore[call-arg]
+
+    def test_v02_time_comparison_relative_rejects_date(self) -> None:
+        """V02 -- TimeComparison type=relative with date raises ValueError."""
+        with pytest.raises(ValueError, match="does not accept date"):
+            TimeComparison(type="relative", unit="month", date="2026-01-01")
+
+    def test_v03_time_comparison_absolute_requires_date(self) -> None:
+        """V03 -- TimeComparison absolute-start without date raises ValueError."""
+        with pytest.raises(ValueError, match="requires date"):
+            TimeComparison(type="absolute-start")
+
+    def test_v04_time_comparison_absolute_rejects_unit(self) -> None:
+        """V04 -- TimeComparison absolute-start with unit raises ValueError."""
+        with pytest.raises(ValueError, match="does not accept unit"):
+            TimeComparison(type="absolute-start", date="2026-01-01", unit="month")
+
+    def test_v05_time_comparison_bad_date_format(self) -> None:
+        """V05 -- TimeComparison with non-YYYY-MM-DD date raises ValueError."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            TimeComparison.absolute_start("01-01-2026")
+
+    def test_v06_time_comparison_rejected_on_flow(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """V06 -- time_comparison is not accepted on flow queries.
+
+        Flow queries deliberately exclude time_comparison from their
+        signature. Passing it raises TypeError (unexpected keyword).
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.relative("month")
+        with pytest.raises(TypeError, match="time_comparison"):
+            ws.build_flow_params(  # type: ignore[call-arg]
+                real_event, last=7, time_comparison=tc
+            )
+
+    def test_v07_frequency_breakdown_empty_event(self) -> None:
+        """V07 -- FrequencyBreakdown with empty event raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyBreakdown("")
+
+    def test_v08_frequency_breakdown_negative_bucket_size(self) -> None:
+        """V08 -- FrequencyBreakdown with negative bucket_size raises ValueError."""
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyBreakdown("Login", bucket_size=-1)
+
+    def test_v09_frequency_breakdown_min_ge_max(self) -> None:
+        """V09 -- FrequencyBreakdown with bucket_min >= bucket_max raises ValueError."""
+        with pytest.raises(ValueError, match="less than"):
+            FrequencyBreakdown("Login", bucket_min=10, bucket_max=5)
+
+    def test_v10_frequency_breakdown_negative_min(self) -> None:
+        """V10 -- FrequencyBreakdown with negative bucket_min raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyBreakdown("Login", bucket_min=-1)
+
+    def test_v11_frequency_filter_empty_event(self) -> None:
+        """V11 -- FrequencyFilter with empty event raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyFilter("", value=5)
+
+    def test_v12_frequency_filter_invalid_operator(self) -> None:
+        """V12 -- FrequencyFilter with invalid operator raises ValueError."""
+        with pytest.raises(ValueError, match="operator"):
+            FrequencyFilter("Login", operator="bad op", value=5)
+
+    def test_v13_frequency_filter_negative_value(self) -> None:
+        """V13 -- FrequencyFilter with negative value raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyFilter("Login", value=-1)
+
+    def test_v14_frequency_filter_date_range_mismatch(self) -> None:
+        """V14 -- FrequencyFilter with only date_range_value raises ValueError."""
+        with pytest.raises(ValueError, match="both be set"):
+            FrequencyFilter("Login", value=5, date_range_value=30)
+
+    def test_v15_frequency_filter_date_range_unit_only(self) -> None:
+        """V15 -- FrequencyFilter with only date_range_unit raises ValueError."""
+        with pytest.raises(ValueError, match="both be set"):
+            FrequencyFilter("Login", value=5, date_range_unit="day")
+
+    def test_v16_frequency_filter_date_range_zero(self) -> None:
+        """V16 -- FrequencyFilter with date_range_value=0 raises ValueError."""
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyFilter("Login", value=5, date_range_value=0, date_range_unit="day")
+
+    def test_v17_cohort_aggregation_requires_property(self) -> None:
+        """V17 -- CohortCriteria aggregation without property raises ValueError."""
+        with pytest.raises(ValueError):
+            CohortCriteria.did_event(
+                "Purchase",
+                aggregation="average",
+                at_least=50,
+                within_days=30,
+            )
+
+    def test_v18_cohort_aggregation_property_requires_aggregation(self) -> None:
+        """V18 -- CohortCriteria aggregation_property without aggregation raises ValueError."""
+        with pytest.raises(ValueError):
+            CohortCriteria.did_event(
+                "Purchase",
+                aggregation_property="amount",
+                at_least=50,
+                within_days=30,
+            )
+
+    def test_v19_flow_step_session_event_mismatch(self) -> None:
+        """V19 -- FlowStep session_event=start with wrong event name raises ValueError."""
+        with pytest.raises(ValueError, match="session_event"):
+            FlowStep("Login", session_event="start")
+
+    def test_v20_flow_step_session_event_end_mismatch(self) -> None:
+        """V20 -- FlowStep session_event=end with wrong event name raises ValueError."""
+        with pytest.raises(ValueError, match="session_event"):
+            FlowStep("Login", session_event="end")
+
+    def test_v21_flow_step_forward_out_of_range(self) -> None:
+        """V21 -- FlowStep with forward=6 raises ValueError."""
+        with pytest.raises(ValueError, match="0-5"):
+            FlowStep("Login", forward=6)
+
+    def test_v22_flow_step_reverse_out_of_range(self) -> None:
+        """V22 -- FlowStep with reverse=6 raises ValueError."""
+        with pytest.raises(ValueError, match="0-5"):
+            FlowStep("Login", reverse=6)
+
+    def test_v23_metric_property_required_math_no_property(self) -> None:
+        """V23 -- Metric with unique_values but no property raises ValueError."""
+        with pytest.raises(ValueError):
+            Metric("Login", math="unique_values")
+
+    def test_v24_metric_property_required_multi_attribution(self) -> None:
+        """V24 -- Metric with multi_attribution but no property raises ValueError."""
+        with pytest.raises(ValueError):
+            Metric("Login", math="multi_attribution")
+
+    def test_v25_metric_property_required_numeric_summary(self) -> None:
+        """V25 -- Metric with numeric_summary but no property raises ValueError."""
+        with pytest.raises(ValueError):
+            Metric("Login", math="numeric_summary")
+
+
+# =============================================================================
+# LIVE API TESTS — US1: Math Types
+# =============================================================================
+
+
+class TestLiveUS1:
+    """Live API tests for expanded math types."""
+
+    def test_l01_cumulative_unique_live(self, ws: Workspace, real_event: str) -> None:
+        """L01 -- cumulative_unique math type returns valid result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(
+            ws.query, real_event, math="cumulative_unique", last=7
+        )
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l02_sessions_math_live(self, ws: Workspace, real_event: str) -> None:
+        """L02 -- sessions math type returns valid result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(ws.query, real_event, math="sessions", last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l03_unique_values_live(self, ws: Workspace, real_event: str) -> None:
+        """L03 -- unique_values math type with property returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(
+            ws.query,
+            real_event,
+            math="unique_values",
+            math_property="$browser",
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l04_most_frequent_live(self, ws: Workspace, real_event: str) -> None:
+        """L04 -- most_frequent math type with property returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(
+            ws.query,
+            real_event,
+            math="most_frequent",
+            math_property="$browser",
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l05_retention_total_live(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L05 -- Retention with math=total returns valid result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_retention,
+            real_events_pair[0],
+            real_events_pair[1],
+            math="total",
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, RetentionQueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US2: Advanced Modes
+# =============================================================================
+
+
+class TestLiveUS2:
+    """Live API tests for funnel reentry, retention unbounded/cumulative."""
+
+    def test_l06_funnel_reentry_aggressive(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L06 -- Funnel with reentry_mode=aggressive returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_funnel,
+            list(real_events_pair),
+            reentry_mode="aggressive",
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, FunnelQueryResult)
+
+    def test_l07_retention_carry_forward(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L07 -- Retention with unbounded_mode=carry_forward returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_retention,
+            real_events_pair[0],
+            real_events_pair[1],
+            unbounded_mode="carry_forward",
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, RetentionQueryResult)
+
+    def test_l08_retention_cumulative_live(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L08 -- Retention with retention_cumulative=True returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        result = _query_or_api_error(
+            ws.query_retention,
+            real_events_pair[0],
+            real_events_pair[1],
+            retention_cumulative=True,
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, RetentionQueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US3: Time Comparison
+# =============================================================================
+
+
+class TestLiveUS3:
+    """Live API tests for time comparison."""
+
+    def test_l09_time_comparison_relative_live(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """L09 -- Query with relative time comparison returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.relative("month")
+        result = _query_or_api_error(ws.query, real_event, last=30, time_comparison=tc)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l10_time_comparison_funnel_live(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L10 -- Funnel with time comparison returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("week")
+        result = _query_or_api_error(
+            ws.query_funnel,
+            list(real_events_pair),
+            last=30,
+            time_comparison=tc,
+        )
+        if result is not None:
+            assert isinstance(result, FunnelQueryResult)
+
+    def test_l11_time_comparison_retention_live(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """L11 -- Retention with time comparison returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("month")
+        result = _query_or_api_error(
+            ws.query_retention,
+            real_events_pair[0],
+            real_events_pair[1],
+            last=30,
+            time_comparison=tc,
+        )
+        if result is not None:
+            assert isinstance(result, RetentionQueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US4: Frequency Analysis
+# =============================================================================
+
+
+class TestLiveUS4:
+    """Live API tests for frequency breakdown and filter."""
+
+    def test_l12_frequency_breakdown_live(self, ws: Workspace, real_event: str) -> None:
+        """L12 -- Query with frequency breakdown returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event)
+        result = _query_or_api_error(ws.query, real_event, group_by=fb, last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l13_frequency_filter_live(self, ws: Workspace, real_event: str) -> None:
+        """L13 -- Query with frequency filter returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        ff = FrequencyFilter(real_event, value=1)
+        result = _query_or_api_error(ws.query, real_event, where=ff, last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US6: Filters
+# =============================================================================
+
+
+class TestLiveUS6:
+    """Live API tests for new filter methods."""
+
+    def test_l14_at_least_filter_live(self, ws: Workspace, real_event: str) -> None:
+        """L14 -- Query with at_least filter returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.at_least("$browser_version", 1)
+        result = _query_or_api_error(ws.query, real_event, where=f, last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l15_starts_with_filter_live(self, ws: Workspace, real_event: str) -> None:
+        """L15 -- Query with starts_with filter returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.starts_with("$browser", "Chr")
+        result = _query_or_api_error(ws.query, real_event, where=f, last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+    def test_l16_not_between_filter_live(self, ws: Workspace, real_event: str) -> None:
+        """L16 -- Query with not_between filter returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.not_between("$browser_version", 0, 50)
+        result = _query_or_api_error(ws.query, real_event, where=f, last=7)
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US7: Data Group ID
+# =============================================================================
+
+
+class TestLiveUS7:
+    """Live API tests for data_group_id parameter."""
+
+    def test_l17_data_group_id_live(self, ws: Workspace, real_event: str) -> None:
+        """L17 -- Query with data_group_id does not crash.
+
+        The server may reject if the project has no data groups,
+        but the client must not crash.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(ws.query, real_event, data_group_id=5, last=7)
+        # Either a valid result or an API error; no crash
+        if result is not None:
+            assert isinstance(result, QueryResult)
+
+
+# =============================================================================
+# LIVE API TESTS — US8: Flow Features
+# =============================================================================
+
+
+class TestLiveUS8:
+    """Live API tests for advanced flow features."""
+
+    def test_l18_flow_with_property_filter_live(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """L18 -- Flow with property filter returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        f = Filter.equals("$browser", "Chrome")
+        result = _query_or_api_error(ws.query_flow, real_event, where=f, last=7)
+        if result is not None:
+            assert isinstance(result, FlowQueryResult)
+
+    def test_l19_flow_with_exclusions_live(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """L19 -- Flow with exclusions returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(
+            ws.query_flow,
+            real_event,
+            exclusions=["$identify"],
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, FlowQueryResult)
+
+    def test_l20_flow_with_segments_live(self, ws: Workspace, real_event: str) -> None:
+        """L20 -- Flow with segments (GroupBy) returns result.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        result = _query_or_api_error(
+            ws.query_flow,
+            real_event,
+            segments=GroupBy(property="$browser"),
+            last=7,
+        )
+        if result is not None:
+            assert isinstance(result, FlowQueryResult)
+
+    def test_l21_flow_session_start_live(self, ws: Workspace) -> None:
+        """L21 -- Flow with session_event=start anchor returns result.
+
+        Args:
+            ws: Workspace fixture.
+        """
+        step = FlowStep("$session_start", session_event="start", forward=3)
+        result = _query_or_api_error(ws.query_flow, step, last=7)
+        if result is not None:
+            assert isinstance(result, FlowQueryResult)
+
+
+# =============================================================================
+# CROSS-PARAMETER INTERACTION TESTS — X01-X07
+# =============================================================================
+
+
+class TestCrossParameterInteractions:
+    """Tests combining multiple new features together."""
+
+    def test_x01_time_comparison_plus_new_math(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """X01 -- Time comparison combined with cumulative_unique math.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        tc = TimeComparison.relative("month")
+        params = ws.build_params(
+            real_event,
+            math="cumulative_unique",
+            last=30,
+            time_comparison=tc,
+        )
+        assert isinstance(params, dict)
+        assert _dig(params, "displayOptions", "timeComparison") is not None
+
+    def test_x02_frequency_breakdown_plus_filter(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """X02 -- Frequency breakdown with a property filter combined.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event)
+        f = Filter.equals("$browser", "Chrome")
+        params = ws.build_params(real_event, group_by=fb, where=f, last=7)
+        assert isinstance(params, dict)
+        assert _dig(params, "sections", "group") is not None
+        assert _dig(params, "sections", "filter") is not None
+
+    def test_x03_frequency_filter_plus_groupby(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """X03 -- Frequency filter with a standard GroupBy combined.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        ff = FrequencyFilter(real_event, value=2)
+        gb = GroupBy(property="$browser")
+        params = ws.build_params(real_event, group_by=gb, where=ff, last=7)
+        assert isinstance(params, dict)
+        assert _dig(params, "sections", "group") is not None
+        assert _dig(params, "sections", "filter") is not None
+
+    def test_x04_reentry_mode_plus_time_comparison(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """X04 -- Funnel reentry mode combined with time comparison.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("week")
+        params = ws.build_funnel_params(
+            list(real_events_pair),
+            reentry_mode="aggressive",
+            time_comparison=tc,
+            last=30,
+        )
+        assert isinstance(params, dict)
+        behavior = _dig(params, "sections", "show", 0, "behavior")
+        assert behavior is not None
+        assert behavior.get("funnelReentryMode") == "aggressive"
+        assert _dig(params, "displayOptions", "timeComparison") is not None
+
+    def test_x05_unbounded_plus_cumulative_plus_time_comparison(
+        self,
+        ws: Workspace,
+        real_events_pair: tuple[str, str],
+    ) -> None:
+        """X05 -- Retention unbounded + cumulative + time comparison combined.
+
+        Args:
+            ws: Workspace fixture.
+            real_events_pair: Two known event names.
+        """
+        tc = TimeComparison.relative("month")
+        params = ws.build_retention_params(
+            real_events_pair[0],
+            real_events_pair[1],
+            unbounded_mode="carry_forward",
+            retention_cumulative=True,
+            time_comparison=tc,
+            last=30,
+        )
+        assert isinstance(params, dict)
+        behavior = _dig(params, "sections", "show", 0, "behavior")
+        measurement = _dig(params, "sections", "show", 0, "measurement")
+        assert behavior is not None
+        assert behavior.get("retentionUnboundedMode") == "carry_forward"
+        assert measurement is not None
+        assert measurement.get("retentionCumulative") is True
+        assert _dig(params, "displayOptions", "timeComparison") is not None
+
+    def test_x06_data_group_id_plus_frequency(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """X06 -- data_group_id combined with frequency breakdown.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        fb = FrequencyBreakdown(real_event)
+        params = ws.build_params(real_event, group_by=fb, data_group_id=5, last=7)
+        assert isinstance(params, dict)
+        assert _dig(params, "sections", "dataGroupId") == 5
+        assert _dig(params, "sections", "group") is not None
+
+    def test_x07_flow_exclusions_plus_segments_plus_filter(
+        self, ws: Workspace, real_event: str
+    ) -> None:
+        """X07 -- Flow with exclusions + segments + property filter combined.
+
+        Args:
+            ws: Workspace fixture.
+            real_event: Known event name.
+        """
+        params = ws.build_flow_params(
+            real_event,
+            exclusions=["$identify"],
+            segments=GroupBy(property="$browser"),
+            where=Filter.equals("$os", "Mac OS X"),
+            last=7,
+        )
+        assert isinstance(params, dict)
+        assert params.get("exclusions") is not None
+        assert params.get("segments") is not None
+        assert params.get("filter_by_event") is not None

--- a/tests/live/test_040_query_completeness_live.py
+++ b/tests/live/test_040_query_completeness_live.py
@@ -883,7 +883,7 @@ class TestOfflineUS4:
             real_event: Known event name.
             operator: Frequency filter operator.
         """
-        ff = FrequencyFilter(real_event, operator=operator, value=5)
+        ff = FrequencyFilter(real_event, operator=operator, value=5)  # type: ignore[arg-type]
         params = ws.build_params(real_event, where=ff, last=7)
         assert isinstance(params, dict)
 
@@ -1301,7 +1301,7 @@ class TestValidationErrors:
     def test_v12_frequency_filter_invalid_operator(self) -> None:
         """V12 -- FrequencyFilter with invalid operator raises ValueError."""
         with pytest.raises(ValueError, match="operator"):
-            FrequencyFilter("Login", operator="bad op", value=5)
+            FrequencyFilter("Login", operator="bad op", value=5)  # type: ignore[arg-type]
 
     def test_v13_frequency_filter_negative_value(self) -> None:
         """V13 -- FrequencyFilter with negative value raises ValueError."""

--- a/tests/live/test_040_query_completeness_live.py
+++ b/tests/live/test_040_query_completeness_live.py
@@ -870,7 +870,6 @@ class TestOfflineUS4:
             "is greater than",
             "is less than",
             "is equal to",
-            "is between",
         ],
     )
     def test_m27_frequency_filter_operators(

--- a/tests/test_build_cohort_params.py
+++ b/tests/test_build_cohort_params.py
@@ -246,13 +246,12 @@ class TestBuildFlowCohortFilter:
         fbc = result["filter_by_cohort"]
         assert fbc["negated"] is False
 
-    def test_flow_non_cohort_filter_raises(self, ws: Workspace) -> None:
-        """Verify non-cohort filter in flow where= raises ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="query_flow where= only accepts cohort filters",
-        ):
-            ws.build_flow_params("Login", where=Filter.equals("country", "US"))
+    def test_flow_property_filter_produces_filter_by_event(self, ws: Workspace) -> None:
+        """Verify property filter in flow where= produces filter_by_event."""
+        result = ws.build_flow_params("Login", where=Filter.equals("country", "US"))
+        assert "filter_by_event" in result
+        assert result["filter_by_event"]["operator"] == "and"
+        assert len(result["filter_by_event"]["children"]) == 1
 
 
 # =============================================================================
@@ -817,13 +816,12 @@ class TestQueryFlowCohortFilter:
         result = ws.build_flow_params("Login")
         assert "filter_by_cohort" not in result
 
-    def test_flow_non_cohort_filter_raises_value_error(self, ws: Workspace) -> None:
-        """Verify non-cohort filter in flow where= raises ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="query_flow where= only accepts cohort filters",
-        ):
-            ws.build_flow_params("Login", where=Filter.equals("country", "US"))
+    def test_flow_property_filter_produces_filter_by_event(self, ws: Workspace) -> None:
+        """Verify property filter in flow where= produces filter_by_event."""
+        result = ws.build_flow_params("Login", where=Filter.equals("country", "US"))
+        assert "filter_by_event" in result
+        assert result["filter_by_event"]["operator"] == "and"
+        assert len(result["filter_by_event"]["children"]) == 1
 
     def test_flow_multiple_cohort_filters_raises_value_error(
         self, ws: Workspace

--- a/tests/test_build_funnel_params.py
+++ b/tests/test_build_funnel_params.py
@@ -794,3 +794,93 @@ class TestBuildFunnelParamsHoldingConstant:
         result = ws.build_funnel_params(["A", "B"])
         behavior = result["sections"]["show"][0]["behavior"]
         assert behavior["aggregateBy"] == []
+
+
+# =============================================================================
+# T005: New funnel math types
+# =============================================================================
+
+
+class TestBuildFunnelParamsNewMathTypes:
+    """T005: New funnel math type histogram is accepted."""
+
+    def test_math_histogram_accepted(self, ws: Workspace) -> None:
+        """build_funnel_params accepts math='histogram' and sets measurement correctly."""
+        result = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            math="histogram",
+            math_property="amount",
+        )
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert measurement["math"] == "histogram"
+        assert measurement["property"]["name"] == "amount"
+
+
+# =============================================================================
+# T009: Funnel reentry_mode parameter
+# =============================================================================
+
+
+class TestBuildFunnelParamsReentryMode:
+    """T009: Tests for reentry_mode parameter in build_funnel_params."""
+
+    def test_reentry_mode_aggressive(self, ws: Workspace) -> None:
+        """build_funnel_params with reentry_mode='aggressive' produces funnelReentryMode."""
+        result = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            reentry_mode="aggressive",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["funnelReentryMode"] == "aggressive"
+
+    def test_reentry_mode_default(self, ws: Workspace) -> None:
+        """build_funnel_params with reentry_mode='default' produces funnelReentryMode."""
+        result = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            reentry_mode="default",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["funnelReentryMode"] == "default"
+
+    def test_reentry_mode_basic(self, ws: Workspace) -> None:
+        """build_funnel_params with reentry_mode='basic' produces funnelReentryMode."""
+        result = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            reentry_mode="basic",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["funnelReentryMode"] == "basic"
+
+    def test_reentry_mode_optimized(self, ws: Workspace) -> None:
+        """build_funnel_params with reentry_mode='optimized' produces funnelReentryMode."""
+        result = ws.build_funnel_params(
+            ["Signup", "Purchase"],
+            reentry_mode="optimized",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["funnelReentryMode"] == "optimized"
+
+    def test_no_reentry_mode_omits_key(self, ws: Workspace) -> None:
+        """build_funnel_params without reentry_mode omits funnelReentryMode (backward compat)."""
+        result = ws.build_funnel_params(["Signup", "Purchase"])
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert "funnelReentryMode" not in behavior
+
+
+# =============================================================================
+# T032: data_group_id on funnel query engine
+# =============================================================================
+
+
+class TestDataGroupIdFunnel:
+    """Tests for data_group_id parameter on funnel query engine (T032)."""
+
+    def test_build_funnel_params_with_data_group_id(self, ws: Workspace) -> None:
+        """build_funnel_params with data_group_id=5 includes dataGroupId: 5 in sections."""
+        result = ws.build_funnel_params(["Signup", "Purchase"], data_group_id=5)
+        assert result["sections"]["dataGroupId"] == 5
+
+    def test_build_funnel_params_without_data_group_id(self, ws: Workspace) -> None:
+        """build_funnel_params without data_group_id omits dataGroupId key (backward compat)."""
+        result = ws.build_funnel_params(["Signup", "Purchase"])
+        assert "dataGroupId" not in result["sections"]

--- a/tests/test_build_retention_params.py
+++ b/tests/test_build_retention_params.py
@@ -327,3 +327,136 @@ class TestBuildRetentionParamsMode:
         """mode='table' must produce chartType 'table'."""
         result = ws.build_retention_params("Signup", "Login", mode="table")
         assert result["displayOptions"]["chartType"] == "table"
+
+
+# =============================================================================
+# T005: New retention math types
+# =============================================================================
+
+
+class TestBuildRetentionParamsNewMathTypes:
+    """T005: New retention math types total and average are accepted."""
+
+    def test_math_total_accepted(self, ws: Workspace) -> None:
+        """build_retention_params accepts math='total' and sets measurement correctly."""
+        result = ws.build_retention_params("Signup", "Login", math="total")
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert measurement["math"] == "total"
+
+    def test_math_average_accepted(self, ws: Workspace) -> None:
+        """build_retention_params accepts math='average' and sets measurement correctly."""
+        result = ws.build_retention_params("Signup", "Login", math="average")
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert measurement["math"] == "average"
+
+
+# =============================================================================
+# T009: Retention unbounded_mode and retention_cumulative parameters
+# =============================================================================
+
+
+class TestBuildRetentionParamsUnboundedMode:
+    """T009: Tests for unbounded_mode parameter in build_retention_params."""
+
+    def test_unbounded_mode_carry_forward(self, ws: Workspace) -> None:
+        """build_retention_params with unbounded_mode='carry_forward' produces retentionUnboundedMode."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            unbounded_mode="carry_forward",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionUnboundedMode"] == "carry_forward"
+
+    def test_unbounded_mode_carry_back(self, ws: Workspace) -> None:
+        """build_retention_params with unbounded_mode='carry_back' produces retentionUnboundedMode."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            unbounded_mode="carry_back",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionUnboundedMode"] == "carry_back"
+
+    def test_unbounded_mode_none_value(self, ws: Workspace) -> None:
+        """build_retention_params with unbounded_mode='none' produces retentionUnboundedMode."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            unbounded_mode="none",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionUnboundedMode"] == "none"
+
+    def test_unbounded_mode_consecutive_forward(self, ws: Workspace) -> None:
+        """build_retention_params with unbounded_mode='consecutive_forward' produces retentionUnboundedMode."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            unbounded_mode="consecutive_forward",
+        )
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert behavior["retentionUnboundedMode"] == "consecutive_forward"
+
+    def test_no_unbounded_mode_omits_key(self, ws: Workspace) -> None:
+        """build_retention_params without unbounded_mode omits retentionUnboundedMode (backward compat)."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        assert "retentionUnboundedMode" not in behavior
+
+
+class TestBuildRetentionParamsCumulative:
+    """T009: Tests for retention_cumulative parameter in build_retention_params."""
+
+    def test_retention_cumulative_true(self, ws: Workspace) -> None:
+        """build_retention_params with retention_cumulative=True produces retentionCumulative."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            retention_cumulative=True,
+        )
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert measurement["retentionCumulative"] is True
+
+    def test_retention_cumulative_false_omits_key(self, ws: Workspace) -> None:
+        """build_retention_params with retention_cumulative=False omits retentionCumulative (backward compat)."""
+        result = ws.build_retention_params("Signup", "Login")
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert "retentionCumulative" not in measurement
+
+    def test_retention_cumulative_explicit_false_omits_key(self, ws: Workspace) -> None:
+        """build_retention_params with explicit retention_cumulative=False omits retentionCumulative."""
+        result = ws.build_retention_params(
+            "Signup",
+            "Login",
+            retention_cumulative=False,
+        )
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert "retentionCumulative" not in measurement
+
+    def test_no_new_params_backward_compat(self, ws: Workspace) -> None:
+        """build_retention_params without new params produces NO retentionUnboundedMode or retentionCumulative."""
+        result = ws.build_retention_params("Signup", "Login")
+        behavior = result["sections"]["show"][0]["behavior"]
+        measurement = result["sections"]["show"][0]["measurement"]
+        assert "retentionUnboundedMode" not in behavior
+        assert "retentionCumulative" not in measurement
+
+
+# =============================================================================
+# T032: data_group_id on retention query engine
+# =============================================================================
+
+
+class TestDataGroupIdRetention:
+    """Tests for data_group_id parameter on retention query engine (T032)."""
+
+    def test_build_retention_params_with_data_group_id(self, ws: Workspace) -> None:
+        """build_retention_params with data_group_id=5 includes dataGroupId: 5 in sections."""
+        result = ws.build_retention_params("Signup", "Login", data_group_id=5)
+        assert result["sections"]["dataGroupId"] == 5
+
+    def test_build_retention_params_without_data_group_id(self, ws: Workspace) -> None:
+        """build_retention_params without data_group_id omits dataGroupId key (backward compat)."""
+        result = ws.build_retention_params("Signup", "Login")
+        assert "dataGroupId" not in result["sections"]

--- a/tests/test_types_cohort_behaviors.py
+++ b/tests/test_types_cohort_behaviors.py
@@ -538,3 +538,123 @@ class TestSanitizeRawCohort:
         _sanitize_raw_cohort(raw)
         # Original should still have selector: None
         assert raw["behaviors"]["b1"]["count"]["event_selector"]["selector"] is None
+
+
+# =============================================================================
+# US5: CohortCriteria.did_event() — aggregation params (T027)
+# =============================================================================
+
+
+class TestCohortCriteriaAggregation:
+    """Tests for aggregation and aggregation_property params on did_event()."""
+
+    def test_aggregation_with_property_succeeds(self) -> None:
+        """did_event with aggregation + aggregation_property creates criteria."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            aggregation="average",
+            aggregation_property="amount",
+            at_least=50,
+            within_days=30,
+        )
+        assert c._behavior is not None
+
+    @pytest.mark.parametrize(
+        "agg_type",
+        ["total", "unique", "average", "min", "max", "median"],
+    )
+    def test_all_six_aggregation_operators_accepted(self, agg_type: Any) -> None:
+        """All 6 CohortAggregationType values are accepted without error."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            aggregation=agg_type,
+            aggregation_property="amount",
+            at_least=1,
+            within_days=30,
+        )
+        assert c._behavior is not None
+
+    def test_ca1_aggregation_without_property_raises(self) -> None:
+        """CA1: aggregation without aggregation_property raises ValueError."""
+        with pytest.raises(
+            ValueError,
+            match="aggregation and aggregation_property must both be set or both be None",
+        ):
+            CohortCriteria.did_event(
+                "Purchase",
+                aggregation="average",
+                at_least=50,
+                within_days=30,
+            )
+
+    def test_ca2_aggregation_property_without_aggregation_raises(self) -> None:
+        """CA2: aggregation_property without aggregation raises ValueError."""
+        with pytest.raises(
+            ValueError,
+            match="aggregation and aggregation_property must both be set or both be None",
+        ):
+            CohortCriteria.did_event(
+                "Purchase",
+                aggregation_property="amount",
+                at_least=50,
+                within_days=30,
+            )
+
+
+class TestCohortCriteriaAggregationSerialization:
+    """Tests for aggregation serialization in behavior dict."""
+
+    def test_serialization_includes_aggregation_operator(self) -> None:
+        """Behavior dict includes aggregationOperator when aggregation is set."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            aggregation="average",
+            aggregation_property="amount",
+            at_least=50,
+            within_days=30,
+        )
+        assert c._behavior is not None
+        count = c._behavior["count"]
+        assert count["aggregationOperator"] == "average"
+
+    def test_serialization_includes_property(self) -> None:
+        """Behavior dict includes property when aggregation_property is set."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            aggregation="total",
+            aggregation_property="revenue",
+            at_least=100,
+            within_days=7,
+        )
+        assert c._behavior is not None
+        count = c._behavior["count"]
+        assert count["property"] == "revenue"
+
+    def test_no_aggregation_behavior_unchanged(self) -> None:
+        """Behavior dict has no aggregationOperator/property when not set."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            at_least=1,
+            within_days=30,
+        )
+        assert c._behavior is not None
+        count = c._behavior["count"]
+        assert "aggregationOperator" not in count
+        assert "property" not in count
+
+    @pytest.mark.parametrize(
+        "agg_type",
+        ["total", "unique", "average", "min", "max", "median"],
+    )
+    def test_all_operators_serialize_correctly(self, agg_type: Any) -> None:
+        """Each aggregation operator serializes as its string value."""
+        c = CohortCriteria.did_event(
+            "Purchase",
+            aggregation=agg_type,
+            aggregation_property="amount",
+            at_least=1,
+            within_days=30,
+        )
+        assert c._behavior is not None
+        assert c._behavior["count"]["aggregationOperator"] == agg_type
+        assert c._behavior["count"]["property"] == "amount"

--- a/tests/test_types_flow.py
+++ b/tests/test_types_flow.py
@@ -792,3 +792,50 @@ class TestSafeInt:
     def test_negative_string(self) -> None:
         """Negative string '-5' is parsed correctly."""
         assert _safe_int("-5") == -5
+
+
+# =============================================================================
+# T037: FlowStep with session_event (US8 — Advanced Flow Features)
+# =============================================================================
+
+
+class TestFlowStepSessionEvent:
+    """Tests for FlowStep.session_event field (FS1)."""
+
+    def test_session_start_succeeds(self) -> None:
+        """FlowStep with session_event='start' and event='$session_start' succeeds."""
+        step = FlowStep(event="$session_start", session_event="start")
+        assert step.session_event == "start"
+        assert step.event == "$session_start"
+
+    def test_session_end_succeeds(self) -> None:
+        """FlowStep with session_event='end' and event='$session_end' succeeds."""
+        step = FlowStep(event="$session_end", session_event="end")
+        assert step.session_event == "end"
+        assert step.event == "$session_end"
+
+    def test_default_session_event_is_none(self) -> None:
+        """FlowStep without session_event has session_event=None."""
+        step = FlowStep("Login")
+        assert step.session_event is None
+
+    def test_regular_event_with_session_event_raises(self) -> None:
+        """FlowStep with a regular event name and session_event raises ValueError."""
+        with pytest.raises(ValueError, match="session_event"):
+            FlowStep(event="Login", session_event="start")
+
+    def test_session_start_wrong_event_raises(self) -> None:
+        """FlowStep with session_event='start' but event='$session_end' raises."""
+        with pytest.raises(ValueError, match="session_event"):
+            FlowStep(event="$session_end", session_event="start")
+
+    def test_session_end_wrong_event_raises(self) -> None:
+        """FlowStep with session_event='end' but event='$session_start' raises."""
+        with pytest.raises(ValueError, match="session_event"):
+            FlowStep(event="$session_start", session_event="end")
+
+    def test_session_event_immutable(self) -> None:
+        """session_event cannot be set on a frozen instance."""
+        step = FlowStep(event="$session_start", session_event="start")
+        with pytest.raises(AttributeError):
+            step.session_event = "end"  # type: ignore[misc]

--- a/tests/test_types_funnel_pbt.py
+++ b/tests/test_types_funnel_pbt.py
@@ -495,7 +495,7 @@ class TestFunnelQueryResultProperties:
 class TestFunnelMathTypeProperties:
     """Property-based tests for FunnelMathType Literal type.
 
-    Verifies the exact set of 13 valid values and membership invariants.
+    Verifies the exact set of 14 valid values and membership invariants.
     """
 
     EXPECTED_VALUES: frozenset[str] = frozenset(
@@ -513,16 +513,17 @@ class TestFunnelMathTypeProperties:
             "p75",
             "p90",
             "p99",
+            "histogram",
         ]
     )
 
-    def test_exactly_13_valid_values(self) -> None:
-        """FunnelMathType has exactly 13 valid values."""
+    def test_exactly_14_valid_values(self) -> None:
+        """FunnelMathType has exactly 14 valid values."""
         actual = set(get_args(FunnelMathType))
-        assert len(actual) == 13
+        assert len(actual) == 14
 
     def test_exact_set_of_values(self) -> None:
-        """FunnelMathType contains exactly the expected 13 values."""
+        """FunnelMathType contains exactly the expected 14 values."""
         actual = set(get_args(FunnelMathType))
         assert actual == self.EXPECTED_VALUES
 

--- a/tests/test_user_query_pbt.py
+++ b/tests/test_user_query_pbt.py
@@ -39,7 +39,7 @@ property_names: st.SearchStrategy[str] = st.text(
 )
 
 # String values for filter comparisons.
-# Restricted to printable alphanumeric + common punctuation to avoid generating
+# Restricted to letters, numbers, and spaces to avoid generating
 # operator-like substrings (e.g. "==", "!=", " or ", " and ") that would break
 # selector-counting assertions in multi-value filter tests.
 string_values: st.SearchStrategy[str] = st.text(

--- a/tests/test_user_query_pbt.py
+++ b/tests/test_user_query_pbt.py
@@ -39,7 +39,11 @@ property_names: st.SearchStrategy[str] = st.text(
 )
 
 # String values for filter comparisons.
+# Restricted to printable alphanumeric + common punctuation to avoid generating
+# operator-like substrings (e.g. "==", "!=", " or ", " and ") that would break
+# selector-counting assertions in multi-value filter tests.
 string_values: st.SearchStrategy[str] = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N", "Zs")),
     min_size=1,
     max_size=20,
 )

--- a/tests/test_validation_flow.py
+++ b/tests/test_validation_flow.py
@@ -996,3 +996,71 @@ class TestValidateFlowBookmarkDefaults:
         """Default valid bookmark params must produce no errors."""
         errors = validate_flow_bookmark(_valid_flow_bookmark())
         assert errors == []
+
+
+# =============================================================================
+# T016: time_comparison validation for flows
+# =============================================================================
+
+
+class TestValidateFlowArgsTimeComparison:
+    """Tests that validate_flow_args rejects time_comparison for flows."""
+
+    def test_time_comparison_set_produces_error(self) -> None:
+        """validate_flow_args() with time_comparison set produces a validation error."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("month")
+        args = _valid_flow_args(time_comparison=tc)
+        errors = validate_flow_args(**args)
+        assert any(e.code == "FL_TIME_COMPARISON_NOT_SUPPORTED" for e in errors), (
+            f"Expected FL_TIME_COMPARISON_NOT_SUPPORTED error, got: {errors}"
+        )
+
+    def test_time_comparison_none_no_error(self) -> None:
+        """validate_flow_args() with time_comparison=None produces no error for it."""
+        args = _valid_flow_args(time_comparison=None)
+        errors = validate_flow_args(**args)
+        assert not any(e.code == "FL_TIME_COMPARISON_NOT_SUPPORTED" for e in errors)
+
+    def test_time_comparison_error_path(self) -> None:
+        """The FL_TIME_COMPARISON_NOT_SUPPORTED error path points to 'time_comparison'."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("month")
+        args = _valid_flow_args(time_comparison=tc)
+        errors = validate_flow_args(**args)
+        tc_errors = [e for e in errors if e.code == "FL_TIME_COMPARISON_NOT_SUPPORTED"]
+        assert len(tc_errors) == 1
+        assert tc_errors[0].path == "time_comparison"
+
+
+# =============================================================================
+# T036: data_group_id validation for flows
+# =============================================================================
+
+
+class TestDataGroupIdValidationFlow:
+    """Tests for data_group_id validation in validate_flow_args (T036)."""
+
+    def test_valid_data_group_id(self) -> None:
+        """Positive integer data_group_id passes flow validation."""
+        errors = validate_flow_args(**_valid_flow_args(data_group_id=5))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_none_data_group_id(self) -> None:
+        """None data_group_id passes flow validation."""
+        errors = validate_flow_args(**_valid_flow_args(data_group_id=None))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_zero_data_group_id(self) -> None:
+        """data_group_id=0 fails flow validation."""
+        errors = validate_flow_args(**_valid_flow_args(data_group_id=0))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1
+
+    def test_negative_data_group_id(self) -> None:
+        """Negative data_group_id fails flow validation."""
+        errors = validate_flow_args(**_valid_flow_args(data_group_id=-1))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1

--- a/tests/test_validation_funnel.py
+++ b/tests/test_validation_funnel.py
@@ -1246,6 +1246,52 @@ class TestValidateFunnelArgsF11MathRejectsProperty:
 # =============================================================================
 
 
+# =============================================================================
+# T010: F12 — reentry_mode validation
+# =============================================================================
+
+
+class TestValidateFunnelArgsF12ReentryMode:
+    """Tests for F12: reentry_mode validation."""
+
+    def test_valid_reentry_mode_default_no_error(self) -> None:
+        """reentry_mode='default' must not produce F12 error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="default"))
+        assert "F12_INVALID_REENTRY_MODE" not in _codes(errors)
+
+    def test_valid_reentry_mode_basic_no_error(self) -> None:
+        """reentry_mode='basic' must not produce F12 error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="basic"))
+        assert "F12_INVALID_REENTRY_MODE" not in _codes(errors)
+
+    def test_valid_reentry_mode_aggressive_no_error(self) -> None:
+        """reentry_mode='aggressive' must not produce F12 error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="aggressive"))
+        assert "F12_INVALID_REENTRY_MODE" not in _codes(errors)
+
+    def test_valid_reentry_mode_optimized_no_error(self) -> None:
+        """reentry_mode='optimized' must not produce F12 error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="optimized"))
+        assert "F12_INVALID_REENTRY_MODE" not in _codes(errors)
+
+    def test_none_reentry_mode_no_error(self) -> None:
+        """reentry_mode=None must not produce F12 error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode=None))
+        assert "F12_INVALID_REENTRY_MODE" not in _codes(errors)
+
+    def test_invalid_reentry_mode_returns_f12_error(self) -> None:
+        """reentry_mode='invalid' must produce F12_INVALID_REENTRY_MODE error."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="invalid"))
+        assert "F12_INVALID_REENTRY_MODE" in _codes(errors)
+
+    def test_f12_error_path_is_reentry_mode(self) -> None:
+        """The F12 error path must point to 'reentry_mode'."""
+        errors = validate_funnel_args(**_valid_funnel_args(reentry_mode="bad"))
+        f12 = [e for e in errors if e.code == "F12_INVALID_REENTRY_MODE"]
+        assert len(f12) == 1
+        assert f12[0].path == "reentry_mode"
+
+
 class TestF8bHoldingConstantPropertyValidation:
     """Tests for F8b: empty holding constant property names."""
 
@@ -1294,3 +1340,34 @@ class TestF8bHoldingConstantPropertyValidation:
             ValueError, match="HoldingConstant.property must be a non-empty string"
         ):
             HoldingConstant("")
+
+
+# =============================================================================
+# T036: data_group_id validation for funnels
+# =============================================================================
+
+
+class TestDataGroupIdValidationFunnel:
+    """Tests for data_group_id validation in validate_funnel_args (T036)."""
+
+    def test_valid_data_group_id(self) -> None:
+        """Positive integer data_group_id passes funnel validation."""
+        errors = validate_funnel_args(**_valid_funnel_args(data_group_id=5))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_none_data_group_id(self) -> None:
+        """None data_group_id passes funnel validation."""
+        errors = validate_funnel_args(**_valid_funnel_args(data_group_id=None))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_zero_data_group_id(self) -> None:
+        """data_group_id=0 fails funnel validation."""
+        errors = validate_funnel_args(**_valid_funnel_args(data_group_id=0))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1
+
+    def test_negative_data_group_id(self) -> None:
+        """Negative data_group_id fails funnel validation."""
+        errors = validate_funnel_args(**_valid_funnel_args(data_group_id=-3))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1

--- a/tests/test_validation_retention.py
+++ b/tests/test_validation_retention.py
@@ -833,6 +833,60 @@ class TestValidateRetentionR12:
 # =============================================================================
 
 
+# =============================================================================
+# T010: R13 — unbounded_mode validation
+# =============================================================================
+
+
+class TestValidateRetentionR13UnboundedMode:
+    """Tests for R13: unbounded_mode validation."""
+
+    def test_valid_unbounded_mode_none_no_error(self) -> None:
+        """unbounded_mode='none' must not produce R13 error."""
+        errors = validate_retention_args(**_valid_retention_args(unbounded_mode="none"))
+        assert "R13_INVALID_UNBOUNDED_MODE" not in _codes(errors)
+
+    def test_valid_unbounded_mode_carry_back_no_error(self) -> None:
+        """unbounded_mode='carry_back' must not produce R13 error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(unbounded_mode="carry_back")
+        )
+        assert "R13_INVALID_UNBOUNDED_MODE" not in _codes(errors)
+
+    def test_valid_unbounded_mode_carry_forward_no_error(self) -> None:
+        """unbounded_mode='carry_forward' must not produce R13 error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(unbounded_mode="carry_forward")
+        )
+        assert "R13_INVALID_UNBOUNDED_MODE" not in _codes(errors)
+
+    def test_valid_unbounded_mode_consecutive_forward_no_error(self) -> None:
+        """unbounded_mode='consecutive_forward' must not produce R13 error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(unbounded_mode="consecutive_forward")
+        )
+        assert "R13_INVALID_UNBOUNDED_MODE" not in _codes(errors)
+
+    def test_none_unbounded_mode_no_error(self) -> None:
+        """unbounded_mode=None (default) must not produce R13 error."""
+        errors = validate_retention_args(**_valid_retention_args(unbounded_mode=None))
+        assert "R13_INVALID_UNBOUNDED_MODE" not in _codes(errors)
+
+    def test_invalid_unbounded_mode_returns_r13_error(self) -> None:
+        """unbounded_mode='invalid' must produce R13_INVALID_UNBOUNDED_MODE error."""
+        errors = validate_retention_args(
+            **_valid_retention_args(unbounded_mode="invalid")
+        )
+        assert "R13_INVALID_UNBOUNDED_MODE" in _codes(errors)
+
+    def test_r13_error_path_is_unbounded_mode(self) -> None:
+        """The R13 error path must point to 'unbounded_mode'."""
+        errors = validate_retention_args(**_valid_retention_args(unbounded_mode="bad"))
+        r13 = [e for e in errors if e.code == "R13_INVALID_UNBOUNDED_MODE"]
+        assert len(r13) == 1
+        assert r13[0].path == "unbounded_mode"
+
+
 class TestValidateRetentionR5Boolean:
     """Tests for R5: boolean values in bucket_sizes are rejected.
 
@@ -1000,3 +1054,34 @@ class TestValidateBookmarkRetentionB9MathDispatch:
         }
         errors = validate_bookmark(bookmark, bookmark_type="retention")
         assert not any(e.code == "B9_INVALID_MATH" for e in errors)
+
+
+# =============================================================================
+# T036: data_group_id validation for retention
+# =============================================================================
+
+
+class TestDataGroupIdValidationRetention:
+    """Tests for data_group_id validation in validate_retention_args (T036)."""
+
+    def test_valid_data_group_id(self) -> None:
+        """Positive integer data_group_id passes retention validation."""
+        errors = validate_retention_args(**_valid_retention_args(data_group_id=5))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_none_data_group_id(self) -> None:
+        """None data_group_id passes retention validation."""
+        errors = validate_retention_args(**_valid_retention_args(data_group_id=None))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_zero_data_group_id(self) -> None:
+        """data_group_id=0 fails retention validation."""
+        errors = validate_retention_args(**_valid_retention_args(data_group_id=0))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1
+
+    def test_negative_data_group_id(self) -> None:
+        """Negative data_group_id fails retention validation."""
+        errors = validate_retention_args(**_valid_retention_args(data_group_id=-2))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1

--- a/tests/test_workspace_cohort.py
+++ b/tests/test_workspace_cohort.py
@@ -186,42 +186,41 @@ class TestQueryFlowWhere:
         finally:
             ws.close()
 
-    def test_non_cohort_filter_raises_value_error(
+    def test_property_filter_produces_filter_by_event(
         self,
         workspace_factory: Callable[..., Workspace],
     ) -> None:
-        """T007: Non-cohort filter in flow where= raises ValueError."""
+        """T007: Property filter in flow where= produces filter_by_event."""
         ws = workspace_factory()
         try:
-            with pytest.raises(
-                ValueError,
-                match="query_flow where= only accepts cohort filters",
-            ):
-                ws.build_flow_params(
-                    "Login",
-                    where=Filter.equals("country", "US"),
-                )
+            result = ws.build_flow_params(
+                "Login",
+                where=Filter.equals("country", "US"),
+            )
+            assert "filter_by_event" in result
+            assert result["filter_by_event"]["operator"] == "and"
+            assert len(result["filter_by_event"]["children"]) == 1
         finally:
             ws.close()
 
-    def test_property_filter_in_list_raises_value_error(
+    def test_mixed_cohort_and_property_filters(
         self,
         workspace_factory: Callable[..., Workspace],
     ) -> None:
-        """T007: Property filter in list with cohort filter raises ValueError."""
+        """T007: Mixed cohort + property filters produce both filter keys."""
         ws = workspace_factory()
         try:
-            with pytest.raises(
-                ValueError,
-                match="query_flow where= only accepts cohort filters",
-            ):
-                ws.build_flow_params(
-                    "Login",
-                    where=[
-                        Filter.in_cohort(123, "PU"),
-                        Filter.equals("country", "US"),
-                    ],
-                )
+            result = ws.build_flow_params(
+                "Login",
+                where=[
+                    Filter.in_cohort(123, "PU"),
+                    Filter.equals("country", "US"),
+                ],
+            )
+            assert "filter_by_cohort" in result
+            assert "filter_by_event" in result
+            assert result["filter_by_cohort"]["name"] == "PU"
+            assert len(result["filter_by_event"]["children"]) == 1
         finally:
             ws.close()
 

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -742,9 +742,7 @@ class TestBuildGroupSectionFrequency:
         """List with GroupBy and FrequencyBreakdown produces correct entries."""
         from mixpanel_data.types import FrequencyBreakdown
 
-        result = build_group_section(
-            ["country", FrequencyBreakdown("Purchase")]  # type: ignore[list-item]
-        )
+        result = build_group_section(["country", FrequencyBreakdown("Purchase")])
         assert len(result) == 2
         assert result[0]["value"] == "country"
         assert result[0]["propertyType"] == "string"
@@ -764,7 +762,7 @@ class TestBuildFilterSectionFrequency:
         """FrequencyFilter produces frequency filter entry in section."""
         from mixpanel_data.types import FrequencyFilter
 
-        result = build_filter_section(FrequencyFilter("Login", value=5))  # type: ignore[arg-type]
+        result = build_filter_section(FrequencyFilter("Login", value=5))
         assert len(result) == 1
         assert result[0]["resourceType"] == "people"
         assert result[0]["behaviorType"] == "$frequency"
@@ -774,7 +772,7 @@ class TestBuildFilterSectionFrequency:
         from mixpanel_data.types import FrequencyFilter
 
         result = build_filter_section(
-            [Filter.equals("country", "US"), FrequencyFilter("Login", value=5)]  # type: ignore[list-item]
+            [Filter.equals("country", "US"), FrequencyFilter("Login", value=5)]
         )
         assert len(result) == 2
         assert result[0]["value"] == "country"
@@ -811,7 +809,7 @@ class TestBuildGroupSectionDataGroupId:
         """GroupBy with InlineCustomProperty and data_group_id=3 produces dataGroupId: 3."""
         prop = InlineCustomProperty(
             formula="A",
-            inputs={"A": PropertyInput(name="price", resource_type="events")},
+            inputs={"A": PropertyInput(name="price", resource_type="event")},
         )
         gb = GroupBy(property=prop, property_type="number")
         result = build_group_section(gb, data_group_id=3)

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -262,7 +262,7 @@ class TestBuildGroupSection:
         """Invalid group_by element type raises TypeError."""
         with pytest.raises(
             TypeError,
-            match="group_by elements must be str, GroupBy, or CohortBreakdown",
+            match="group_by elements must be str, GroupBy, CohortBreakdown, or FrequencyBreakdown",
         ):
             build_group_section(123)  # type: ignore[arg-type]
 
@@ -270,7 +270,7 @@ class TestBuildGroupSection:
         """Invalid element inside list raises TypeError."""
         with pytest.raises(
             TypeError,
-            match="group_by elements must be str, GroupBy, or CohortBreakdown",
+            match="group_by elements must be str, GroupBy, CohortBreakdown, or FrequencyBreakdown",
         ):
             build_group_section(["country", 42])  # type: ignore[list-item]
 
@@ -360,6 +360,68 @@ class TestBuildFilterEntry:
         assert entry["dataset"] == "$mixpanel"
 
 
+class TestNewFilterOperatorsInBuilder:
+    """T030: Tests for new filter operators in build_filter_entry() output."""
+
+    def test_not_between_filter_operator(self) -> None:
+        """not_between filter produces 'not between' filterOperator."""
+        f = Filter.not_between("age", 18, 65)
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "not between"
+        assert entry["filterType"] == "number"
+        assert entry["filterValue"] == [18, 65]
+
+    def test_starts_with_filter_operator(self) -> None:
+        """starts_with filter produces 'starts with' filterOperator."""
+        f = Filter.starts_with("url", "https://")
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "starts with"
+        assert entry["filterType"] == "string"
+        assert entry["filterValue"] == "https://"
+
+    def test_ends_with_filter_operator(self) -> None:
+        """ends_with filter produces 'ends with' filterOperator."""
+        f = Filter.ends_with("email", "@example.com")
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "ends with"
+        assert entry["filterType"] == "string"
+        assert entry["filterValue"] == "@example.com"
+
+    def test_date_not_between_filter_operator(self) -> None:
+        """date_not_between filter produces 'was not between' filterOperator."""
+        f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "was not between"
+        assert entry["filterType"] == "datetime"
+        assert entry["filterValue"] == ["2024-01-01", "2024-06-30"]
+        assert "filterDateUnit" not in entry
+
+    def test_in_the_next_filter_operator(self) -> None:
+        """in_the_next filter produces 'was in the next' filterOperator."""
+        f = Filter.in_the_next("expires", 7, "day")
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "was in the next"
+        assert entry["filterType"] == "datetime"
+        assert entry["filterValue"] == 7
+        assert entry["filterDateUnit"] == "day"
+
+    def test_at_least_filter_operator(self) -> None:
+        """at_least filter produces 'is at least' filterOperator."""
+        f = Filter.at_least("score", 80)
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "is at least"
+        assert entry["filterType"] == "number"
+        assert entry["filterValue"] == 80
+
+    def test_at_most_filter_operator(self) -> None:
+        """at_most filter produces 'is at most' filterOperator."""
+        f = Filter.at_most("errors", 5)
+        entry = build_filter_entry(f)
+        assert entry["filterOperator"] == "is at most"
+        assert entry["filterType"] == "number"
+        assert entry["filterValue"] == 5
+
+
 class TestPatchCustomPropertyFiltersForTransform:
     """Tests for the server-compat sentinel injection.
 
@@ -400,3 +462,437 @@ class TestPatchCustomPropertyFiltersForTransform:
     def test_empty_list(self) -> None:
         """Empty list returns empty list."""
         assert patch_custom_property_filters_for_transform([]) == []
+
+
+# =============================================================================
+# T015: build_time_comparison() builder tests
+# =============================================================================
+
+
+class TestBuildTimeComparison:
+    """Tests for build_time_comparison() — timeComparison dict building."""
+
+    def test_relative_produces_correct_dict(self) -> None:
+        """Relative time comparison produces {"type": "relative", "value": unit}."""
+        from mixpanel_data._internal.bookmark_builders import build_time_comparison
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("month")
+        result = build_time_comparison(tc)
+        assert result == {"type": "relative", "value": "month"}
+
+    def test_absolute_start_produces_correct_dict(self) -> None:
+        """Absolute-start produces {"type": "absolute-start", "value": date}."""
+        from mixpanel_data._internal.bookmark_builders import build_time_comparison
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.absolute_start("2026-01-01")
+        result = build_time_comparison(tc)
+        assert result == {"type": "absolute-start", "value": "2026-01-01"}
+
+    def test_absolute_end_produces_correct_dict(self) -> None:
+        """Absolute-end produces {"type": "absolute-end", "value": date}."""
+        from mixpanel_data._internal.bookmark_builders import build_time_comparison
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.absolute_end("2026-12-31")
+        result = build_time_comparison(tc)
+        assert result == {"type": "absolute-end", "value": "2026-12-31"}
+
+    def test_relative_day_unit(self) -> None:
+        """Relative with unit='day' produces correct value."""
+        from mixpanel_data._internal.bookmark_builders import build_time_comparison
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("day")
+        result = build_time_comparison(tc)
+        assert result["value"] == "day"
+
+    def test_relative_year_unit(self) -> None:
+        """Relative with unit='year' produces correct value."""
+        from mixpanel_data._internal.bookmark_builders import build_time_comparison
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("year")
+        result = build_time_comparison(tc)
+        assert result["value"] == "year"
+
+
+# =============================================================================
+# T022: build_frequency_group_entry() builder tests (US4)
+# =============================================================================
+
+
+class TestBuildFrequencyGroupEntry:
+    """Tests for build_frequency_group_entry() — frequency breakdown dict."""
+
+    def test_basic_structure(self) -> None:
+        """FrequencyBreakdown produces correct group entry structure."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        assert result["resourceType"] == "people"
+        assert result["behaviorType"] == "$frequency"
+        assert "behavior" in result
+        assert result["behavior"]["event"] == "Purchase"
+        assert result["behavior"]["bucket_size"] == 1
+        assert result["behavior"]["bucket_min"] == 0
+        assert result["behavior"]["bucket_max"] == 10
+
+    def test_custom_bucket_values(self) -> None:
+        """Custom bucket params are reflected in output."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", bucket_size=5, bucket_min=0, bucket_max=50)
+        result = build_frequency_group_entry(fb)
+        assert result["behavior"]["bucket_size"] == 5
+        assert result["behavior"]["bucket_min"] == 0
+        assert result["behavior"]["bucket_max"] == 50
+
+    def test_label_included(self) -> None:
+        """Label is included in output when set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", label="Purchase Frequency")
+        result = build_frequency_group_entry(fb)
+        assert result["label"] == "Purchase Frequency"
+
+    def test_label_omitted_when_none(self) -> None:
+        """Label key is omitted when label is None."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        assert "label" not in result
+
+
+# =============================================================================
+# T022: build_frequency_filter_entry() builder tests (US4)
+# =============================================================================
+
+
+class TestBuildFrequencyFilterEntry:
+    """Tests for build_frequency_filter_entry() — frequency filter dict."""
+
+    def test_basic_structure(self) -> None:
+        """FrequencyFilter produces correct filter entry structure."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        result = build_frequency_filter_entry(ff)
+        assert result["resourceType"] == "people"
+        assert result["behaviorType"] == "$frequency"
+        assert "customProperty" in result
+        behavior = result["customProperty"]["behavior"]
+        assert behavior["event"] == "Login"
+        assert behavior["aggregation"] == "total"
+        assert behavior["filterOperator"] == "is at least"
+        assert behavior["filterValue"] == 5
+
+    def test_custom_operator(self) -> None:
+        """Custom operator is reflected in output."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", operator="is greater than", value=10)
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert behavior["filterOperator"] == "is greater than"
+        assert behavior["filterValue"] == 10
+
+    def test_with_date_range(self) -> None:
+        """Date range is included when set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Login", value=5, date_range_value=30, date_range_unit="day"
+        )
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert "dateRange" in behavior
+        assert behavior["dateRange"]["value"] == 30
+        assert behavior["dateRange"]["unit"] == "day"
+
+    def test_without_date_range(self) -> None:
+        """Date range is omitted when not set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert "dateRange" not in behavior
+
+    def test_with_event_filters(self) -> None:
+        """Event filters are included when set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Purchase",
+            value=1,
+            event_filters=[Filter.equals("country", "US")],
+        )
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert "eventFilters" in behavior
+        assert len(behavior["eventFilters"]) == 1
+        assert behavior["eventFilters"][0]["value"] == "country"
+        assert behavior["eventFilters"][0]["filterOperator"] == "equals"
+
+    def test_without_event_filters(self) -> None:
+        """Event filters key is omitted when not set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert "eventFilters" not in behavior
+
+    def test_label_included(self) -> None:
+        """Label is included in output when set."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5, label="Active Users")
+        result = build_frequency_filter_entry(ff)
+        assert result["label"] == "Active Users"
+
+    def test_label_omitted_when_none(self) -> None:
+        """Label key is omitted when label is None."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        result = build_frequency_filter_entry(ff)
+        assert "label" not in result
+
+    def test_multiple_event_filters(self) -> None:
+        """Multiple event filters each produce a filter entry."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_filter_entry,
+        )
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Purchase",
+            value=3,
+            event_filters=[
+                Filter.equals("country", "US"),
+                Filter.greater_than("amount", 10),
+            ],
+        )
+        result = build_frequency_filter_entry(ff)
+        behavior = result["customProperty"]["behavior"]
+        assert len(behavior["eventFilters"]) == 2
+        assert behavior["eventFilters"][0]["filterOperator"] == "equals"
+        assert behavior["eventFilters"][1]["filterOperator"] == "is greater than"
+
+
+# =============================================================================
+# T022: build_group_section handles FrequencyBreakdown (US4)
+# =============================================================================
+
+
+class TestBuildGroupSectionFrequency:
+    """Tests for build_group_section() handling FrequencyBreakdown."""
+
+    def test_frequency_breakdown_in_group_section(self) -> None:
+        """FrequencyBreakdown produces frequency group entry in section."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        result = build_group_section(FrequencyBreakdown("Purchase"))
+        assert len(result) == 1
+        assert result[0]["resourceType"] == "people"
+        assert result[0]["behaviorType"] == "$frequency"
+
+    def test_mixed_groupby_and_frequency(self) -> None:
+        """List with GroupBy and FrequencyBreakdown produces correct entries."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        result = build_group_section(
+            ["country", FrequencyBreakdown("Purchase")]  # type: ignore[list-item]
+        )
+        assert len(result) == 2
+        assert result[0]["value"] == "country"
+        assert result[0]["propertyType"] == "string"
+        assert result[1]["resourceType"] == "people"
+        assert result[1]["behaviorType"] == "$frequency"
+
+
+# =============================================================================
+# T022: build_filter_section handles FrequencyFilter (US4)
+# =============================================================================
+
+
+class TestBuildFilterSectionFrequency:
+    """Tests for build_filter_section() handling FrequencyFilter."""
+
+    def test_frequency_filter_in_filter_section(self) -> None:
+        """FrequencyFilter produces frequency filter entry in section."""
+        from mixpanel_data.types import FrequencyFilter
+
+        result = build_filter_section(FrequencyFilter("Login", value=5))  # type: ignore[arg-type]
+        assert len(result) == 1
+        assert result[0]["resourceType"] == "people"
+        assert result[0]["behaviorType"] == "$frequency"
+
+    def test_mixed_filter_and_frequency(self) -> None:
+        """List with Filter and FrequencyFilter produces correct entries."""
+        from mixpanel_data.types import FrequencyFilter
+
+        result = build_filter_section(
+            [Filter.equals("country", "US"), FrequencyFilter("Login", value=5)]  # type: ignore[list-item]
+        )
+        assert len(result) == 2
+        assert result[0]["value"] == "country"
+        assert result[0]["filterOperator"] == "equals"
+        assert result[1]["resourceType"] == "people"
+        assert result[1]["behaviorType"] == "$frequency"
+
+
+# =============================================================================
+# T033: data_group_id threading through builders
+# =============================================================================
+
+
+class TestBuildGroupSectionDataGroupId:
+    """Tests for data_group_id threading through build_group_section (T033)."""
+
+    def test_custom_property_ref_group_with_data_group_id(self) -> None:
+        """GroupBy with CustomPropertyRef and data_group_id=5 produces dataGroupId: 5."""
+        ref = CustomPropertyRef(id=42)
+        gb = GroupBy(property=ref)
+        result = build_group_section(gb, data_group_id=5)
+        assert len(result) == 1
+        assert result[0]["dataGroupId"] == 5
+
+    def test_custom_property_ref_group_without_data_group_id(self) -> None:
+        """GroupBy with CustomPropertyRef without data_group_id produces dataGroupId: None."""
+        ref = CustomPropertyRef(id=42)
+        gb = GroupBy(property=ref)
+        result = build_group_section(gb)
+        assert len(result) == 1
+        assert result[0]["dataGroupId"] is None
+
+    def test_inline_custom_property_group_with_data_group_id(self) -> None:
+        """GroupBy with InlineCustomProperty and data_group_id=3 produces dataGroupId: 3."""
+        prop = InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput(name="price", resource_type="events")},
+        )
+        gb = GroupBy(property=prop, property_type="number")
+        result = build_group_section(gb, data_group_id=3)
+        assert len(result) == 1
+        assert result[0]["dataGroupId"] == 3
+
+    def test_cohort_breakdown_group_with_data_group_id(self) -> None:
+        """CohortBreakdown with data_group_id=7 threads to both cohort entry and group entry."""
+        cb = CohortBreakdown(123, "Power Users")
+        result = build_group_section(cb, data_group_id=7)
+        assert len(result) == 1
+        # Top-level group entry
+        assert result[0]["dataGroupId"] == 7
+        # Cohort entries inside
+        for cohort in result[0]["cohorts"]:
+            assert cohort["data_group_id"] == 7
+
+    def test_string_group_unaffected_by_data_group_id(self) -> None:
+        """String group_by does not have dataGroupId field (simple property entries)."""
+        result = build_group_section("country", data_group_id=5)
+        assert len(result) == 1
+        # String entries use a simpler format without dataGroupId
+        assert "dataGroupId" not in result[0]
+
+    def test_none_group_returns_empty(self) -> None:
+        """None group_by returns empty list regardless of data_group_id."""
+        result = build_group_section(None, data_group_id=5)
+        assert result == []
+
+
+# =========================================================================
+# T039: build_flow_property_filter — flow property filter builder (US8)
+# =========================================================================
+
+
+class TestBuildFlowPropertyFilter:
+    """Tests for build_flow_property_filter() — filter_by_event structure."""
+
+    def test_single_filter_structure(self) -> None:
+        """Single Filter produces correct filter_by_event structure."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_flow_property_filter,
+        )
+
+        result = build_flow_property_filter([Filter.equals("country", "US")])
+        assert result["operator"] == "and"
+        assert len(result["children"]) == 1
+        child = result["children"][0]
+        assert child["filterOperator"] == "equals"
+        assert child["filterType"] == "string"
+        assert child["propertyName"] == "country"
+        assert child["filterValue"] == ["US"]
+        assert child["resourceType"] == "events"
+
+    def test_multiple_filters_produce_children(self) -> None:
+        """Multiple Filters produce a children array with one entry per filter."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_flow_property_filter,
+        )
+
+        result = build_flow_property_filter(
+            [
+                Filter.equals("country", "US"),
+                Filter.greater_than("age", 18),
+            ]
+        )
+        assert result["operator"] == "and"
+        assert len(result["children"]) == 2
+        assert result["children"][0]["propertyName"] == "country"
+        assert result["children"][1]["propertyName"] == "age"
+
+    def test_filter_entry_uses_build_filter_entry(self) -> None:
+        """Each child uses build_filter_entry structure (resourceType, filterType, etc.)."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_flow_property_filter,
+        )
+
+        result = build_flow_property_filter([Filter.contains("name", "test")])
+        child = result["children"][0]
+        assert "resourceType" in child
+        assert "filterType" in child
+        assert "filterOperator" in child
+        assert "filterValue" in child
+        assert "propertyName" in child

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -894,3 +894,29 @@ class TestBuildFlowPropertyFilter:
         assert "filterOperator" in child
         assert "filterValue" in child
         assert "propertyName" in child
+
+    def test_custom_property_ref_raises_type_error(self) -> None:
+        """build_flow_property_filter rejects CustomPropertyRef properties."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_flow_property_filter,
+        )
+        from mixpanel_data.types import CustomPropertyRef
+
+        f = Filter(
+            _property=CustomPropertyRef(id=123),
+            _operator="equals",
+            _value=["high"],
+            _property_type="string",
+            _resource_type="events",
+        )
+        with pytest.raises(TypeError, match="custom property refs"):
+            build_flow_property_filter([f])
+
+    def test_empty_list_raises_value_error(self) -> None:
+        """build_flow_property_filter rejects empty filter list."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_flow_property_filter,
+        )
+
+        with pytest.raises(ValueError, match="requires at least one filter"):
+            build_flow_property_filter([])

--- a/tests/unit/test_bookmark_enums.py
+++ b/tests/unit/test_bookmark_enums.py
@@ -243,7 +243,7 @@ class TestExtendedMathFunnels:
         assert property_agg <= VALID_MATH_FUNNELS
 
     def test_all_expected_values(self) -> None:
-        """VALID_MATH_FUNNELS contains exactly 16 expected values."""
+        """VALID_MATH_FUNNELS contains exactly 17 expected values."""
         expected = {
             "general",
             "unique",
@@ -261,6 +261,7 @@ class TestExtendedMathFunnels:
             "p75",
             "p90",
             "p99",
+            "histogram",
         }
         assert expected == VALID_MATH_FUNNELS
 

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -909,7 +909,7 @@ class TestGroupByTypeError:
         """Non-str, non-GroupBy group_by element raises TypeError."""
         with pytest.raises(
             TypeError,
-            match="group_by elements must be str, GroupBy, or CohortBreakdown",
+            match="group_by elements must be str, GroupBy, CohortBreakdown, or FrequencyBreakdown",
         ):
             ws._build_query_params(
                 events=["Login"],
@@ -1378,3 +1378,249 @@ class TestHistogramParams:
         m = params["sections"]["show"][0]["measurement"]
         assert m["math"] == "histogram"
         assert m["perUserAggregation"] == "total"
+
+
+# =============================================================================
+# T005: New math types in build_params
+# =============================================================================
+
+
+class TestNewMathTypesInBuildParams:
+    """T005: New math types produce correct measurement blocks in build_params."""
+
+    def test_cumulative_unique_in_build_params(self, ws: Workspace) -> None:
+        """build_params with math='cumulative_unique' produces correct measurement."""
+        params = ws.build_params("Login", math="cumulative_unique")
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "cumulative_unique"
+
+    def test_sessions_in_build_params(self, ws: Workspace) -> None:
+        """build_params with math='sessions' produces correct measurement."""
+        params = ws.build_params("Login", math="sessions")
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == "sessions"
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_property_requiring_math_in_build_params(
+        self, ws: Workspace, math_type: str
+    ) -> None:
+        """build_params with property-requiring math produces correct measurement."""
+        params = ws.build_params(
+            "Purchase",
+            math=math_type,  # type: ignore[arg-type]
+            math_property="amount",
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["math"] == math_type
+        assert m["property"]["name"] == "amount"
+
+
+# =============================================================================
+# T009: Metric.segment_method in build_params
+# =============================================================================
+
+
+class TestSegmentMethodInBuildParams:
+    """T009: Metric.segment_method produces segmentMethod in measurement block."""
+
+    def test_segment_method_first_in_measurement(self, ws: Workspace) -> None:
+        """build_params with Metric(event, segment_method='first') produces segmentMethod='first'."""
+        params = ws.build_params(
+            Metric("Login", segment_method="first"),
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["segmentMethod"] == "first"
+
+    def test_segment_method_all_in_measurement(self, ws: Workspace) -> None:
+        """build_params with Metric(event, segment_method='all') produces segmentMethod='all'."""
+        params = ws.build_params(
+            Metric("Login", segment_method="all"),
+        )
+        m = params["sections"]["show"][0]["measurement"]
+        assert m["segmentMethod"] == "all"
+
+    def test_segment_method_none_omits_key(self, ws: Workspace) -> None:
+        """build_params with Metric(event) omits segmentMethod (backward compat)."""
+        params = ws.build_params(Metric("Login"))
+        m = params["sections"]["show"][0]["measurement"]
+        assert "segmentMethod" not in m
+
+    def test_segment_method_string_event_omits_key(self, ws: Workspace) -> None:
+        """build_params with plain string event omits segmentMethod."""
+        params = ws.build_params("Login")
+        m = params["sections"]["show"][0]["measurement"]
+        assert "segmentMethod" not in m
+
+
+# =============================================================================
+# T023: FrequencyBreakdown in build_params group_by (US4)
+# =============================================================================
+
+
+class TestFrequencyBreakdownInBuildParams:
+    """T023: FrequencyBreakdown accepted in build_params group_by."""
+
+    def test_frequency_breakdown_in_group_section(self, ws: Workspace) -> None:
+        """build_params with FrequencyBreakdown produces frequency group entry."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        params = ws.build_params(
+            "Login",
+            group_by=FrequencyBreakdown("Purchase"),
+        )
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert group[0]["resourceType"] == "people"
+        assert group[0]["behaviorType"] == "$frequency"
+        assert group[0]["behavior"]["event"] == "Purchase"
+
+    def test_frequency_breakdown_with_label(self, ws: Workspace) -> None:
+        """build_params with labeled FrequencyBreakdown includes label."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        params = ws.build_params(
+            "Login",
+            group_by=FrequencyBreakdown("Purchase", label="Buy Freq"),
+        )
+        group = params["sections"]["group"]
+        assert group[0]["label"] == "Buy Freq"
+
+    def test_frequency_breakdown_mixed_with_string(self, ws: Workspace) -> None:
+        """build_params with mixed string and FrequencyBreakdown in list."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        params = ws.build_params(
+            "Login",
+            group_by=["country", FrequencyBreakdown("Purchase")],  # type: ignore[list-item]
+        )
+        group = params["sections"]["group"]
+        assert len(group) == 2
+        assert group[0]["value"] == "country"
+        assert group[1]["behaviorType"] == "$frequency"
+
+    def test_existing_groupby_still_works(self, ws: Workspace) -> None:
+        """Backward compat: existing GroupBy usage still works."""
+        params = ws.build_params(
+            "Login",
+            group_by=GroupBy("country"),
+        )
+        group = params["sections"]["group"]
+        assert len(group) == 1
+        assert group[0]["value"] == "country"
+
+
+# =============================================================================
+# T023: FrequencyFilter in build_params where (US4)
+# =============================================================================
+
+
+class TestFrequencyFilterInBuildParams:
+    """T023: FrequencyFilter accepted in build_params where."""
+
+    def test_frequency_filter_in_filter_section(self, ws: Workspace) -> None:
+        """build_params with FrequencyFilter produces frequency filter entry."""
+        from mixpanel_data.types import FrequencyFilter
+
+        params = ws.build_params(
+            "Login",
+            where=FrequencyFilter("Login", value=5),  # type: ignore[arg-type]
+        )
+        filt = params["sections"]["filter"]
+        assert len(filt) == 1
+        assert filt[0]["resourceType"] == "people"
+        assert filt[0]["behaviorType"] == "$frequency"
+
+    def test_frequency_filter_mixed_with_filter(self, ws: Workspace) -> None:
+        """build_params with mixed Filter and FrequencyFilter in list."""
+        from mixpanel_data.types import FrequencyFilter
+
+        params = ws.build_params(
+            "Login",
+            where=[
+                Filter.equals("country", "US"),
+                FrequencyFilter("Login", value=5),
+            ],  # type: ignore[list-item]
+        )
+        filt = params["sections"]["filter"]
+        assert len(filt) == 2
+        assert filt[0]["value"] == "country"
+        assert filt[1]["behaviorType"] == "$frequency"
+
+    def test_existing_filter_still_works(self, ws: Workspace) -> None:
+        """Backward compat: existing Filter usage still works."""
+        params = ws.build_params(
+            "Login",
+            where=Filter.equals("country", "US"),
+        )
+        filt = params["sections"]["filter"]
+        assert len(filt) == 1
+        assert filt[0]["value"] == "country"
+
+
+# =============================================================================
+# T032: data_group_id on insights query engine
+# =============================================================================
+
+
+class TestDataGroupIdInsights:
+    """Tests for data_group_id parameter on insights query engine (T032)."""
+
+    def test_build_params_with_data_group_id(self, ws: Workspace) -> None:
+        """build_params with data_group_id=5 includes dataGroupId: 5 in output."""
+        params = ws.build_params("Login", data_group_id=5)
+        assert params["sections"]["dataGroupId"] == 5
+
+    def test_build_params_without_data_group_id(self, ws: Workspace) -> None:
+        """build_params without data_group_id omits dataGroupId key (backward compat)."""
+        params = ws.build_params("Login")
+        assert "dataGroupId" not in params["sections"]
+
+    def test_build_query_params_with_data_group_id(self, ws: Workspace) -> None:
+        """_build_query_params with data_group_id=3 includes dataGroupId: 3."""
+        params = ws._build_query_params(
+            events=["Login"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+            data_group_id=3,
+        )
+        assert params["sections"]["dataGroupId"] == 3
+
+    def test_build_query_params_default_data_group_id_none(self, ws: Workspace) -> None:
+        """_build_query_params without data_group_id defaults to None."""
+        params = ws._build_query_params(
+            events=["Login"],
+            math="total",
+            math_property=None,
+            per_user=None,
+            from_date=None,
+            to_date=None,
+            last=30,
+            unit="day",
+            group_by=None,
+            where=None,
+            formulas=[],
+            rolling=None,
+            cumulative=False,
+            mode="timeseries",
+        )
+        assert "dataGroupId" not in params["sections"]

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -1500,7 +1500,7 @@ class TestFrequencyBreakdownInBuildParams:
 
         params = ws.build_params(
             "Login",
-            group_by=["country", FrequencyBreakdown("Purchase")],  # type: ignore[list-item]
+            group_by=["country", FrequencyBreakdown("Purchase")],
         )
         group = params["sections"]["group"]
         assert len(group) == 2
@@ -1532,7 +1532,7 @@ class TestFrequencyFilterInBuildParams:
 
         params = ws.build_params(
             "Login",
-            where=FrequencyFilter("Login", value=5),  # type: ignore[arg-type]
+            where=FrequencyFilter("Login", value=5),
         )
         filt = params["sections"]["filter"]
         assert len(filt) == 1
@@ -1548,7 +1548,7 @@ class TestFrequencyFilterInBuildParams:
             where=[
                 Filter.equals("country", "US"),
                 FrequencyFilter("Login", value=5),
-            ],  # type: ignore[list-item]
+            ],
         )
         filt = params["sections"]["filter"]
         assert len(filt) == 2

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -98,6 +98,12 @@ class TestTypeConstants:
             "custom_percentile",
             "percentile",
             "histogram",
+            # Advanced property-requiring types
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
         }
         assert expected == MATH_REQUIRING_PROPERTY
 
@@ -769,3 +775,780 @@ class TestHistogramType:
     def test_histogram_in_requiring_property(self) -> None:
         """'histogram' is in MATH_REQUIRING_PROPERTY."""
         assert "histogram" in MATH_REQUIRING_PROPERTY
+
+
+# =============================================================================
+# T004: New math types — non-property-requiring
+# =============================================================================
+
+
+class TestNewMathTypesNoProperty:
+    """T004: cumulative_unique and sessions math types need no property."""
+
+    @pytest.mark.parametrize("math_type", ["cumulative_unique", "sessions"])
+    def test_new_math_no_property_succeeds(self, math_type: str) -> None:
+        """Metric with math={math_type} succeeds without property."""
+        m = Metric("Login", math=math_type)  # type: ignore[arg-type]
+        assert m.math == math_type
+        assert m.property is None
+
+    @pytest.mark.parametrize("math_type", ["cumulative_unique", "sessions"])
+    def test_new_math_no_property_with_property_also_works(
+        self, math_type: str
+    ) -> None:
+        """Metric with math={math_type} also accepts an optional property."""
+        m = Metric("Login", math=math_type, property="duration")  # type: ignore[arg-type]
+        assert m.math == math_type
+        assert m.property == "duration"
+
+
+# =============================================================================
+# T004: New math types — property-requiring
+# =============================================================================
+
+
+class TestNewMathTypesPropertyRequired:
+    """T004: unique_values, most_frequent, first_value, multi_attribution, numeric_summary require property."""
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_new_math_with_property_succeeds(self, math_type: str) -> None:
+        """Metric with math={math_type} and property set succeeds."""
+        m = Metric("Login", math=math_type, property="amount")  # type: ignore[arg-type]
+        assert m.math == math_type
+        assert m.property == "amount"
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_new_math_without_property_raises(self, math_type: str) -> None:
+        """Metric with math={math_type} but no property raises ValueError."""
+        with pytest.raises(ValueError, match="requires a property"):
+            Metric("Login", math=math_type)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "math_type",
+        [
+            "unique_values",
+            "most_frequent",
+            "first_value",
+            "multi_attribution",
+            "numeric_summary",
+        ],
+    )
+    def test_new_math_in_requiring_property_set(self, math_type: str) -> None:
+        """New property-requiring math type is in MATH_REQUIRING_PROPERTY."""
+        assert math_type in MATH_REQUIRING_PROPERTY
+
+
+# =============================================================================
+# T008: Metric with segment_method
+# =============================================================================
+
+
+class TestMetricSegmentMethod:
+    """T008: Tests for Metric.segment_method field."""
+
+    def test_segment_method_first_construction(self) -> None:
+        """Metric('evt', segment_method='first') construction succeeds."""
+        m = Metric("evt", segment_method="first")
+        assert m.segment_method == "first"
+
+    def test_segment_method_all_construction(self) -> None:
+        """Metric('evt', segment_method='all') construction succeeds."""
+        m = Metric("evt", segment_method="all")
+        assert m.segment_method == "all"
+
+    def test_segment_method_default_none(self) -> None:
+        """Metric('evt') has segment_method=None by default."""
+        m = Metric("evt")
+        assert m.segment_method is None
+
+    def test_segment_method_immutable(self) -> None:
+        """Metric.segment_method is frozen."""
+        m = Metric("evt", segment_method="first")
+        with pytest.raises(AttributeError):
+            m.segment_method = "all"  # type: ignore[misc]
+
+    def test_segment_method_equality(self) -> None:
+        """Metrics with different segment_method are not equal."""
+        m1 = Metric("evt", segment_method="first")
+        m2 = Metric("evt", segment_method="all")
+        assert m1 != m2
+
+    def test_segment_method_none_vs_unset_equal(self) -> None:
+        """Metric with segment_method=None equals Metric without segment_method."""
+        m1 = Metric("evt", segment_method=None)
+        m2 = Metric("evt")
+        assert m1 == m2
+
+
+# =============================================================================
+# T014: TimeComparison dataclass tests
+# =============================================================================
+
+
+class TestTimeComparison:
+    """Tests for TimeComparison frozen dataclass construction and validation."""
+
+    def test_relative_factory_creates_correct_instance(self) -> None:
+        """TimeComparison.relative('month') creates type='relative', unit='month'."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("month")
+        assert tc.type == "relative"
+        assert tc.unit == "month"
+        assert tc.date is None
+
+    def test_absolute_start_factory_creates_correct_instance(self) -> None:
+        """TimeComparison.absolute_start('2026-01-01') creates correct instance."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.absolute_start("2026-01-01")
+        assert tc.type == "absolute-start"
+        assert tc.date == "2026-01-01"
+        assert tc.unit is None
+
+    def test_absolute_end_factory_creates_correct_instance(self) -> None:
+        """TimeComparison.absolute_end('2026-12-31') creates correct instance."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.absolute_end("2026-12-31")
+        assert tc.type == "absolute-end"
+        assert tc.date == "2026-12-31"
+        assert tc.unit is None
+
+    def test_tc1_relative_requires_unit(self) -> None:
+        """TC1: type='relative' requires unit to be set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="unit"):
+            TimeComparison(type="relative", unit=None, date=None)
+
+    def test_tc1_relative_rejects_date(self) -> None:
+        """TC1: type='relative' rejects date being set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="date"):
+            TimeComparison(type="relative", unit="month", date="2026-01-01")
+
+    def test_tc2_absolute_start_requires_date(self) -> None:
+        """TC2: type='absolute-start' requires date to be set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="date"):
+            TimeComparison(type="absolute-start", unit=None, date=None)
+
+    def test_tc2_absolute_start_rejects_unit(self) -> None:
+        """TC2: type='absolute-start' rejects unit being set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="unit"):
+            TimeComparison(type="absolute-start", unit="month", date="2026-01-01")
+
+    def test_tc2_absolute_end_requires_date(self) -> None:
+        """TC2: type='absolute-end' requires date to be set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="date"):
+            TimeComparison(type="absolute-end", unit=None, date=None)
+
+    def test_tc2_absolute_end_rejects_unit(self) -> None:
+        """TC2: type='absolute-end' rejects unit being set."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="unit"):
+            TimeComparison(type="absolute-end", unit="month", date="2026-12-31")
+
+    def test_tc3_invalid_date_format_raises(self) -> None:
+        """TC3: date must match YYYY-MM-DD format."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            TimeComparison.absolute_start("01-01-2026")
+
+    def test_tc3_invalid_date_format_partial(self) -> None:
+        """TC3: date='2026-1-1' (missing leading zeros) is rejected."""
+        from mixpanel_data.types import TimeComparison
+
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            TimeComparison.absolute_start("2026-1-1")
+
+    def test_frozen_immutable(self) -> None:
+        """TimeComparison is frozen and cannot be modified after construction."""
+        from mixpanel_data.types import TimeComparison
+
+        tc = TimeComparison.relative("month")
+        with pytest.raises(AttributeError):
+            tc.type = "absolute-start"  # type: ignore[misc]
+
+    def test_equality_same_fields(self) -> None:
+        """Two TimeComparisons with identical fields are equal."""
+        from mixpanel_data.types import TimeComparison
+
+        tc1 = TimeComparison.relative("month")
+        tc2 = TimeComparison.relative("month")
+        assert tc1 == tc2
+
+    def test_inequality_different_type(self) -> None:
+        """TimeComparisons with different types are not equal."""
+        from mixpanel_data.types import TimeComparison
+
+        tc1 = TimeComparison.relative("month")
+        tc2 = TimeComparison.absolute_start("2026-01-01")
+        assert tc1 != tc2
+
+    def test_relative_all_valid_units(self) -> None:
+        """All valid TimeComparisonUnit values create successfully."""
+        from mixpanel_data.types import TimeComparison
+
+        for unit in ("day", "week", "month", "quarter", "year"):
+            tc = TimeComparison.relative(unit)  # type: ignore[arg-type]
+            assert tc.unit == unit
+
+
+# =============================================================================
+# T021: FrequencyBreakdown dataclass tests (US4)
+# =============================================================================
+
+
+class TestFrequencyBreakdownConstruction:
+    """Tests for FrequencyBreakdown frozen dataclass construction and defaults."""
+
+    def test_event_only_uses_defaults(self) -> None:
+        """FrequencyBreakdown('Purchase') uses default bucket params."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        assert fb.event == "Purchase"
+        assert fb.bucket_size == 1
+        assert fb.bucket_min == 0
+        assert fb.bucket_max == 10
+        assert fb.label is None
+
+    def test_all_fields_set(self) -> None:
+        """FrequencyBreakdown with all fields explicitly set."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown(
+            "Purchase",
+            bucket_size=5,
+            bucket_min=0,
+            bucket_max=50,
+            label="Purchase Frequency",
+        )
+        assert fb.event == "Purchase"
+        assert fb.bucket_size == 5
+        assert fb.bucket_min == 0
+        assert fb.bucket_max == 50
+        assert fb.label == "Purchase Frequency"
+
+    def test_immutability(self) -> None:
+        """FrequencyBreakdown is frozen and cannot be modified."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        with pytest.raises(AttributeError):
+            fb.event = "Login"  # type: ignore[misc]
+
+    def test_equality_same_fields(self) -> None:
+        """Two FrequencyBreakdowns with identical fields are equal."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb1 = FrequencyBreakdown("Purchase")
+        fb2 = FrequencyBreakdown("Purchase")
+        assert fb1 == fb2
+
+    def test_inequality_different_event(self) -> None:
+        """FrequencyBreakdowns with different events are not equal."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        assert FrequencyBreakdown("Purchase") != FrequencyBreakdown("Login")
+
+
+class TestFrequencyBreakdownValidation:
+    """Tests for FrequencyBreakdown validation rules FB1-FB4."""
+
+    def test_fb1_empty_event_raises(self) -> None:
+        """FB1: event must be non-empty."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyBreakdown("")
+
+    def test_fb1_whitespace_event_raises(self) -> None:
+        """FB1: whitespace-only event must be rejected."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyBreakdown("   ")
+
+    def test_fb2_zero_bucket_size_raises(self) -> None:
+        """FB2: bucket_size must be positive (> 0)."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyBreakdown("Purchase", bucket_size=0)
+
+    def test_fb2_negative_bucket_size_raises(self) -> None:
+        """FB2: negative bucket_size must be rejected."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyBreakdown("Purchase", bucket_size=-1)
+
+    def test_fb3_bucket_min_equals_max_raises(self) -> None:
+        """FB3: bucket_min must be < bucket_max."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="less than"):
+            FrequencyBreakdown("Purchase", bucket_min=10, bucket_max=10)
+
+    def test_fb3_bucket_min_greater_than_max_raises(self) -> None:
+        """FB3: bucket_min > bucket_max must be rejected."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="less than"):
+            FrequencyBreakdown("Purchase", bucket_min=20, bucket_max=10)
+
+    def test_fb4_negative_bucket_min_raises(self) -> None:
+        """FB4: bucket_min must be >= 0."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyBreakdown("Purchase", bucket_min=-1)
+
+
+# =============================================================================
+# T021: FrequencyFilter dataclass tests (US4)
+# =============================================================================
+
+
+class TestFrequencyFilterConstruction:
+    """Tests for FrequencyFilter frozen dataclass construction and defaults."""
+
+    def test_event_and_value_uses_defaults(self) -> None:
+        """FrequencyFilter('Login', value=5) uses default operator."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        assert ff.event == "Login"
+        assert ff.operator == "is at least"
+        assert ff.value == 5
+        assert ff.date_range_value is None
+        assert ff.date_range_unit is None
+        assert ff.event_filters is None
+        assert ff.label is None
+
+    def test_all_fields_set(self) -> None:
+        """FrequencyFilter with all fields explicitly set."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Login",
+            operator="is greater than",
+            value=10,
+            date_range_value=30,
+            date_range_unit="day",
+            event_filters=[Filter.equals("country", "US")],
+            label="Active Users",
+        )
+        assert ff.event == "Login"
+        assert ff.operator == "is greater than"
+        assert ff.value == 10
+        assert ff.date_range_value == 30
+        assert ff.date_range_unit == "day"
+        assert ff.event_filters is not None
+        assert len(ff.event_filters) == 1
+        assert ff.label == "Active Users"
+
+    def test_immutability(self) -> None:
+        """FrequencyFilter is frozen and cannot be modified."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        with pytest.raises(AttributeError):
+            ff.event = "Signup"  # type: ignore[misc]
+
+    def test_equality_same_fields(self) -> None:
+        """Two FrequencyFilters with identical fields are equal."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff1 = FrequencyFilter("Login", value=5)
+        ff2 = FrequencyFilter("Login", value=5)
+        assert ff1 == ff2
+
+    def test_float_value(self) -> None:
+        """FrequencyFilter value accepts float."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=3.5)
+        assert ff.value == 3.5
+
+    def test_event_filters_list(self) -> None:
+        """FrequencyFilter accepts multiple event_filters."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Purchase",
+            value=1,
+            event_filters=[
+                Filter.equals("country", "US"),
+                Filter.greater_than("amount", 10),
+            ],
+        )
+        assert ff.event_filters is not None
+        assert len(ff.event_filters) == 2
+
+
+class TestFrequencyFilterValidation:
+    """Tests for FrequencyFilter validation rules FF1-FF5."""
+
+    def test_ff1_empty_event_raises(self) -> None:
+        """FF1: event must be non-empty."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyFilter("", value=5)
+
+    def test_ff1_whitespace_event_raises(self) -> None:
+        """FF1: whitespace-only event must be rejected."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyFilter("   ", value=5)
+
+    def test_ff2_invalid_operator_raises(self) -> None:
+        """FF2: operator must be in VALID_FREQUENCY_FILTER_OPERATORS."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="operator"):
+            FrequencyFilter("Login", operator="invalid_op", value=5)
+
+    def test_ff2_all_valid_operators_accepted(self) -> None:
+        """FF2: all valid operators are accepted."""
+        from mixpanel_data.types import FrequencyFilter
+
+        valid_ops = [
+            "is at least",
+            "is at most",
+            "is greater than",
+            "is less than",
+            "is equal to",
+            "is between",
+        ]
+        for op in valid_ops:
+            ff = FrequencyFilter("Login", operator=op, value=5)
+            assert ff.operator == op
+
+    def test_ff3_negative_value_raises(self) -> None:
+        """FF3: value must be non-negative (>= 0)."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyFilter("Login", value=-1)
+
+    def test_ff3_zero_value_accepted(self) -> None:
+        """FF3: value=0 is valid."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=0)
+        assert ff.value == 0
+
+    def test_ff4_date_range_value_without_unit_raises(self) -> None:
+        """FF4: date_range_value without date_range_unit raises."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="both.*set or both.*None"):
+            FrequencyFilter("Login", value=5, date_range_value=30)
+
+    def test_ff4_date_range_unit_without_value_raises(self) -> None:
+        """FF4: date_range_unit without date_range_value raises."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="both.*set or both.*None"):
+            FrequencyFilter("Login", value=5, date_range_unit="day")
+
+    def test_ff4_both_none_accepted(self) -> None:
+        """FF4: both date_range_value and date_range_unit None is valid."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter("Login", value=5)
+        assert ff.date_range_value is None
+        assert ff.date_range_unit is None
+
+    def test_ff4_both_set_accepted(self) -> None:
+        """FF4: both date_range_value and date_range_unit set is valid."""
+        from mixpanel_data.types import FrequencyFilter
+
+        ff = FrequencyFilter(
+            "Login", value=5, date_range_value=30, date_range_unit="day"
+        )
+        assert ff.date_range_value == 30
+        assert ff.date_range_unit == "day"
+
+    def test_ff5_zero_date_range_value_raises(self) -> None:
+        """FF5: date_range_value must be positive if set."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyFilter("Login", value=5, date_range_value=0, date_range_unit="day")
+
+    def test_ff5_negative_date_range_value_raises(self) -> None:
+        """FF5: negative date_range_value must be rejected."""
+        from mixpanel_data.types import FrequencyFilter
+
+        with pytest.raises(ValueError, match="positive"):
+            FrequencyFilter(
+                "Login", value=5, date_range_value=-7, date_range_unit="day"
+            )
+
+
+# =============================================================================
+# T029: New Filter factory methods (US6 — Complete Filter Operator Coverage)
+# =============================================================================
+
+
+class TestNewFilterFactoryMethods:
+    """T029: Tests for 7 new Filter factory methods."""
+
+    # --- not_between ---
+
+    def test_not_between_operator(self) -> None:
+        """Filter.not_between() uses 'not between' operator."""
+        f = Filter.not_between("age", 18, 65)
+        assert f._operator == "not between"
+
+    def test_not_between_property_type(self) -> None:
+        """Filter.not_between() sets property_type to 'number'."""
+        f = Filter.not_between("age", 18, 65)
+        assert f._property_type == "number"
+
+    def test_not_between_value(self) -> None:
+        """Filter.not_between() stores [min, max] as value."""
+        f = Filter.not_between("amount", 10, 100)
+        assert f._value == [10, 100]
+
+    def test_not_between_property(self) -> None:
+        """Filter.not_between() stores property name."""
+        f = Filter.not_between("age", 18, 65)
+        assert f._property == "age"
+
+    def test_not_between_resource_type_default(self) -> None:
+        """Filter.not_between() defaults to resource_type='events'."""
+        f = Filter.not_between("age", 18, 65)
+        assert f._resource_type == "events"
+
+    def test_not_between_resource_type_people(self) -> None:
+        """Filter.not_between() accepts resource_type='people'."""
+        f = Filter.not_between("age", 18, 65, resource_type="people")
+        assert f._resource_type == "people"
+
+    # --- starts_with ---
+
+    def test_starts_with_operator(self) -> None:
+        """Filter.starts_with() uses 'starts with' operator."""
+        f = Filter.starts_with("url", "https://")
+        assert f._operator == "starts with"
+
+    def test_starts_with_property_type(self) -> None:
+        """Filter.starts_with() sets property_type to 'string'."""
+        f = Filter.starts_with("url", "https://")
+        assert f._property_type == "string"
+
+    def test_starts_with_value(self) -> None:
+        """Filter.starts_with() stores prefix as value."""
+        f = Filter.starts_with("url", "https://")
+        assert f._value == "https://"
+
+    def test_starts_with_resource_type_people(self) -> None:
+        """Filter.starts_with() accepts resource_type='people'."""
+        f = Filter.starts_with("email", "admin@", resource_type="people")
+        assert f._resource_type == "people"
+
+    # --- ends_with ---
+
+    def test_ends_with_operator(self) -> None:
+        """Filter.ends_with() uses 'ends with' operator."""
+        f = Filter.ends_with("email", "@example.com")
+        assert f._operator == "ends with"
+
+    def test_ends_with_property_type(self) -> None:
+        """Filter.ends_with() sets property_type to 'string'."""
+        f = Filter.ends_with("email", "@example.com")
+        assert f._property_type == "string"
+
+    def test_ends_with_value(self) -> None:
+        """Filter.ends_with() stores suffix as value."""
+        f = Filter.ends_with("email", "@example.com")
+        assert f._value == "@example.com"
+
+    def test_ends_with_resource_type_people(self) -> None:
+        """Filter.ends_with() accepts resource_type='people'."""
+        f = Filter.ends_with("email", ".edu", resource_type="people")
+        assert f._resource_type == "people"
+
+    # --- date_not_between ---
+
+    def test_date_not_between_operator(self) -> None:
+        """Filter.date_not_between() uses 'was not between' operator."""
+        f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+        assert f._operator == "was not between"
+
+    def test_date_not_between_property_type(self) -> None:
+        """Filter.date_not_between() sets property_type to 'datetime'."""
+        f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+        assert f._property_type == "datetime"
+
+    def test_date_not_between_value(self) -> None:
+        """Filter.date_not_between() stores [from, to] as value."""
+        f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+        assert f._value == ["2024-01-01", "2024-06-30"]
+
+    def test_date_not_between_no_date_unit(self) -> None:
+        """Filter.date_not_between() has no date_unit."""
+        f = Filter.date_not_between("created", "2024-01-01", "2024-06-30")
+        assert f._date_unit is None
+
+    def test_date_not_between_resource_type_people(self) -> None:
+        """Filter.date_not_between() accepts resource_type='people'."""
+        f = Filter.date_not_between(
+            "$created", "2024-01-01", "2024-06-30", resource_type="people"
+        )
+        assert f._resource_type == "people"
+
+    def test_date_not_between_rejects_invalid_from(self) -> None:
+        """Filter.date_not_between() rejects invalid from_date."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.date_not_between("created", "bad", "2024-06-30")
+
+    def test_date_not_between_rejects_invalid_to(self) -> None:
+        """Filter.date_not_between() rejects invalid to_date."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            Filter.date_not_between("created", "2024-01-01", "bad")
+
+    def test_date_not_between_rejects_reversed_dates(self) -> None:
+        """Filter.date_not_between() rejects from > to."""
+        with pytest.raises(ValueError, match="must be before"):
+            Filter.date_not_between("created", "2024-12-31", "2024-01-01")
+
+    # --- in_the_next ---
+
+    def test_in_the_next_operator(self) -> None:
+        """Filter.in_the_next() uses 'was in the next' operator."""
+        f = Filter.in_the_next("expires", 7, "day")
+        assert f._operator == "was in the next"
+
+    def test_in_the_next_property_type(self) -> None:
+        """Filter.in_the_next() sets property_type to 'datetime'."""
+        f = Filter.in_the_next("expires", 7, "day")
+        assert f._property_type == "datetime"
+
+    def test_in_the_next_value(self) -> None:
+        """Filter.in_the_next() stores quantity as value."""
+        f = Filter.in_the_next("expires", 7, "day")
+        assert f._value == 7
+
+    def test_in_the_next_date_unit(self) -> None:
+        """Filter.in_the_next() sets _date_unit correctly."""
+        f = Filter.in_the_next("expires", 7, "day")
+        assert f._date_unit == "day"
+
+    def test_in_the_next_hour_unit(self) -> None:
+        """Filter.in_the_next() supports hour unit."""
+        f = Filter.in_the_next("expires", 24, "hour")
+        assert f._date_unit == "hour"
+
+    def test_in_the_next_week_unit(self) -> None:
+        """Filter.in_the_next() supports week unit."""
+        f = Filter.in_the_next("expires", 2, "week")
+        assert f._date_unit == "week"
+
+    def test_in_the_next_month_unit(self) -> None:
+        """Filter.in_the_next() supports month unit."""
+        f = Filter.in_the_next("expires", 3, "month")
+        assert f._date_unit == "month"
+
+    def test_in_the_next_resource_type_people(self) -> None:
+        """Filter.in_the_next() accepts resource_type='people'."""
+        f = Filter.in_the_next("renewal", 30, "day", resource_type="people")
+        assert f._resource_type == "people"
+
+    def test_in_the_next_rejects_zero(self) -> None:
+        """Filter.in_the_next() rejects non-positive quantity."""
+        with pytest.raises(ValueError, match="positive"):
+            Filter.in_the_next("expires", 0, "day")
+
+    def test_in_the_next_rejects_negative(self) -> None:
+        """Filter.in_the_next() rejects negative quantity."""
+        with pytest.raises(ValueError, match="positive"):
+            Filter.in_the_next("expires", -5, "day")
+
+    # --- at_least ---
+
+    def test_at_least_operator(self) -> None:
+        """Filter.at_least() uses 'is at least' operator."""
+        f = Filter.at_least("score", 80)
+        assert f._operator == "is at least"
+
+    def test_at_least_property_type(self) -> None:
+        """Filter.at_least() sets property_type to 'number'."""
+        f = Filter.at_least("score", 80)
+        assert f._property_type == "number"
+
+    def test_at_least_value(self) -> None:
+        """Filter.at_least() stores numeric value."""
+        f = Filter.at_least("score", 80)
+        assert f._value == 80
+
+    def test_at_least_float_value(self) -> None:
+        """Filter.at_least() accepts float value."""
+        f = Filter.at_least("score", 79.5)
+        assert f._value == 79.5
+
+    def test_at_least_resource_type_people(self) -> None:
+        """Filter.at_least() accepts resource_type='people'."""
+        f = Filter.at_least("purchases", 10, resource_type="people")
+        assert f._resource_type == "people"
+
+    # --- at_most ---
+
+    def test_at_most_operator(self) -> None:
+        """Filter.at_most() uses 'is at most' operator."""
+        f = Filter.at_most("errors", 5)
+        assert f._operator == "is at most"
+
+    def test_at_most_property_type(self) -> None:
+        """Filter.at_most() sets property_type to 'number'."""
+        f = Filter.at_most("errors", 5)
+        assert f._property_type == "number"
+
+    def test_at_most_value(self) -> None:
+        """Filter.at_most() stores numeric value."""
+        f = Filter.at_most("errors", 5)
+        assert f._value == 5
+
+    def test_at_most_float_value(self) -> None:
+        """Filter.at_most() accepts float value."""
+        f = Filter.at_most("latency", 99.9)
+        assert f._value == 99.9
+
+    def test_at_most_resource_type_people(self) -> None:
+        """Filter.at_most() accepts resource_type='people'."""
+        f = Filter.at_most("complaints", 3, resource_type="people")
+        assert f._resource_type == "people"

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -1018,7 +1018,7 @@ class TestTimeComparison:
         from mixpanel_data.types import TimeComparison
 
         for unit in ("day", "week", "month", "quarter", "year"):
-            tc = TimeComparison.relative(unit)  # type: ignore[arg-type]
+            tc = TimeComparison.relative(unit)
             assert tc.unit == unit
 
 

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -1250,7 +1250,6 @@ class TestFrequencyFilterValidation:
             "is greater than",
             "is less than",
             "is equal to",
-            "is between",
         ]
         for op in valid_ops:
             ff = FrequencyFilter("Login", operator=op, value=5)  # type: ignore[arg-type]

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -1238,7 +1238,7 @@ class TestFrequencyFilterValidation:
         from mixpanel_data.types import FrequencyFilter
 
         with pytest.raises(ValueError, match="operator"):
-            FrequencyFilter("Login", operator="invalid_op", value=5)
+            FrequencyFilter("Login", operator="invalid_op", value=5)  # type: ignore[arg-type]
 
     def test_ff2_all_valid_operators_accepted(self) -> None:
         """FF2: all valid operators are accepted."""
@@ -1253,7 +1253,7 @@ class TestFrequencyFilterValidation:
             "is between",
         ]
         for op in valid_ops:
-            ff = FrequencyFilter("Login", operator=op, value=5)
+            ff = FrequencyFilter("Login", operator=op, value=5)  # type: ignore[arg-type]
             assert ff.operator == op
 
     def test_ff3_negative_value_raises(self) -> None:

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -18,8 +18,9 @@ Usage:
 from __future__ import annotations
 
 import dataclasses
+import datetime
 import json
-from datetime import datetime
+from datetime import datetime as dt_datetime
 from pathlib import Path
 from typing import get_args
 
@@ -71,8 +72,12 @@ from mixpanel_data.types import (
 # Custom Strategies
 # =============================================================================
 
-# Strategy for generating valid date strings (YYYY-MM-DD format)
-date_strings = st.dates().map(lambda d: d.strftime("%Y-%m-%d"))
+# Strategy for generating valid date strings (YYYY-MM-DD format).
+# Constrained to 4-digit years (1000-9999) to match _DATE_RE regex.
+date_strings = st.dates(
+    min_value=datetime.date(1000, 1, 1),
+    max_value=datetime.date(9999, 12, 31),
+).map(lambda d: d.strftime("%Y-%m-%d"))
 
 # Strategy for event names (non-empty printable strings)
 event_names = st.text(
@@ -103,8 +108,8 @@ time_units = st.sampled_from(["day", "week", "month"])
 
 # Strategy for datetime values (deterministic for reproducibility)
 datetimes = st.datetimes(
-    min_value=datetime(2020, 1, 1),
-    max_value=datetime(2030, 12, 31),
+    min_value=dt_datetime(2020, 1, 1),
+    max_value=dt_datetime(2030, 12, 31),
 )
 
 
@@ -1354,7 +1359,7 @@ class TestActivityFeedResultProperties:
         from_date: str | None,
         to_date: str | None,
         event_count: int,
-        event_time: datetime,
+        event_time: dt_datetime,
     ) -> None:
         """to_dict() output should always be JSON-serializable."""
         events = [
@@ -1380,7 +1385,7 @@ class TestActivityFeedResultProperties:
 
     @given(event_count=st.integers(min_value=0, max_value=20), event_time=datetimes)
     def test_df_row_count_matches_events(
-        self, event_count: int, event_time: datetime
+        self, event_count: int, event_time: dt_datetime
     ) -> None:
         """DataFrame row count should equal number of events."""
         events = [
@@ -1637,7 +1642,7 @@ class TestHelperTypeProperties:
         ),
     )
     def test_user_event_to_dict_json_serializable(
-        self, event: str, event_time: datetime, properties: dict[str, object]
+        self, event: str, event_time: dt_datetime, properties: dict[str, object]
     ) -> None:
         """UserEvent.to_dict() should always be JSON-serializable."""
         result = UserEvent(event=event, time=event_time, properties=properties)
@@ -2377,7 +2382,7 @@ class TestOAuthTokensRoundTripPBT:
 
         from mixpanel_data._internal.auth.token import OAuthTokens
 
-        now = datetime.now(timezone.utc)
+        now = dt_datetime.now(timezone.utc)
         tokens = OAuthTokens(
             access_token=SecretStr("tok"),
             expires_at=now - timedelta(seconds=seconds_past),

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -21,11 +21,15 @@ import dataclasses
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import get_args
 
 import pandas as pd
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from mixpanel_data._internal.bookmark_enums import VALID_FREQUENCY_FILTER_OPERATORS
+from mixpanel_data._literal_types import MathType, TimeComparisonUnit
 from mixpanel_data.types import (
     ActivityFeedResult,
     BookmarkInfo,
@@ -36,11 +40,14 @@ from mixpanel_data.types import (
     EngagementDistributionResult,
     EventCountsResult,
     FlowsResult,
+    FrequencyBreakdown,
+    FrequencyFilter,
     FrequencyResult,
     FunnelInfo,
     FunnelResult,
     FunnelResultStep,
     JQLResult,
+    Metric,
     NumericAverageResult,
     NumericBucketResult,
     NumericPropertySummaryResult,
@@ -55,6 +62,7 @@ from mixpanel_data.types import (
     SavedCohort,
     SavedReportResult,
     SegmentationResult,
+    TimeComparison,
     TopEvent,
     UserEvent,
 )
@@ -2429,3 +2437,405 @@ class TestOAuthTokensRoundTripPBT:
         assert loaded.access_token.get_secret_value() == access_token
         assert loaded.scope == scope
         assert loaded.project_id == project_id
+
+
+# =============================================================================
+# TimeComparison Property Tests (Phase 040)
+# =============================================================================
+
+# Strategies for TimeComparison
+time_comparison_units = st.sampled_from(list(get_args(TimeComparisonUnit)))
+
+
+class TestTimeComparisonProperties:
+    """Property-based tests for TimeComparison factory methods and validation."""
+
+    @given(unit=time_comparison_units)
+    def test_relative_factory_always_valid(self, unit: str) -> None:
+        """TimeComparison.relative() with any valid unit never raises."""
+        tc = TimeComparison.relative(unit)  # type: ignore[arg-type]
+        assert tc.type == "relative"
+        assert tc.unit == unit
+        assert tc.date is None
+
+    @given(date=date_strings)
+    def test_absolute_start_factory_always_valid(self, date: str) -> None:
+        """TimeComparison.absolute_start() with YYYY-MM-DD date never raises."""
+        tc = TimeComparison.absolute_start(date)
+        assert tc.type == "absolute-start"
+        assert tc.date == date
+        assert tc.unit is None
+
+    @given(date=date_strings)
+    def test_absolute_end_factory_always_valid(self, date: str) -> None:
+        """TimeComparison.absolute_end() with YYYY-MM-DD date never raises."""
+        tc = TimeComparison.absolute_end(date)
+        assert tc.type == "absolute-end"
+        assert tc.date == date
+        assert tc.unit is None
+
+    @given(unit=time_comparison_units, date=date_strings)
+    def test_relative_with_date_raises(self, unit: str, date: str) -> None:
+        """TC1: type='relative' with date set always raises ValueError."""
+        with pytest.raises(ValueError, match="does not accept date"):
+            TimeComparison(type="relative", unit=unit, date=date)  # type: ignore[arg-type]
+
+    @given(
+        tc_type=st.sampled_from(["absolute-start", "absolute-end"]),
+        unit=time_comparison_units,
+        date=date_strings,
+    )
+    def test_absolute_with_unit_raises(
+        self, tc_type: str, unit: str, date: str
+    ) -> None:
+        """TC2: absolute types with unit set always raises ValueError."""
+        with pytest.raises(ValueError, match="does not accept unit"):
+            TimeComparison(type=tc_type, unit=unit, date=date)  # type: ignore[arg-type]
+
+    def test_relative_without_unit_raises(self) -> None:
+        """TC1: type='relative' without unit always raises ValueError."""
+        with pytest.raises(ValueError, match="requires unit"):
+            TimeComparison(type="relative")
+
+    @given(tc_type=st.sampled_from(["absolute-start", "absolute-end"]))
+    def test_absolute_without_date_raises(self, tc_type: str) -> None:
+        """TC2: absolute types without date always raises ValueError."""
+        with pytest.raises(ValueError, match="requires date"):
+            TimeComparison(type=tc_type)  # type: ignore[arg-type]
+
+    @given(
+        tc_type=st.sampled_from(["absolute-start", "absolute-end"]),
+        bad_date=st.text(min_size=1, max_size=20).filter(
+            lambda s: not __import__("re").match(r"^\d{4}-\d{2}-\d{2}$", s)
+        ),
+    )
+    def test_absolute_with_bad_date_format_raises(
+        self, tc_type: str, bad_date: str
+    ) -> None:
+        """TC3: absolute types with non-YYYY-MM-DD date always raises ValueError."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            TimeComparison(type=tc_type, date=bad_date)  # type: ignore[arg-type]
+
+    @given(unit=time_comparison_units)
+    def test_relative_is_frozen(self, unit: str) -> None:
+        """TimeComparison instances are immutable (frozen dataclass)."""
+        tc = TimeComparison.relative(unit)  # type: ignore[arg-type]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            tc.unit = "day"  # type: ignore[misc]
+
+
+# =============================================================================
+# FrequencyBreakdown Property Tests (Phase 040)
+# =============================================================================
+
+
+class TestFrequencyBreakdownProperties:
+    """Property-based tests for FrequencyBreakdown construction and validation."""
+
+    @given(
+        event=event_names,
+        bucket_size=st.integers(min_value=1, max_value=1000),
+        bucket_max=st.integers(min_value=2, max_value=10000),
+    )
+    def test_valid_construction_never_raises(
+        self, event: str, bucket_size: int, bucket_max: int
+    ) -> None:
+        """Valid FrequencyBreakdown construction never raises.
+
+        Uses bucket_min=0 (default) and ensures bucket_max > 0.
+        """
+        fb = FrequencyBreakdown(
+            event=event, bucket_size=bucket_size, bucket_min=0, bucket_max=bucket_max
+        )
+        assert fb.event == event
+        assert fb.bucket_size == bucket_size
+        assert fb.bucket_min < fb.bucket_max
+
+    @given(
+        event=event_names,
+        bucket_min=st.integers(min_value=0, max_value=100),
+        gap=st.integers(min_value=1, max_value=1000),
+    )
+    def test_bucket_min_always_less_than_max(
+        self, event: str, bucket_min: int, gap: int
+    ) -> None:
+        """For any valid FrequencyBreakdown, bucket_min < bucket_max holds."""
+        bucket_max = bucket_min + gap
+        fb = FrequencyBreakdown(
+            event=event, bucket_min=bucket_min, bucket_max=bucket_max
+        )
+        assert fb.bucket_min < fb.bucket_max
+
+    @given(
+        bad_event=st.just(""),
+        bucket_size=st.integers(min_value=1, max_value=100),
+    )
+    def test_empty_event_raises(self, bad_event: str, bucket_size: int) -> None:
+        """FB1: empty event name always raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyBreakdown(event=bad_event, bucket_size=bucket_size)
+
+    @given(
+        event=event_names,
+        bad_size=st.integers(min_value=-100, max_value=0),
+    )
+    def test_non_positive_bucket_size_raises(self, event: str, bad_size: int) -> None:
+        """FB2: non-positive bucket_size always raises ValueError."""
+        with pytest.raises(ValueError, match="bucket_size must be positive"):
+            FrequencyBreakdown(event=event, bucket_size=bad_size)
+
+    @given(
+        event=event_names,
+        same_val=st.integers(min_value=0, max_value=1000),
+    )
+    def test_bucket_min_equals_max_raises(self, event: str, same_val: int) -> None:
+        """FB3: bucket_min == bucket_max always raises ValueError."""
+        with pytest.raises(ValueError, match="less than bucket_max"):
+            FrequencyBreakdown(event=event, bucket_min=same_val, bucket_max=same_val)
+
+    @given(
+        event=event_names,
+        bad_min=st.integers(min_value=-1000, max_value=-1),
+    )
+    def test_negative_bucket_min_raises(self, event: str, bad_min: int) -> None:
+        """FB4: negative bucket_min always raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyBreakdown(event=event, bucket_min=bad_min, bucket_max=bad_min + 10)
+
+    @given(event=event_names)
+    def test_frozen_instance(self, event: str) -> None:
+        """FrequencyBreakdown instances are immutable (frozen dataclass)."""
+        fb = FrequencyBreakdown(event=event)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            fb.event = "other"  # type: ignore[misc]
+
+
+# =============================================================================
+# FrequencyFilter Property Tests (Phase 040)
+# =============================================================================
+
+valid_ff_operators = st.sampled_from(sorted(VALID_FREQUENCY_FILTER_OPERATORS))
+
+
+class TestFrequencyFilterProperties:
+    """Property-based tests for FrequencyFilter construction and validation."""
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=10000),
+    )
+    def test_valid_construction_never_raises(
+        self, event: str, operator: str, value: int
+    ) -> None:
+        """Valid FrequencyFilter construction (no date range) never raises."""
+        ff = FrequencyFilter(event=event, operator=operator, value=value)
+        assert ff.event == event
+        assert ff.operator == operator
+        assert ff.value == value
+        assert ff.date_range_value is None
+        assert ff.date_range_unit is None
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=10000),
+        dr_value=st.integers(min_value=1, max_value=365),
+        dr_unit=st.sampled_from(["day", "week", "month"]),
+    )
+    def test_valid_with_date_range_never_raises(
+        self, event: str, operator: str, value: int, dr_value: int, dr_unit: str
+    ) -> None:
+        """Valid FrequencyFilter with date range pair never raises."""
+        ff = FrequencyFilter(
+            event=event,
+            operator=operator,
+            value=value,
+            date_range_value=dr_value,
+            date_range_unit=dr_unit,  # type: ignore[arg-type]
+        )
+        assert ff.date_range_value == dr_value
+        assert ff.date_range_unit == dr_unit
+
+    @given(
+        event=event_names,
+        bad_op=st.text(min_size=1, max_size=30).filter(
+            lambda s: s not in VALID_FREQUENCY_FILTER_OPERATORS
+        ),
+        value=st.integers(min_value=0, max_value=100),
+    )
+    def test_invalid_operator_raises(self, event: str, bad_op: str, value: int) -> None:
+        """FF2: invalid operator always raises ValueError."""
+        with pytest.raises(ValueError, match="operator must be one of"):
+            FrequencyFilter(event=event, operator=bad_op, value=value)
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        bad_value=st.integers(min_value=-10000, max_value=-1),
+    )
+    def test_negative_value_raises(
+        self, event: str, operator: str, bad_value: int
+    ) -> None:
+        """FF3: negative value always raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            FrequencyFilter(event=event, operator=operator, value=bad_value)
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=100),
+        dr_value=st.integers(min_value=1, max_value=365),
+    )
+    def test_date_range_value_without_unit_raises(
+        self, event: str, operator: str, value: int, dr_value: int
+    ) -> None:
+        """FF4: date_range_value without date_range_unit always raises."""
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            FrequencyFilter(
+                event=event,
+                operator=operator,
+                value=value,
+                date_range_value=dr_value,
+                date_range_unit=None,
+            )
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=100),
+        dr_unit=st.sampled_from(["day", "week", "month"]),
+    )
+    def test_date_range_unit_without_value_raises(
+        self, event: str, operator: str, value: int, dr_unit: str
+    ) -> None:
+        """FF4: date_range_unit without date_range_value always raises."""
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            FrequencyFilter(
+                event=event,
+                operator=operator,
+                value=value,
+                date_range_value=None,
+                date_range_unit=dr_unit,  # type: ignore[arg-type]
+            )
+
+    @given(
+        event=event_names,
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=100),
+        bad_dr_value=st.integers(min_value=-100, max_value=0),
+        dr_unit=st.sampled_from(["day", "week", "month"]),
+    )
+    def test_non_positive_date_range_value_raises(
+        self, event: str, operator: str, value: int, bad_dr_value: int, dr_unit: str
+    ) -> None:
+        """FF5: non-positive date_range_value always raises ValueError."""
+        with pytest.raises(ValueError, match="positive when set"):
+            FrequencyFilter(
+                event=event,
+                operator=operator,
+                value=value,
+                date_range_value=bad_dr_value,
+                date_range_unit=dr_unit,  # type: ignore[arg-type]
+            )
+
+    @given(
+        bad_event=st.just(""),
+        operator=valid_ff_operators,
+        value=st.integers(min_value=0, max_value=100),
+    )
+    def test_empty_event_raises(
+        self, bad_event: str, operator: str, value: int
+    ) -> None:
+        """FF1: empty event name always raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            FrequencyFilter(event=bad_event, operator=operator, value=value)
+
+    @given(event=event_names)
+    def test_frozen_instance(self, event: str) -> None:
+        """FrequencyFilter instances are immutable (frozen dataclass)."""
+        ff = FrequencyFilter(event=event, value=1)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ff.value = 99  # type: ignore[misc]
+
+
+# =============================================================================
+# MathType / Metric Exhaustive Property Tests (Phase 040)
+# =============================================================================
+
+# Math types that require a property argument
+_MATH_REQUIRING_PROPERTY: frozenset[str] = frozenset(
+    {
+        "average",
+        "median",
+        "min",
+        "max",
+        "p25",
+        "p75",
+        "p90",
+        "p99",
+        "percentile",
+        "histogram",
+        "unique_values",
+        "most_frequent",
+        "first_value",
+        "multi_attribution",
+        "numeric_summary",
+    }
+)
+
+# All 22 MathType values from the Literal definition
+_ALL_MATH_TYPES: tuple[str, ...] = get_args(MathType)
+
+
+class TestMathTypeMetricProperties:
+    """Property-based tests verifying all MathType values are accepted by Metric."""
+
+    @given(math=st.sampled_from(_ALL_MATH_TYPES))
+    def test_all_math_types_accepted_by_metric(self, math: str) -> None:
+        """Every MathType value produces a valid Metric when property requirements are met.
+
+        For math types requiring a property, passes property="test_prop".
+        For math="percentile", also passes percentile_value=50.
+        """
+        kwargs: dict[str, object] = {"event": "TestEvent", "math": math}
+        if math in _MATH_REQUIRING_PROPERTY:
+            kwargs["property"] = "test_prop"
+        if math == "percentile":
+            kwargs["percentile_value"] = 50
+        m = Metric(**kwargs)  # type: ignore[arg-type]
+        assert m.math == math
+        assert m.event == "TestEvent"
+
+    @given(
+        math=st.sampled_from(
+            [m for m in _ALL_MATH_TYPES if m in _MATH_REQUIRING_PROPERTY]
+        )
+    )
+    def test_property_required_math_without_property_raises(self, math: str) -> None:
+        """Math types requiring a property raise ValueError when property is None."""
+        kwargs: dict[str, object] = {"event": "TestEvent", "math": math}
+        if math == "percentile":
+            kwargs["percentile_value"] = 50
+        with pytest.raises(ValueError, match="requires a property"):
+            Metric(**kwargs)  # type: ignore[arg-type]
+
+    @given(
+        math=st.sampled_from(
+            [m for m in _ALL_MATH_TYPES if m not in _MATH_REQUIRING_PROPERTY]
+        )
+    )
+    def test_non_property_math_without_property_succeeds(self, math: str) -> None:
+        """Math types not requiring a property succeed without one."""
+        m = Metric(event="TestEvent", math=math)  # type: ignore[arg-type]
+        assert m.math == math
+        assert m.property is None
+
+    def test_percentile_without_value_raises(self) -> None:
+        """math='percentile' without percentile_value raises ValueError."""
+        with pytest.raises(ValueError, match="percentile_value"):
+            Metric(event="TestEvent", math="percentile", property="amount")
+
+    def test_math_type_count_is_22(self) -> None:
+        """Verify MathType has exactly 22 values (guard against drift)."""
+        assert len(_ALL_MATH_TYPES) == 22

--- a/tests/unit/test_types_pbt.py
+++ b/tests/unit/test_types_pbt.py
@@ -2629,7 +2629,7 @@ class TestFrequencyFilterProperties:
         self, event: str, operator: str, value: int
     ) -> None:
         """Valid FrequencyFilter construction (no date range) never raises."""
-        ff = FrequencyFilter(event=event, operator=operator, value=value)
+        ff = FrequencyFilter(event=event, operator=operator, value=value)  # type: ignore[arg-type]
         assert ff.event == event
         assert ff.operator == operator
         assert ff.value == value
@@ -2649,7 +2649,7 @@ class TestFrequencyFilterProperties:
         """Valid FrequencyFilter with date range pair never raises."""
         ff = FrequencyFilter(
             event=event,
-            operator=operator,
+            operator=operator,  # type: ignore[arg-type]
             value=value,
             date_range_value=dr_value,
             date_range_unit=dr_unit,  # type: ignore[arg-type]
@@ -2667,7 +2667,7 @@ class TestFrequencyFilterProperties:
     def test_invalid_operator_raises(self, event: str, bad_op: str, value: int) -> None:
         """FF2: invalid operator always raises ValueError."""
         with pytest.raises(ValueError, match="operator must be one of"):
-            FrequencyFilter(event=event, operator=bad_op, value=value)
+            FrequencyFilter(event=event, operator=bad_op, value=value)  # type: ignore[arg-type]
 
     @given(
         event=event_names,
@@ -2679,7 +2679,7 @@ class TestFrequencyFilterProperties:
     ) -> None:
         """FF3: negative value always raises ValueError."""
         with pytest.raises(ValueError, match="non-negative"):
-            FrequencyFilter(event=event, operator=operator, value=bad_value)
+            FrequencyFilter(event=event, operator=operator, value=bad_value)  # type: ignore[arg-type]
 
     @given(
         event=event_names,
@@ -2694,7 +2694,7 @@ class TestFrequencyFilterProperties:
         with pytest.raises(ValueError, match="both be set or both be None"):
             FrequencyFilter(
                 event=event,
-                operator=operator,
+                operator=operator,  # type: ignore[arg-type]
                 value=value,
                 date_range_value=dr_value,
                 date_range_unit=None,
@@ -2713,7 +2713,7 @@ class TestFrequencyFilterProperties:
         with pytest.raises(ValueError, match="both be set or both be None"):
             FrequencyFilter(
                 event=event,
-                operator=operator,
+                operator=operator,  # type: ignore[arg-type]
                 value=value,
                 date_range_value=None,
                 date_range_unit=dr_unit,  # type: ignore[arg-type]
@@ -2733,7 +2733,7 @@ class TestFrequencyFilterProperties:
         with pytest.raises(ValueError, match="positive when set"):
             FrequencyFilter(
                 event=event,
-                operator=operator,
+                operator=operator,  # type: ignore[arg-type]
                 value=value,
                 date_range_value=bad_dr_value,
                 date_range_unit=dr_unit,  # type: ignore[arg-type]
@@ -2749,7 +2749,7 @@ class TestFrequencyFilterProperties:
     ) -> None:
         """FF1: empty event name always raises ValueError."""
         with pytest.raises(ValueError, match="non-empty"):
-            FrequencyFilter(event=bad_event, operator=operator, value=value)
+            FrequencyFilter(event=bad_event, operator=operator, value=value)  # type: ignore[arg-type]
 
     @given(event=event_names)
     def test_frozen_instance(self, event: str) -> None:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -650,7 +650,7 @@ class TestValidateMeasurementFunnelContext:
 
     def test_insights_only_math_rejected_in_funnel_context(self) -> None:
         """Insights-only math types are rejected when bookmark_type='funnels'."""
-        insights_only = ["dau", "wau", "mau", "cumulative_unique", "histogram"]
+        insights_only = ["dau", "wau", "mau", "cumulative_unique"]
         for math_type in insights_only:
             bm = _minimal_funnel_bookmark(math=math_type)
             errors = validate_bookmark(bm, bookmark_type="funnels")
@@ -715,3 +715,35 @@ def _minimal_funnel_bookmark(
             "chartType": "funnel-steps",
         },
     }
+
+
+# =============================================================================
+# T036: data_group_id validation for insights
+# =============================================================================
+
+
+class TestDataGroupIdValidationInsights:
+    """Tests for data_group_id validation in validate_query_args (T036)."""
+
+    def test_valid_data_group_id(self) -> None:
+        """Positive integer data_group_id passes validation."""
+        errors = validate_query_args(**_valid_args(data_group_id=5))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_none_data_group_id(self) -> None:
+        """None data_group_id passes validation (optional parameter)."""
+        errors = validate_query_args(**_valid_args(data_group_id=None))
+        assert not any(e.code == "DG1_INVALID_DATA_GROUP_ID" for e in errors)
+
+    def test_zero_data_group_id(self) -> None:
+        """data_group_id=0 fails validation (must be positive)."""
+        errors = validate_query_args(**_valid_args(data_group_id=0))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1
+        assert dg_errors[0].path == "data_group_id"
+
+    def test_negative_data_group_id(self) -> None:
+        """Negative data_group_id fails validation."""
+        errors = validate_query_args(**_valid_args(data_group_id=-1))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -747,3 +747,15 @@ class TestDataGroupIdValidationInsights:
         errors = validate_query_args(**_valid_args(data_group_id=-1))
         dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
         assert len(dg_errors) == 1
+
+    def test_data_group_id_true_rejected(self) -> None:
+        """data_group_id=True is rejected (bool is subtype of int)."""
+        errors = validate_query_args(**_valid_args(data_group_id=True))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1
+
+    def test_data_group_id_false_rejected(self) -> None:
+        """data_group_id=False is rejected (bool is subtype of int)."""
+        errors = validate_query_args(**_valid_args(data_group_id=False))
+        dg_errors = [e for e in errors if e.code == "DG1_INVALID_DATA_GROUP_ID"]
+        assert len(dg_errors) == 1

--- a/tests/unit/test_workspace_flow.py
+++ b/tests/unit/test_workspace_flow.py
@@ -1017,10 +1017,10 @@ class TestDataGroupIdFlow:
         self,
         workspace_factory: Callable[..., Workspace],
     ) -> None:
-        """build_flow_params without data_group_id produces data_group_id: None (backward compat)."""
+        """build_flow_params without data_group_id omits the key entirely."""
         ws = workspace_factory()
         result = ws.build_flow_params("Login")
-        assert result["data_group_id"] is None
+        assert "data_group_id" not in result
 
 
 # =========================================================================

--- a/tests/unit/test_workspace_flow.py
+++ b/tests/unit/test_workspace_flow.py
@@ -16,7 +16,7 @@ from pydantic import SecretStr
 from mixpanel_data import Workspace
 from mixpanel_data._internal.config import ConfigManager, Credentials
 from mixpanel_data.exceptions import BookmarkValidationError, ConfigError
-from mixpanel_data.types import Filter, FlowQueryResult, FlowStep, FlowTreeNode
+from mixpanel_data.types import Filter, FlowQueryResult, FlowStep, FlowTreeNode, GroupBy
 
 # =========================================================================
 # Fixtures
@@ -992,5 +992,269 @@ class TestQueryFlowTreeIntegration:
             assert len(at_roots) == 1
             assert at_roots[0].event == "Login"
             assert len(at_roots[0].children) == 1
+        finally:
+            ws.close()
+
+
+# =========================================================================
+# T032: data_group_id on flow query engine
+# =========================================================================
+
+
+class TestDataGroupIdFlow:
+    """Tests for data_group_id parameter on flow query engine (T032)."""
+
+    def test_build_flow_params_with_data_group_id(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with data_group_id=5 includes data_group_id: 5 (snake_case for flows)."""
+        ws = workspace_factory()
+        result = ws.build_flow_params("Login", data_group_id=5)
+        assert result["data_group_id"] == 5
+
+    def test_build_flow_params_without_data_group_id(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params without data_group_id produces data_group_id: None (backward compat)."""
+        ws = workspace_factory()
+        result = ws.build_flow_params("Login")
+        assert result["data_group_id"] is None
+
+
+# =========================================================================
+# T038: Advanced Flow Features — session_event, segments, exclusions, where
+# =========================================================================
+
+
+class TestFlowSessionEvent:
+    """Tests for session_event in built flow params (T038)."""
+
+    def test_session_event_in_step_output(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with session_event='start' emits session_event in step dict."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                FlowStep(event="$session_start", session_event="start"),
+            )
+            step = params["steps"][0]
+            assert step["session_event"] == "start"
+        finally:
+            ws.close()
+
+    def test_session_event_end_in_step_output(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with session_event='end' emits session_event in step dict."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                FlowStep(event="$session_end", session_event="end"),
+            )
+            step = params["steps"][0]
+            assert step["session_event"] == "end"
+        finally:
+            ws.close()
+
+    def test_no_session_event_omitted_from_step(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """Regular FlowStep does not include session_event key in step dict."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params("Login")
+            step = params["steps"][0]
+            assert "session_event" not in step
+        finally:
+            ws.close()
+
+
+class TestFlowSegments:
+    """Tests for segments parameter on flow queries (T038)."""
+
+    def test_segments_single_groupby(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with segments=GroupBy('country') produces segments in output."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                segments=GroupBy("country"),
+            )
+            assert "segments" in params
+            assert isinstance(params["segments"], list)
+            assert len(params["segments"]) == 1
+            assert params["segments"][0]["value"] == "country"
+        finally:
+            ws.close()
+
+    def test_segments_string_shorthand(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with segments='country' produces segments in output."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                segments="country",
+            )
+            assert "segments" in params
+            assert len(params["segments"]) == 1
+        finally:
+            ws.close()
+
+    def test_segments_list_of_groupby(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with list of GroupBy produces multiple segments."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                segments=[GroupBy("country"), GroupBy("platform")],
+            )
+            assert len(params["segments"]) == 2
+        finally:
+            ws.close()
+
+    def test_segments_none_not_in_output(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params without segments does not include segments key."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params("Login")
+            assert "segments" not in params
+        finally:
+            ws.close()
+
+
+class TestFlowExclusions:
+    """Tests for exclusions parameter on flow queries (T038)."""
+
+    def test_exclusions_single_event(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with exclusions=['Error'] produces exclusions list."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                exclusions=["Error Event"],
+            )
+            assert params["exclusions"] == ["Error Event"]
+        finally:
+            ws.close()
+
+    def test_exclusions_multiple_events(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with multiple exclusions produces them all."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                exclusions=["Error", "Debug", "Test"],
+            )
+            assert params["exclusions"] == ["Error", "Debug", "Test"]
+        finally:
+            ws.close()
+
+    def test_exclusions_none_produces_empty_list(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params without exclusions produces empty exclusions list (default)."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params("Login")
+            assert params["exclusions"] == []
+        finally:
+            ws.close()
+
+
+class TestFlowPropertyFilters:
+    """Tests for property filters (filter_by_event) on flow queries (T038)."""
+
+    def test_property_filter_produces_filter_by_event(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with where=Filter.equals produces filter_by_event."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                where=Filter.equals("country", "US"),
+            )
+            assert "filter_by_event" in params
+            fbe = params["filter_by_event"]
+            assert fbe["operator"] == "and"
+            assert len(fbe["children"]) == 1
+            child = fbe["children"][0]
+            assert child["filterOperator"] == "equals"
+            assert child["propertyName"] == "country"
+            assert child["filterValue"] == ["US"]
+        finally:
+            ws.close()
+
+    def test_multiple_property_filters(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with list of property filters produces children array."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                where=[
+                    Filter.equals("country", "US"),
+                    Filter.greater_than("age", 18),
+                ],
+            )
+            fbe = params["filter_by_event"]
+            assert len(fbe["children"]) == 2
+        finally:
+            ws.close()
+
+    def test_cohort_filter_still_produces_filter_by_cohort(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params with cohort filter still produces filter_by_cohort."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params(
+                "Login",
+                where=Filter.in_cohort(123, "Power Users"),
+            )
+            assert "filter_by_cohort" in params
+            assert "filter_by_event" not in params
+        finally:
+            ws.close()
+
+    def test_no_where_no_filter_keys(
+        self,
+        workspace_factory: Callable[..., Workspace],
+    ) -> None:
+        """build_flow_params without where has no filter_by_event or filter_by_cohort."""
+        ws = workspace_factory()
+        try:
+            params = ws.build_flow_params("Login")
+            assert "filter_by_event" not in params
+            assert "filter_by_cohort" not in params
         finally:
             ws.close()


### PR DESCRIPTION
## Summary

- Closes all 29 capability gaps identified by the Mixpanel Query API Capability Audit across insights, funnels, retention, and flows
- **Math types**: MathType +7 (cumulative_unique, sessions, unique_values, most_frequent, first_value, multi_attribution, numeric_summary), RetentionMathType +2 (total, average), FunnelMathType +1 (histogram)
- **Advanced modes**: segment_method on Metric, reentry_mode on funnels, unbounded_mode and retention_cumulative on retention
- **New feature types**: TimeComparison (period-over-period overlay), FrequencyBreakdown/FrequencyFilter (frequency analysis), CohortCriteria aggregation operators (6 types)
- **Filter operators**: 7 new Filter factory methods (not_between, starts_with, ends_with, date_not_between, in_the_next, at_least, at_most)
- **Completeness**: data_group_id on all 4 query engines, FlowStep session_event, flow property filters (filter_by_event), flow segments and exclusions
- All changes are additive with backward-compatible None/False defaults
- Bug fix: `dataGroupId: None` was always emitted in sections — Mixpanel API rejects this extra field. Now only emitted when explicitly set.

## Test plan

- [x] 5939 unit tests pass (0 failures)
- [x] 30 PBT tests covering TimeComparison, FrequencyBreakdown, FrequencyFilter, expanded MathType
- [x] 159 live QA tests pass against real Mixpanel API (smoke suite, offline validation, validation errors, live API, cross-parameter interactions)
- [x] 92% test coverage (above 90% threshold)
- [x] mypy --strict: 0 errors across 60 source files
- [x] ruff check + ruff format: clean
- [x] Quickstart examples validated