### PR TITLE
fix: correct FrequencyBreakdown serialization to match Mixpanel API format

### DIFF
--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -257,7 +257,7 @@ from mixpanel_data.types import (
 )
 from mixpanel_data.workspace import Workspace
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Core

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -300,7 +300,9 @@ def build_group_section(
                 }
             )
         elif isinstance(g, FrequencyBreakdown):
-            group_section.append(build_frequency_group_entry(g))
+            group_section.append(
+                build_frequency_group_entry(g, data_group_id=data_group_id)
+            )
         elif isinstance(g, GroupBy):
             prop = g.property
             if isinstance(prop, CustomPropertyRef):
@@ -638,7 +640,11 @@ def build_flow_cohort_filter(
     return result
 
 
-def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
+def build_frequency_group_entry(
+    fb: FrequencyBreakdown,
+    *,
+    data_group_id: int | None = None,
+) -> dict[str, Any]:
     """Build a single frequency group entry for sections.group[].
 
     Produces the frequency-specific group dict matching the Mixpanel
@@ -648,6 +654,7 @@ def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
 
     Args:
         fb: FrequencyBreakdown specification.
+        data_group_id: Optional data group ID for group-level analytics.
 
     Returns:
         Group entry dict matching the Mixpanel bookmark API schema:
@@ -687,7 +694,7 @@ def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
         "value": display_label,
         "resourceType": "people",
         "propertyType": "number",
-        "dataGroupId": None,
+        "dataGroupId": data_group_id,
         "customBucket": {
             "bucketSize": fb.bucket_size,
             "min": fb.bucket_min,

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -641,15 +641,22 @@ def build_flow_cohort_filter(
 def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
     """Build a single frequency group entry for sections.group[].
 
-    Produces the frequency-specific group dict with ``behaviorType``
-    set to ``"$frequency"`` and ``resourceType`` set to ``"people"``.
+    Produces the frequency-specific group dict matching the Mixpanel
+    bookmark API format with ``behaviorType`` inside the ``behavior``
+    sub-dict, ``event`` as a ``{label, value}`` object, and bucket
+    configuration in a ``customBucket`` object with camelCase keys.
 
     Args:
         fb: FrequencyBreakdown specification.
 
     Returns:
-        Group entry dict with ``behavior`` sub-dict containing the
-        frequency event and bucket configuration.
+        Group entry dict matching the Mixpanel bookmark API schema:
+        ``dataset``, ``behavior`` (with ``behaviorType``, ``event``
+        object, ``aggregationOperator``, ``filters``,
+        ``filtersOperator``, ``dateRange``), ``value`` (display
+        label), ``resourceType``, ``propertyType``, ``dataGroupId``,
+        and ``customBucket`` (with ``bucketSize``, ``min``, ``max``,
+        ``disabled``).
 
     Example:
         ```python
@@ -659,22 +666,35 @@ def build_frequency_group_entry(fb: FrequencyBreakdown) -> dict[str, Any]:
         from mixpanel_data.types import FrequencyBreakdown
 
         entry = build_frequency_group_entry(FrequencyBreakdown("Purchase"))
-        # {"resourceType": "people", "behaviorType": "$frequency",
-        #  "behavior": {"event": "Purchase", ...}}
+        # {"dataset": "$mixpanel", "resourceType": "people",
+        #  "behavior": {"behaviorType": "$frequency",
+        #               "event": {"label": "Purchase", "value": "Purchase"},
+        #               ...},
+        #  "customBucket": {"bucketSize": 1, "min": 0, "max": 10, ...}}
         ```
     """
+    display_label = fb.label if fb.label is not None else f"{fb.event} Frequency"
     entry: dict[str, Any] = {
-        "resourceType": "people",
-        "behaviorType": "$frequency",
+        "dataset": "$mixpanel",
         "behavior": {
-            "event": fb.event,
-            "bucket_size": fb.bucket_size,
-            "bucket_min": fb.bucket_min,
-            "bucket_max": fb.bucket_max,
+            "aggregationOperator": "total",
+            "event": {"label": fb.event, "value": fb.event},
+            "behaviorType": "$frequency",
+            "filters": [],
+            "filtersOperator": "and",
+            "dateRange": None,
+        },
+        "value": display_label,
+        "resourceType": "people",
+        "propertyType": "number",
+        "dataGroupId": None,
+        "customBucket": {
+            "bucketSize": fb.bucket_size,
+            "min": fb.bucket_min,
+            "max": fb.bucket_max,
+            "disabled": False,
         },
     }
-    if fb.label is not None:
-        entry["label"] = fb.label
     return entry
 
 

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -9404,8 +9404,8 @@ class FrequencyBreakdown:
         bucket_size: Width of each frequency bucket. Default: ``1``.
         bucket_min: Minimum frequency value. Default: ``0``.
         bucket_max: Maximum frequency value. Default: ``10``.
-        label: Display label for the breakdown. ``None`` uses
-            the event name.
+        label: Display label for the breakdown. ``None`` generates
+            ``"<event> Frequency"`` (e.g., ``"Purchase Frequency"``).
 
     Raises:
         ValueError: If validation rules FB1-FB4 are violated.

--- a/tests/live/test_040_query_completeness_live.py
+++ b/tests/live/test_040_query_completeness_live.py
@@ -793,7 +793,7 @@ class TestOfflineUS4:
     def test_m23_frequency_breakdown_has_behavior_type(
         self, ws: Workspace, real_event: str
     ) -> None:
-        """M23 -- FrequencyBreakdown group entry has behaviorType=$frequency.
+        """M23 -- FrequencyBreakdown group entry has behavior.behaviorType=$frequency.
 
         Args:
             ws: Workspace fixture.
@@ -803,11 +803,12 @@ class TestOfflineUS4:
         params = ws.build_params(real_event, group_by=fb, last=7)
         group = _dig(params, "sections", "group")
         assert group is not None
-        # Find the frequency group entry
+        # Find the frequency group entry (behaviorType is inside behavior dict)
         freq_entries = [
             g
             for g in group
-            if isinstance(g, dict) and g.get("behaviorType") == "$frequency"
+            if isinstance(g, dict)
+            and g.get("behavior", {}).get("behaviorType") == "$frequency"
         ]
         assert len(freq_entries) > 0
 
@@ -827,7 +828,8 @@ class TestOfflineUS4:
         freq_entries = [
             g
             for g in group
-            if isinstance(g, dict) and g.get("behaviorType") == "$frequency"
+            if isinstance(g, dict)
+            and g.get("behavior", {}).get("behaviorType") == "$frequency"
         ]
         assert len(freq_entries) > 0
         assert freq_entries[0].get("resourceType") == "people"

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -654,6 +654,35 @@ class TestBuildFrequencyGroupEntry:
         result = build_frequency_group_entry(fb)
         assert "label" not in result
 
+    def test_no_snake_case_bucket_keys_in_behavior(self) -> None:
+        """Old snake_case bucket keys must not appear in behavior dict."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", bucket_size=5, bucket_min=0, bucket_max=50)
+        result = build_frequency_group_entry(fb)
+        behavior = result["behavior"]
+        assert "bucket_size" not in behavior
+        assert "bucket_min" not in behavior
+        assert "bucket_max" not in behavior
+
+    def test_event_object_uses_event_name_not_display_label(self) -> None:
+        """Event object label/value must use raw event name, not display label."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", label="Buy Count")
+        result = build_frequency_group_entry(fb)
+        assert result["behavior"]["event"] == {
+            "label": "Purchase",
+            "value": "Purchase",
+        }
+        assert result["value"] == "Buy Count"
+
 
 # =============================================================================
 # T022: build_frequency_filter_entry() builder tests (US4)

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -524,7 +524,29 @@ class TestBuildTimeComparison:
 
 
 class TestBuildFrequencyGroupEntry:
-    """Tests for build_frequency_group_entry() — frequency breakdown dict."""
+    """Tests for build_frequency_group_entry() — frequency breakdown dict.
+
+    Expected API format (from audit report section 2.2.1):
+
+    .. code-block:: json
+
+        {
+          "dataset": "$mixpanel",
+          "behavior": {
+            "aggregationOperator": "total",
+            "event": {"label": "Purchase", "value": "Purchase"},
+            "behaviorType": "$frequency",
+            "filters": [],
+            "filtersOperator": "and",
+            "dateRange": null
+          },
+          "value": "Purchase Frequency",
+          "resourceType": "people",
+          "propertyType": "number",
+          "dataGroupId": null,
+          "customBucket": {"bucketSize": 1, "min": 0, "max": 10, "disabled": false}
+        }
+    """
 
     def test_basic_structure(self) -> None:
         """FrequencyBreakdown produces correct group entry structure."""
@@ -535,16 +557,57 @@ class TestBuildFrequencyGroupEntry:
 
         fb = FrequencyBreakdown("Purchase")
         result = build_frequency_group_entry(fb)
+        assert result["dataset"] == "$mixpanel"
         assert result["resourceType"] == "people"
-        assert result["behaviorType"] == "$frequency"
-        assert "behavior" in result
-        assert result["behavior"]["event"] == "Purchase"
-        assert result["behavior"]["bucket_size"] == 1
-        assert result["behavior"]["bucket_min"] == 0
-        assert result["behavior"]["bucket_max"] == 10
+        assert result["propertyType"] == "number"
+        assert result["dataGroupId"] is None
+
+    def test_behavior_dict_structure(self) -> None:
+        """Behavior dict contains behaviorType, event object, and defaults."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        behavior = result["behavior"]
+        assert behavior["behaviorType"] == "$frequency"
+        assert behavior["aggregationOperator"] == "total"
+        assert behavior["event"] == {"label": "Purchase", "value": "Purchase"}
+        assert behavior["filters"] == []
+        assert behavior["filtersOperator"] == "and"
+        assert behavior["dateRange"] is None
+
+    def test_behaviortype_not_at_top_level(self) -> None:
+        """behaviorType must be inside behavior, not at the top level."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        assert "behaviorType" not in result
+        assert result["behavior"]["behaviorType"] == "$frequency"
+
+    def test_custom_bucket_default_values(self) -> None:
+        """Default bucket config uses camelCase in customBucket object."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        bucket = result["customBucket"]
+        assert bucket["bucketSize"] == 1
+        assert bucket["min"] == 0
+        assert bucket["max"] == 10
+        assert bucket["disabled"] is False
 
     def test_custom_bucket_values(self) -> None:
-        """Custom bucket params are reflected in output."""
+        """Custom bucket params are reflected in customBucket object."""
         from mixpanel_data._internal.bookmark_builders import (
             build_frequency_group_entry,
         )
@@ -552,29 +615,42 @@ class TestBuildFrequencyGroupEntry:
 
         fb = FrequencyBreakdown("Purchase", bucket_size=5, bucket_min=0, bucket_max=50)
         result = build_frequency_group_entry(fb)
-        assert result["behavior"]["bucket_size"] == 5
-        assert result["behavior"]["bucket_min"] == 0
-        assert result["behavior"]["bucket_max"] == 50
+        bucket = result["customBucket"]
+        assert bucket["bucketSize"] == 5
+        assert bucket["min"] == 0
+        assert bucket["max"] == 50
+        assert bucket["disabled"] is False
 
-    def test_label_included(self) -> None:
-        """Label is included in output when set."""
-        from mixpanel_data._internal.bookmark_builders import (
-            build_frequency_group_entry,
-        )
-        from mixpanel_data.types import FrequencyBreakdown
-
-        fb = FrequencyBreakdown("Purchase", label="Purchase Frequency")
-        result = build_frequency_group_entry(fb)
-        assert result["label"] == "Purchase Frequency"
-
-    def test_label_omitted_when_none(self) -> None:
-        """Label key is omitted when label is None."""
+    def test_value_label_from_event_name(self) -> None:
+        """Value field defaults to '<event> Frequency' when no label set."""
         from mixpanel_data._internal.bookmark_builders import (
             build_frequency_group_entry,
         )
         from mixpanel_data.types import FrequencyBreakdown
 
         fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        assert result["value"] == "Purchase Frequency"
+
+    def test_label_overrides_value(self) -> None:
+        """Custom label overrides the default value field."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", label="Buy Count")
+        result = build_frequency_group_entry(fb)
+        assert result["value"] == "Buy Count"
+
+    def test_no_top_level_label_key(self) -> None:
+        """Label is expressed via value field, not a separate label key."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase", label="Buy Count")
         result = build_frequency_group_entry(fb)
         assert "label" not in result
 
@@ -736,7 +812,7 @@ class TestBuildGroupSectionFrequency:
         result = build_group_section(FrequencyBreakdown("Purchase"))
         assert len(result) == 1
         assert result[0]["resourceType"] == "people"
-        assert result[0]["behaviorType"] == "$frequency"
+        assert result[0]["behavior"]["behaviorType"] == "$frequency"
 
     def test_mixed_groupby_and_frequency(self) -> None:
         """List with GroupBy and FrequencyBreakdown produces correct entries."""
@@ -747,7 +823,7 @@ class TestBuildGroupSectionFrequency:
         assert result[0]["value"] == "country"
         assert result[0]["propertyType"] == "string"
         assert result[1]["resourceType"] == "people"
-        assert result[1]["behaviorType"] == "$frequency"
+        assert result[1]["behavior"]["behaviorType"] == "$frequency"
 
 
 # =============================================================================

--- a/tests/unit/test_bookmark_builders.py
+++ b/tests/unit/test_bookmark_builders.py
@@ -683,6 +683,28 @@ class TestBuildFrequencyGroupEntry:
         }
         assert result["value"] == "Buy Count"
 
+    def test_data_group_id_default_none(self) -> None:
+        """dataGroupId defaults to None when not specified."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb)
+        assert result["dataGroupId"] is None
+
+    def test_data_group_id_threaded(self) -> None:
+        """dataGroupId is threaded when passed explicitly."""
+        from mixpanel_data._internal.bookmark_builders import (
+            build_frequency_group_entry,
+        )
+        from mixpanel_data.types import FrequencyBreakdown
+
+        fb = FrequencyBreakdown("Purchase")
+        result = build_frequency_group_entry(fb, data_group_id=5)
+        assert result["dataGroupId"] == 5
+
 
 # =============================================================================
 # T022: build_frequency_filter_entry() builder tests (US4)
@@ -853,6 +875,13 @@ class TestBuildGroupSectionFrequency:
         assert result[0]["propertyType"] == "string"
         assert result[1]["resourceType"] == "people"
         assert result[1]["behavior"]["behaviorType"] == "$frequency"
+
+    def test_data_group_id_threaded_to_frequency(self) -> None:
+        """data_group_id is threaded into frequency group entries."""
+        from mixpanel_data.types import FrequencyBreakdown
+
+        result = build_group_section(FrequencyBreakdown("Purchase"), data_group_id=5)
+        assert result[0]["dataGroupId"] == 5
 
 
 # =============================================================================

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -1480,11 +1480,14 @@ class TestFrequencyBreakdownInBuildParams:
         group = params["sections"]["group"]
         assert len(group) == 1
         assert group[0]["resourceType"] == "people"
-        assert group[0]["behaviorType"] == "$frequency"
-        assert group[0]["behavior"]["event"] == "Purchase"
+        assert group[0]["behavior"]["behaviorType"] == "$frequency"
+        assert group[0]["behavior"]["event"] == {
+            "label": "Purchase",
+            "value": "Purchase",
+        }
 
     def test_frequency_breakdown_with_label(self, ws: Workspace) -> None:
-        """build_params with labeled FrequencyBreakdown includes label."""
+        """build_params with labeled FrequencyBreakdown includes label in value."""
         from mixpanel_data.types import FrequencyBreakdown
 
         params = ws.build_params(
@@ -1492,7 +1495,7 @@ class TestFrequencyBreakdownInBuildParams:
             group_by=FrequencyBreakdown("Purchase", label="Buy Freq"),
         )
         group = params["sections"]["group"]
-        assert group[0]["label"] == "Buy Freq"
+        assert group[0]["value"] == "Buy Freq"
 
     def test_frequency_breakdown_mixed_with_string(self, ws: Workspace) -> None:
         """build_params with mixed string and FrequencyBreakdown in list."""
@@ -1505,7 +1508,7 @@ class TestFrequencyBreakdownInBuildParams:
         group = params["sections"]["group"]
         assert len(group) == 2
         assert group[0]["value"] == "country"
-        assert group[1]["behaviorType"] == "$frequency"
+        assert group[1]["behavior"]["behaviorType"] == "$frequency"
 
     def test_existing_groupby_still_works(self, ws: Workspace) -> None:
         """Backward compat: existing GroupBy usage still works."""


### PR DESCRIPTION
## Summary

- Fixed `build_frequency_group_entry()` in `bookmark_builders.py` to produce the correct Mixpanel bookmark API format, resolving `behaviorType` validation errors when using `FrequencyBreakdown` in `group_by`
- Moved `behaviorType` inside the `behavior` dict, serialized `event` as `{label, value}` object, added `customBucket` with camelCase keys, and included all required fields (`dataset`, `aggregationOperator`, `filters`, `filtersOperator`, `dateRange`, `value`, `propertyType`, `dataGroupId`)
- Updated tests in `test_bookmark_builders.py` and `test_query_params.py` to assert the correct API structure

## Test plan

- [x] TDD: wrote 8 failing tests first, then fixed implementation until green
- [x] `just check` passes (ruff, mypy, 5959/5959 tests, 0 failures)
- [x] Live QA: verified 3 FrequencyBreakdown queries against Mixpanel API (basic, custom buckets, custom label) — all return correct frequency segment data