### PR TITLE
feat: support raw OAuth bearer tokens via MP_OAUTH_TOKEN env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ just mutate-check        # Check score meets 80% threshold
 |----------|---------|
 | `MP_USERNAME` | Service account username |
 | `MP_SECRET` | Service account secret |
-| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored when `MP_USERNAME`/`MP_SECRET` are also set) |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored only when the full service-account env-var set — `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` — is also present) |
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency (us, eu, in) |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,4 +315,5 @@ python help.py Filter                  # type fields + construction patterns + r
 - N/A — query parameter types only, no persistence (040-query-engine-completeness)
 
 ## Recent Changes
+- PR #125: Added `MP_OAUTH_TOKEN` env-var auth path for non-interactive bearer-token authentication (agents, CI). Service-account env quad takes precedence when both sets are complete. Public `Credentials.from_oauth_token()` factory exposes the same path to SDK callers.
 - 029-insights-query-api: Added Python 3.10+ with full type hints (mypy --strict) + httpx (HTTP client), Pydantic v2 (validation), pandas (DataFrames)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ just mutate-check        # Check score meets 80% threshold
 |----------|---------|
 | `MP_USERNAME` | Service account username |
 | `MP_SECRET` | Service account secret |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored when `MP_USERNAME`/`MP_SECRET` are also set) |
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency (us, eu, in) |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ Design documents in `context/`:
 - [mp-cli-project-spec.md](context/mp-cli-project-spec.md) — CLI specification
 - [mixpanel-http-api-specification.md](context/mixpanel-http-api-specification.md) — Mixpanel API reference
 
-## mixpanel-data Plugin (v4.0 — Distilled API Surface + Live Docs)
+## mixpanel-data Plugin (v4.1 — Distilled API Surface + Live Docs)
 
 This project includes a Claude Code plugin in `mixpanel-plugin/`. The plugin provides the `mixpanel_data` API surface and a live documentation system (`help.py`) for querying and analyzing Mixpanel data with Python.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ echo "$SECRET" | mp auth add production --username sa_xxx --project 12345 --secr
 
 Or set all credentials as environment variables: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
 
+**Option C: Raw OAuth Bearer Token (CI / agents)**
+
+If a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) already gave you an access token, inject it via env vars without going through the browser flow:
+
+```bash
+export MP_OAUTH_TOKEN="<bearer-token>"
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"  # or "eu", "in"
+```
+
+The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete, so this is safe to add to a shell that already exports the service-account vars.
+
 ### 2. Explore Your Data
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Key design features:
 
 ## Claude Code Plugin
 
-This project includes a Claude Code plugin (v4.0) that turns Claude into a senior data analyst. The plugin is **CodeMode-first**: Claude writes Python code using `mixpanel_data` + `pandas` rather than calling CLI commands or MCP tools.
+This project includes a Claude Code plugin (v4.1) that turns Claude into a senior data analyst. The plugin is **CodeMode-first**: Claude writes Python code using `mixpanel_data` + `pandas` rather than calling CLI commands or MCP tools.
 
 The plugin is built around the 5-engine query taxonomy — `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and `query_user()` — with full cohort-scoped query support. Claude translates natural language analytics questions into typed query calls with filters, breakdowns, formulas, cohort definitions, and aggregations, then interprets results as DataFrames.
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -65,6 +65,20 @@ Immutable container for authentication credentials. Supports both Basic Auth (se
 **Key methods:**
 
 - `auth_header()` — Returns the appropriate `Authorization` header value (`"Basic <base64>"` or `"Bearer <token>"`)
+- `from_oauth_token(token, project_id, region)` — Class method factory for building OAuth-method `Credentials` from a pre-obtained bearer token (skips the PKCE browser flow). Strips surrounding whitespace defensively and rejects tokens containing control characters.
+
+```python
+from mixpanel_data.auth import Credentials
+
+creds = Credentials.from_oauth_token(
+    token="my-bearer-token",
+    project_id="12345",
+    region="us",
+)
+assert creds.auth_header() == "Bearer my-bearer-token"
+```
+
+To drive a `Workspace` with these credentials, set the corresponding `MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION` env vars and let `Workspace()` resolve them — see [Configuration → Raw OAuth Bearer Token](../getting-started/configuration.md#raw-oauth-bearer-token).
 
 ::: mixpanel_data.auth.Credentials
     options:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -460,6 +460,7 @@ mp inspect events --format plain | wc -l
 |----------|-------------|
 | `MP_USERNAME` | Service account username |
 | `MP_SECRET` | Service account secret |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored when the full service-account env-var set is also present) |
 | `MP_PROJECT_ID` | Project ID |
 | `MP_REGION` | Data residency region |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-mixpanel_data supports two authentication methods: **Service Accounts** (Basic Auth) for server-side automation and **OAuth 2.0** for interactive use. Both methods support multiple configuration approaches.
+mixpanel_data supports three authentication methods: **Service Accounts** (Basic Auth) for server-side automation, **OAuth 2.0 PKCE** for interactive browser login, and **raw OAuth bearer tokens** for non-interactive contexts like CI or AI agents. All three integrate with the same credential resolution chain.
 
 !!! tip "Explore on DeepWiki"
     🤖 **[Authentication Setup →](https://deepwiki.com/jaredmcfarland/mixpanel_data/2.2-authentication-setup)**
@@ -13,24 +13,26 @@ mixpanel_data supports two authentication methods: **Service Accounts** (Basic A
 |--------|----------|--------------|
 | **Service Account** (Basic Auth) | Scripts, CI/CD, automation | Username + secret from env vars or config file |
 | **OAuth 2.0** (PKCE) | Interactive use, personal access | Browser-based login, tokens stored locally |
+| **Raw OAuth Bearer Token** | CI, agents, ephemeral environments | Pre-obtained access token injected via env vars; no browser, no local storage |
 
-Service accounts are the default and work everywhere. OAuth is ideal when you want to authenticate as yourself without managing service account credentials.
+Service accounts are the default and work everywhere. OAuth PKCE is ideal when you want to authenticate as yourself without managing service account credentials. Raw bearer tokens are the right choice when a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) hands you a token and you cannot run the browser flow.
 
 ## Environment Variables
 
-Set these environment variables to configure service account credentials:
+Set these environment variables to configure credentials:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `MP_USERNAME` | Service account username | Yes (Basic Auth) |
 | `MP_SECRET` | Service account secret | Yes (Basic Auth) |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account) | Yes (Bearer) |
 | `MP_PROJECT_ID` | Mixpanel project ID | Yes |
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) | No (default: `us`) |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations | No |
 | `MP_CONFIG_PATH` | Override config file location | No |
 | `MP_ACCOUNT` | Account name to use from config file | No |
 
-Example:
+### Service Account (Basic Auth)
 
 ```bash
 export MP_USERNAME="sa_abc123..."
@@ -38,6 +40,21 @@ export MP_SECRET="your-secret-here"
 export MP_PROJECT_ID="12345"
 export MP_REGION="us"
 ```
+
+### Raw OAuth Bearer Token
+
+For non-interactive contexts (CI, agents) that already hold an OAuth 2.0 access token:
+
+```bash
+export MP_OAUTH_TOKEN="<bearer-token>"
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"  # or "eu", "in"
+```
+
+The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh capability — pass a fresh token when the previous one expires).
+
+!!! note "Precedence when both are set"
+    The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete, so adding `MP_OAUTH_TOKEN` to a shell that already exports the service-account vars is safe — the bearer token is silently ignored and a debug-level log records the choice.
 
 ## Config File
 
@@ -204,29 +221,24 @@ Tokens are automatically refreshed when expired. The client registration is cach
 
 When creating a Workspace, credentials are resolved in this order:
 
-1. **Environment variables** — `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION` (all four required)
-2. **OAuth tokens** — Valid (non-expired) tokens from `~/.mp/oauth/`
-3. **Named account** — `Workspace(account="staging")` or `MP_ACCOUNT=staging`
-4. **Default account** — The account marked as `default` in config.toml
+1. **Environment variables** — either the service-account quad (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) or the OAuth-token triple (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`). The service-account quad takes precedence when both sets are complete.
+2. **Auth bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json` (for Claude Cowork environments).
+3. **OAuth tokens from local storage** — Valid (non-expired) tokens from `~/.mp/oauth/`, populated by `mp auth login`.
+4. **Named account** — `Workspace(account="staging")` or `MP_ACCOUNT=staging`.
+5. **Default account** — The account marked as `default` in `config.toml`.
 
-If environment variables provide all four values, they take priority. Otherwise, the system checks for a valid OAuth token before falling back to config file accounts.
+If a complete env-var set is present, it always wins. Otherwise the chain falls through bridge file → stored OAuth tokens → named or default config account.
 
 Example showing resolution:
 
 ```python
 import mixpanel_data as mp
 
-# Uses explicit arguments
-ws = mp.Workspace(
-    username="sa_...",
-    secret="...",
-    project_id="12345"
-)
-
-# Uses environment variables (if set), then OAuth, then config
+# Uses environment variables (either set), then bridge file, then
+# stored OAuth tokens, then config file
 ws = mp.Workspace()
 
-# Uses named account from config file
+# Uses named account from config file (skips OAuth and bridge)
 ws = mp.Workspace(account="staging")
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -63,6 +63,18 @@ mp auth status
 
 OAuth tokens are stored locally at `~/.mp/oauth/` and automatically refreshed when expired. See [Configuration](configuration.md#oauth-authentication) for details.
 
+### Option D: Raw OAuth Bearer Token (CI / Agents)
+
+If a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) hands you a pre-obtained access token, inject it via env vars without going through the browser flow:
+
+```bash
+export MP_OAUTH_TOKEN="<bearer-token>"
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"  # or "eu", "in"
+```
+
+The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh — pass a fresh token when the previous one expires). See [Configuration → Raw OAuth Bearer Token](configuration.md#raw-oauth-bearer-token) for precedence rules.
+
 ## Step 2: Test Your Connection
 
 Verify credentials are working:

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-data",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_data API surface (5 query engines, discovery, entity CRUD) with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -25,14 +25,14 @@ Parse `$ARGUMENTS` and route to the appropriate operation:
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py status`
 
 Present the result conversationally:
-- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts/credentials exist, mention `/mp-auth list`. The possible `active_method` values are:
+- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts/credentials exist, mention `/mixpanel-data:auth list`. The possible `active_method` values are:
   - `env_vars` — service-account env vars (`MP_USERNAME`/`MP_SECRET`/`MP_PROJECT_ID`/`MP_REGION`)
   - `oauth_token_env` — raw OAuth bearer-token env vars (`MP_OAUTH_TOKEN`/`MP_PROJECT_ID`/`MP_REGION`)
   - `oauth` — OAuth tokens from PKCE storage or v2 OAuth credentials
   - `service_account` — stored service-account credentials
-- If `active_method` is `"none"`: Diagnose what's missing. Suggest `/mp-auth add` (service account), `/mp-auth login` (OAuth PKCE browser flow), or `MP_OAUTH_TOKEN` env var (raw bearer token — best for non-interactive contexts like CI or agents).
-- If `env_vars.partial` is true: Show which variables are set and which are missing for the service-account triple. Also check `env_vars.oauth_token` for the raw-bearer triple — if either is `partial`, surface the missing vars.
-- If `config_version` is `1`: Mention that `/mp-auth migrate` can upgrade to v2 for project switching.
+- If `active_method` is `"none"`: Diagnose what's missing. Suggest `/mixpanel-data:auth add` (service account), `/mixpanel-data:auth login` (OAuth PKCE browser flow), or `MP_OAUTH_TOKEN` env var (raw bearer token — best for non-interactive contexts like CI or agents).
+- If `env_vars.partial` is true: Show which variables are set and which are missing for the four service-account env vars. Also check `env_vars.oauth_token` for the OAuth-token triple — if either is `partial`, surface the missing vars.
+- If `config_version` is `1`: Mention that `/mixpanel-data:auth migrate` can upgrade to v2 for project switching.
 - If `config_version` is `2`: Show active context (credential + project + workspace) and mention project aliases if any exist.
 
 #### Raw OAuth bearer-token env vars (`MP_OAUTH_TOKEN`)
@@ -45,7 +45,7 @@ export MP_PROJECT_ID=<project-id>
 export MP_REGION=<us|eu|in>
 ```
 
-The library builds an `Authorization: Bearer <token>` header for every Mixpanel endpoint. Service-account env vars (`MP_USERNAME`/`MP_SECRET`) take precedence when both triples are set, so this is safe to add to a shell that already exports the service-account vars.
+The library builds an `Authorization: Bearer <token>` header for every Mixpanel endpoint. The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete, so this is safe to add to a shell that already exports the service-account vars.
 
 ### "list"
 
@@ -96,8 +96,8 @@ Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py t
 On success: "Connected! Found N events in project P (region R)."
 On failure: Diagnose the specific error and suggest remediation:
 - `AuthenticationError` → "Credentials are invalid. Check your username and secret."
-- `AccountNotFoundError` → "Account not found. Run `/mp-auth list` to see available accounts."
-- `ConfigError` → "No credentials configured. Run `/mp-auth add` to set up."
+- `AccountNotFoundError` → "Account not found. Run `/mixpanel-data:auth list` to see available accounts."
+- `ConfigError` → "No credentials configured. Run `/mixpanel-data:auth add` to set up."
 
 ### "login" or "login --region <R>"
 
@@ -144,7 +144,7 @@ If already v2: Tell the user no migration is needed.
 
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py projects`
 
-Present accessible projects as a table: organization, project name, project ID, timezone. Suggest `/mp-auth switch-project <ID>` to switch.
+Present accessible projects as a table: organization, project name, project ID, timezone. Suggest `/mixpanel-data:auth switch-project <ID>` to switch.
 
 ### "context"
 
@@ -159,7 +159,7 @@ If no project_id: run `projects` first, then ask which to switch to.
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py switch-project <PROJECT_ID> [--workspace-id <WS_ID>]`
 
 On success: Confirm the active project was changed.
-If v1 config: Error suggests running `/mp-auth migrate` first.
+If v1 config: Error suggests running `/mixpanel-data:auth migrate` first.
 
 ### "cowork-setup"
 

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -25,11 +25,27 @@ Parse `$ARGUMENTS` and route to the appropriate operation:
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py status`
 
 Present the result conversationally:
-- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts/credentials exist, mention `/mp-auth list`.
-- If `active_method` is `"none"`: Diagnose what's missing. Suggest `/mp-auth add` (service account) or `/mp-auth login` (OAuth).
-- If `env_vars.partial` is true: Show which variables are set and which are missing.
+- If `active_method` is not `"none"`: Show a brief confirmation with the active method, account name, project ID, and region. If multiple accounts/credentials exist, mention `/mp-auth list`. The possible `active_method` values are:
+  - `env_vars` — service-account env vars (`MP_USERNAME`/`MP_SECRET`/`MP_PROJECT_ID`/`MP_REGION`)
+  - `oauth_token_env` — raw OAuth bearer-token env vars (`MP_OAUTH_TOKEN`/`MP_PROJECT_ID`/`MP_REGION`)
+  - `oauth` — OAuth tokens from PKCE storage or v2 OAuth credentials
+  - `service_account` — stored service-account credentials
+- If `active_method` is `"none"`: Diagnose what's missing. Suggest `/mp-auth add` (service account), `/mp-auth login` (OAuth PKCE browser flow), or `MP_OAUTH_TOKEN` env var (raw bearer token — best for non-interactive contexts like CI or agents).
+- If `env_vars.partial` is true: Show which variables are set and which are missing for the service-account triple. Also check `env_vars.oauth_token` for the raw-bearer triple — if either is `partial`, surface the missing vars.
 - If `config_version` is `1`: Mention that `/mp-auth migrate` can upgrade to v2 for project switching.
 - If `config_version` is `2`: Show active context (credential + project + workspace) and mention project aliases if any exist.
+
+#### Raw OAuth bearer-token env vars (`MP_OAUTH_TOKEN`)
+
+For non-interactive contexts (CI, agents, ephemeral environments) where the PKCE browser flow isn't viable, set:
+
+```
+export MP_OAUTH_TOKEN=<bearer-token>
+export MP_PROJECT_ID=<project-id>
+export MP_REGION=<us|eu|in>
+```
+
+The library builds an `Authorization: Bearer <token>` header for every Mixpanel endpoint. Service-account env vars (`MP_USERNAME`/`MP_SECRET`) take precedence when both triples are set, so this is safe to add to a shell that already exports the service-account vars.
 
 ### "list"
 

--- a/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
@@ -2,7 +2,7 @@
 """Mixpanel authentication manager for the Claude Code plugin.
 
 Provides JSON-formatted output for all auth operations, designed
-to be called by the /mp-auth command and setup skill.
+to be called by the /mixpanel-data:auth command and setup skill.
 
 Supports both v1 (account-based) and v2 (credential + project context)
 config schemas. Detects the active schema version automatically.
@@ -80,9 +80,7 @@ def _check_env_vars() -> dict[str, Any]:
     the service-account block for backward compatibility with consumers of
     this JSON.
     """
-    sa_block = _env_status(
-        ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
-    )
+    sa_block = _env_status(["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"])
     oauth_block = _env_status(["MP_OAUTH_TOKEN", "MP_PROJECT_ID", "MP_REGION"])
     return {**sa_block, "service_account": sa_block, "oauth_token": oauth_block}
 
@@ -185,10 +183,14 @@ def _check_oauth() -> list[dict[str, Any]]:
 def _resolve_active(cm: Any, version: int) -> dict[str, Any]:
     """Determine the active authentication method.
 
-    Returns one of: ``env_vars`` (service-account env triple),
+    Returns one of: ``env_vars`` (the four service-account env vars),
     ``oauth_token_env`` (``MP_OAUTH_TOKEN`` env triple), ``oauth`` (PKCE
     storage or v2 OAuth credential), or ``service_account`` (stored
     service-account credential).
+
+    On failure, returns ``active_method == "none"`` plus a
+    ``resolution_error`` field carrying ``f"{type(e).__name__}: {e}"``
+    so callers can surface the underlying reason instead of guessing.
     """
     try:
         creds = cm.resolve_credentials()
@@ -199,8 +201,7 @@ def _resolve_active(cm: Any, version: int) -> dict[str, Any]:
             for v in ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
         )
         oauth_env_complete = all(
-            os.environ.get(v)
-            for v in ["MP_OAUTH_TOKEN", "MP_PROJECT_ID", "MP_REGION"]
+            os.environ.get(v) for v in ["MP_OAUTH_TOKEN", "MP_PROJECT_ID", "MP_REGION"]
         )
 
         if sa_env_complete:
@@ -229,12 +230,13 @@ def _resolve_active(cm: Any, version: int) -> dict[str, Any]:
             "active_project_id": creds.project_id,
             "active_region": creds.region,
         }
-    except Exception:
+    except Exception as e:
         return {
             "active_method": "none",
             "active_account": None,
             "active_project_id": None,
             "active_region": None,
+            "resolution_error": f"{type(e).__name__}: {e}",
         }
 
 
@@ -253,7 +255,7 @@ def _generate_suggestion(
         }.get(active["active_method"], active["active_method"])
         msg = f"Authenticated via {method_label} (project {active['active_project_id']}, {active['active_region']} region)."
         if version == 1:
-            msg += " Config is v1 — run /mp-auth migrate to upgrade to v2 for project switching."
+            msg += " Config is v1 — run /mixpanel-data:auth migrate to upgrade to v2 for project switching."
         return msg
 
     sa_env = env.get("service_account", env)
@@ -261,13 +263,16 @@ def _generate_suggestion(
     # Env vars complete but auth still resolved to "none" — the values are
     # syntactically present but produced a ConfigError (e.g., bad MP_REGION).
     if sa_env.get("configured") or oauth_env.get("configured"):
-        return "Auth env vars are set but credentials could not be resolved (likely an invalid value such as MP_REGION). Run /mp-auth test for details."
+        err = active.get("resolution_error")
+        if err:
+            return f"Auth env vars are set but credentials could not be resolved: {err}"
+        return "Auth env vars are set but credentials could not be resolved (likely an invalid value such as MP_REGION). Run /mixpanel-data:auth test for details."
     if sa_env.get("partial"):
-        return f"Partial service-account env config — missing: {', '.join(sa_env['missing'])}. Set the rest, switch to MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION, or run /mp-auth add."
+        return f"Partial service-account env config — missing: {', '.join(sa_env['missing'])}. Set the rest, switch to MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION, or run /mixpanel-data:auth add."
     if oauth_env.get("partial"):
-        return f"Partial OAuth-token env config — missing: {', '.join(oauth_env['missing'])}. Set the remaining variables or use /mp-auth add / login."
+        return f"Partial OAuth-token env config — missing: {', '.join(oauth_env['missing'])}. Set the remaining variables or use /mixpanel-data:auth add / login."
 
-    return "No credentials configured. Run /mp-auth add (service account), /mp-auth login (OAuth PKCE), or set MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION for bearer-token auth."
+    return "No credentials configured. Run /mixpanel-data:auth add (service account), /mixpanel-data:auth login (OAuth PKCE), or set MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION for bearer-token auth."
 
 
 # --- Subcommand handlers ---
@@ -540,7 +545,7 @@ def cmd_context(_args: argparse.Namespace) -> None:
                 "operation": "context",
                 "config_version": version,
                 **active,
-                "suggestion": "Config is v1. Run /mp-auth migrate to upgrade to v2 for project switching.",
+                "suggestion": "Config is v1. Run /mixpanel-data:auth migrate to upgrade to v2 for project switching.",
             }
         )
         return
@@ -565,7 +570,7 @@ def cmd_switch_project(args: argparse.Namespace) -> None:
     if version < 2:
         _json_error(
             "ConfigError",
-            "Project switching requires v2 config. Run /mp-auth migrate first.",
+            "Project switching requires v2 config. Run /mixpanel-data:auth migrate first.",
         )
         return
 

--- a/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
@@ -258,6 +258,10 @@ def _generate_suggestion(
 
     sa_env = env.get("service_account", env)
     oauth_env = env.get("oauth_token", {})
+    # Env vars complete but auth still resolved to "none" — the values are
+    # syntactically present but produced a ConfigError (e.g., bad MP_REGION).
+    if sa_env.get("configured") or oauth_env.get("configured"):
+        return "Auth env vars are set but credentials could not be resolved (likely an invalid value such as MP_REGION). Run /mp-auth test for details."
     if sa_env.get("partial"):
         return f"Partial service-account env config — missing: {', '.join(sa_env['missing'])}. Set the rest, switch to MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION, or run /mp-auth add."
     if oauth_env.get("partial"):

--- a/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
@@ -61,17 +61,30 @@ def _config_version(cm: Any) -> int:
         return 1
 
 
-def _check_env_vars() -> dict[str, Any]:
-    """Check which MP_* environment variables are set."""
-    required = ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
-    set_vars = [v for v in required if os.environ.get(v)]
-    missing = [v for v in required if not os.environ.get(v)]
+def _env_status(names: list[str]) -> dict[str, Any]:
+    """Return configured/partial/set/missing for a group of env vars."""
+    present = [v for v in names if os.environ.get(v)]
+    missing = [v for v in names if not os.environ.get(v)]
     return {
         "configured": len(missing) == 0,
-        "partial": 0 < len(set_vars) < len(required),
-        "set": set_vars,
+        "partial": 0 < len(present) < len(names),
+        "set": present,
         "missing": missing,
     }
+
+
+def _check_env_vars() -> dict[str, Any]:
+    """Check which MP_* environment variables are set.
+
+    Top-level ``configured``/``partial``/``set``/``missing`` fields mirror
+    the service-account block for backward compatibility with consumers of
+    this JSON.
+    """
+    sa_block = _env_status(
+        ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
+    )
+    oauth_block = _env_status(["MP_OAUTH_TOKEN", "MP_PROJECT_ID", "MP_REGION"])
+    return {**sa_block, "service_account": sa_block, "oauth_token": oauth_block}
 
 
 def _get_accounts(cm: Any) -> list[dict[str, Any]]:
@@ -170,16 +183,30 @@ def _check_oauth() -> list[dict[str, Any]]:
 
 
 def _resolve_active(cm: Any, version: int) -> dict[str, Any]:
-    """Determine the active authentication method."""
+    """Determine the active authentication method.
+
+    Returns one of: ``env_vars`` (service-account env triple),
+    ``oauth_token_env`` (``MP_OAUTH_TOKEN`` env triple), ``oauth`` (PKCE
+    storage or v2 OAuth credential), or ``service_account`` (stored
+    service-account credential).
+    """
     try:
         creds = cm.resolve_credentials()
         from mixpanel_data.auth import AuthMethod
 
-        if all(
+        sa_env_complete = all(
             os.environ.get(v)
             for v in ["MP_USERNAME", "MP_SECRET", "MP_PROJECT_ID", "MP_REGION"]
-        ):
+        )
+        oauth_env_complete = all(
+            os.environ.get(v)
+            for v in ["MP_OAUTH_TOKEN", "MP_PROJECT_ID", "MP_REGION"]
+        )
+
+        if sa_env_complete:
             method = "env_vars"
+        elif oauth_env_complete:
+            method = "oauth_token_env"
         elif creds.auth_method == AuthMethod.oauth:
             method = "oauth"
         else:
@@ -219,7 +246,8 @@ def _generate_suggestion(
     """Generate a human-readable suggestion based on auth state."""
     if active["active_method"] != "none":
         method_label = {
-            "env_vars": "environment variables",
+            "env_vars": "service-account environment variables",
+            "oauth_token_env": "MP_OAUTH_TOKEN environment variables",
             "service_account": f"service account '{active['active_account']}'",
             "oauth": "OAuth",
         }.get(active["active_method"], active["active_method"])
@@ -228,10 +256,14 @@ def _generate_suggestion(
             msg += " Config is v1 — run /mp-auth migrate to upgrade to v2 for project switching."
         return msg
 
-    if env["partial"]:
-        return f"Partial environment config — missing: {', '.join(env['missing'])}. Set all 4 variables or run /mp-auth add."
+    sa_env = env.get("service_account", env)
+    oauth_env = env.get("oauth_token", {})
+    if sa_env.get("partial"):
+        return f"Partial service-account env config — missing: {', '.join(sa_env['missing'])}. Set the rest, switch to MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION, or run /mp-auth add."
+    if oauth_env.get("partial"):
+        return f"Partial OAuth-token env config — missing: {', '.join(oauth_env['missing'])}. Set the remaining variables or use /mp-auth add / login."
 
-    return "No credentials configured. Run /mp-auth add (service account) or /mp-auth login (OAuth)."
+    return "No credentials configured. Run /mp-auth add (service account), /mp-auth login (OAuth PKCE), or set MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION for bearer-token auth."
 
 
 # --- Subcommand handlers ---

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -46,7 +46,7 @@ Tell the user to run `/mp-auth add` for a step-by-step walkthrough that securely
 
 Tell the user to run `/mp-auth login` for browser-based authentication (no service account needed).
 
-### Alternative: Environment Variables (temporary)
+### Alternative: Service-Account Environment Variables (temporary)
 
 For quick testing, set all four variables in the shell:
 
@@ -56,6 +56,20 @@ export MP_SECRET="service-account-secret"
 export MP_PROJECT_ID="12345"
 export MP_REGION="us"  # or "eu", "in"
 ```
+
+### Alternative: Raw OAuth Bearer Token (best for agents / CI)
+
+If the user has an OAuth 2.0 access token from another source, they can use
+it directly without the PKCE browser flow:
+
+```bash
+export MP_OAUTH_TOKEN="<bearer-token>"
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"  # or "eu", "in"
+```
+
+This is the recommended mode for non-interactive contexts. Service-account
+env vars take precedence if both are set.
 
 ## Cowork Environment
 

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -31,7 +31,7 @@ python3 ${CLAUDE_SKILL_DIR}/../mixpanelyst/scripts/auth_manager.py status
 
 Parse the JSON result:
 - If `active_method` is not `"none"`, credentials are configured — proceed to verification.
-- If `config_version` is `1`, suggest `/mp-auth migrate` to upgrade to v2 for project switching.
+- If `config_version` is `1`, suggest `/mixpanel-data:auth migrate` to upgrade to v2 for project switching.
 - If `config_version` is `2`, show the active credential and project context.
 
 ## If Credentials Are Missing
@@ -40,11 +40,11 @@ If no credentials are configured, guide the user to one of these methods:
 
 ### Recommended: Guided Setup
 
-Tell the user to run `/mp-auth add` for a step-by-step walkthrough that securely collects credentials.
+Tell the user to run `/mixpanel-data:auth add` for a step-by-step walkthrough that securely collects credentials.
 
 ### Alternative: OAuth Login
 
-Tell the user to run `/mp-auth login` for browser-based authentication (no service account needed).
+Tell the user to run `/mixpanel-data:auth login` for browser-based authentication (no service account needed).
 
 ### Alternative: Service-Account Environment Variables (temporary)
 
@@ -68,8 +68,9 @@ export MP_PROJECT_ID="12345"
 export MP_REGION="us"  # or "eu", "in"
 ```
 
-This is the recommended mode for non-interactive contexts. Service-account
-env vars take precedence if both are set.
+This is the recommended mode for non-interactive contexts. The full
+service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID`
++ `MP_REGION`) takes precedence when both sets are complete.
 
 ## Cowork Environment
 
@@ -93,7 +94,7 @@ Tell the user:
 > 
 > Then **start a new Cowork session** — credentials will be available automatically.
 
-Do NOT suggest `/mp-auth login`, `/mp-auth add`, or environment variables — these won't work inside Cowork.
+Do NOT suggest `/mixpanel-data:auth login`, `/mixpanel-data:auth add`, or environment variables — these won't work inside Cowork.
 
 ### If Bridge File Found But Token Expired
 
@@ -115,15 +116,15 @@ python3 ${CLAUDE_SKILL_DIR}/../mixpanelyst/scripts/auth_manager.py test
 
 If the result shows `"success": true`, setup is complete. The user can now ask questions about their Mixpanel data.
 
-If verification fails, suggest `/mp-auth test` for detailed diagnostics.
+If verification fails, suggest `/mixpanel-data:auth test` for detailed diagnostics.
 
 ## Post-Setup: Explore Your Data
 
 Once authenticated, these commands help orient the user:
 
-- `/mp-auth projects` — discover all accessible projects via the /me API
-- `/mp-auth context` — see the active credential + project + workspace
-- `/mp-auth switch-project <ID>` — switch to a different project (v2 config only)
+- `/mixpanel-data:auth projects` — discover all accessible projects via the /me API
+- `/mixpanel-data:auth context` — see the active credential + project + workspace
+- `/mixpanel-data:auth switch-project <ID>` — switch to a different project (v2 config only)
 
 The user can also construct a Workspace targeting a specific credential or project:
 

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -110,7 +110,7 @@ try:
                 print(f'  {len(aliases)} project alias(es) configured')
         else:
             print('⚠ Config v2 but no credentials configured.')
-            print('  Run /mp-auth add (service account) or /mp-auth login (OAuth)')
+            print('  Run /mixpanel-data:auth add (service account) or /mixpanel-data:auth login (OAuth)')
     else:
         # v1 config: account-based
         accounts = cm.list_accounts()
@@ -120,10 +120,10 @@ try:
             default = next((a.name for a in accounts if a.is_default), None)
             if default:
                 print(f'  Default: {default}')
-            print(f'  Tip: Run /mp-auth migrate to upgrade to v2 for project switching')
+            print(f'  Tip: Run /mixpanel-data:auth migrate to upgrade to v2 for project switching')
         else:
             print('⚠ No accounts configured yet.')
-            print('  Run /mp-auth add (service account) or /mp-auth login (OAuth)')
+            print('  Run /mixpanel-data:auth add (service account) or /mixpanel-data:auth login (OAuth)')
 except Exception as e:
     print(f'⚠ Could not check config file credentials: {e}')
     print('  Set environment variables: MP_USERNAME, MP_SECRET, MP_PROJECT_ID')

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -261,7 +261,7 @@ from mixpanel_data.types import (
 )
 from mixpanel_data.workspace import Workspace
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 __all__ = [
     # Core

--- a/src/mixpanel_data/_internal/CLAUDE.md
+++ b/src/mixpanel_data/_internal/CLAUDE.md
@@ -32,9 +32,13 @@ Private infrastructure powering mixpanel_data's complete programmable interface 
 
 ## Credential Resolution Order
 
-1. Environment variables: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
-2. Named account (if `account` parameter specified)
-3. Default account from config file
+1. Environment variables — either service-account vars (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) or OAuth-token vars (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`); service-account wins when both sets are complete
+2. Auth bridge file (`MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json`)
+3. OAuth tokens from local storage (`~/.mp/oauth/`) — only when no `account` requested
+4. Named account (if `account` parameter specified)
+5. Default account from config file
+
+See `ConfigManager.resolve_credentials` for the authoritative chain.
 
 ## Error Handling
 

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -136,8 +136,14 @@ class Credentials(BaseModel):
                 raise ValueError(
                     "oauth_access_token is required when auth_method is oauth"
                 )
-            if not self.oauth_access_token.get_secret_value():
+            token_value = self.oauth_access_token.get_secret_value()
+            if not token_value:
                 raise ValueError("oauth_access_token cannot be empty for oauth auth")
+            if any(ord(c) < 0x20 or ord(c) == 0x7F for c in token_value):
+                raise ValueError(
+                    "oauth_access_token contains control characters "
+                    "(check for embedded newlines, tabs, or other non-printable bytes)"
+                )
         return self
 
     def auth_header(self) -> str:
@@ -202,7 +208,6 @@ class Credentials(BaseModel):
 
         Example:
             ```python
-            from mixpanel_data import Workspace
             from mixpanel_data.auth import Credentials
 
             creds = Credentials.from_oauth_token(
@@ -210,7 +215,14 @@ class Credentials(BaseModel):
                 project_id="12345",
                 region="us",
             )
-            ws = Workspace(credentials=creds)
+            assert creds.auth_header() == "Bearer my-bearer-token"
+
+            # To drive Workspace with these credentials, set the
+            # corresponding env vars and let Workspace() resolve them:
+            #   export MP_OAUTH_TOKEN="my-bearer-token"
+            #   export MP_PROJECT_ID="12345"
+            #   export MP_REGION="us"
+            #   ws = Workspace()
             ```
         """
         # Strip whitespace defensively — shell exports / copy-paste often
@@ -526,7 +538,7 @@ class ConfigManager:
         # they should be available regardless of which resolution path succeeds.
         self.apply_config_custom_header()
 
-        # Priority 1: Environment variables (all four must be set)
+        # Priority 1: Environment variables (SA quad or OAuth triple)
         env_creds = self._resolve_from_env()
         if env_creds is not None:
             return env_creds
@@ -835,6 +847,11 @@ class ConfigManager:
         oauth_token = os.environ.get("MP_OAUTH_TOKEN")
 
         if username and secret and project_id and region:
+            if oauth_token:
+                logger.info(
+                    "MP_USERNAME/MP_SECRET present; ignoring MP_OAUTH_TOKEN. "
+                    "Unset MP_USERNAME and MP_SECRET to use bearer-token auth."
+                )
             normalized_region = self._validate_env_region(region)
             return Credentials(
                 username=username,
@@ -854,13 +871,14 @@ class ConfigManager:
 
     @staticmethod
     def _validate_env_region(region: str) -> str:
-        """Normalize ``MP_REGION`` to lowercase and validate the value.
+        """Strip whitespace, normalize to lowercase, and validate the region.
 
         Args:
-            region: Raw ``MP_REGION`` env-var value.
+            region: Raw ``MP_REGION`` env-var value (may carry surrounding
+                whitespace from shell exports — e.g. ``" us\\n"``).
 
         Returns:
-            The lowercased region string.
+            The stripped, lowercased region string.
 
         Raises:
             ConfigError: If the region is not one of ``us``, ``eu``, ``in``.

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -213,13 +213,15 @@ class Credentials(BaseModel):
             ws = Workspace(credentials=creds)
             ```
         """
+        # Strip whitespace defensively — shell exports / copy-paste often
+        # introduce trailing newlines that would corrupt the Bearer header.
         return cls(
             username="",
             secret=SecretStr(""),
             project_id=project_id,
             region=region,
             auth_method=AuthMethod.oauth,
-            oauth_access_token=SecretStr(token),
+            oauth_access_token=SecretStr(token.strip()),
         )
 
     def to_resolved_session(self, workspace_id: int | None = None) -> ResolvedSession:
@@ -479,18 +481,18 @@ class ConfigManager:
 
         Resolution order when ``account`` is None:
 
-        1. Environment variables — either the service-account triple
+        1. Environment variables — either the service-account env vars
            (``MP_USERNAME`` + ``MP_SECRET`` + ``MP_PROJECT_ID`` + ``MP_REGION``)
-           or the OAuth-token triple (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID``
+           or the OAuth-token env vars (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID``
            + ``MP_REGION``). Service-account env vars take precedence when
-           both are set.
+           both sets are complete.
         2. Auth bridge file (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
         3. OAuth tokens from local storage (if valid and not expired)
         4. Default account from config file
 
         Resolution order when ``account`` is provided:
 
-        1. Environment variables (one complete triple must be set)
+        1. Environment variables (one complete set must be present)
         2. Named account from config file (bridge and OAuth are skipped)
 
         For OAuth resolution, the region and project_id are determined from:
@@ -813,16 +815,18 @@ class ConfigManager:
     def _resolve_from_env(self) -> Credentials | None:
         """Attempt to resolve credentials from environment variables.
 
-        Accepts either the service-account triple (``MP_USERNAME`` +
+        Accepts either the service-account env vars (``MP_USERNAME`` +
         ``MP_SECRET`` + ``MP_PROJECT_ID`` + ``MP_REGION``) or the OAuth
-        triple (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID`` + ``MP_REGION``).
-        Service-account wins when both are complete.
+        env vars (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID`` + ``MP_REGION``).
+        Service-account wins when both sets are complete.
 
         Returns:
-            Credentials if either triple is complete, ``None`` otherwise.
+            Credentials if either set is complete, ``None`` otherwise.
 
         Raises:
-            ConfigError: If ``MP_REGION`` is set but invalid.
+            ConfigError: If a complete env-var set is present and
+                ``MP_REGION`` is invalid. ``MP_REGION`` is only validated
+                when the rest of its set is also present.
         """
         username = os.environ.get("MP_USERNAME")
         secret = os.environ.get("MP_SECRET")
@@ -861,7 +865,7 @@ class ConfigManager:
         Raises:
             ConfigError: If the region is not one of ``us``, ``eu``, ``in``.
         """
-        normalized = region.lower()
+        normalized = region.strip().lower()
         if normalized not in VALID_REGIONS:
             raise ConfigError(
                 f"Invalid MP_REGION: '{normalized}'. Must be 'us', 'eu', or 'in'."
@@ -1548,10 +1552,10 @@ class ConfigManager:
         """Resolve a complete session using the v2 priority chain.
 
         Priority order:
-        1. ENV VARS — service-account triple (MP_USERNAME + MP_SECRET +
-           MP_PROJECT_ID + MP_REGION) OR OAuth-token triple (MP_OAUTH_TOKEN
-           + MP_PROJECT_ID + MP_REGION). Service-account wins when both
-           are set.
+        1. ENV VARS — service-account env vars (MP_USERNAME + MP_SECRET +
+           MP_PROJECT_ID + MP_REGION) OR OAuth-token env vars
+           (MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION). Service-account
+           wins when both sets are complete.
         2. AUTH BRIDGE FILE (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
         3. EXPLICIT PARAMS (credential + project_id + workspace_id)
         4. ACTIVE CONTEXT (config [active] section)

--- a/src/mixpanel_data/_internal/config.py
+++ b/src/mixpanel_data/_internal/config.py
@@ -176,6 +176,52 @@ class Credentials(BaseModel):
         encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
         return f"Basic {encoded}"
 
+    @classmethod
+    def from_oauth_token(
+        cls,
+        token: str,
+        project_id: str,
+        region: RegionType,
+    ) -> Credentials:
+        """Build OAuth-method ``Credentials`` from a pre-obtained bearer token.
+
+        Skips the PKCE browser flow — for callers who already hold an
+        OAuth 2.0 access token.
+
+        Args:
+            token: The OAuth 2.0 bearer token.
+            project_id: Mixpanel project identifier.
+            region: Data residency region (``"us"``, ``"eu"``, or ``"in"``).
+
+        Returns:
+            Immutable OAuth-method ``Credentials``.
+
+        Raises:
+            ValueError: If ``token`` or ``project_id`` is empty, or
+                ``region`` is invalid.
+
+        Example:
+            ```python
+            from mixpanel_data import Workspace
+            from mixpanel_data.auth import Credentials
+
+            creds = Credentials.from_oauth_token(
+                token="my-bearer-token",
+                project_id="12345",
+                region="us",
+            )
+            ws = Workspace(credentials=creds)
+            ```
+        """
+        return cls(
+            username="",
+            secret=SecretStr(""),
+            project_id=project_id,
+            region=region,
+            auth_method=AuthMethod.oauth,
+            oauth_access_token=SecretStr(token),
+        )
+
     def to_resolved_session(self, workspace_id: int | None = None) -> ResolvedSession:
         """Convert legacy Credentials to a ResolvedSession.
 
@@ -433,14 +479,18 @@ class ConfigManager:
 
         Resolution order when ``account`` is None:
 
-        1. Environment variables (MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION)
+        1. Environment variables — either the service-account triple
+           (``MP_USERNAME`` + ``MP_SECRET`` + ``MP_PROJECT_ID`` + ``MP_REGION``)
+           or the OAuth-token triple (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID``
+           + ``MP_REGION``). Service-account env vars take precedence when
+           both are set.
         2. Auth bridge file (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
         3. OAuth tokens from local storage (if valid and not expired)
         4. Default account from config file
 
         Resolution order when ``account`` is provided:
 
-        1. Environment variables (all four must be set)
+        1. Environment variables (one complete triple must be set)
         2. Named account from config file (bridge and OAuth are skipped)
 
         For OAuth resolution, the region and project_id are determined from:
@@ -502,8 +552,9 @@ class ConfigManager:
             raise ConfigError(
                 "No credentials configured. "
                 "Run 'mp auth login' to authenticate via OAuth, "
-                "or set MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION "
-                "environment variables."
+                "set MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION "
+                "for service-account auth, or set MP_OAUTH_TOKEN + "
+                "MP_PROJECT_ID + MP_REGION to use a pre-obtained bearer token."
             )
 
         # Determine which account to use
@@ -762,28 +813,60 @@ class ConfigManager:
     def _resolve_from_env(self) -> Credentials | None:
         """Attempt to resolve credentials from environment variables.
 
+        Accepts either the service-account triple (``MP_USERNAME`` +
+        ``MP_SECRET`` + ``MP_PROJECT_ID`` + ``MP_REGION``) or the OAuth
+        triple (``MP_OAUTH_TOKEN`` + ``MP_PROJECT_ID`` + ``MP_REGION``).
+        Service-account wins when both are complete.
+
         Returns:
-            Credentials if all env vars are set, None otherwise.
+            Credentials if either triple is complete, ``None`` otherwise.
+
+        Raises:
+            ConfigError: If ``MP_REGION`` is set but invalid.
         """
         username = os.environ.get("MP_USERNAME")
         secret = os.environ.get("MP_SECRET")
         project_id = os.environ.get("MP_PROJECT_ID")
         region = os.environ.get("MP_REGION")
+        oauth_token = os.environ.get("MP_OAUTH_TOKEN")
 
-        # All four must be set to use env vars
         if username and secret and project_id and region:
-            region = region.lower()
-            if region not in VALID_REGIONS:
-                raise ConfigError(
-                    f"Invalid MP_REGION: '{region}'. Must be 'us', 'eu', or 'in'."
-                )
+            normalized_region = self._validate_env_region(region)
             return Credentials(
                 username=username,
                 secret=SecretStr(secret),
                 project_id=project_id,
-                region=cast(RegionType, region),
+                region=cast(RegionType, normalized_region),
+            )
+
+        if oauth_token and project_id and region:
+            normalized_region = self._validate_env_region(region)
+            return Credentials.from_oauth_token(
+                token=oauth_token,
+                project_id=project_id,
+                region=cast(RegionType, normalized_region),
             )
         return None
+
+    @staticmethod
+    def _validate_env_region(region: str) -> str:
+        """Normalize ``MP_REGION`` to lowercase and validate the value.
+
+        Args:
+            region: Raw ``MP_REGION`` env-var value.
+
+        Returns:
+            The lowercased region string.
+
+        Raises:
+            ConfigError: If the region is not one of ``us``, ``eu``, ``in``.
+        """
+        normalized = region.lower()
+        if normalized not in VALID_REGIONS:
+            raise ConfigError(
+                f"Invalid MP_REGION: '{normalized}'. Must be 'us', 'eu', or 'in'."
+            )
+        return normalized
 
     def list_accounts(self) -> list[AccountInfo]:
         """List all configured accounts.
@@ -1465,7 +1548,10 @@ class ConfigManager:
         """Resolve a complete session using the v2 priority chain.
 
         Priority order:
-        1. ENV VARS (MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION)
+        1. ENV VARS — service-account triple (MP_USERNAME + MP_SECRET +
+           MP_PROJECT_ID + MP_REGION) OR OAuth-token triple (MP_OAUTH_TOKEN
+           + MP_PROJECT_ID + MP_REGION). Service-account wins when both
+           are set.
         2. AUTH BRIDGE FILE (MP_AUTH_FILE or ~/.claude/mixpanel/auth.json)
         3. EXPLICIT PARAMS (credential + project_id + workspace_id)
         4. ACTIVE CONTEXT (config [active] section)
@@ -1649,8 +1735,9 @@ class ConfigManager:
             raise ConfigError(
                 "No credentials configured. "
                 "Run 'mp auth login' to authenticate via OAuth, "
-                "or set MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION "
-                "environment variables.",
+                "set MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION "
+                "for service-account auth, or set MP_OAUTH_TOKEN + "
+                "MP_PROJECT_ID + MP_REGION to use a pre-obtained bearer token.",
             )
 
         cred_data = credentials[cred_name]

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -365,7 +365,10 @@ class Workspace:
         """Create a new Workspace with credentials.
 
         Credentials are resolved in priority order:
-        1. Environment variables (MP_USERNAME, MP_SECRET, MP_PROJECT_ID, MP_REGION)
+        1. Environment variables — either the service-account env vars
+           (MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION) or the
+           OAuth-token env vars (MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION).
+           Service-account env vars take precedence when both sets are complete.
         2. OAuth tokens from local storage (if available and not expired)
         3. Named account from config file (if account parameter specified)
         4. Default account from config file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,31 @@ if TYPE_CHECKING:
     from mixpanel_data._internal.config import ConfigManager, Credentials
 
 
+_MP_ENV_VARS = (
+    "MP_USERNAME",
+    "MP_SECRET",
+    "MP_PROJECT_ID",
+    "MP_REGION",
+    "MP_OAUTH_TOKEN",
+    "MP_AUTH_FILE",
+    "MP_WORKSPACE_ID",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_mp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic test isolation: scrub all MP_* env vars before each test.
+
+    Tests that depend on env-var resolution behavior must opt-in by
+    re-setting the vars they need via ``monkeypatch.setenv``. Without this
+    fixture, a developer who exports ``MP_OAUTH_TOKEN`` (or any service-
+    account var) in their shell would silently fail credential-resolution
+    tests that expect "no credentials configured".
+    """
+    for var in _MP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def temp_dir() -> Generator[Path, None, None]:
     """Create a temporary directory for test files."""

--- a/tests/integration/test_workspace_integration.py
+++ b/tests/integration/test_workspace_integration.py
@@ -1,4 +1,63 @@
 """Integration tests for Workspace facade.
 
-This file is kept for future API-level integration tests.
+Verifies that Workspace correctly threads credentials through the
+v1 ``resolve_credentials`` path under ``MP_OAUTH_TOKEN``-based env auth.
 """
+
+from __future__ import annotations
+
+import pytest
+
+from mixpanel_data import Workspace
+from mixpanel_data._internal.config import AuthMethod, ConfigManager
+
+
+class TestWorkspaceOAuthEnv:
+    """Workspace integration with the ``MP_OAUTH_TOKEN`` env-var path."""
+
+    def test_workspace_uses_oauth_env_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config_manager: ConfigManager,
+    ) -> None:
+        """Workspace resolves MP_OAUTH_TOKEN env vars and surfaces a Bearer header.
+
+        Pins the end-to-end flow: env-var detection in
+        ``ConfigManager._resolve_from_env`` → OAuth ``Credentials`` →
+        Workspace. ``_credentials.auth_method`` MUST stay ``oauth``.
+        """
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "ws-bearer-token")
+        monkeypatch.setenv("MP_PROJECT_ID", "1234")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        ws = Workspace(_config_manager=config_manager)
+
+        assert ws._credentials is not None
+        assert ws._credentials.auth_method == AuthMethod.oauth
+        assert ws._credentials.project_id == "1234"
+        assert ws._credentials.region == "us"
+        assert ws._credentials.auth_header() == "Bearer ws-bearer-token"
+
+    def test_workspace_oauth_env_with_project_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config_manager: ConfigManager,
+    ) -> None:
+        """A ``project_id`` override must NOT downgrade OAuth to Basic Auth.
+
+        Pins the override-reconstruction block in ``Workspace.__init__``
+        (the v1 branch that builds a fresh ``Credentials`` carrying
+        ``auth_method`` and ``oauth_access_token``). A regression that
+        defaults the new ``Credentials`` to Basic Auth would be silent
+        without this test.
+        """
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "override-bearer")
+        monkeypatch.setenv("MP_PROJECT_ID", "original-pid")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        ws = Workspace(_config_manager=config_manager, project_id="override-pid")
+
+        assert ws._credentials is not None
+        assert ws._credentials.auth_method == AuthMethod.oauth
+        assert ws._credentials.project_id == "override-pid"
+        assert ws._credentials.auth_header() == "Bearer override-bearer"

--- a/tests/pbt/test_config_pbt.py
+++ b/tests/pbt/test_config_pbt.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
+import pytest
 import tomli_w
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -240,9 +241,22 @@ class TestConfigV2RoundTrip:
 # ── Credentials.from_oauth_token ──────────────────────────────────────
 
 
-# Strategy for OAuth bearer tokens — printable ASCII without whitespace,
-# bounded length to keep examples reasonable.
-oauth_token_st = st.from_regex(r"[A-Za-z0-9._\-]{1,64}", fullmatch=True)
+# Strategy for OAuth bearer tokens — printable ASCII covering RFC 6750
+# token68 syntax (alphanumerics + - . _ ~ + / =). The `[A-Za-z._\-~+/=]`
+# prefix forces a non-digit first character, which both matches realistic
+# token shapes and prevents accidental substring collisions with the
+# all-digit ``project_id_st`` strategy in redaction assertions.
+oauth_token_st = st.from_regex(
+    r"[A-Za-z._\-~+/=][A-Za-z0-9._\-~+/=]{7,63}", fullmatch=True
+)
+
+# Whitespace strategy for edge-stripping property — ASCII whitespace only,
+# avoiding control chars that would correctly be rejected by the validator.
+edge_ws_st = st.text(alphabet=" \t\n\r", min_size=0, max_size=4)
+
+# Strategy for control characters (0x00-0x1F + 0x7F). Used to assert
+# rejection — any token with one of these bytes embedded must raise.
+control_char_st = st.sampled_from([chr(c) for c in list(range(0x20)) + [0x7F]])
 
 
 class TestFromOAuthTokenProperties:
@@ -270,3 +284,100 @@ class TestFromOAuthTokenProperties:
         )
         assert creds.auth_header() == f"Bearer {token}"
         assert creds.auth_method == AuthMethod.oauth
+
+    @given(token=oauth_token_st, project_id=project_id_st, region=region_st)
+    @settings(max_examples=50)
+    def test_token_redacted_in_repr(
+        self,
+        token: str,
+        project_id: str,
+        region: str,
+    ) -> None:
+        """The token must never appear in ``repr``/``str`` output.
+
+        Args:
+            token: A non-empty bearer token.
+            project_id: A valid Mixpanel project ID.
+            region: A valid Mixpanel region.
+        """
+        creds = Credentials.from_oauth_token(
+            token=token,
+            project_id=project_id,
+            region=cast(RegionType, region),
+        )
+        assert token not in repr(creds)
+        assert token not in str(creds)
+
+    @given(
+        leading_ws=edge_ws_st,
+        token=oauth_token_st,
+        trailing_ws=edge_ws_st,
+        project_id=project_id_st,
+        region=region_st,
+    )
+    @settings(max_examples=50)
+    def test_edge_whitespace_is_stripped(
+        self,
+        leading_ws: str,
+        token: str,
+        trailing_ws: str,
+        project_id: str,
+        region: str,
+    ) -> None:
+        """Surrounding whitespace must be stripped before the Bearer header.
+
+        Args:
+            leading_ws: Whitespace prepended to the token.
+            token: Core bearer token.
+            trailing_ws: Whitespace appended to the token.
+            project_id: A valid Mixpanel project ID.
+            region: A valid Mixpanel region.
+        """
+        padded = f"{leading_ws}{token}{trailing_ws}"
+        creds = Credentials.from_oauth_token(
+            token=padded,
+            project_id=project_id,
+            region=cast(RegionType, region),
+        )
+        assert creds.auth_header() == f"Bearer {token}"
+
+    @given(
+        prefix=oauth_token_st,
+        bad_char=control_char_st,
+        suffix=oauth_token_st,
+        project_id=project_id_st,
+        region=region_st,
+    )
+    @settings(max_examples=50)
+    def test_control_char_token_rejected(
+        self,
+        prefix: str,
+        bad_char: str,
+        suffix: str,
+        project_id: str,
+        region: str,
+    ) -> None:
+        """Any embedded control character must be rejected with ValueError.
+
+        Whitespace-only embedded control chars (``\\n``, ``\\t``, ``\\r``)
+        are stripped at the edges by ``from_oauth_token`` but survive in
+        the middle of a token, where they would corrupt the
+        ``Authorization: Bearer`` header.
+
+        Args:
+            prefix: Token characters before the control char.
+            bad_char: A single control character (0x00-0x1F or 0x7F).
+            suffix: Token characters after the control char.
+            project_id: A valid Mixpanel project ID.
+            region: A valid Mixpanel region.
+        """
+        token = f"{prefix}{bad_char}{suffix}"
+        # If the bad char survives stripping (i.e. it's not whitespace at
+        # an edge), the validator must reject. We assert rejection for the
+        # general case where prefix/suffix are non-empty.
+        with pytest.raises(ValueError):
+            Credentials.from_oauth_token(
+                token=token,
+                project_id=project_id,
+                region=cast(RegionType, region),
+            )

--- a/tests/pbt/test_config_pbt.py
+++ b/tests/pbt/test_config_pbt.py
@@ -10,12 +10,14 @@ Uses Hypothesis with profiles configured in tests/conftest.py.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import tomli_w
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from mixpanel_data._internal.config import ConfigManager
+from mixpanel_data._internal.auth_credential import RegionType
+from mixpanel_data._internal.config import AuthMethod, ConfigManager, Credentials
 
 # ── Strategies ────────────────────────────────────────────────────────
 
@@ -233,3 +235,38 @@ class TestConfigV2RoundTrip:
             assert len(aliases) == 1
             assert aliases[0].name == alias_name
             assert aliases[0].project_id == project_id
+
+
+# ── Credentials.from_oauth_token ──────────────────────────────────────
+
+
+# Strategy for OAuth bearer tokens — printable ASCII without whitespace,
+# bounded length to keep examples reasonable.
+oauth_token_st = st.from_regex(r"[A-Za-z0-9._\-]{1,64}", fullmatch=True)
+
+
+class TestFromOAuthTokenProperties:
+    """Property-based tests for ``Credentials.from_oauth_token``."""
+
+    @given(token=oauth_token_st, project_id=project_id_st, region=region_st)
+    @settings(max_examples=50)
+    def test_auth_header_is_bearer_token(
+        self,
+        token: str,
+        project_id: str,
+        region: str,
+    ) -> None:
+        """For any valid token, ``auth_header`` must equal ``f"Bearer {token}"``.
+
+        Args:
+            token: A non-empty bearer token.
+            project_id: A valid Mixpanel project ID.
+            region: A valid Mixpanel region.
+        """
+        creds = Credentials.from_oauth_token(
+            token=token,
+            project_id=project_id,
+            region=cast(RegionType, region),
+        )
+        assert creds.auth_header() == f"Bearer {token}"
+        assert creds.auth_method == AuthMethod.oauth

--- a/tests/unit/test_config_oauth.py
+++ b/tests/unit/test_config_oauth.py
@@ -345,6 +345,24 @@ class TestCredentialsFromOAuthToken:
         assert "super-secret-bearer" not in repr(creds)
         assert "super-secret-bearer" not in str(creds)
 
+    def test_factory_strips_token_whitespace(self) -> None:
+        """Surrounding whitespace on the token must be stripped.
+
+        Shell exports and copy-paste commonly introduce trailing newlines
+        that would otherwise corrupt the ``Authorization: Bearer`` header.
+        """
+        creds = Credentials.from_oauth_token(
+            token="  abc123\n", project_id="1", region="us"
+        )
+        assert creds.auth_header() == "Bearer abc123"
+
+    def test_factory_rejects_whitespace_only_token(self) -> None:
+        """A whitespace-only token strips to empty and is rejected."""
+        with pytest.raises(ValueError, match="oauth_access_token"):
+            Credentials.from_oauth_token(
+                token="   ", project_id="1", region="us"
+            )
+
 
 class TestEnvOAuthTokenResolution:
     """Tests for ``_resolve_from_env`` handling of ``MP_OAUTH_TOKEN``."""
@@ -380,7 +398,7 @@ class TestEnvOAuthTokenResolution:
         config_manager: ConfigManager,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When both env triples are set, the service-account triple wins."""
+        """When both env-var sets are complete, the service-account set wins."""
         monkeypatch.setenv("MP_USERNAME", "sa_user")
         monkeypatch.setenv("MP_SECRET", "sa_secret")
         monkeypatch.setenv("MP_PROJECT_ID", "111")
@@ -451,6 +469,25 @@ class TestEnvOAuthTokenResolution:
 
         assert creds.region == expected
         assert creds.auth_method == AuthMethod.oauth
+
+    def test_oauth_token_env_strips_whitespace(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """Whitespace around MP_OAUTH_TOKEN and MP_REGION is stripped."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "  abc123\n")
+        monkeypatch.setenv("MP_PROJECT_ID", "1")
+        monkeypatch.setenv("MP_REGION", " US ")
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+        assert creds.auth_header() == "Bearer abc123"
+        assert creds.region == "us"
 
     def test_oauth_token_env_short_circuits_other_sources(
         self,

--- a/tests/unit/test_config_oauth.py
+++ b/tests/unit/test_config_oauth.py
@@ -281,3 +281,191 @@ class TestCredentialResolutionRegression:
 
         with pytest.raises(ConfigError, match="Invalid MP_REGION"):
             config_manager.resolve_credentials()
+
+
+class TestCredentialsFromOAuthToken:
+    """Tests for the ``Credentials.from_oauth_token`` factory method."""
+
+    def test_factory_constructs_oauth_credentials(self) -> None:
+        """``from_oauth_token`` populates OAuth fields and clears Basic-Auth fields."""
+        creds = Credentials.from_oauth_token(
+            token="my-bearer-token",
+            project_id="12345",
+            region="us",
+        )
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.oauth_access_token is not None
+        assert creds.oauth_access_token.get_secret_value() == "my-bearer-token"
+        assert creds.project_id == "12345"
+        assert creds.region == "us"
+        assert creds.username == ""
+        assert creds.secret.get_secret_value() == ""
+
+    def test_factory_auth_header_is_bearer(self) -> None:
+        """``from_oauth_token`` credentials must produce a Bearer header."""
+        creds = Credentials.from_oauth_token(
+            token="abc123", project_id="1", region="us"
+        )
+        assert creds.auth_header() == "Bearer abc123"
+
+    def test_factory_normalizes_region(self) -> None:
+        """Region should be lowercased like the model validator does."""
+        creds = Credentials.from_oauth_token(
+            token="t",
+            project_id="1",
+            region="EU",  # type: ignore[arg-type]
+        )
+        assert creds.region == "eu"
+
+    def test_factory_rejects_empty_token(self) -> None:
+        """Empty token should be rejected by the model validator."""
+        with pytest.raises(ValueError, match="oauth_access_token"):
+            Credentials.from_oauth_token(token="", project_id="1", region="us")
+
+    def test_factory_rejects_empty_project_id(self) -> None:
+        """Empty project_id should be rejected by the model validator."""
+        with pytest.raises(ValueError, match="project_id"):
+            Credentials.from_oauth_token(token="t", project_id="", region="us")
+
+    def test_factory_rejects_invalid_region(self) -> None:
+        """Invalid region should be rejected by the model validator."""
+        with pytest.raises(ValueError, match="Region must be one of"):
+            Credentials.from_oauth_token(
+                token="t",
+                project_id="1",
+                region="mars",  # type: ignore[arg-type]
+            )
+
+    def test_factory_secret_redacted(self) -> None:
+        """Token must not appear in repr/str output."""
+        creds = Credentials.from_oauth_token(
+            token="super-secret-bearer", project_id="1", region="us"
+        )
+        assert "super-secret-bearer" not in repr(creds)
+        assert "super-secret-bearer" not in str(creds)
+
+
+class TestEnvOAuthTokenResolution:
+    """Tests for ``_resolve_from_env`` handling of ``MP_OAUTH_TOKEN``."""
+
+    def test_resolve_from_oauth_token_env(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """``MP_OAUTH_TOKEN`` + project_id + region produces OAuth credentials."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "env-bearer-token")
+        monkeypatch.setenv("MP_PROJECT_ID", "9999")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.oauth_access_token is not None
+        assert (
+            creds.oauth_access_token.get_secret_value() == "env-bearer-token"
+        )
+        assert creds.project_id == "9999"
+        assert creds.region == "us"
+        assert creds.auth_header() == "Bearer env-bearer-token"
+
+    def test_service_account_env_wins_over_oauth_token_env(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When both env triples are set, the service-account triple wins."""
+        monkeypatch.setenv("MP_USERNAME", "sa_user")
+        monkeypatch.setenv("MP_SECRET", "sa_secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "111")
+        monkeypatch.setenv("MP_REGION", "us")
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "should-be-ignored")
+
+        creds = config_manager.resolve_credentials()
+
+        assert creds.auth_method == AuthMethod.basic
+        assert creds.username == "sa_user"
+        assert creds.secret.get_secret_value() == "sa_secret"
+
+    def test_oauth_token_env_requires_project_id(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """``MP_OAUTH_TOKEN`` alone (no project/region) is ignored."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.delenv("MP_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MP_REGION", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "lonely-token")
+
+        with pytest.raises(ConfigError, match="No credentials configured"):
+            config_manager.resolve_credentials(
+                _oauth_storage_dir=temp_dir / "oauth",
+            )
+
+    def test_oauth_token_env_invalid_region_raises(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invalid ``MP_REGION`` raises even on the OAuth path."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "t")
+        monkeypatch.setenv("MP_PROJECT_ID", "1")
+        monkeypatch.setenv("MP_REGION", "moon")
+
+        with pytest.raises(ConfigError, match="Invalid MP_REGION"):
+            config_manager.resolve_credentials()
+
+    @pytest.mark.parametrize(
+        "region_input,expected",
+        [("US", "us"), ("Eu", "eu"), ("IN", "in")],
+    )
+    def test_oauth_token_env_region_case_insensitive(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+        region_input: str,
+        expected: str,
+    ) -> None:
+        """``MP_REGION`` should be case-insensitive on the OAuth path too."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "t")
+        monkeypatch.setenv("MP_PROJECT_ID", "1")
+        monkeypatch.setenv("MP_REGION", region_input)
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+
+        assert creds.region == expected
+        assert creds.auth_method == AuthMethod.oauth
+
+    def test_oauth_token_env_short_circuits_other_sources(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """OAuth env triple resolves with empty config and missing OAuth storage dir."""
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "t")
+        monkeypatch.setenv("MP_PROJECT_ID", "1")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "does-not-exist",
+        )
+        assert creds.auth_method == AuthMethod.oauth

--- a/tests/unit/test_config_oauth.py
+++ b/tests/unit/test_config_oauth.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 from pydantic import SecretStr, ValidationError
 
+from mixpanel_data._internal.auth_credential import CredentialType
 from mixpanel_data._internal.config import (
     AuthMethod,
     ConfigManager,
@@ -282,6 +283,26 @@ class TestCredentialResolutionRegression:
         with pytest.raises(ConfigError, match="Invalid MP_REGION"):
             config_manager.resolve_credentials()
 
+    def test_sa_env_region_strips_whitespace(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SA-path MP_REGION tolerates surrounding whitespace.
+
+        Symmetric with ``test_oauth_token_env_strips_whitespace`` — both
+        paths route through ``_validate_env_region`` which strips before
+        validating.
+        """
+        monkeypatch.setenv("MP_USERNAME", "user")
+        monkeypatch.setenv("MP_SECRET", "secret")
+        monkeypatch.setenv("MP_PROJECT_ID", "123")
+        monkeypatch.setenv("MP_REGION", " US ")
+
+        creds = config_manager.resolve_credentials()
+        assert creds.region == "us"
+        assert creds.auth_method == AuthMethod.basic
+
 
 class TestCredentialsFromOAuthToken:
     """Tests for the ``Credentials.from_oauth_token`` factory method."""
@@ -359,9 +380,7 @@ class TestCredentialsFromOAuthToken:
     def test_factory_rejects_whitespace_only_token(self) -> None:
         """A whitespace-only token strips to empty and is rejected."""
         with pytest.raises(ValueError, match="oauth_access_token"):
-            Credentials.from_oauth_token(
-                token="   ", project_id="1", region="us"
-            )
+            Credentials.from_oauth_token(token="   ", project_id="1", region="us")
 
 
 class TestEnvOAuthTokenResolution:
@@ -386,9 +405,7 @@ class TestEnvOAuthTokenResolution:
 
         assert creds.auth_method == AuthMethod.oauth
         assert creds.oauth_access_token is not None
-        assert (
-            creds.oauth_access_token.get_secret_value() == "env-bearer-token"
-        )
+        assert creds.oauth_access_token.get_secret_value() == "env-bearer-token"
         assert creds.project_id == "9999"
         assert creds.region == "us"
         assert creds.auth_header() == "Bearer env-bearer-token"
@@ -489,13 +506,19 @@ class TestEnvOAuthTokenResolution:
         assert creds.auth_header() == "Bearer abc123"
         assert creds.region == "us"
 
-    def test_oauth_token_env_short_circuits_other_sources(
+    def test_oauth_token_env_works_with_no_other_sources(
         self,
         config_manager: ConfigManager,
         monkeypatch: pytest.MonkeyPatch,
         temp_dir: Path,
     ) -> None:
-        """OAuth env triple resolves with empty config and missing OAuth storage dir."""
+        """OAuth env triple resolves with empty config and unreadable OAuth storage.
+
+        Pointing ``_oauth_storage_dir`` at a non-existent path proves the
+        env-var path short-circuits before any OAuth storage I/O — if the
+        env path didn't take precedence, this test would either crash on
+        the missing dir or silently miss the env credentials.
+        """
         monkeypatch.delenv("MP_USERNAME", raising=False)
         monkeypatch.delenv("MP_SECRET", raising=False)
         monkeypatch.setenv("MP_OAUTH_TOKEN", "t")
@@ -506,3 +529,109 @@ class TestEnvOAuthTokenResolution:
             _oauth_storage_dir=temp_dir / "does-not-exist",
         )
         assert creds.auth_method == AuthMethod.oauth
+
+    def test_oauth_token_env_wins_over_config_account(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """OAuth env triple takes precedence over a default account in config."""
+        config_manager.add_account(
+            name="default",
+            username="cfg_user",
+            secret="cfg_secret",
+            project_id="cfg_pid",
+            region="us",
+        )
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "env-wins-token")
+        monkeypatch.setenv("MP_PROJECT_ID", "env-pid")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.project_id == "env-pid"
+        assert creds.auth_header() == "Bearer env-wins-token"
+
+    def test_partial_sa_env_falls_through_to_oauth(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """Partial SA env vars do not block the OAuth env path.
+
+        Pins the ``if/if`` (not ``if/elif``) structure in
+        ``_resolve_from_env`` — switching to ``elif`` would change behavior
+        so a partial SA quad would suppress the complete OAuth triple.
+        """
+        monkeypatch.setenv("MP_USERNAME", "partial_user")
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "fallback-bearer")
+        monkeypatch.setenv("MP_PROJECT_ID", "111")
+        monkeypatch.setenv("MP_REGION", "us")
+
+        creds = config_manager.resolve_credentials(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+        assert creds.auth_method == AuthMethod.oauth
+        assert creds.auth_header() == "Bearer fallback-bearer"
+
+    def test_no_credentials_error_mentions_oauth_token_env(
+        self,
+        config_manager: ConfigManager,
+        temp_dir: Path,
+    ) -> None:
+        """The 'no credentials' error must mention MP_OAUTH_TOKEN guidance."""
+        with pytest.raises(ConfigError, match="MP_OAUTH_TOKEN"):
+            config_manager.resolve_credentials(
+                _oauth_storage_dir=temp_dir / "oauth",
+            )
+
+    def test_v2_no_credentials_error_mentions_oauth_token_env(
+        self,
+        config_path: Path,
+        temp_dir: Path,
+    ) -> None:
+        """The v2 'no credentials' error must mention MP_OAUTH_TOKEN guidance."""
+        import tomli_w
+
+        with config_path.open("wb") as f:
+            tomli_w.dump({"config_version": 2}, f)
+
+        cm = ConfigManager(config_path=config_path)
+        with pytest.raises(ConfigError, match="MP_OAUTH_TOKEN"):
+            cm.resolve_session(_oauth_storage_dir=temp_dir / "oauth")
+
+    def test_resolve_session_with_oauth_token_env(
+        self,
+        config_manager: ConfigManager,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_dir: Path,
+    ) -> None:
+        """``resolve_session()`` honors MP_OAUTH_TOKEN and returns OAuth-typed session.
+
+        Pins both the ``_resolve_from_env`` short-circuit in
+        ``resolve_session`` and the OAuth branch in
+        ``Credentials.to_resolved_session`` — including the literal
+        ``name="oauth"`` fallback when ``username`` is empty.
+        """
+        monkeypatch.delenv("MP_USERNAME", raising=False)
+        monkeypatch.delenv("MP_SECRET", raising=False)
+        monkeypatch.setenv("MP_OAUTH_TOKEN", "session-bearer-token")
+        monkeypatch.setenv("MP_PROJECT_ID", "9999")
+        monkeypatch.setenv("MP_REGION", "eu")
+
+        session = config_manager.resolve_session(
+            _oauth_storage_dir=temp_dir / "oauth",
+        )
+        assert session.auth.type == CredentialType.oauth
+        assert session.auth.region == "eu"
+        assert session.project_id == "9999"
+        assert session.auth_header() == "Bearer session-bearer-token"
+        # Pin the literal — catches refactors that drop the `or "oauth"` fallback
+        assert session.auth.name == "oauth"


### PR DESCRIPTION
## Summary

Adds a new env-var auth path so callers can authenticate with a pre-obtained OAuth 2.0 access token without going through the PKCE browser flow. Primary use case: agents and CI environments that hold a token from a managed OAuth client.

```bash
export MP_OAUTH_TOKEN=<bearer-token>
export MP_PROJECT_ID=<project-id>
export MP_REGION=<us|eu|in>
```

The library sends `Authorization: Bearer <token>` on every endpoint (Query API and App API). All the OAuth plumbing already existed — `Credentials` already carried `auth_method` + `oauth_access_token`, `auth_header()` already built the Bearer header, and `CredentialType.oauth` already existed in v2. The only gap was a way to inject a token without the PKCE browser flow. This PR closes that gap.

### Changes

- **`Credentials.from_oauth_token(token, project_id, region)`** factory for SDK callers (`Workspace(credentials=Credentials.from_oauth_token(...))`).
- **`_resolve_from_env`** extended to recognize the `MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION` triple. Service-account env vars (`MP_USERNAME`/`MP_SECRET`) take precedence when both triples are set, preserving backward compatibility for users who add `MP_OAUTH_TOKEN` to a shell that already exports the service-account vars.
- **Plugin `auth_manager.py`** reports the new source as `active_method=oauth_token_env` and surfaces partial config for both triples.
- **Plugin docs** (`/mixpanel-data:auth` command + setup skill) document the new path.

### What this is NOT

- Not a new CLI command — `mp auth set-oauth-token` was scoped out (env-var injection covers the agent/CI use case).
- Not stored in `OAuthStorage` — externally-provided tokens have no refresh capability, so they live as env vars only.
- Not a breaking change — existing service-account and PKCE flows are untouched.

## Test plan

- [x] 15 new unit tests in `tests/unit/test_config_oauth.py` (factory + env-var resolution + precedence + region validation + redaction)
- [x] 1 new property-based test in `tests/pbt/test_config_pbt.py` (`auth_header() == f"Bearer {token}"` for any non-empty token)
- [x] Full suite: 6064 passed, 0 failed
- [x] `just lint` clean
- [x] `just typecheck` clean (`mypy --strict`)
- [ ] End-to-end smoke test against a real Mixpanel project with a real OAuth bearer token