### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_data API surface (5 query engines, discovery, entity CRUD) with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -38,7 +38,7 @@ Guessing event names causes silent empty results. Guessing API parameters causes
 
 ```python
 import mixpanel_data as mp
-from mixpanel_data import Filter, FunnelStep, GroupBy, Metric
+from mixpanel_data import Filter, GroupBy, Metric
 ws = mp.Workspace()
 
 # 1. Find real event names
@@ -215,15 +215,23 @@ LET(x, A * B, IFS(x < 50, "low", x < 200, "mid", TRUE, "high"))
 - `REGEX_EXTRACT(haystack, pattern, capture_group)` — returns match or capture group
 - `REGEX_REPLACE(haystack, pattern, replacement)` — replaces all matches
 
-**Regex tips:**
-- Backreferences work: `REGEX_REPLACE(A, "([a-z])([A-Z])", "$1 $2")` inserts space between camelCase
-- Case-sensitive flag: `(?-i)` switches to case-sensitive within the pattern
-- Nest `REGEX_REPLACE` calls with `LET` for multi-step cleanup:
+**Regex engine quirks (Mixpanel-specific):**
+- **Case-insensitive by default** — use `(?-i)` to switch to case-sensitive matching within a pattern
+- **Backreferences work** — `$1`, `$2` capture groups and `$0` whole-match all work in `REGEX_REPLACE` replacements
+- **`{n,m}` quantifiers conflict with formula syntax** — curly braces are parsed as formula constructs. Use repeated character classes instead (e.g., `[0-9][0-9][0-9][0-9]` instead of `[0-9]{4}`)
+- **`\d`, `\w` shorthand classes don't work** — use `[0-9]`, `[A-Za-z0-9_]` explicitly
+- **Zero-width assertions match at every position** — pure lookahead/lookbehind replacements insert at every character boundary. Use consuming patterns instead
+
+**CamelCase splitting:** `REGEX_REPLACE(A, "(?-i)([a-z])([A-Z])", "$1 $2")` inserts space between camelCase boundaries.
+
+**Practical multi-step cleanup example** (campaign names from Braze):
 ```
-LET(step1, REGEX_REPLACE(A, "^[0-9]{4,6}_", ""),
-LET(step2, REGEX_REPLACE(step1, "_Email_.*$", ""),
-  REGEX_REPLACE(step2, "([a-z])([A-Z])", "$1 $2")
-))
+LET(s1, REGEX_REPLACE(A, "^[0-9][0-9][0-9][0-9][0-9]*_", ""),
+LET(s2, REGEX_REPLACE(s1, "^(NW|TARGETED|REGIONAL|NTL)_", ""),
+LET(s3, REGEX_REPLACE(s2, "_(Push|Email|NotificationCenter|ModalInAppMessage)_.*$", ""),
+LET(s4, REGEX_REPLACE(s3, "_", " "),
+  REGEX_REPLACE(s4, " +", " ")
+))))
 ```
 
 **Type functions:** `STRING(x)`, `NUMBER(x)`, `BOOLEAN(x)`, `DEFINED(x)`
@@ -505,7 +513,6 @@ Every query engine has parameters that look like simple settings but are actuall
 When a single breakdown shows a difference, verify it holds across dimensions:
 
 ```python
-event = 'Purchase'  # use a real event name
 # Step 1: Find the interesting segment
 result = ws.query(event, math='average', math_property='order_total',
                    group_by='deal_sweet_spot', last=90, mode='total')
@@ -564,7 +571,6 @@ Funnel queries return time data in step metadata columns (`avg_time`, `avg_time_
 **Choosing a window:** Match it to the user journey being measured. Short funnels (ordering food, adding to cart) need tight windows — hours, not days. Long funnels (onboarding, subscription purchase) need wider windows — days or weeks. When unsure, experiment:
 
 ```python
-steps = [FunnelStep("Signup"), FunnelStep("Add to Cart"), FunnelStep("Purchase")]
 # Try progressively tighter windows to find where signal emerges
 for window, unit in [(14, 'day'), (7, 'day'), (1, 'day'), (12, 'hour'), (6, 'hour')]:
     result = ws.query_funnel(steps, last=90,
@@ -600,9 +606,9 @@ android = ws.query_funnel(steps, where=Filter.equals('platform', 'Android'),
 
 ```python
 # order='loose' vs 'any' — same steps, fundamentally different questions
-for order_mode in ['loose', 'any']:
-    result = ws.query_funnel(steps, last=90, order=order_mode)
-    print(f"order={order_mode}: {result.overall_conversion_rate:.3f}")
+for ord in ['loose', 'any']:
+    result = ws.query_funnel(steps, last=90, order=ord)
+    print(f"order={ord}: {result.overall_conversion_rate:.3f}")
 # If 'any' >> 'loose', users are completing all steps but not in the expected order
 # This often reveals UX issues — users accomplish the goal but not via the designed path
 ```
@@ -780,7 +786,6 @@ result = ws.query("Login", group_by=CohortBreakdown(power_users, "Power Users"),
 # Use inline cohort as a filter in user queries
 result = ws.query_user(cohort=power_users, mode='aggregate', aggregate='count')
 
-saved_cohort_id = 12345  # ID from ws.cohorts()
 # Track saved cohort size over time alongside event metrics
 result = ws.query(
     [Metric("Login", math="unique"), CohortMetric(saved_cohort_id, "Power Users")],

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -38,7 +38,7 @@ Guessing event names causes silent empty results. Guessing API parameters causes
 
 ```python
 import mixpanel_data as mp
-from mixpanel_data import Filter, GroupBy, Metric
+from mixpanel_data import Filter, FunnelStep, GroupBy, Metric
 ws = mp.Workspace()
 
 # 1. Find real event names
@@ -505,6 +505,7 @@ Every query engine has parameters that look like simple settings but are actuall
 When a single breakdown shows a difference, verify it holds across dimensions:
 
 ```python
+event = 'Purchase'  # use a real event name
 # Step 1: Find the interesting segment
 result = ws.query(event, math='average', math_property='order_total',
                    group_by='deal_sweet_spot', last=90, mode='total')
@@ -563,6 +564,7 @@ Funnel queries return time data in step metadata columns (`avg_time`, `avg_time_
 **Choosing a window:** Match it to the user journey being measured. Short funnels (ordering food, adding to cart) need tight windows — hours, not days. Long funnels (onboarding, subscription purchase) need wider windows — days or weeks. When unsure, experiment:
 
 ```python
+steps = [FunnelStep("Signup"), FunnelStep("Add to Cart"), FunnelStep("Purchase")]
 # Try progressively tighter windows to find where signal emerges
 for window, unit in [(14, 'day'), (7, 'day'), (1, 'day'), (12, 'hour'), (6, 'hour')]:
     result = ws.query_funnel(steps, last=90,
@@ -598,9 +600,9 @@ android = ws.query_funnel(steps, where=Filter.equals('platform', 'Android'),
 
 ```python
 # order='loose' vs 'any' — same steps, fundamentally different questions
-for ord in ['loose', 'any']:
-    result = ws.query_funnel(steps, last=90, order=ord)
-    print(f"order={ord}: {result.overall_conversion_rate:.3f}")
+for order_mode in ['loose', 'any']:
+    result = ws.query_funnel(steps, last=90, order=order_mode)
+    print(f"order={order_mode}: {result.overall_conversion_rate:.3f}")
 # If 'any' >> 'loose', users are completing all steps but not in the expected order
 # This often reveals UX issues — users accomplish the goal but not via the designed path
 ```
@@ -778,6 +780,7 @@ result = ws.query("Login", group_by=CohortBreakdown(power_users, "Power Users"),
 # Use inline cohort as a filter in user queries
 result = ws.query_user(cohort=power_users, mode='aggregate', aggregate='count')
 
+saved_cohort_id = 12345  # ID from ws.cohorts()
 # Track saved cohort size over time alongside event metrics
 result = ws.query(
     [Metric("Login", math="unique"), CohortMetric(saved_cohort_id, "Power Users")],

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -220,9 +220,13 @@ LET(x, A * B, IFS(x < 50, "low", x < 200, "mid", TRUE, "high"))
 - **Backreferences work** — `$1`, `$2` capture groups and `$0` whole-match all work in `REGEX_REPLACE` replacements
 - **`{n,m}` quantifiers conflict with formula syntax** — curly braces are parsed as formula constructs. Use repeated character classes instead (e.g., `[0-9][0-9][0-9][0-9]` instead of `[0-9]{4}`)
 - **`\d`, `\w` shorthand classes don't work** — use `[0-9]`, `[A-Za-z0-9_]` explicitly
-- **Zero-width assertions match at every position** — pure lookahead/lookbehind replacements insert at every character boundary. Use consuming patterns instead
+- **Escape backslashes carefully** — in formula strings, `\\\\` may be needed for a literal `\` depending on how the formula is constructed (Python string → JSON → regex engine)
 
-**CamelCase splitting:** `REGEX_REPLACE(A, "(?-i)([a-z])([A-Z])", "$1 $2")` inserts space between camelCase boundaries.
+**CamelCase splitting** — insert space between lowercase→uppercase boundaries:
+```
+REGEX_REPLACE(text, "(?-i)([a-z])([A-Z])", "$1 $2")
+// ChickenSundaysApril → Chicken Sundays April
+```
 
 **Practical multi-step cleanup example** (campaign names from Braze):
 ```

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -16,6 +16,7 @@ from mixpanel_data._literal_types import (
     CohortAggregationType,
     ConversionWindowUnit,
     CountType,
+    CustomPropertyType,
     FilterDateUnit,
     FilterPropertyType,
     FiltersCombinator,
@@ -295,6 +296,7 @@ __all__ = [
     # Type aliases — insights
     "InsightsMode",
     # Type aliases — filter types
+    "CustomPropertyType",
     "FilterPropertyType",
     "FilterDateUnit",
     "FiltersCombinator",
@@ -499,6 +501,7 @@ __all__ = [
     "Filter",
     "Formula",
     "GroupBy",
+    "CustomPropertyType",
     "FilterDateUnit",
     "FilterPropertyType",
     "QueryResult",

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -257,7 +257,7 @@ from mixpanel_data.types import (
 )
 from mixpanel_data.workspace import Workspace
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     # Core

--- a/src/mixpanel_data/_internal/bookmark_builders.py
+++ b/src/mixpanel_data/_internal/bookmark_builders.py
@@ -199,7 +199,7 @@ def build_filter_section(
     for f in filters_list:
         if isinstance(f, FrequencyFilter):
             result.append(build_frequency_filter_entry(f))
-        else:
+        elif isinstance(f, Filter):
             result.append(build_filter_entry(f))
     return result
 

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -1634,6 +1634,17 @@ class ConfigManager:
         if not cred_name and credentials:
             cred_name = next(iter(credentials.keys()))
 
+        # Fallback: check if name is a project alias (e.g. migrated v1 account)
+        if cred_name and cred_name not in credentials:
+            projects = config.get("projects", {})
+            if cred_name in projects:
+                alias = projects[cred_name]
+                alias_cred = alias.get("credential")
+                if alias_cred and alias_cred in credentials:
+                    if project_id is None:
+                        project_id = alias.get("project_id")
+                    cred_name = alias_cred
+
         if not cred_name or cred_name not in credentials:
             raise ConfigError(
                 "No credentials configured. "

--- a/src/mixpanel_data/_internal/validation.py
+++ b/src/mixpanel_data/_internal/validation.py
@@ -282,7 +282,9 @@ def _scan_custom_properties(
                                 _validate_custom_property(ef._property, fpath)
                             )
                 continue
-            if isinstance(f._property, (CustomPropertyRef, InlineCustomProperty)):
+            if isinstance(f, Filter) and isinstance(
+                f._property, (CustomPropertyRef, InlineCustomProperty)
+            ):
                 fpath = f"where[{i}]" if len(filters) > 1 else "where"
                 errors.extend(_validate_custom_property(f._property, fpath))
 

--- a/src/mixpanel_data/_literal_types.py
+++ b/src/mixpanel_data/_literal_types.py
@@ -513,6 +513,13 @@ Datetime factory methods (``Filter.on``, ``Filter.before``, etc.)
 produce filters with ``filterType="datetime"``.
 """
 
+CustomPropertyType = Literal["string", "number", "boolean", "datetime"]
+"""Output type for custom property definitions.
+
+Unlike ``FilterPropertyType``, excludes ``"list"`` which is not valid
+for custom property output types.
+"""
+
 FilterDateUnit = Literal["hour", "day", "week", "month"]
 """Time unit for relative date filters.
 

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -11593,7 +11593,7 @@ class UserQueryResult(ResultWithDataFrame):
         ordered: list[str] = [c for c in priority if c in cols]
         remaining = sorted(c for c in cols if c not in priority)
         ordered.extend(remaining)
-        return result_df[ordered]
+        return pd.DataFrame(result_df[ordered])
 
     @property
     def distinct_ids(self) -> list[str]:

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -30,6 +30,7 @@ from mixpanel_data._literal_types import (
     CohortAggregationType as CohortAggregationType,
 )
 from mixpanel_data._literal_types import ConversionWindowUnit as ConversionWindowUnit
+from mixpanel_data._literal_types import CustomPropertyType as CustomPropertyType
 from mixpanel_data._literal_types import FilterDateUnit as FilterDateUnit
 from mixpanel_data._literal_types import FilterPropertyType as FilterPropertyType
 from mixpanel_data._literal_types import FiltersCombinator as FiltersCombinator
@@ -5776,7 +5777,7 @@ class ComposedPropertyValue(BaseModel):
     label: str | None = None
     """Human-readable label for the property (e.g. ``"Deal Name"``)."""
 
-    property_default_type: str | None = None
+    property_default_type: CustomPropertyType | None = None
     """Default property type hint (e.g. ``"string"``, ``"number"``)."""
 
     behavior: Any | None = (
@@ -5897,7 +5898,7 @@ class CreateCustomPropertyParams(BaseModel):
     resource_type: CustomPropertyResourceType
     """Resource type (events, people, group_profiles)."""
 
-    description: str = ""
+    description: str | None = None
     """Property description."""
 
     display_formula: str | None = None
@@ -5912,11 +5913,11 @@ class CreateCustomPropertyParams(BaseModel):
     is_visible: bool | None = None
     """Whether the property is visible."""
 
-    property_type: str | None = "string"
+    property_type: CustomPropertyType | None = None
     """Output type of the custom property (string, number, boolean, datetime).
-    Defaults to string. Auto-inferred by the API from the formula if not set."""
+    Auto-inferred by the API from the formula if not set."""
 
-    example_value: str | None = ""
+    example_value: str | None = None
     """Example output value for documentation purposes."""
 
     data_group_id: str | None = None

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -5770,6 +5770,15 @@ class ComposedPropertyValue(BaseModel):
     Mixpanel API composed property schema — distinct from
     ``CustomPropertyResourceType`` which uses plural form."""
 
+    value: str | None = None
+    """Property name in the project (e.g. ``"deal_name"``)."""
+
+    label: str | None = None
+    """Human-readable label for the property (e.g. ``"Deal Name"``)."""
+
+    property_default_type: str | None = None
+    """Default property type hint (e.g. ``"string"``, ``"number"``)."""
+
     behavior: Any | None = (
         None  # Any justified: API behavior spec varies by resource type
     )
@@ -5888,7 +5897,7 @@ class CreateCustomPropertyParams(BaseModel):
     resource_type: CustomPropertyResourceType
     """Resource type (events, people, group_profiles)."""
 
-    description: str | None = None
+    description: str = ""
     """Property description."""
 
     display_formula: str | None = None
@@ -5902,6 +5911,13 @@ class CreateCustomPropertyParams(BaseModel):
 
     is_visible: bool | None = None
     """Whether the property is visible."""
+
+    property_type: str | None = "string"
+    """Output type of the custom property (string, number, boolean, datetime).
+    Defaults to string. Auto-inferred by the API from the formula if not set."""
+
+    example_value: str | None = ""
+    """Example output value for documentation purposes."""
 
     data_group_id: str | None = None
     """Data group identifier."""

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -408,9 +408,9 @@ class Workspace:
             self._credentials = self._session_to_credentials(session)
         else:
             if self._config_manager.config_version() >= 2:
-                # v2 config detected — use resolve_session with defaults
+                # v2 config detected — use resolve_session
                 session = self._config_manager.resolve_session(
-                    credential=None,
+                    credential=account,
                     project_id=project_id,
                     workspace_id=workspace_id,
                 )
@@ -7556,7 +7556,7 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        body = params.model_dump(exclude_none=True, by_alias=True)
+        body = params.model_dump(exclude_none=True, by_alias=True, mode="json")
         raw = client.create_custom_property(body)
         return CustomProperty.model_validate(raw)
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -372,7 +372,10 @@ class Workspace:
         path instead of the legacy ``resolve_credentials()`` path.
 
         Args:
-            account: Named account from config file to use (v1 path).
+            account: Named account from config file. Selects credentials
+                in both v1 (resolve_credentials) and v2 (resolve_session)
+                configs. For migrated v2 configs, also resolves project
+                aliases.
             project_id: Override project ID from credentials.
             region: Override region from credentials (us, eu, in).
             workspace_id: Optional workspace ID for scoped App API requests.

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -604,6 +604,119 @@ class TestWorkspaceCredentialParam:
         assert ws._credentials is not None
         assert ws._credentials.project_id == "12345"
 
+    def test_workspace_v2_with_account_uses_resolve_session(
+        self,
+    ) -> None:
+        """Test Workspace(account=...) uses resolve_session on v2 config."""
+        from unittest.mock import MagicMock
+
+        from mixpanel_data._internal.auth_credential import CredentialType
+
+        mock_cm = MagicMock()
+        mock_cm.config_version.return_value = 2
+        mock_session = MagicMock()
+        mock_session.project_id = "3713224"
+        mock_session.region = "us"
+        mock_session.auth.type = CredentialType.service_account
+        mock_session.auth.username = "user"
+        mock_session.auth.secret = SecretStr("secret")
+        mock_session.auth.oauth_access_token = None
+        mock_cm.resolve_session.return_value = mock_session
+
+        from mixpanel_data.workspace import Workspace
+
+        ws = Workspace(account="prod", _config_manager=mock_cm)
+        mock_cm.resolve_session.assert_called_once_with(
+            credential="prod",
+            project_id=None,
+            workspace_id=None,
+        )
+        assert ws._credentials is not None
+        assert ws._credentials.project_id == "3713224"
+
+    def test_resolve_session_project_alias_fallback(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test resolve_session falls back to project aliases for credential lookup."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_AUTH_FILE", raising=False)
+
+        import tomli_w
+
+        config_path = tmp_path / ".mp" / "config.toml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config: dict[str, object] = {
+            "config_version": 2,
+            "credentials": {
+                "main-sa": {
+                    "type": "service_account",
+                    "username": "user",
+                    "secret": "secret",
+                    "region": "us",
+                },
+            },
+            "projects": {
+                "prod": {
+                    "credential": "main-sa",
+                    "project_id": "222",
+                },
+            },
+            "active": {},
+        }
+        with config_path.open("wb") as f:
+            tomli_w.dump(config, f)
+
+        cm = ConfigManager(config_path=config_path)
+        session = cm.resolve_session(credential="prod")
+        assert session.project_id == "222"
+        assert session.auth.username == "user"
+
+    def test_resolve_session_project_alias_explicit_project_id_wins(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test explicit project_id overrides alias project_id."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.delenv("MP_AUTH_FILE", raising=False)
+
+        import tomli_w
+
+        config_path = tmp_path / ".mp" / "config.toml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config: dict[str, object] = {
+            "config_version": 2,
+            "credentials": {
+                "main-sa": {
+                    "type": "service_account",
+                    "username": "user",
+                    "secret": "secret",
+                    "region": "us",
+                },
+            },
+            "projects": {
+                "prod": {
+                    "credential": "main-sa",
+                    "project_id": "222",
+                },
+            },
+            "active": {},
+        }
+        with config_path.open("wb") as f:
+            tomli_w.dump(config, f)
+
+        cm = ConfigManager(config_path=config_path)
+        session = cm.resolve_session(credential="prod", project_id="999")
+        assert session.project_id == "999"
+
 
 # ── T088-T089: OAuth credential resolution via resolve_session() ─────
 

--- a/tests/unit/test_types_data_governance.py
+++ b/tests/unit/test_types_data_governance.py
@@ -919,12 +919,17 @@ class TestCreateCustomPropertyParams:
             behavior={"type": "count"},
         )
         data = params.model_dump(exclude_none=True)
-        assert "description" not in data
+        # Fields with non-None defaults are present
+        assert data["description"] == ""
+        assert data["property_type"] == "string"
+        assert data["example_value"] == ""
+        # None-defaulted fields are excluded
         assert "display_formula" not in data
         assert "composed_properties" not in data
         assert "is_locked" not in data
         assert "is_visible" not in data
         assert "data_group_id" not in data
+        # Required fields are present
         assert "name" in data
         assert "resource_type" in data
 

--- a/tests/unit/test_types_data_governance.py
+++ b/tests/unit/test_types_data_governance.py
@@ -919,19 +919,33 @@ class TestCreateCustomPropertyParams:
             behavior={"type": "count"},
         )
         data = params.model_dump(exclude_none=True)
-        # Fields with non-None defaults are present
-        assert data["description"] == ""
-        assert data["property_type"] == "string"
-        assert data["example_value"] == ""
-        # None-defaulted fields are excluded
+        assert "description" not in data
         assert "display_formula" not in data
         assert "composed_properties" not in data
         assert "is_locked" not in data
         assert "is_visible" not in data
         assert "data_group_id" not in data
-        # Required fields are present
+        assert "property_type" not in data
+        assert "example_value" not in data
         assert "name" in data
         assert "resource_type" in data
+
+    def test_json_serialization_mode(self) -> None:
+        """CreateCustomPropertyParams serializes enums correctly with mode='json'."""
+        params = CreateCustomPropertyParams(
+            name="Revenue",
+            resource_type="events",
+            description="Revenue metric",
+            display_formula='number(properties["amount"])',
+            composed_properties={
+                "amount": ComposedPropertyValue(resource_type="events", type="number"),
+            },
+        )
+        data = params.model_dump(exclude_none=True, by_alias=True, mode="json")
+        assert isinstance(data["resourceType"], str)
+        assert data["resourceType"] == "events"
+        assert data["name"] == "Revenue"
+        assert "displayFormula" in data
 
     def test_missing_required_raises(self) -> None:
         """CreateCustomPropertyParams raises ValidationError when required fields missing."""


### PR DESCRIPTION
## Summary
- Bump library version to 0.2.2 and plugin version to 4.0.2
- Fix custom property creation: use JSON serialization mode and add missing fields (`value`, `label`, `property_default_type`, `property_type`, `example_value`) to `ComposedPropertyValue` and `CreateCustomPropertyParams`
- Fix account credential resolution in v2 config (`resolve_session` now passes `account` parameter)
- Expand mixpanelyst skill with exploratory analysis workflows and multi-step analysis patterns for all query engines

## Test plan
- [ ] Verify `mp --version` shows 0.2.2
- [ ] Verify custom property creation works with new fields
- [ ] Verify account switching works correctly with v2 config
- [ ] Verify plugin loads with updated version