### PR TITLE
docs: sync user-facing docs with 0.4.0 auth architecture redesign

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,7 +9,7 @@ The devcontainer uses Docker volumes for configuration directories to ensure it 
 ### Automatic Credential Syncing
 - **GitHub CLI config** (`~/.config/gh`): Automatically synced from host if it exists
 - **GCloud credentials** (`~/.config/gcloud`): Automatically synced from host if it exists
-- **Mixpanel config** (`~/.mp`): Stored in volume (create with `mp auth add` if needed)
+- **Mixpanel config** (`~/.mp`): Stored in volume (create with `mp account add` if needed)
 
 When you start or rebuild the container, your existing GitHub and GCloud authentication from the host will be automatically available inside the container. No manual steps required!
 
@@ -20,8 +20,9 @@ If credentials aren't found on your host, you can authenticate inside the contai
 # GitHub CLI
 gh auth login
 
-# Mixpanel
-mp auth add
+# Mixpanel — pick one of:
+mp account add personal --type oauth_browser --region us && mp account login personal
+mp account add team --type service_account --username sa_xxx --project 12345 --region us
 ```
 
 Note: GCloud is not installed in the devcontainer. If you need gcloud credentials for Vertex AI, authenticate on your host machine first and the credentials will be synced automatically.

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Key design features:
 
 ## Claude Code Plugin
 
-This project includes a Claude Code plugin (v4.1) that turns Claude into a senior data analyst. The plugin is **CodeMode-first**: Claude writes Python code using `mixpanel_data` + `pandas` rather than calling CLI commands or MCP tools.
+This project includes a Claude Code plugin (v5.0) that turns Claude into a senior data analyst. The plugin is **CodeMode-first**: Claude writes Python code using `mixpanel_data` + `pandas` rather than calling CLI commands or MCP tools.
 
 The plugin is built around the 5-engine query taxonomy — `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and `query_user()` — with full cohort-scoped query support. Claude translates natural language analytics questions into typed query calls with filters, breakdowns, formulas, cohort definitions, and aggregations, then interprets results as DataFrames.
 

--- a/README.md
+++ b/README.md
@@ -29,33 +29,34 @@ mp --version
 
 ## Quick Start
 
+> **What's new in 0.4.0:** Three first-class account types (`service_account` / `oauth_browser` / `oauth_token`), single resolver (`env > param > target > bridge > [active]`), fluent in-session switching via `Workspace.use(...)`, new CLI groups (`mp account` / `mp project` / `mp workspace` / `mp target` / `mp session`). **Hard break from 0.3.x** — see [Migration → 0.3.x to 0.4.0](docs/migration/0.4.0.md) for the upgrade walkthrough.
+
 ### 1. Authenticate
 
 **Option A: OAuth Login (interactive, recommended)**
 
 ```bash
-mp auth login --region us --project-id 12345  # Opens browser
-mp auth status  # Verify connection
+mp account add personal --type oauth_browser --region us
+mp account login personal     # Opens browser for PKCE flow
+mp session                    # Verify resolved state
 ```
 
 **Option B: Service Account (scripts, CI/CD)**
 
 ```bash
-# Interactive prompt (secure)
-mp auth add production --username sa_xxx --project 12345 --region us
-# You'll be prompted for the service account secret with hidden input
+# Set the secret via env var (preferred)
+export MP_SECRET="your-secret-here"
+mp account add team --type service_account --username sa_xxx --region us
+# Added account 'team' (service_account, us). Set as active.
 
-mp auth test  # Verify connection
+mp account test team          # Verify connection
 ```
 
-Alternative methods for CI/CD:
+For CI/CD environments where the secret lives in a shell variable, pipe it via stdin:
 
 ```bash
-# Via inline environment variable (secret is only exposed to this command)
-MP_SECRET=xxx mp auth add production --username sa_xxx --project 12345
-
-# Via stdin (useful when secret is already in a variable)
-echo "$SECRET" | mp auth add production --username sa_xxx --project 12345 --secret-stdin
+echo "$SECRET" | mp account add team --type service_account \
+    --username sa_xxx --region us --secret-stdin
 ```
 
 Or set all credentials as environment variables: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
@@ -256,7 +257,15 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 ## CLI Reference
 
-**`mp auth`** — Authentication: `login`, `logout`, `status`, `token` (OAuth); `list`, `add`, `remove`, `switch`, `show`, `test` (service accounts)
+**`mp account`** — Manage accounts: `list`, `add`, `update`, `remove`, `use`, `show`, `test`, `login`, `logout`, `token`, `export-bridge`, `remove-bridge`
+
+**`mp project`** — Switch the active project: `list`, `use`, `show`
+
+**`mp workspace`** — Switch the active workspace: `list`, `use`, `show`
+
+**`mp target`** — Saved (account, project, workspace?) cursors: `list`, `add`, `use`, `show`, `remove`
+
+**`mp session`** — Show resolved auth state (`mp session [--bridge]`)
 
 **`mp query`** — Run analytics: `segmentation`, `funnel`, `retention`, `jql`, `saved-report`, `flows`, `event-counts`, `property-counts`, `activity-feed`, `frequency`, `segmentation-numeric`, `segmentation-sum`, `segmentation-average`
 
@@ -338,7 +347,7 @@ Key design features:
 - **Consistent interfaces**: Same operations available as Python methods and CLI commands
 - **Structured output**: All CLI commands support `--format json` for machine-readable responses, plus `--jq` for inline filtering
 - **Streaming data extraction**: Memory-efficient iterators for events and profiles
-- **Dual authentication**: Service accounts (Basic Auth) for automation, OAuth 2.0 PKCE for interactive use
+- **Three first-class account types**: `service_account` (Basic Auth) for unattended automation, `oauth_browser` (PKCE flow with auto-refreshed tokens) for interactive use, `oauth_token` (static bearer) for CI / agents
 - **Typed exceptions**: Error codes and context for programmatic handling
 
 ## Claude Code Plugin

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ mp session                    # Verify resolved state
 ```bash
 # Set the secret via env var (preferred)
 export MP_SECRET="your-secret-here"
-mp account add team --type service_account --username sa_xxx --region us
+mp account add team --type service_account --username sa_xxx --project 12345 --region us
 # Added account 'team' (service_account, us). Set as active.
 
 mp account test team          # Verify connection
@@ -56,7 +56,7 @@ For CI/CD environments where the secret lives in a shell variable, pipe it via s
 
 ```bash
 echo "$SECRET" | mp account add team --type service_account \
-    --username sa_xxx --region us --secret-stdin
+    --username sa_xxx --project 12345 --region us --secret-stdin
 ```
 
 Or set all credentials as environment variables: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
@@ -263,7 +263,7 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 **`mp workspace`** — Switch the active workspace: `list`, `use`, `show`
 
-**`mp target`** — Saved (account, project, workspace?) cursors: `list`, `add`, `use`, `show`, `remove`
+**`mp target`** — Saved (account, project, optional workspace) cursors: `list`, `add`, `use`, `show`, `remove`
 
 **`mp session`** — Show resolved auth state (`mp session [--bridge]`)
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -253,7 +253,7 @@ Read-only structured results returned from the namespaces above.
 
 When constructing a `Workspace`, each axis is resolved independently in this priority order:
 
-1. **Environment variables** — `MP_ACCOUNT`, `MP_PROJECT_ID`, `MP_WORKSPACE_ID`, `MP_OAUTH_TOKEN`, etc.
+1. **Environment variables** — the resolver reads `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` (service-account quad), `MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION` (OAuth-token triple), `MP_PROJECT_ID` (project axis), and `MP_WORKSPACE_ID` (workspace axis). `MP_ACCOUNT` is **not** consumed by the Python resolver — it only feeds the CLI's `--account` / `-a` flag via Typer's `envvar=` default.
 2. **Constructor / CLI param** — `Workspace(account="...")`, `mp -a NAME ...`.
 3. **Saved target** — `Workspace(target="ecom")`, `mp -t ecom ...`.
 4. **Bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json`.

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,178 +1,327 @@
-# Auth Module
+# Auth
 
-The auth module provides credential management, configuration, and OAuth 2.0 authentication.
+The auth surface in `mixpanel_data` 0.4.0 is organized around three independent axes — Account, Project, Workspace — with three first-class account types, a single resolver, fluent in-session switching via `Workspace.use()`, and a Cowork bridge for remote authentication.
 
 !!! tip "Explore on DeepWiki"
-    🤖 **[Configuration Reference →](https://deepwiki.com/jaredmcfarland/mixpanel_data/7.3-configuration-reference)**
+    🤖 **[Configuration Reference →](https://deepwiki.com/jaredmcfarland/mixpanel_data/7.3-configuration-reference)** (updated for 0.4.0)
 
-    Ask questions about credential management, ConfigManager, OAuth, or account configuration.
+    Ask questions about account types, session axes, OAuth, the Cowork bridge, or in-session switching.
 
 ## Overview
 
 ```python
-from mixpanel_data._internal.config import ConfigManager
-from mixpanel_data.auth_types import Account, ServiceAccount
+import mixpanel_data as mp
 
-# Manage service accounts
-config = ConfigManager()
-config.add_account(
-    "production",
-    type="service_account",
+# Construct a Workspace from active config
+ws = mp.Workspace()
+
+# Override per Workspace (env > param > target > bridge > [active] > default_project)
+ws = mp.Workspace(account="team", project="3713224")
+ws = mp.Workspace(target="ecom")
+ws = mp.Workspace(session=mp.Session(account=..., project=..., workspace=...))
+
+# In-session switching — fluent, O(1), no re-auth on project swap
+ws.use(project="3018488").events()
+ws.use(account="personal").events()    # rebuilds auth header; preserves _http
+ws.use(target="ecom").events()         # applies all three axes atomically
+ws.use(workspace=3448414).events()
+
+# Functional namespaces (also re-exported as mp.accounts / mp.session / mp.targets)
+summaries = mp.accounts.list()
+mp.accounts.use("team")
+active = mp.session.show()             # ActiveSession
+mp.targets.add("ecom", account="team", project="3018488", workspace=3448414)
+```
+
+See [Configuration](../getting-started/configuration.md) for the full setup walkthrough.
+
+## Account Types
+
+`Account` is a Pydantic discriminated union over three first-class variants. The `type` field selects the variant; each variant carries the credentials it needs.
+
+```python
+from mixpanel_data import (
+    Account,                      # discriminated union type
+    ServiceAccount,               # type == "service_account"
+    OAuthBrowserAccount,          # type == "oauth_browser"
+    OAuthTokenAccount,            # type == "oauth_token"
+    AccountType,                  # Literal["service_account" | "oauth_browser" | "oauth_token"]
+    Region,                       # Literal["us" | "eu" | "in"]
+)
+
+account: Account = ServiceAccount(
+    name="team",
     region="us",
-    default_project="12345",
-    username="...",
+    default_project="3018488",
+    username="team-mp...",
     secret="...",
 )
-accounts = config.list_accounts()  # list[AccountSummary]
 
-# Inspect a single account (returns the canonical ``Account`` discriminated union)
-account: Account = config.get_account("production")
 if isinstance(account, ServiceAccount):
     print(f"SA {account.name} → project {account.default_project}")
 ```
 
-## ConfigManager
-
-Manages the single-schema TOML config file (`~/.mp/config.toml`) — accounts, targets, and the `[active]` session axes. Higher-level workflows (`mp account add`, `mp account use`, `mp login`) live in `mixpanel_data.accounts` and `mixpanel_data.session`.
-
-::: mixpanel_data._internal.config.ConfigManager
-    options:
-      show_root_heading: true
-      show_root_toc_entry: true
-      members:
-        - __init__
-        - config_path
-        - list_accounts
-        - get_account
-        - add_account
-        - update_account
-        - remove_account
-        - get_active
-        - set_active
-        - clear_active
-        - apply_target
-
-## Authentication
-
-Authentication is dispatched on the account variant — see the [Account discriminated union](#account-discriminated-union) below. To drive a `Workspace` with a raw OAuth bearer token, set `MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION` env vars and let `Workspace()` resolve them — see [Configuration → Raw OAuth Bearer Token](../getting-started/configuration.md#raw-oauth-bearer-token).
-
-## Account (discriminated union)
-
-`Account` is the canonical persisted representation of a configured Mixpanel account. It is a Pydantic discriminated union dispatched on the `type` field — the runtime types are the three concrete variant classes below. Use `mixpanel_data.auth_types.Account` as the type hint and `pydantic.TypeAdapter(Account)` to construct from a raw dict.
-
-```python
-from mixpanel_data.auth_types import (
-    Account,
-    ServiceAccount,
-    OAuthBrowserAccount,
-    OAuthTokenAccount,
-)
-
-account: Account = ServiceAccount(
-    name="prod",
-    region="us",
-    default_project="12345",
-    username="...",
-    secret="...",
-)
-```
-
 ### ServiceAccount
 
-Long-lived HTTP Basic Auth credentials.
+Long-lived HTTP Basic Auth credentials. Best for CI / scripts / unattended automation.
 
-::: mixpanel_data.auth_types.ServiceAccount
+::: mixpanel_data.ServiceAccount
     options:
       show_root_heading: true
       show_root_toc_entry: true
 
 ### OAuthBrowserAccount
 
-PKCE browser flow; access/refresh tokens persisted on disk under `~/.mp/oauth/`.
+PKCE browser flow; access/refresh tokens persisted at `~/.mp/accounts/{name}/tokens.json` and auto-refreshed on expiry.
 
-::: mixpanel_data.auth_types.OAuthBrowserAccount
+::: mixpanel_data.OAuthBrowserAccount
     options:
       show_root_heading: true
       show_root_toc_entry: true
 
 ### OAuthTokenAccount
 
-Static bearer token (CI / agents) — supplied inline or via an env var.
+Static bearer token (CI / agents) — supplied inline or via an env var (`token_env`).
 
-::: mixpanel_data.auth_types.OAuthTokenAccount
+::: mixpanel_data.OAuthTokenAccount
     options:
       show_root_heading: true
       show_root_toc_entry: true
 
-## AccountSummary
+## Session Axes
 
-Read-only account metadata (no secrets) returned by `ConfigManager.list_accounts()` and `mp account list`.
+A `Session` is the immutable resolved state for a single Workspace at construction time — account, project, optional workspace, and the auth headers they generate.
 
-::: mixpanel_data.types.AccountSummary
+::: mixpanel_data.Session
     options:
       show_root_heading: true
       show_root_toc_entry: true
 
-## OAuth 2.0 Module
+::: mixpanel_data.Project
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
-The OAuth module (`mixpanel_data._internal.auth`) implements the OAuth 2.0 PKCE flow for interactive authentication.
+::: mixpanel_data.WorkspaceRef
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
-### OAuthFlow
+::: mixpanel_data.auth_types.ActiveSession
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
-Orchestrates the complete OAuth 2.0 PKCE login flow: dynamic client registration, browser-based authorization, token exchange, and token refresh.
+## Workspace.use() — In-Session Switching
+
+`Workspace.use()` is the only in-session switching method. It returns `self` for fluent chaining and preserves the underlying `httpx.Client` and per-account `/me` cache across switches, so cross-project / cross-account iteration is O(1) per turn.
 
 ```python
-from mixpanel_data._internal.auth.flow import OAuthFlow
-from mixpanel_data._internal.auth.storage import OAuthStorage
+import mixpanel_data as mp
 
-storage = OAuthStorage()
-flow = OAuthFlow(region="us", storage=storage)
+ws = mp.Workspace()                                # active session
 
-# Interactive login (opens browser)
-tokens = flow.login(project_id="12345")
+# In-session switching (returns self for chaining)
+ws.use(account="team")                              # implicitly clears workspace
+ws.use(project="3018488")
+ws.use(workspace=3448414)
+ws.use(target="ecom")                               # apply all three at once
 
-# Get valid token (auto-refreshes if expired)
-tokens = flow.get_valid_token(region="us")
+# Persist the new state
+ws.use(project="3018488", persist=True)             # writes [active].project
+
+# Fluent chain
+result = ws.use(project="3018488").segmentation(
+    "Login", from_date="2026-04-01", to_date="2026-04-21"
+)
 ```
+
+Switching the active account clears the workspace (workspaces are project-scoped). The project re-resolves on account swap via `env > explicit > new account's default_project`. There is **no silent cross-axis fallback**: if an axis can't be resolved on the new account, `use()` raises `ConfigError`.
+
+::: mixpanel_data.Workspace.use
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+
+### Snapshot mode (parallel iteration)
+
+For parallel cross-project iteration, snapshot the resolved `Session` and construct a fresh `Workspace` per task:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+sessions = [
+    ws.session.replace(project=mp.Project(id=p.id))
+    for p in ws.projects()
+]
+
+def event_count(s: mp.Session) -> int:
+    return len(mp.Workspace(session=s).events())
+
+with ThreadPoolExecutor(max_workers=4) as pool:
+    counts = list(pool.map(event_count, sessions))
+```
+
+## Functional Namespaces
+
+The auth surface exposes three module-level namespaces re-exported from `mixpanel_data`. These are the canonical Python API for managing accounts, the active session, and saved targets.
+
+### `mp.accounts`
+
+Account lifecycle: register, switch, probe, OAuth flows, bridge export.
+
+::: mixpanel_data.accounts
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+      members:
+        - list
+        - add
+        - update
+        - remove
+        - use
+        - show
+        - test
+        - login
+        - logout
+        - token
+        - export_bridge
+        - remove_bridge
+
+### `mp.session`
+
+Read and write the persisted `[active]` block.
+
+::: mixpanel_data.session
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+      members:
+        - show
+        - use
+
+### `mp.targets`
+
+Manage saved (account, project, workspace?) cursor positions.
+
+::: mixpanel_data.targets
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+      members:
+        - list
+        - add
+        - remove
+        - use
+        - show
+
+## Result Types
+
+Read-only structured results returned from the namespaces above.
+
+### AccountSummary
+
+::: mixpanel_data.AccountSummary
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+### AccountTestResult
+
+::: mixpanel_data.AccountTestResult
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+### OAuthLoginResult
+
+::: mixpanel_data.OAuthLoginResult
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+### Target
+
+::: mixpanel_data.Target
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+## Credential Resolution Chain
+
+When constructing a `Workspace`, each axis is resolved independently in this priority order:
+
+1. **Environment variables** — `MP_ACCOUNT`, `MP_PROJECT_ID`, `MP_WORKSPACE_ID`, `MP_OAUTH_TOKEN`, etc.
+2. **Constructor / CLI param** — `Workspace(account="...")`, `mp -a NAME ...`.
+3. **Saved target** — `Workspace(target="ecom")`, `mp -t ecom ...`.
+4. **Bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json`.
+5. **Persisted active session** — the `[active]` block in `~/.mp/config.toml`.
+6. **Account default** — `account.default_project` for the project axis.
+
+See [Configuration → Credential Resolution Chain](../getting-started/configuration.md#credential-resolution-chain) for examples.
+
+## Cowork Bridge (v2)
+
+The Cowork bridge is a v2 JSON file that lets a remote VM authenticate against Mixpanel using your host machine's account and tokens. It embeds the full `Account`, optional OAuth tokens, and optional pinned project/workspace/headers.
+
+```python
+from pathlib import Path
+import mixpanel_data as mp
+
+# On the host
+mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json"))
+mp.accounts.remove_bridge()
+```
+
+```bash
+# CLI equivalents
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
+mp account remove-bridge
+mp session --bridge          # show bridge-resolved state
+```
+
+Default search order: `MP_AUTH_FILE` → `~/.claude/mixpanel/auth.json` → `./mixpanel_auth.json`.
+
+::: mixpanel_data.auth_types.BridgeFile
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.auth_types.load_bridge
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+## OAuth Token Plumbing
+
+Low-level types for OAuth token handling. Most users never touch these directly — `mp.accounts.login(name)` drives the full flow and `OnDiskTokenResolver` materializes refreshed tokens automatically.
 
 ### OAuthTokens
 
-Immutable model for OAuth access and refresh tokens.
-
-**Key fields:** `access_token`, `refresh_token`, `expires_at`, `scope`, `token_type`, `project_id`
-
-**Key methods:** `is_expired()` (includes 30-second safety buffer), `from_token_response(data, project_id)`
+::: mixpanel_data.auth_types.OAuthTokens
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
 ### OAuthClientInfo
 
-Dynamic Client Registration metadata.
+::: mixpanel_data.auth_types.OAuthClientInfo
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
-**Key fields:** `client_id`, `region`, `redirect_uri`, `scope`, `created_at`
+### TokenResolver Protocol
 
-### OAuthStorage
+::: mixpanel_data.auth_types.TokenResolver
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
 
-Manages JSON persistence of tokens and client info at `~/.mp/oauth/`.
+### OnDiskTokenResolver
 
-```python
-from mixpanel_data._internal.auth.storage import OAuthStorage
-
-storage = OAuthStorage()
-tokens = storage.load_tokens(region="us")
-storage.delete_tokens(region="us")
-storage.delete_all()  # Clear all regions
-```
-
-**Key methods:** `load_tokens(region)`, `save_tokens(tokens, region)`, `delete_tokens(region)`, `load_client_info(region)`, `save_client_info(info)`, `delete_all()`
-
-### PkceChallenge
-
-PKCE challenge generation (RFC 7636).
-
-```python
-from mixpanel_data._internal.auth.pkce import PkceChallenge
-
-challenge = PkceChallenge.generate()
-# challenge.verifier — URL-safe random string (43-128 chars)
-# challenge.challenge — SHA256 hash, Base64URL encoded
-# challenge.challenge_method — Always "S256"
-```
+::: mixpanel_data.auth_types.OnDiskTokenResolver
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -22,7 +22,7 @@ ws = mp.Workspace(session=mp.Session(account=..., project=..., workspace=...))
 
 # In-session switching — fluent, O(1), no re-auth on project swap
 ws.use(project="3018488").events()
-ws.use(account="personal").events()    # rebuilds auth header; preserves _http
+ws.use(account="personal").events()    # rebuilds auth header; preserves underlying HTTP client
 ws.use(target="ecom").events()         # applies all three axes atomically
 ws.use(workspace=3448414).events()
 
@@ -128,7 +128,7 @@ ws.use(workspace=3448414)
 ws.use(target="ecom")                               # apply all three at once
 
 # Persist the new state
-ws.use(project="3018488", persist=True)             # writes [active].project
+ws.use(project="3018488", persist=True)             # writes account.default_project; [active] only stores account + workspace
 
 # Fluent chain
 result = ws.use(project="3018488").segmentation(
@@ -204,7 +204,7 @@ Read and write the persisted `[active]` block.
 
 ### `mp.targets`
 
-Manage saved (account, project, workspace?) cursor positions.
+Manage saved (account, project, optional workspace) cursor positions.
 
 ::: mixpanel_data.targets
     options:
@@ -271,7 +271,7 @@ from pathlib import Path
 import mixpanel_data as mp
 
 # On the host
-mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json"))
+mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json").expanduser())
 mp.accounts.remove_bridge()
 ```
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -13,7 +13,9 @@ All library exceptions inherit from `MixpanelDataError`, enabling callers to cat
 MixpanelDataError
 ├── ConfigError
 │   ├── AccountNotFoundError
-│   └── AccountExistsError
+│   ├── AccountExistsError
+│   ├── AccountInUseError
+│   └── ProjectNotFoundError
 ├── APIError
 │   ├── AuthenticationError
 │   ├── RateLimitError
@@ -40,6 +42,8 @@ except mp.OAuthError as e:
     print(f"OAuth error [{e.code}]: {e.message}")
 except mp.WorkspaceScopeError as e:
     print(f"Workspace error [{e.code}]: {e.message}")
+except mp.AccountInUseError as e:
+    print(f"Account '{e.account_name}' referenced by targets: {e.referenced_by}")
 except mp.MixpanelDataError as e:
     print(f"Error [{e.code}]: {e.message}")
 ```
@@ -100,6 +104,16 @@ except mp.MixpanelDataError as e:
       show_root_heading: true
       show_root_toc_entry: true
 
+::: mixpanel_data.AccountInUseError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.ProjectNotFoundError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## OAuth Exceptions
 
 Raised during OAuth 2.0 PKCE authentication flows.
@@ -107,7 +121,8 @@ Raised during OAuth 2.0 PKCE authentication flows.
 | Error Code | Raised When |
 |------------|-------------|
 | `OAUTH_TOKEN_ERROR` | Token exchange fails |
-| `OAUTH_REFRESH_ERROR` | Token refresh fails |
+| `OAUTH_REFRESH_ERROR` | Token refresh fails (transient) |
+| `OAUTH_REFRESH_REVOKED` | Refresh token rejected by IdP as `invalid_grant` (re-run `mp account login NAME`) |
 | `OAUTH_REGISTRATION_ERROR` | Dynamic client registration fails |
 | `OAUTH_TIMEOUT` | Callback server times out waiting for authorization |
 | `OAUTH_PORT_ERROR` | Cannot bind to a local port for the callback server |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -43,11 +43,17 @@ from mixpanel_data import FlowStep, FlowTreeNode, FlowQueryResult
 # User Profile Query types
 from mixpanel_data import UserQueryResult
 
-# Auth utilities
-from mixpanel_data.auth_types import (
+# Auth surface — recommended top-level imports
+from mixpanel_data import (
     Account, ServiceAccount, OAuthBrowserAccount, OAuthTokenAccount,
     Session, Project, WorkspaceRef, OAuthTokens, Region,
+    AccountSummary, AccountTestResult, OAuthLoginResult, Target,
 )
+# These are also available from mixpanel_data.auth_types (single source of truth);
+# the top-level form is canonical throughout the docs.
+
+# Functional namespaces
+from mixpanel_data import accounts, session, targets
 
 # OAuth and workspace exceptions
 from mixpanel_data import OAuthError, WorkspaceScopeError
@@ -96,17 +102,18 @@ The main entry point for all operations:
 
 [View Workspace API](workspace.md)
 
-### Auth Module
+### Auth Surface
 
-Credential and account management:
+Three first-class account types and three functional namespaces, all re-exported from `mixpanel_data`:
 
-- **ConfigManager** — Manage accounts and the active session in `~/.mp/config.toml`
-- **Credentials** — Credential container with secrets (Basic Auth and OAuth)
-- **AuthMethod** — Authentication method enum (`basic`, `oauth`)
-- **Account** — v3 discriminated union over `ServiceAccount` / `OAuthBrowserAccount` / `OAuthTokenAccount` (from `mixpanel_data.auth_types`)
-- **AccountSummary** — Read-only account metadata (no secrets)
-- **OAuthFlow** — OAuth 2.0 PKCE login flow orchestration
-- **OAuthStorage** — Local token and client info persistence
+- **`Account`** — Discriminated union over `ServiceAccount` (Basic Auth), `OAuthBrowserAccount` (PKCE flow, auto-refreshed), `OAuthTokenAccount` (static bearer for CI/agents)
+- **`Session` / `Project` / `WorkspaceRef` / `ActiveSession`** — Immutable resolved-state types
+- **`mp.accounts`** — Account lifecycle: `add`, `list`, `use`, `show`, `test`, `login`, `logout`, `token`, `export_bridge`, `remove_bridge`, `update`, `remove`
+- **`mp.session`** — Read/write the persisted `[active]` block: `show`, `use`
+- **`mp.targets`** — Saved (account, project, workspace?) cursor positions: `list`, `add`, `use`, `show`, `remove`
+- **`AccountSummary` / `AccountTestResult` / `OAuthLoginResult` / `Target`** — Result types
+- **`OAuthTokens`** — Low-level token type (most users never touch this)
+- **`BridgeFile` / `load_bridge`** — Cowork bridge v2 integration
 
 [View Auth API](auth.md)
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -104,16 +104,17 @@ The main entry point for all operations:
 
 ### Auth Surface
 
-Three first-class account types and three functional namespaces, all re-exported from `mixpanel_data`:
+Three first-class account types and three functional namespaces. Most are re-exported from `mixpanel_data`; a few low-level types live under `mixpanel_data.auth_types`:
 
 - **`Account`** — Discriminated union over `ServiceAccount` (Basic Auth), `OAuthBrowserAccount` (PKCE flow, auto-refreshed), `OAuthTokenAccount` (static bearer for CI/agents)
-- **`Session` / `Project` / `WorkspaceRef` / `ActiveSession`** — Immutable resolved-state types
+- **`Session` / `Project` / `WorkspaceRef`** — Immutable resolved-state types (top-level)
+- **`ActiveSession`** — Persisted `[active]`-block snapshot (only from `mixpanel_data.auth_types`)
 - **`mp.accounts`** — Account lifecycle: `add`, `list`, `use`, `show`, `test`, `login`, `logout`, `token`, `export_bridge`, `remove_bridge`, `update`, `remove`
 - **`mp.session`** — Read/write the persisted `[active]` block: `show`, `use`
-- **`mp.targets`** — Saved (account, project, workspace?) cursor positions: `list`, `add`, `use`, `show`, `remove`
+- **`mp.targets`** — Saved (account, project, optional workspace) cursor positions: `list`, `add`, `use`, `show`, `remove`
 - **`AccountSummary` / `AccountTestResult` / `OAuthLoginResult` / `Target`** — Result types
-- **`OAuthTokens`** — Low-level token type (most users never touch this)
-- **`BridgeFile` / `load_bridge`** — Cowork bridge v2 integration
+- **`OAuthTokens`** — Low-level token type, available from `mixpanel_data.auth_types`
+- **`BridgeFile` / `load_bridge`** — Cowork bridge v2 integration, available from `mixpanel_data.auth_types`
 
 [View Auth API](auth.md)
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -46,11 +46,18 @@ from mixpanel_data import UserQueryResult
 # Auth surface — recommended top-level imports
 from mixpanel_data import (
     Account, ServiceAccount, OAuthBrowserAccount, OAuthTokenAccount,
-    Session, Project, WorkspaceRef, OAuthTokens, Region,
+    Session, Project, WorkspaceRef, Region,
     AccountSummary, AccountTestResult, OAuthLoginResult, Target,
 )
-# These are also available from mixpanel_data.auth_types (single source of truth);
+# Account/Session/WorkspaceRef/account variants are also available from
+# mixpanel_data.auth_types (single source of truth for the auth subsystem);
 # the top-level form is canonical throughout the docs.
+
+# Low-level types live only under mixpanel_data.auth_types
+from mixpanel_data.auth_types import (
+    OAuthTokens, OAuthClientInfo, TokenResolver, OnDiskTokenResolver,
+    BridgeFile, load_bridge, ActiveSession,
+)
 
 # Functional namespaces
 from mixpanel_data import accounts, session, targets

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -116,6 +116,9 @@ events = ws.list_custom_events()
 
 See the [Data Governance guide](../guide/data-governance.md) for complete coverage.
 
+!!! note "`workspaces()` vs `list_workspaces()`"
+    Both methods are exposed. `workspaces()` (recommended) returns `list[WorkspaceRef]` from the cached `/me` response — fast, typed, and consistent with `events()` / `properties()` / `funnels()` / `cohorts()`. `list_workspaces()` is a lower-level escape hatch that calls `GET /api/app/projects/{pid}/workspaces/public` directly and returns `list[PublicWorkspace]`.
+
 ## In-Session Switching
 
 `Workspace.use()` swaps the active account, project, workspace, or target without rebuilding the underlying `httpx.Client` or per-account `/me` cache. It returns `self` for fluent chaining, so cross-project iteration is O(1) per swap.

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -49,7 +49,7 @@ cohort = ws.create_cohort(mp.CreateCohortParams(name="Power Users"))
 ws.update_cohort(cohort.id, mp.UpdateCohortParams(name="Super Users"))
 ```
 
-Dashboard, report, and cohort operations require a workspace ID, set via `MP_WORKSPACE_ID` environment variable, `--workspace-id` CLI flag, or `ws.set_workspace_id()`.
+Dashboard, report, and cohort operations require a workspace ID, set via `MP_WORKSPACE_ID` environment variable, `--workspace` / `-w` CLI flag, `Workspace(workspace=N)`, or `ws.use(workspace=N)`. List available workspaces with `mp workspace list` or `ws.workspaces()`.
 
 ### Feature Flags & Experiments
 
@@ -116,6 +116,29 @@ events = ws.list_custom_events()
 
 See the [Data Governance guide](../guide/data-governance.md) for complete coverage.
 
+## In-Session Switching
+
+`Workspace.use()` swaps the active account, project, workspace, or target without rebuilding the underlying `httpx.Client` or per-account `/me` cache. It returns `self` for fluent chaining, so cross-project iteration is O(1) per swap.
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+ws.use(account="team")                              # implicitly clears workspace
+ws.use(project="3018488")
+ws.use(workspace=3448414)
+ws.use(target="ecom")                               # apply all three at once
+
+# Persist the new state
+ws.use(project="3018488", persist=True)             # writes [active]
+
+# Read the resolved state
+print(ws.account.name, ws.project.id, ws.workspace.id if ws.workspace else None)
+print(ws.session)                                   # full Session snapshot
+```
+
+See [Auth → Workspace.use()](auth.md#workspaceuse-in-session-switching) for the resolution semantics and parallel-snapshot patterns.
+
 ## Class Reference
 
 ::: mixpanel_data.Workspace
@@ -125,9 +148,14 @@ See the [Data Governance guide](../guide/data-governance.md) for complete covera
       members:
         - __init__
         - close
-        - test_credentials
-        - workspace_id
-        - set_workspace_id
+        - account
+        - project
+        - workspace
+        - session
+        - use
+        - me
+        - projects
+        - workspaces
         - list_workspaces
         - resolve_workspace_id
         - events

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -18,7 +18,7 @@ mixpanel_data follows a layered architecture with clear separation of concerns.
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                   Public API Layer                          │
-│              Workspace class, auth module                   │
+│   Workspace · Account/Session · accounts/session/targets    │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -40,7 +40,8 @@ mixpanel_data follows a layered architecture with clear separation of concerns.
 
 The `Workspace` class is the unified entry point that coordinates all services:
 
-- **Credential Resolution** — Env vars → named account → default account
+- **Session resolution** — Three independent axes resolved via `env > param > target > bridge > [active] > default_project`. Single resolver in `_internal/auth/resolver.py`; no silent cross-axis fallback.
+- **In-session switching** — `Workspace.use(account=, project=, workspace=, target=)` returns `self` for chaining and preserves the underlying `httpx.Client` and per-account `/me` cache (O(1) per swap).
 - **Service Orchestration** — Creates and manages service instances
 - **Entity CRUD** — Direct App API access for dashboards, reports, cohorts (workspace-scoped) and feature flags, experiments (project-scoped)
 - **Data Governance** — Schema registry, enforcement, auditing, volume anomalies, event deletion requests, Lexicon definitions, drop filters, custom properties, custom events, and lookup tables
@@ -72,11 +73,12 @@ Executes live analytics queries against Mixpanel Query API:
 
 #### ConfigManager
 
-TOML-based account management at `~/.mp/config.toml`:
+TOML-based account management at `~/.mp/config.toml` (single schema; legacy v1/v2 do not load):
 
-- Account CRUD operations
-- Credential resolution
-- Default account management
+- Account CRUD over `[accounts.NAME]` blocks
+- Target CRUD over `[targets.NAME]` blocks
+- Active-session read/write over the `[active]` block (account + optional workspace)
+- Atomic writes via temp-file + rename
 
 #### MixpanelAPIClient
 
@@ -86,6 +88,16 @@ HTTP client with Mixpanel-specific features:
 - Regional endpoint routing (US, EU, India)
 - Automatic rate limit handling with exponential backoff
 - Streaming JSONL parsing for large exports
+
+### Three-Axis Hierarchy
+
+The 0.4.0 redesign organizes auth around three independent axes:
+
+- **Account** — *who* is authenticating. Three first-class types managed through one surface: `service_account` (Basic Auth), `oauth_browser` (PKCE flow, tokens auto-refreshed), `oauth_token` (static bearer for CI/agents).
+- **Project** — *which Mixpanel project* the calls run against. Lives on the active account as `default_project`; can be overridden per call.
+- **Workspace** — *which workspace inside the project*. Optional; lazy-resolves to the project's default workspace on first workspace-scoped call.
+
+Persisted (account, project, workspace?) bundles are called **targets** and act as named cursor positions: `mp target add ecom --account team --project 3018488` then `mp target use ecom`.
 
 ## Data Paths
 
@@ -126,9 +138,9 @@ Best for:
 
 The API client returns iterators for memory-efficient processing of large datasets without loading everything into memory.
 
-### Immutable Credentials
+### Immutable Session
 
-Credentials are resolved once at Workspace construction. This prevents confusion from mid-session credential changes.
+A `Session` (account + project + optional workspace) is resolved once at `Workspace` construction; `Workspace.use()` swaps in a new `Session` atomically. The `httpx.Client` and per-account `/me` cache are preserved across swaps, so cross-project iteration is O(1) per turn.
 
 ### Dependency Injection
 
@@ -152,21 +164,38 @@ All services accept their dependencies as constructor arguments. This enables:
 
 ```
 src/mixpanel_data/
-├── __init__.py              # Public API exports
-├── workspace.py             # Workspace facade
-├── auth.py                  # Public auth module
-├── exceptions.py            # Exception hierarchy
-├── types.py                 # Result types
+├── __init__.py              # Public exports (Workspace, Account, Session, namespaces, exceptions, types)
+├── workspace.py             # Workspace facade with Workspace.use()
+├── auth_types.py            # Public auth surface (Account union, Session, Region, OAuthTokens, BridgeFile, ...)
+├── accounts.py              # mp.accounts namespace (add/list/use/login/test/...)
+├── session.py               # mp.session namespace (show/use)
+├── targets.py               # mp.targets namespace (saved cursors)
+├── exceptions.py            # Exception hierarchy (incl. AccountInUseError, WorkspaceScopeError)
+├── types.py                 # Result dataclasses (SegmentationResult, AccountSummary, Target, ...)
 ├── py.typed                 # PEP 561 marker
-├── _internal/               # Private implementation
-│   ├── config.py            # ConfigManager, Credentials
+├── _internal/
+│   ├── config.py            # ConfigManager (single TOML schema)
 │   ├── api_client.py        # MixpanelAPIClient
+│   ├── me.py                # MeService + per-account MeCache
+│   ├── pagination.py        # Cursor-based App API pagination
+│   ├── auth/
+│   │   ├── account.py       # Account variants (ServiceAccount/OAuthBrowserAccount/OAuthTokenAccount)
+│   │   ├── session.py       # Session, Project, WorkspaceRef, ActiveSession
+│   │   ├── resolver.py      # env > param > target > bridge > [active] resolver
+│   │   ├── token_resolver.py# OnDiskTokenResolver
+│   │   ├── token.py         # OAuthTokens, OAuthClientInfo
+│   │   ├── flow.py          # OAuth PKCE browser flow
+│   │   ├── bridge.py        # Cowork bridge file v2
+│   │   ├── storage.py       # account_dir, ensure_account_dir (atomic 0o600 writes)
+│   │   ├── pkce.py          # PKCE challenge generation (RFC 7636)
+│   │   ├── callback_server.py # Local HTTP callback server
+│   │   └── client_registration.py # Dynamic Client Registration (RFC 7591)
 │   └── services/
 │       ├── discovery.py     # DiscoveryService
 │       └── live_query.py    # LiveQueryService
 └── cli/
-    ├── main.py              # Typer app entry point
-    ├── commands/            # auth, query, inspect, dashboards, reports, cohorts, flags, experiments
+    ├── main.py              # Typer app + global flags (-a / -p / -w / -t)
+    ├── commands/            # account / project / workspace / target / session + query / inspect / ...
     ├── formatters.py        # Output formatters
     └── utils.py             # CLI utilities
 ```

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -97,7 +97,7 @@ The 0.4.0 redesign organizes auth around three independent axes:
 - **Project** — *which Mixpanel project* the calls run against. Lives on the active account as `default_project`; can be overridden per call.
 - **Workspace** — *which workspace inside the project*. Optional; lazy-resolves to the project's default workspace on first workspace-scoped call.
 
-Persisted (account, project, workspace?) bundles are called **targets** and act as named cursor positions: `mp target add ecom --account team --project 3018488` then `mp target use ecom`.
+Persisted (account, project, optional workspace) bundles are called **targets** and act as named cursor positions: `mp target add ecom --account team --project 3018488` then `mp target use ecom`.
 
 ## Data Paths
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -79,7 +79,7 @@ Discover and switch the active workspace within the current project.
 
 ### target — Saved Targets
 
-A target is a saved (account, project, workspace?) bundle — a named cursor position you can apply with one command.
+A target is a saved (account, project, optional workspace) bundle — a named cursor position you can apply with one command.
 
 | Command | Description |
 |---------|-------------|
@@ -508,9 +508,9 @@ These resolve via `env > param > target > bridge > [active] > default_project` �
 | `MP_PROJECT_ID` | Project override |
 | `MP_WORKSPACE_ID` | Workspace override |
 | `MP_TARGET` | Apply a saved target (mutually exclusive with `MP_ACCOUNT`/`MP_PROJECT_ID`/`MP_WORKSPACE_ID`) |
-| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account; requires `MP_REGION`) |
-| `MP_USERNAME` | Service-account username (env-var path; requires `MP_SECRET`/`MP_PROJECT_ID`/`MP_REGION`) |
-| `MP_SECRET` | Service-account secret |
+| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account; env-var path requires `MP_PROJECT_ID` + `MP_REGION`) |
+| `MP_USERNAME` | Service-account username (requires `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`) |
+| `MP_SECRET` | Service-account secret (paired with `MP_USERNAME`) |
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -25,31 +25,78 @@ mp --version
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--account` | `-a` | Account name to use (overrides default) |
-| `--workspace-id` | | Workspace ID for App API operations (env: `MP_WORKSPACE_ID`) |
+| `--account` | `-a` | Account name to use (env: `MP_ACCOUNT`) |
+| `--project` | `-p` | Project ID override (env: `MP_PROJECT_ID`) |
+| `--workspace` | `-w` | Workspace ID override (env: `MP_WORKSPACE_ID`) |
+| `--target` | `-t` | Apply a saved target (env: `MP_TARGET`) — mutually exclusive with `-a`/`-p`/`-w` |
 | `--quiet` | `-q` | Suppress progress output |
 | `--verbose` | `-v` | Enable debug output |
 | `--version` | | Show version and exit |
 | `--help` | | Show help and exit |
 
+These resolve via the priority chain `env > param > target > bridge > [active] > default_project`. See [Configuration → Credential Resolution Chain](../getting-started/configuration.md#credential-resolution-chain).
+
 ## Command Groups
 
-### auth — Account & Authentication Management
+### account — Account Management
 
-Manage stored credentials, accounts, and OAuth authentication.
+Manage configured accounts (service accounts, OAuth browser, OAuth token) and the active account.
 
 | Command | Description |
 |---------|-------------|
-| `mp auth list` | List configured service accounts |
-| `mp auth add` | Add a new service account |
-| `mp auth remove` | Remove a service account |
-| `mp auth switch` | Set the default account |
-| `mp auth show` | Display account details |
-| `mp auth test` | Test account credentials |
-| `mp auth login` | OAuth 2.0 login via browser |
-| `mp auth logout` | Remove stored OAuth tokens |
-| `mp auth status` | Show OAuth authentication state per region |
-| `mp auth token` | Output raw OAuth access token (for piping) |
+| `mp account list` | List configured accounts (active marked with `*`) |
+| `mp account add` | Register a new account (`--type {service_account, oauth_browser, oauth_token}`) |
+| `mp account update` | Rotate region / secret / token / default_project on an existing account |
+| `mp account remove` | Delete an account (`--force` orphans dependent targets) |
+| `mp account use` | Switch the active account (clears workspace) |
+| `mp account show` | Display account metadata (omit name for active) |
+| `mp account test` | Probe `/me`; returns `AccountTestResult` |
+| `mp account login` | Run the OAuth browser PKCE flow (oauth_browser only) |
+| `mp account logout` | Delete on-disk OAuth tokens (oauth_browser only) |
+| `mp account token` | Print the bearer token (for piping to curl etc.) |
+| `mp account export-bridge` | Write a v2 Cowork bridge file |
+| `mp account remove-bridge` | Delete the bridge file (idempotent) |
+
+### project — Project Switching
+
+Discover and switch the active Mixpanel project (resolved against the active account's `/me` response).
+
+| Command | Description |
+|---------|-------------|
+| `mp project list` | List accessible projects |
+| `mp project use` | Persist the active project (writes to the active account's `default_project`) |
+| `mp project show` | Show the active project |
+
+### workspace — Workspace Switching
+
+Discover and switch the active workspace within the current project.
+
+| Command | Description |
+|---------|-------------|
+| `mp workspace list` | List workspaces for the current project |
+| `mp workspace use` | Persist the active workspace (writes to `[active].workspace`) |
+| `mp workspace show` | Show the active workspace |
+
+### target — Saved Targets
+
+A target is a saved (account, project, workspace?) bundle — a named cursor position you can apply with one command.
+
+| Command | Description |
+|---------|-------------|
+| `mp target list` | List configured targets |
+| `mp target add` | Register a new target (`--account A --project P [--workspace W]`) |
+| `mp target use` | Apply a target atomically (writes all three `[active]` axes in one save) |
+| `mp target show` | Show target details |
+| `mp target remove` | Delete a target |
+
+### session — Active Session Inspection
+
+Show the resolved active session — account, project, workspace, user.
+
+| Command | Description |
+|---------|-------------|
+| `mp session` | Print the active session (`-f json` for machine-readable output) |
+| `mp session --bridge` | Show bridge-resolved state (Cowork integration) |
 
 ### query — Query Operations
 
@@ -444,28 +491,30 @@ mp inspect events --format plain | wc -l
 | Code | Meaning | Exception |
 |------|---------|-----------|
 | 0 | Success | — |
-| 1 | General error | `MixpanelDataError` |
-| 2 | Authentication error | `AuthenticationError` |
+| 1 | General error | `MixpanelDataError`, `WorkspaceScopeError`, `AccountInUseError` |
+| 2 | Authentication error | `AuthenticationError`, `OAuthError` |
 | 3 | Invalid arguments | `ConfigError`, validation errors |
-| 4 | Resource not found | `AccountNotFoundError` |
+| 4 | Resource not found | `AccountNotFoundError`, `ProjectNotFoundError` |
 | 5 | Rate limit exceeded | `RateLimitError` |
 | 130 | Interrupted | Ctrl+C |
 
-!!! note "OAuth and Workspace Errors"
-    `OAuthError` maps to exit code 2 (authentication error). `WorkspaceScopeError` maps to exit code 1 (general error).
-
 ## Environment Variables
+
+These resolve via `env > param > target > bridge > [active] > default_project` — see [Configuration → Credential Resolution Chain](../getting-started/configuration.md#credential-resolution-chain).
 
 | Variable | Description |
 |----------|-------------|
-| `MP_USERNAME` | Service account username |
-| `MP_SECRET` | Service account secret |
-| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored when the full service-account env-var set is also present) |
-| `MP_PROJECT_ID` | Project ID |
-| `MP_REGION` | Data residency region |
-| `MP_WORKSPACE_ID` | Workspace ID for App API operations |
-| `MP_ACCOUNT` | Account name to use |
-| `MP_CONFIG_PATH` | Override config file path |
+| `MP_ACCOUNT` | Active account override |
+| `MP_PROJECT_ID` | Project override |
+| `MP_WORKSPACE_ID` | Workspace override |
+| `MP_TARGET` | Apply a saved target (mutually exclusive with `MP_ACCOUNT`/`MP_PROJECT_ID`/`MP_WORKSPACE_ID`) |
+| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account; requires `MP_REGION`) |
+| `MP_USERNAME` | Service-account username (env-var path; requires `MP_SECRET`/`MP_PROJECT_ID`/`MP_REGION`) |
+| `MP_SECRET` | Service-account secret |
+| `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
+| `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
+| `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
+| `MP_OAUTH_STORAGE_DIR` | Override storage root (`~/.mp`) |
 
 ## Examples
 
@@ -473,7 +522,8 @@ mp inspect events --format plain | wc -l
 
 ```bash
 # 1. Set up credentials (prompts for secret securely)
-mp auth add production --username sa_... --project 12345 --region us
+mp account add personal --type oauth_browser --region us
+mp account login personal       # opens browser for PKCE flow
 
 # 2. Explore schema
 mp inspect events

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -101,10 +101,13 @@ mp query segmentation -e Login --from 2026-04-01 --to 2026-04-21
 Or register a named account that pulls the token from an env var at request time:
 
 ```bash
-mp account add ci --type oauth_token --token-env MP_CI_TOKEN --region us
+mp account add ci --type oauth_token --token-env MP_CI_TOKEN \
+    --project 3713224 --region us
 mp account use ci
 MP_CI_TOKEN=ey... mp query segmentation -e Login --from 2026-04-01
 ```
+
+`--project` is required when registering an `oauth_token` account (it becomes the account's `default_project`).
 
 Static bearers are not persisted (no refresh capability — pass a fresh token when the previous one expires).
 
@@ -322,6 +325,8 @@ mp account remove-bridge
 The bridge file embeds the full `Account` (with secrets), optional OAuth tokens (for `oauth_browser` accounts), and optional pinned project/workspace/headers. Default search order: `MP_AUTH_FILE` → `~/.claude/mixpanel/auth.json` → `./mixpanel_auth.json`.
 
 ```python
+from pathlib import Path
+
 import mixpanel_data as mp
 
 mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json").expanduser())

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -231,7 +231,7 @@ When constructing a `Workspace` (or running a CLI command), each axis is resolve
 
 Per-axis details:
 
-- **Account** — the resolver reads the **service-account env quad** (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) and the **OAuth-token env triple** (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`) directly. The SA quad wins over the OAuth triple. `MP_ACCOUNT` is wired as the env default for the `--account` CLI flag (Typer `envvar=`); it acts at the **param** layer, not the env layer, so an explicit `--account NAME` (or `Workspace(account="...")`) does **not** override it.
+- **Account** — the resolver reads the **service-account env quad** (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) and the **OAuth-token env triple** (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`) directly. The SA quad wins over the OAuth triple. `MP_ACCOUNT` is wired as the `envvar=` default for `--account` / `-a` by Typer — it is **not** read directly by the resolver's env step (unlike `MP_USERNAME` / `MP_OAUTH_TOKEN`). An explicit `--account NAME` or `Workspace(account="...")` overrides it normally.
 - **Project** — `MP_PROJECT_ID` is read directly by the resolver (env layer), then `--project` / `Workspace(project=...)` (param), then target, bridge, and finally the active account's `default_project`.
 - **Workspace** — `MP_WORKSPACE_ID` is read directly by the resolver (env layer), then `--workspace` / `Workspace(workspace=...)` (param), then target, bridge, and `[active].workspace`.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -34,9 +34,9 @@ Service accounts are the right default for unattended automation. OAuth browser 
 | `MP_PROJECT_ID` | Project override (CLI: `--project` / `-p`) |
 | `MP_WORKSPACE_ID` | Workspace override (CLI: `--workspace` / `-w`) |
 | `MP_TARGET` | Apply a saved target (CLI: `--target` / `-t`) |
-| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account) |
-| `MP_USERNAME` | Service-account username (env-var path) |
-| `MP_SECRET` | Service-account secret (env-var path) |
+| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account; env-var path requires `MP_PROJECT_ID` + `MP_REGION`) |
+| `MP_USERNAME` | Service-account username (requires `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`) |
+| `MP_SECRET` | Service-account secret (paired with `MP_USERNAME`) |
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
 | `MP_AUTH_FILE` | Override path to the Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
@@ -56,6 +56,7 @@ These map onto the [credential resolution chain](#credential-resolution-chain) b
 export MP_SECRET="aQUXhKokwLywLoxE3AxLt0g9dXC2G7bT"
 mp account add team --type service_account \
     --username "team-mp.292e7c.mp-service-account" \
+    --project 3018488 \
     --region us
 # Added account 'team' (service_account, us). Set as active.
 ```
@@ -64,7 +65,7 @@ Or read the secret from stdin (useful when it lives in a shell variable):
 
 ```bash
 echo "$SECRET" | mp account add team --type service_account \
-    --username "team-mp..." --region us --secret-stdin
+    --username "team-mp..." --project 3018488 --region us --secret-stdin
 ```
 
 Verify:
@@ -219,14 +220,20 @@ curl -H "Authorization: Bearer $(mp account token personal)" \
 
 ## Credential Resolution Chain
 
-When constructing a `Workspace` (or running a CLI command), each axis is resolved independently in this priority order:
+When constructing a `Workspace` (or running a CLI command), each axis is resolved independently. The general chain is:
 
-1. **Environment variables** — `MP_ACCOUNT`, `MP_PROJECT_ID`, `MP_WORKSPACE_ID`, `MP_OAUTH_TOKEN`, etc.
+1. **Environment variables** — direct env reads inside the resolver.
 2. **Constructor / CLI param** — `Workspace(account="...")`, `mp -a NAME ...`.
 3. **Saved target** — `Workspace(target="ecom")`, `mp -t ecom ...`.
 4. **Bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json` (Cowork integration).
 5. **Persisted active session** — the `[active]` block in `config.toml`.
 6. **Account default** — `account.default_project` for the project axis.
+
+Per-axis details:
+
+- **Account** — the resolver reads the **service-account env quad** (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) and the **OAuth-token env triple** (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`) directly. The SA quad wins over the OAuth triple. `MP_ACCOUNT` is wired as the env default for the `--account` CLI flag (Typer `envvar=`); it acts at the **param** layer, not the env layer, so an explicit `--account NAME` (or `Workspace(account="...")`) does **not** override it.
+- **Project** — `MP_PROJECT_ID` is read directly by the resolver (env layer), then `--project` / `Workspace(project=...)` (param), then target, bridge, and finally the active account's `default_project`.
+- **Workspace** — `MP_WORKSPACE_ID` is read directly by the resolver (env layer), then `--workspace` / `Workspace(workspace=...)` (param), then target, bridge, and `[active].workspace`.
 
 There is **no silent cross-axis fallback**: switching the active account clears the workspace (workspaces are project-scoped), and project doesn't carry forward to a new account. If an axis can't be resolved, the resolver raises `ConfigError` rather than silently falling back to a default.
 
@@ -263,7 +270,7 @@ If no workspace is specified, workspace-scoped endpoints lazy-resolve to the pro
 
 ## Saved Targets
 
-A **target** is a saved (account, project, workspace?) bundle — a named cursor position you can apply with one command:
+A **target** is a saved (account, project, optional workspace) bundle — a named cursor position you can apply with one command:
 
 ```bash
 mp target add ecom --account team --project 3018488 --workspace 3448414
@@ -317,7 +324,7 @@ The bridge file embeds the full `Account` (with secrets), optional OAuth tokens 
 ```python
 import mixpanel_data as mp
 
-mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json"))
+mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json").expanduser())
 mp.accounts.remove_bridge()
 ```
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,245 +1,324 @@
 # Configuration
 
-mixpanel_data supports three authentication methods: **Service Accounts** (Basic Auth) for server-side automation, **OAuth 2.0 PKCE** for interactive browser login, and **raw OAuth bearer tokens** for non-interactive contexts like CI or AI agents. All three integrate with the same credential resolution chain.
+`mixpanel_data` organizes auth around three independent axes: **Account → Project → Workspace**.
+
+- **Account** — *who* is authenticating. Three first-class types managed through one surface: `service_account` (Basic Auth), `oauth_browser` (PKCE flow with auto-refreshed tokens), and `oauth_token` (static bearer for CI / agents).
+- **Project** — *which* Mixpanel project the calls run against. Lives on the active account as `default_project`; can be overridden per call.
+- **Workspace** — *which* workspace inside the project. Optional; lazy-resolves to the project's default workspace on first workspace-scoped call.
+
+In-session switching is a one-line operation: `Workspace.use(account=..., project=..., workspace=..., target=...)`. The underlying HTTP client and per-account `/me` cache are preserved across switches, so cross-project / cross-account iteration is O(1) per turn.
 
 !!! tip "Explore on DeepWiki"
-    🤖 **[Authentication Setup →](https://deepwiki.com/jaredmcfarland/mixpanel_data/2.2-authentication-setup)**
+    🤖 **[Authentication Setup →](https://deepwiki.com/jaredmcfarland/mixpanel_data/2.2-authentication-setup)** (updated for 0.4.0)
 
     Ask questions about service accounts, OAuth, environment variables, or multi-account configuration.
 
-## Authentication Methods
+!!! info "Upgrading from 0.3.x?"
+    The 0.4.0 auth schema is a hard break — legacy `~/.mp/config.toml` files do not load. See [Migration → From 0.3.x to 0.4.0](../migration/0.4.0.md) for the recovery recipe.
 
-| Method | Best For | How It Works |
-|--------|----------|--------------|
-| **Service Account** (Basic Auth) | Scripts, CI/CD, automation | Username + secret from env vars or config file |
-| **OAuth 2.0** (PKCE) | Interactive use, personal access | Browser-based login, tokens stored locally |
-| **Raw OAuth Bearer Token** | CI, agents, ephemeral environments | Pre-obtained access token injected via env vars; no browser, no local storage |
+## Account Types
 
-Service accounts are the default and work everywhere. OAuth PKCE is ideal when you want to authenticate as yourself without managing service account credentials. Raw bearer tokens are the right choice when a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) hands you a token and you cannot run the browser flow.
+| Type | Best For | Storage |
+|---|---|---|
+| `service_account` | CI / scripts / unattended automation | `~/.mp/config.toml` (Basic Auth username + secret) |
+| `oauth_browser` | Interactive personal use | `~/.mp/accounts/{name}/tokens.json` (auto-refreshed) |
+| `oauth_token` | CI bots / agents (no browser) | Inline secret OR `--token-env VAR` indirection |
+
+Service accounts are the right default for unattended automation. OAuth browser is the right default for personal/interactive use. OAuth token (static bearer) is the right default when a managed OAuth client (Claude Code plugin, CI pipeline) hands you a pre-obtained access token.
 
 ## Environment Variables
 
-Set these environment variables to configure credentials:
+| Variable | Purpose |
+|---|---|
+| `MP_ACCOUNT` | Active account override (CLI: `--account` / `-a`) |
+| `MP_PROJECT_ID` | Project override (CLI: `--project` / `-p`) |
+| `MP_WORKSPACE_ID` | Workspace override (CLI: `--workspace` / `-w`) |
+| `MP_TARGET` | Apply a saved target (CLI: `--target` / `-t`) |
+| `MP_OAUTH_TOKEN` | Static bearer token (alternative to a registered account) |
+| `MP_USERNAME` | Service-account username (env-var path) |
+| `MP_SECRET` | Service-account secret (env-var path) |
+| `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
+| `MP_AUTH_FILE` | Override path to the Cowork bridge file |
+| `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
+| `MP_OAUTH_STORAGE_DIR` | Override storage root (`~/.mp`) |
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `MP_USERNAME` | Service account username | Yes (Basic Auth) |
-| `MP_SECRET` | Service account secret | Yes (Basic Auth) |
-| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account) | Yes (Bearer) |
-| `MP_PROJECT_ID` | Mixpanel project ID | Yes |
-| `MP_REGION` | Data residency region (`us`, `eu`, `in`) | No (default: `us`) |
-| `MP_WORKSPACE_ID` | Workspace ID for App API operations | No |
-| `MP_CONFIG_PATH` | Override config file location | No |
-| `MP_ACCOUNT` | Account name to use from config file | No |
+These map onto the [credential resolution chain](#credential-resolution-chain) below.
 
-### Service Account (Basic Auth)
+!!! note "Service-account env quad takes precedence over `MP_OAUTH_TOKEN`"
+    If `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` are all set, the service-account quad wins even when `MP_OAUTH_TOKEN` is also present. This is safe to add to a shell that already exports the service-account vars.
 
-```bash
-export MP_USERNAME="sa_abc123..."
-export MP_SECRET="your-secret-here"
-export MP_PROJECT_ID="12345"
-export MP_REGION="us"
-```
+## Setting Up an Account
 
-### Raw OAuth Bearer Token
-
-For non-interactive contexts (CI, agents) that already hold an OAuth 2.0 access token:
+### Service account (Basic Auth)
 
 ```bash
-export MP_OAUTH_TOKEN="<bearer-token>"
-export MP_PROJECT_ID="12345"
-export MP_REGION="us"  # or "eu", "in"
+# Set the secret via env var (preferred)
+export MP_SECRET="aQUXhKokwLywLoxE3AxLt0g9dXC2G7bT"
+mp account add team --type service_account \
+    --username "team-mp.292e7c.mp-service-account" \
+    --region us
+# Added account 'team' (service_account, us). Set as active.
 ```
 
-The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh capability — pass a fresh token when the previous one expires).
+Or read the secret from stdin (useful when it lives in a shell variable):
 
-!!! note "Precedence when both are set"
-    The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete, so adding `MP_OAUTH_TOKEN` to a shell that already exports the service-account vars is safe — the bearer token is silently ignored and a debug-level log records the choice.
+```bash
+echo "$SECRET" | mp account add team --type service_account \
+    --username "team-mp..." --region us --secret-stdin
+```
+
+Verify:
+
+```bash
+mp account test team
+# { "account_name": "team", "ok": true, "user": {...}, "accessible_project_count": 7 }
+```
+
+### OAuth (browser, PKCE)
+
+```bash
+mp account add personal --type oauth_browser --region us
+# Added account 'personal' (oauth_browser, us). Set as active.
+
+mp account login personal
+# Opening browser...
+# ✓ Authenticated as jared@example.com
+```
+
+The PKCE flow opens your browser for Mixpanel authorization. Tokens land at `~/.mp/accounts/personal/tokens.json` (mode `0o600`) and refresh automatically before each call. The `default_project` field on the account is backfilled from the post-login `/me` probe.
+
+### OAuth (static bearer / CI)
+
+```bash
+# Pure env-var path — no persistent state
+export MP_OAUTH_TOKEN="ey..."
+export MP_REGION=us
+export MP_PROJECT_ID=3713224
+mp query segmentation -e Login --from 2026-04-01 --to 2026-04-21
+```
+
+Or register a named account that pulls the token from an env var at request time:
+
+```bash
+mp account add ci --type oauth_token --token-env MP_CI_TOKEN --region us
+mp account use ci
+MP_CI_TOKEN=ey... mp query segmentation -e Login --from 2026-04-01
+```
+
+Static bearers are not persisted (no refresh capability — pass a fresh token when the previous one expires).
 
 ## Config File
 
-For persistent credential storage, use the config file at `~/.mp/config.toml`:
+Persistent state lives in `~/.mp/config.toml` (mode `0o600`), with a single schema and four section types:
 
 ```toml
-default = "production"
+[active]
+account = "personal"
+workspace = 3448414       # optional
 
-[accounts.production]
-username = "sa_abc123..."
-secret = "..."
-project_id = "12345"
+[accounts.personal]
+type = "oauth_browser"
 region = "us"
+default_project = "3713224"
 
-[accounts.staging]
-username = "sa_xyz789..."
-secret = "..."
-project_id = "67890"
-region = "eu"
-
-[accounts.development]
-username = "sa_dev456..."
-secret = "..."
-project_id = "11111"
+[accounts.team]
+type = "service_account"
 region = "us"
+default_project = "3018488"
+username = "team-mp..."
+secret = "..."
+
+[accounts.ci]
+type = "oauth_token"
+region = "us"
+default_project = "3713224"
+token_env = "MP_CI_TOKEN"  # XOR with `token = "..."`
+
+[targets.ecom]
+account = "team"
+project = "3018488"
+workspace = 3448414
 ```
 
-### Managing Accounts with CLI
+The `[active]` block stores only `account` and (optionally) `workspace` — project lives on the active account as `default_project`. Targets are saved cursor positions (see [Saved Targets](#saved-targets) below).
 
-Add a new account:
+## Managing Accounts via CLI
 
 ```bash
-# Interactive prompt (secure, recommended)
-mp auth add production \
-    --username sa_abc123... \
-    --project 12345 \
-    --region us
-# You'll be prompted for the secret with hidden input
+mp account list                           # All accounts; active marked with *
+mp account show [NAME]                    # Account details (omit NAME for active)
+mp account use NAME                       # Switch active account (clears workspace)
+mp account test [NAME]                    # Probe /me; returns AccountTestResult
+mp account login NAME                     # Run PKCE flow (oauth_browser only)
+mp account logout NAME                    # Delete on-disk tokens (oauth_browser only)
+mp account token [NAME]                   # Print bearer (for piping to curl etc.)
+mp account update NAME --region eu        # Rotate region/secret/token/etc.
+mp account remove NAME [--force]          # Delete; --force orphans dependent targets
 ```
 
-For CI/CD environments, provide the secret via environment variable or stdin:
+The first account added auto-promotes to active.
 
-```bash
-# Via environment variable
-MP_SECRET=your-secret mp auth add production --username sa_abc123... --project 12345
+## Managing Accounts via Python
 
-# Via stdin
-echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 --secret-stdin
-```
-
-List configured accounts:
-
-```bash
-mp auth list
-```
-
-Switch the default account:
-
-```bash
-mp auth switch staging
-```
-
-Remove an account:
-
-```bash
-mp auth remove development
-```
-
-Show account details (secrets hidden):
-
-```bash
-mp auth show production
-```
-
-### Managing Accounts with Python
-
-```python
-from mixpanel_data._internal.config import ConfigManager
-
-config = ConfigManager()
-
-# Add account
-config.add_account(
-    name="production",
-    username="sa_abc123...",
-    secret="your-secret",
-    project_id="12345",
-    region="us"
-)
-
-# List accounts
-accounts = config.list_accounts()
-for account in accounts:
-    print(f"{account.name}: project {account.project_id} ({account.region})")
-
-# Set default
-config.set_default("production")
-
-# Remove account
-config.remove_account("old_account")
-```
-
-## OAuth Authentication
-
-OAuth 2.0 with PKCE provides browser-based login without managing service account credentials. Tokens are stored locally per region.
-
-### Login
-
-```bash
-# Login to your default region
-mp auth login
-
-# Login to a specific region and project
-mp auth login --region eu --project-id 12345
-```
-
-This opens your browser for Mixpanel authorization. After approval, tokens are saved to `~/.mp/oauth/{region}/`.
-
-### Check Status
-
-```bash
-mp auth status
-```
-
-Shows authentication state for each region (us, eu, in), including token expiry and scope.
-
-### Get a Token
-
-```bash
-# Output raw access token (useful for piping to other tools)
-mp auth token
-
-# Use with curl
-curl -H "Authorization: Bearer $(mp auth token)" https://mixpanel.com/api/app/...
-```
-
-### Logout
-
-```bash
-# Logout from a specific region
-mp auth logout --region us
-
-# Logout from all regions
-mp auth logout
-```
-
-### Token Storage
-
-OAuth tokens are stored as JSON files:
-
-```
-~/.mp/oauth/
-├── tokens_us.json         # Access/refresh tokens, expiry, scope
-├── client_us.json         # Dynamic client registration data
-├── tokens_eu.json
-├── client_eu.json
-├── tokens_in.json
-└── client_in.json
-```
-
-Tokens are automatically refreshed when expired. The client registration is cached per region.
-
-## Credential Resolution Order
-
-When creating a Workspace, credentials are resolved in this order:
-
-1. **Environment variables** — either the service-account quad (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) or the OAuth-token triple (`MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION`). The service-account quad takes precedence when both sets are complete.
-2. **Auth bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json` (for Claude Cowork environments).
-3. **OAuth tokens from local storage** — Valid (non-expired) tokens from `~/.mp/oauth/`, populated by `mp auth login`.
-4. **Named account** — `Workspace(account="staging")` or `MP_ACCOUNT=staging`.
-5. **Default account** — The account marked as `default` in `config.toml`.
-
-If a complete env-var set is present, it always wins. Otherwise the chain falls through bridge file → stored OAuth tokens → named or default config account.
-
-Example showing resolution:
+The public surface lives in three functional namespaces:
 
 ```python
 import mixpanel_data as mp
 
-# Uses environment variables (either set), then bridge file, then
-# stored OAuth tokens, then config file
+# Add a service account
+mp.accounts.add(
+    "team",
+    type="service_account",
+    region="us",
+    default_project="3018488",
+    username="team-mp...",
+    secret="...",
+)
+
+# Add an OAuth account and run the browser flow
+mp.accounts.add("personal", type="oauth_browser", region="us")
+result = mp.accounts.login("personal")          # OAuthLoginResult
+print(result.user.email, result.expires_at)
+
+# List + switch + probe
+for s in mp.accounts.list():                    # list[AccountSummary]
+    print(s.name, s.type, s.region, "*" if s.is_active else "")
+mp.accounts.use("team")
+probe = mp.accounts.test()                      # AccountTestResult
+print(probe.ok, probe.accessible_project_count)
+```
+
+See [API → Auth](../api/auth.md) for the full namespace reference.
+
+## OAuth (browser) — token storage
+
+OAuth browser tokens are stored per account; OAuth client metadata (Dynamic Client Registration) is shared per region:
+
+```
+~/.mp/
+├── config.toml                        # accounts, targets, [active]
+├── accounts/
+│   ├── personal/
+│   │   ├── tokens.json                # access + refresh tokens (0o600)
+│   │   └── me.json                    # cached /me response (0o600)
+│   └── team/
+│       └── me.json
+└── oauth/
+    ├── client_us.json                 # shared DCR client per region
+    ├── client_eu.json
+    └── client_in.json
+```
+
+Tokens auto-refresh on expiry. If the refresh token is rejected (e.g., revoked at the IdP), the next call raises `OAuthError(code="OAUTH_REFRESH_REVOKED")` — re-run `mp account login NAME` to recover.
+
+```bash
+mp account token personal                          # Print the active access token
+curl -H "Authorization: Bearer $(mp account token personal)" \
+    https://mixpanel.com/api/app/me
+```
+
+## Credential Resolution Chain
+
+When constructing a `Workspace` (or running a CLI command), each axis is resolved independently in this priority order:
+
+1. **Environment variables** — `MP_ACCOUNT`, `MP_PROJECT_ID`, `MP_WORKSPACE_ID`, `MP_OAUTH_TOKEN`, etc.
+2. **Constructor / CLI param** — `Workspace(account="...")`, `mp -a NAME ...`.
+3. **Saved target** — `Workspace(target="ecom")`, `mp -t ecom ...`.
+4. **Bridge file** — `MP_AUTH_FILE` or `~/.claude/mixpanel/auth.json` (Cowork integration).
+5. **Persisted active session** — the `[active]` block in `config.toml`.
+6. **Account default** — `account.default_project` for the project axis.
+
+There is **no silent cross-axis fallback**: switching the active account clears the workspace (workspaces are project-scoped), and project doesn't carry forward to a new account. If an axis can't be resolved, the resolver raises `ConfigError` rather than silently falling back to a default.
+
+```python
+import mixpanel_data as mp
+
+# Default — resolve everything from config + env
 ws = mp.Workspace()
 
-# Uses named account from config file (skips OAuth and bridge)
-ws = mp.Workspace(account="staging")
+# Explicit per-axis overrides
+ws = mp.Workspace(account="team", project="3713224")
+ws = mp.Workspace(target="ecom")
+```
+
+## Workspace Axis (in-session switching)
+
+Workspaces are project-scoped. Set the workspace via env var, CLI flag, constructor arg, or `Workspace.use()`:
+
+```bash
+mp --workspace 3448414 inspect events     # one-off override
+mp workspace use 3448414                  # persist to [active].workspace
+export MP_WORKSPACE_ID=3448414            # env-var override
+```
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace(workspace=3448414)      # at construction
+ws.use(workspace=3448414)                 # in-session switch (returns self)
+ws.use(workspace=3448414, persist=True)   # also write to [active]
+```
+
+If no workspace is specified, workspace-scoped endpoints lazy-resolve to the project's default workspace on first use.
+
+## Saved Targets
+
+A **target** is a saved (account, project, workspace?) bundle — a named cursor position you can apply with one command:
+
+```bash
+mp target add ecom --account team --project 3018488 --workspace 3448414
+mp target list
+
+# One-off application (CLI override only)
+mp --target ecom query segmentation -e Login --from 2026-04-01
+
+# Persistent application (writes [active] atomically)
+mp target use ecom
+# Active: team → E-Commerce Demo (3018488), workspace 3448414
+```
+
+Python:
+
+```python
+import mixpanel_data as mp
+
+mp.targets.add("ecom", account="team", project="3018488", workspace=3448414)
+mp.targets.use("ecom")                            # writes [active] atomically
+
+ws = mp.Workspace(target="ecom")                  # apply at construction
+ws.use(target="ecom")                             # apply in-session
+```
+
+`--target` is mutually exclusive with `--account` / `--project` / `--workspace` (and the equivalent constructor kwargs).
+
+## Bridge Files (Cowork integration)
+
+The Cowork bridge is a v2 JSON file that lets a remote VM (or any environment that doesn't have your `~/.mp/config.toml`) authenticate against Mixpanel using your host machine's account and tokens.
+
+```bash
+# On the host — write the bridge
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
+# Wrote bridge: ~/.claude/mixpanel/auth.json
+#   Account:  personal (oauth_browser, us)
+#   Tokens:   included (refresh-capable)
+
+# In the VM — bridge is auto-discovered, or override with env var
+export MP_AUTH_FILE=/host/.claude/mixpanel/auth.json
+mp project list                # works without `mp account add`
+mp session --bridge            # show bridge-resolved state
+
+# On the host — tear down
+mp account remove-bridge
+# Removed bridge: ~/.claude/mixpanel/auth.json
+```
+
+The bridge file embeds the full `Account` (with secrets), optional OAuth tokens (for `oauth_browser` accounts), and optional pinned project/workspace/headers. Default search order: `MP_AUTH_FILE` → `~/.claude/mixpanel/auth.json` → `./mixpanel_auth.json`.
+
+```python
+import mixpanel_data as mp
+
+mp.accounts.export_bridge(to=Path("~/.claude/mixpanel/auth.json"))
+mp.accounts.remove_bridge()
 ```
 
 ## Data Residency Regions
@@ -247,42 +326,17 @@ ws = mp.Workspace(account="staging")
 Mixpanel stores data in regional data centers. Use the correct region for your project:
 
 | Region | Code | API Endpoint |
-|--------|------|--------------|
+|---|---|---|
 | United States | `us` | `mixpanel.com` |
 | European Union | `eu` | `eu.mixpanel.com` |
 | India | `in` | `in.mixpanel.com` |
 
-!!! warning "Region Mismatch"
-    Using the wrong region will result in authentication errors or empty data.
-
-## Workspace ID
-
-Some App API endpoints are scoped to a workspace. You can set a workspace ID globally:
-
-```bash
-# CLI: global option
-mp --workspace-id 123 inspect events
-
-# Or via environment variable
-export MP_WORKSPACE_ID=123
-```
-
-```python
-import mixpanel_data as mp
-
-# Set at construction
-ws = mp.Workspace(workspace_id=123)
-
-# Or set later
-ws.set_workspace_id(123)
-
-# Auto-discover (uses default workspace)
-ws_id = ws.resolve_workspace_id()
-```
-
-If no workspace ID is set, workspace-scoped endpoints will auto-discover by listing available workspaces and selecting the default.
+!!! warning "Region mismatch"
+    Using the wrong region results in authentication errors or empty data. The region lives on the account (`account.region`); change it via `mp account update NAME --region eu`.
 
 ## Next Steps
 
-- [Streaming Data](../guide/streaming.md) — Stream events and profiles
-- [API Reference](../api/index.md) — Complete API documentation
+- [Quick Start](quickstart.md) — Run your first queries
+- [API → Auth](../api/auth.md) — Full Python API reference for accounts, sessions, and targets
+- [CLI Reference](../cli/index.md) — Complete CLI command reference
+- [Migration → 0.3.x → 0.4.0](../migration/0.4.0.md) — Upgrade walkthrough

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -53,7 +53,7 @@ mp --version
 You should see output like:
 
 ```
-mixpanel_data 0.1.0
+mixpanel_data 0.4.0
 ```
 
 Test the Python import:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -80,7 +80,7 @@ The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. To
 
 ## Step 2: Choose a Project
 
-After authenticating, select which Mixpanel project to query:
+After authenticating with a registered account (Options B or C above), select which Mixpanel project to query:
 
 === "CLI"
 
@@ -108,6 +108,9 @@ After authenticating, select which Mixpanel project to query:
 
 `mp project use` writes to the active account's `default_project`. To override per-call without persisting, pass `--project` / `-p` on the CLI or `Workspace(project="...")` in Python.
 
+!!! note "Env-only paths skip this step"
+    `mp project use` requires an active account in `~/.mp/config.toml`. If you set up via Option A (`MP_USERNAME`/`MP_SECRET`/...) or Option D (`MP_OAUTH_TOKEN`/...) without registering an account, set the project via `MP_PROJECT_ID` directly (already required by both env-only paths) or pass `--project` / `Workspace(project=...)` per call. Don't run `mp project use` — it errors with "No active account configured."
+
 ## Step 3: Test Your Connection
 
 Verify credentials are working:
@@ -124,8 +127,11 @@ Verify credentials are working:
     ```python
     import mixpanel_data as mp
 
-    result = mp.accounts.test()  # AccountTestResult; raises ConfigError if no active account
-    print(result.ok, result.user.email, result.accessible_project_count)
+    result = mp.accounts.test()  # AccountTestResult; never raises — check result.ok / result.error
+    if result.ok:
+        print(result.user.email, result.accessible_project_count)
+    else:
+        print("test failed:", result.error)
     ```
 
 ## Step 4: Explore Your Data

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -29,24 +29,21 @@ export MP_REGION="us"
 ### Option B: Config File (Service Account)
 
 ```bash
-# Interactive prompt (secure, recommended)
-mp auth add production \
+# Set the secret via env var (preferred)
+export MP_SECRET="your-secret-here"
+mp account add production --type service_account \
     --username sa_abc123... \
-    --project 12345 \
     --region us
-# You'll be prompted for the service account secret with hidden input
+# Added account 'production' (service_account, us). Set as active.
 ```
 
-This stores credentials in `~/.mp/config.toml` and sets `production` as the default account.
+This stores credentials in `~/.mp/config.toml` and sets `production` as the active account.
 
-For CI/CD environments, provide the secret via environment variable or stdin:
+For CI/CD environments where the secret lives in a shell variable, pipe it via stdin:
 
 ```bash
-# Via environment variable
-MP_SECRET=your-secret mp auth add production --username sa_abc123... --project 12345
-
-# Via stdin
-echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 --secret-stdin
+echo "$SECRET" | mp account add production --type service_account \
+    --username sa_abc123... --region us --secret-stdin
 ```
 
 ### Option C: OAuth Login (Interactive)
@@ -54,14 +51,19 @@ echo "$SECRET" | mp auth add production --username sa_abc123... --project 12345 
 For interactive use without managing service account credentials:
 
 ```bash
-# Login via browser (opens Mixpanel authorization page)
-mp auth login --region us --project-id 12345
+# Register an OAuth account
+mp account add personal --type oauth_browser --region us
 
-# Check your auth status
-mp auth status
+# Run the PKCE browser flow
+mp account login personal
+# Opening browser...
+# ✓ Authenticated as jared@example.com
+
+# Inspect resolved state
+mp session
 ```
 
-OAuth tokens are stored locally at `~/.mp/oauth/` and automatically refreshed when expired. See [Configuration](configuration.md#oauth-authentication) for details.
+OAuth tokens are stored at `~/.mp/accounts/personal/tokens.json` and automatically refreshed when expired. The active project is backfilled from the post-login `/me` probe. See [Configuration → OAuth (browser) — token storage](configuration.md#oauth-browser-token-storage) for details.
 
 ### Option D: Raw OAuth Bearer Token (CI / Agents)
 
@@ -73,16 +75,22 @@ export MP_PROJECT_ID="12345"
 export MP_REGION="us"  # or "eu", "in"
 ```
 
-The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh — pass a fresh token when the previous one expires). See [Configuration → Raw OAuth Bearer Token](configuration.md#raw-oauth-bearer-token) for precedence rules.
+The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh — pass a fresh token when the previous one expires). See [Configuration → OAuth (static bearer / CI)](configuration.md#oauth-static-bearer-ci) and the precedence note under [Environment Variables](configuration.md#environment-variables).
 
-## Step 2: Test Your Connection
+## Step 2: Choose a Project
 
-Verify credentials are working:
+After authenticating, select which Mixpanel project to query:
 
 === "CLI"
 
     ```bash
-    mp auth test
+    mp project list
+    # ID        NAME              ORG       WORKSPACES
+    # 3713224   AI Demo           Acme      ✓
+    # 3018488   E-Commerce Demo   Acme      ✓
+
+    mp project use 3713224
+    # Active project: AI Demo (3713224)
     ```
 
 === "Python"
@@ -91,10 +99,35 @@ Verify credentials are working:
     import mixpanel_data as mp
 
     ws = mp.Workspace()
-    ws.test_credentials()  # Raises AuthenticationError if invalid
+    for project in ws.projects():
+        print(project.id, project.name)
+
+    ws.use(project="3713224", persist=True)
     ```
 
-## Step 3: Explore Your Data
+`mp project use` writes to the active account's `default_project`. To override per-call without persisting, pass `--project` / `-p` on the CLI or `Workspace(project="...")` in Python.
+
+## Step 3: Test Your Connection
+
+Verify credentials are working:
+
+=== "CLI"
+
+    ```bash
+    mp account test
+    # { "account_name": "production", "ok": true, "user": {...}, "accessible_project_count": 7 }
+    ```
+
+=== "Python"
+
+    ```python
+    import mixpanel_data as mp
+
+    result = mp.accounts.test()  # AccountTestResult; raises ConfigError if no active account
+    print(result.ok, result.user.email, result.accessible_project_count)
+    ```
+
+## Step 4: Explore Your Data
 
 Before writing queries, survey your data landscape. Discovery commands let you see what exists in your Mixpanel project without guessing.
 
@@ -112,9 +145,9 @@ Before writing queries, survey your data landscape. Discovery commands let you s
     import mixpanel_data as mp
 
     ws = mp.Workspace()
-    events = ws.list_events()
-    for e in events[:10]:
-        print(e.name)
+    events = ws.events()         # list[str]
+    for name in events[:10]:
+        print(name)
     ```
 
 ### Drill Into Properties
@@ -130,9 +163,9 @@ Once you know an event name, see what properties it has:
 === "Python"
 
     ```python
-    props = ws.list_properties("Purchase")
-    for p in props:
-        print(f"{p.name}: {p.type}")
+    props = ws.properties("Purchase")    # list[str]
+    for name in props:
+        print(name)
     ```
 
 ### Sample Property Values
@@ -148,7 +181,7 @@ See actual values a property contains:
 === "Python"
 
     ```python
-    values = ws.list_property_values("Purchase", "country")
+    values = ws.property_values("country", event="Purchase")
     print(values)  # ['US', 'UK', 'DE', 'FR', ...]
     ```
 
@@ -185,14 +218,14 @@ See funnels, cohorts, and saved reports already defined in Mixpanel:
 === "Python"
 
     ```python
-    funnels = ws.list_funnels()
-    cohorts = ws.list_cohorts()
+    funnels = ws.funnels()
+    cohorts = ws.cohorts()
     bookmarks = ws.list_bookmarks()
     ```
 
 This discovery workflow ensures your queries reference real event names, valid properties, and actual values—no trial and error.
 
-## Step 4: Run Analytics Queries
+## Step 5: Run Analytics Queries
 
 ### Insights Queries (Recommended)
 
@@ -377,7 +410,33 @@ For segmentation, funnels, and retention via the older Query API:
     print(result.df)
     ```
 
-## Step 5: Manage Entities & Data Governance (Optional)
+## Step 6: Switch Accounts and Projects In-Session
+
+`Workspace.use()` swaps any axis without rebuilding the underlying HTTP client (O(1) per swap), so cross-project iteration is cheap:
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+
+# In-session switching (returns self for chaining)
+ws.use(account="team")              # implicitly clears workspace
+ws.use(project="3018488")
+ws.use(workspace=3448414)
+ws.use(target="ecom")               # apply all three at once
+
+# Persist the new state
+ws.use(project="3018488", persist=True)
+
+# Iterate across projects
+for project in ws.projects():
+    ws.use(project=project.id)
+    print(project.name, len(ws.events()))
+```
+
+See [Configuration → Saved Targets](configuration.md#saved-targets) for the full target workflow.
+
+## Step 7: Manage Entities & Data Governance (Optional)
 
 Create, update, and delete dashboards, reports, cohorts, feature flags, and experiments:
 
@@ -431,7 +490,7 @@ Create, update, and delete dashboards, reports, cohorts, feature flags, and expe
 
 See the [Entity Management guide](../guide/entity-management.md) for complete coverage of dashboard, report, cohort, feature flag, and experiment operations. See the [Data Governance guide](../guide/data-governance.md) for Lexicon definitions, drop filters, custom properties, custom events, lookup tables, schema registry, schema enforcement, data auditing, and event deletion requests.
 
-## Step 6: Stream Data
+## Step 8: Stream Data
 
 For ETL pipelines or data processing, stream data directly:
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -158,7 +158,7 @@ Once you know an event name, see what properties it has:
 === "CLI"
 
     ```bash
-    mp inspect properties "Purchase"
+    mp inspect properties --event Purchase
     ```
 
 === "Python"
@@ -176,7 +176,7 @@ See actual values a property contains:
 === "CLI"
 
     ```bash
-    mp inspect values "Purchase" "country"
+    mp inspect values --event Purchase --property country
     ```
 
 === "Python"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -33,6 +33,7 @@ export MP_REGION="us"
 export MP_SECRET="your-secret-here"
 mp account add production --type service_account \
     --username sa_abc123... \
+    --project 12345 \
     --region us
 # Added account 'production' (service_account, us). Set as active.
 ```
@@ -43,7 +44,7 @@ For CI/CD environments where the secret lives in a shell variable, pipe it via s
 
 ```bash
 echo "$SECRET" | mp account add production --type service_account \
-    --username sa_abc123... --region us --secret-stdin
+    --username sa_abc123... --project 12345 --region us --secret-stdin
 ```
 
 ### Option C: OAuth Login (Interactive)

--- a/docs/guide/data-governance.md
+++ b/docs/guide/data-governance.md
@@ -5,7 +5,7 @@ Manage Mixpanel data governance programmatically: Lexicon definitions (events, p
 !!! note "Prerequisites"
     Data governance requires **authentication** — service account or OAuth credentials.
 
-    All data governance operations require a **workspace ID** — set via `MP_WORKSPACE_ID` env var, `--workspace-id` CLI flag, or `ws.set_workspace_id()`. Find yours with `mp inspect info` or `ws.info()`.
+    All data governance operations require a **workspace ID** — set via `MP_WORKSPACE_ID` env var, `--workspace` / `-w` CLI flag, `Workspace(workspace=N)`, or `ws.use(workspace=N)`. List available workspaces with `mp workspace list` or `ws.workspaces()`.
 
 !!! tip "Read-Only Discovery"
     For read-only Lexicon schema exploration (listing events/properties with descriptions and metadata), see the [Discovery guide — Lexicon Schemas](discovery.md#lexicon-schemas). This guide covers **write operations**: creating, updating, and deleting definitions.

--- a/docs/guide/entity-management.md
+++ b/docs/guide/entity-management.md
@@ -7,7 +7,7 @@ Manage Mixpanel dashboards, reports (bookmarks), cohorts, feature flags, experim
 
     **Scoping differs by entity type:**
 
-    - **Dashboards, reports, cohorts, alerts, annotations, webhooks** require a **workspace ID** — set via `MP_WORKSPACE_ID` env var, `--workspace-id` CLI flag, or `ws.set_workspace_id()`. Find yours with `mp inspect info` or `ws.info()`.
+    - **Dashboards, reports, cohorts, alerts, annotations, webhooks** require a **workspace ID** — set via `MP_WORKSPACE_ID` env var, `--workspace` / `-w` CLI flag, `Workspace(workspace=N)`, or `ws.use(workspace=N)`. List available workspaces with `mp workspace list` or `ws.workspaces()`.
     - **Feature flags and experiments** are **project-scoped** and do NOT require a workspace ID.
 
 ## Dashboards

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,11 @@ import mixpanel_data as mp
 ws = mp.Workspace()
 
 # Discover what's in your project
-events = ws.list_events()
-props = ws.list_properties("Purchase")
-values = ws.list_property_values("Purchase", "country")
-funnels = ws.list_funnels()
-cohorts = ws.list_cohorts()
+events = ws.events()
+props = ws.properties("Purchase")
+values = ws.property_values("country", event="Purchase")
+funnels = ws.funnels()
+cohorts = ws.cohorts()
 bookmarks = ws.list_bookmarks()
 
 # Manage entities
@@ -133,7 +133,7 @@ result = ws.query(CohortMetric(123, "Power Users"), last=90, unit="week")
 
 # Legacy live queries
 segmentation = ws.segmentation(
-    event=events[0].name,
+    event=events[0],
     from_date="2025-01-01",
     to_date="2025-01-31",
     on="country"

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,8 +160,8 @@ funnel.df
 ```bash
 # Discover your data landscape
 mp inspect events
-mp inspect properties "Purchase"
-mp inspect values "Purchase" "country"
+mp inspect properties --event Purchase
+mp inspect values --event Purchase --property country
 mp inspect top-events
 mp inspect funnels
 mp inspect cohorts

--- a/docs/migration/0.4.0.md
+++ b/docs/migration/0.4.0.md
@@ -90,7 +90,7 @@ The following names were **added** as part of the v3 surface and are canonical g
 - **Result types:** `AccountSummary`, `AccountTestResult`, `OAuthLoginResult`, `Target`
 - **Token plumbing:** `OAuthTokens`, `OAuthClientInfo`, `TokenResolver`, `OnDiskTokenResolver`
 - **Cowork bridge:** `BridgeFile`, `load_bridge`
-- **Exceptions:** `AccountInUseError`, `WorkspaceScopeError`
+- **Exceptions:** `AccountInUseError`, `ProjectNotFoundError`, `WorkspaceScopeError`
 - **Functional namespaces:** `mp.accounts`, `mp.session`, `mp.targets`
 
 ### Token & config file moves

--- a/docs/migration/0.4.0.md
+++ b/docs/migration/0.4.0.md
@@ -1,0 +1,126 @@
+# Migration: 0.3.x → 0.4.0
+
+> Mirrors the canonical [`RELEASE_NOTES_0.4.0.md`](https://github.com/jaredmcfarland/mixpanel_data/blob/main/RELEASE_NOTES_0.4.0.md) — update both together.
+
+`mixpanel_data` 0.4.0 ships a complete rewrite of the auth subsystem (single TOML schema, three first-class account types, a single resolver, fluent in-session switching). It is a **hard break** from 0.3.x: legacy `~/.mp/config.toml` files no longer load and there is no auto-migration path. Recovery is a wipe + re-add (5 commands).
+
+## Recovery recipe
+
+```bash
+# 1. Back up your existing config (it will become unreadable on 0.4.x)
+cp ~/.mp/config.toml ~/.mp/config.toml.0.3-backup
+rm ~/.mp/config.toml
+
+# 2. Re-add accounts
+
+# Service account
+mp account add team --type service_account \
+  --username <SA_USERNAME> --region us
+# (will prompt for the secret with hidden input)
+
+# OAuth browser
+mp account add personal --type oauth_browser --region us
+mp account login personal     # opens browser for PKCE flow
+```
+
+Confirm the new state:
+
+```bash
+mp session              # shows resolved account / project / workspace
+mp account list         # shows all configured accounts
+mp project list         # shows accessible projects via /me
+```
+
+## Breaking Changes
+
+### Configuration schema
+
+- **No legacy v1 / v2 detection.** Configs written by 0.3.x raise a Pydantic validation error on first load. There is **no `mp config convert`** — recovery is a wipe + re-add via `mp account add ...`.
+- `[active].project` is rejected (the project axis lives on the account itself as `default_project`). Sessions persist `[active].account` + `[active].workspace` only.
+- v1 / v2 OAuth token files at `~/.mp/oauth/tokens_{region}.json` are no longer read; tokens now live at `~/.mp/accounts/{name}/tokens.json`.
+
+### CLI command groups
+
+The following entire command groups were **deleted** (no backwards-compat shim, no deprecation banner):
+
+| Removed | Replacement |
+|---|---|
+| `mp auth list/add/remove/switch/show/test/login/logout` | [`mp account list/add/remove/use/show/test/login/logout`](../cli/index.md#account-account-management) |
+| `mp auth migrate` | (no replacement — schema break, wipe `~/.mp/config.toml`) |
+| `mp auth cowork-setup` | [`mp account export-bridge --to PATH`](../cli/index.md#account-account-management) |
+| `mp auth cowork-status` | [`mp session --bridge`](../cli/index.md#session-active-session-inspection) |
+| `mp auth cowork-teardown` | [`mp account remove-bridge [--at PATH]`](../cli/index.md#account-account-management) |
+| `mp projects list/use/show` | [`mp project list/use/show`](../cli/index.md#project-project-switching) |
+| `mp workspaces list/use/show` | [`mp workspace list/use/show`](../cli/index.md#workspace-workspace-switching) |
+| `mp context show` | [`mp session`](../cli/index.md#session-active-session-inspection) |
+| `mp config convert` | (descoped — see above) |
+
+### CLI globals
+
+| Removed | Replacement |
+|---|---|
+| `--credential` | `--account` (`-a`) |
+| `--workspace-id` | `--workspace` (`-w`) |
+| (added) | `--project` (`-p`) |
+| (added) | `--target` (`-t`) — apply a saved target |
+
+`--target` is mutually exclusive with `--account`/`--project`/`--workspace`.
+
+### Public Python API
+
+The following names were **deleted** from `mixpanel_data`:
+
+| Removed | Notes |
+|---|---|
+| `Credentials`, `AuthMethod` | Internal shim types — use `Workspace(...)` directly. |
+| `AccountInfo`, `CredentialInfo`, `ProjectAlias` | Replaced by `AccountSummary` / `Account` (discriminated union) / `Target`. |
+| `MigrationResult`, `ActiveContext` | Migration descoped; active state lives in `Session` / `ActiveSession`. |
+| `AuthCredential`, `CredentialType`, `ProjectContext`, `ResolvedSession` | v2 internals — see `Account` + `Session` instead. |
+| `Workspace.set_workspace_id(...)` | `Workspace.use(workspace=N)` |
+| `Workspace.switch_project(...)` | `Workspace.use(project=P)` |
+| `Workspace.switch_workspace(...)` | `Workspace.use(workspace=N)` |
+| `Workspace.current_credential()` | `Workspace.account` (read-only property) |
+| `Workspace.current_project()` | `Workspace.project` (read-only property) |
+| `Workspace.test_credentials(...)` | `mp.accounts.test(NAME)` returning `AccountTestResult` |
+
+The following names were **added** as part of the v3 surface and are canonical going forward (re-exported from `mixpanel_data`):
+
+- **Discriminated account union:** `Account`, `AccountType`, `ServiceAccount`, `OAuthBrowserAccount`, `OAuthTokenAccount`, `Region`
+- **Session axes:** `Session`, `Project`, `WorkspaceRef`, `ActiveSession`
+- **Result types:** `AccountSummary`, `AccountTestResult`, `OAuthLoginResult`, `Target`
+- **Token plumbing:** `OAuthTokens`, `OAuthClientInfo`, `TokenResolver`, `OnDiskTokenResolver`
+- **Cowork bridge:** `BridgeFile`, `load_bridge`
+- **Exceptions:** `AccountInUseError`, `WorkspaceScopeError`
+- **Functional namespaces:** `mp.accounts`, `mp.session`, `mp.targets`
+
+### Token & config file moves
+
+| Was | Now |
+|---|---|
+| `~/.mp/oauth/tokens_{region}.json` | `~/.mp/accounts/{name}/tokens.json` (per-account) |
+| `~/.mp/oauth/me_{region}.json` | `~/.mp/accounts/{name}/me.json` (per-account) |
+| `~/.mp/oauth/client_{region}.json` | unchanged (still shared per region) |
+| `[default]` + `[accounts.X].project_id` | `[active].account` + `[accounts.X].default_project` |
+
+The legacy `~/.mp/oauth/tokens_*.json` and `~/.mp/oauth/me_*.json` files are left untouched on disk — delete them manually if you want a clean slate.
+
+## Plugin
+
+- The `mixpanel-data` Claude Code plugin manifest version bumps from `4.1.0` → `5.0.0`.
+- The `/mixpanel-data:auth` slash command re-routes to the new subcommand vocabulary (`account / project / workspace / target / session / bridge`). Old verbs (`status / list / switch / migrate / context / cowork-setup`) are gone.
+- `auth_manager.py` JSON shape is now stable with `schema_version: 1` and a discriminated `state` field (`ok` | `needs_account` | `needs_project` | `error`).
+
+Pin `mixpanel-data >= 5.0.0` so the slash command consumes the new JSON contract.
+
+## What stayed the same
+
+- Region defaults (`us`, `eu`, `in`)
+- Output formats (`json`, `jsonl`, `table`, `csv`, `plain`)
+- Discovery / live query / streaming / entity CRUD APIs (no auth-only methods affected — `Workspace.events()`, `.segmentation()`, `.list_dashboards()`, etc. are unchanged)
+- All entity CRUD on dashboards, reports, cohorts, flags, experiments, alerts, annotations, webhooks, lexicon, drop filters, custom properties, custom events, lookup tables, schemas
+
+## Next Steps
+
+- [Configuration](../getting-started/configuration.md) — Full setup walkthrough with the new commands and config schema
+- [API → Auth](../api/auth.md) — Python API reference for the v3 surface
+- [CLI Reference](../cli/index.md) — Full command and global-options reference

--- a/docs/migration/0.4.0.md
+++ b/docs/migration/0.4.0.md
@@ -15,7 +15,7 @@ rm ~/.mp/config.toml
 
 # Service account (default_project is required at add-time)
 mp account add team --type service_account \
-  --username <SA_USERNAME> --project <PROJECT_ID> --region us
+  --username "sa_abc123..." --project 12345 --region us
 # (will prompt for the secret with hidden input)
 
 # OAuth browser
@@ -83,15 +83,19 @@ The following names were **deleted** from `mixpanel_data`:
 | `Workspace.current_project()` | `Workspace.project` (read-only property) |
 | `Workspace.test_credentials(...)` | `mp.accounts.test(NAME)` returning `AccountTestResult` |
 
-The following names were **added** as part of the v3 surface and are canonical going forward (re-exported from `mixpanel_data`):
+The following names were **added** as part of the v3 surface and are canonical going forward (re-exported from the top-level `mixpanel_data` namespace):
 
 - **Discriminated account union:** `Account`, `AccountType`, `ServiceAccount`, `OAuthBrowserAccount`, `OAuthTokenAccount`, `Region`
-- **Session axes:** `Session`, `Project`, `WorkspaceRef`, `ActiveSession`
+- **Session axes:** `Session`, `Project`, `WorkspaceRef`
 - **Result types:** `AccountSummary`, `AccountTestResult`, `OAuthLoginResult`, `Target`
-- **Token plumbing:** `OAuthTokens`, `OAuthClientInfo`, `TokenResolver`, `OnDiskTokenResolver`
-- **Cowork bridge:** `BridgeFile`, `load_bridge`
 - **Exceptions:** `AccountInUseError`, `ProjectNotFoundError`, `WorkspaceScopeError`
 - **Functional namespaces:** `mp.accounts`, `mp.session`, `mp.targets`
+
+The following low-level types are available only from `mixpanel_data.auth_types`:
+
+- **Active session snapshot:** `ActiveSession`
+- **Token plumbing:** `OAuthTokens`, `OAuthClientInfo`, `TokenResolver`, `OnDiskTokenResolver`
+- **Cowork bridge:** `BridgeFile`, `load_bridge`
 
 ### Token & config file moves
 

--- a/docs/migration/0.4.0.md
+++ b/docs/migration/0.4.0.md
@@ -13,9 +13,9 @@ rm ~/.mp/config.toml
 
 # 2. Re-add accounts
 
-# Service account
+# Service account (default_project is required at add-time)
 mp account add team --type service_account \
-  --username <SA_USERNAME> --region us
+  --username <SA_USERNAME> --project <PROJECT_ID> --region us
 # (will prompt for the secret with hidden input)
 
 # OAuth browser

--- a/mixpanel-plugin/docs/getting-started-guide.md
+++ b/mixpanel-plugin/docs/getting-started-guide.md
@@ -313,6 +313,20 @@ print(flow.top_transitions(5))     # Top 5 most common paths
 print(flow.drop_off_summary())     # Where users drop off
 ```
 
+### User Profile Query
+
+```python
+from mixpanel_data import Filter
+
+# Pull profile fields for high-value users
+result = ws.query_user(
+    where=Filter.greater_than("purchase_count", 10),
+    properties=["$name", "$email", "plan"],
+    limit=None,                      # fetch every match (None = no cap)
+)
+print(result.df.head())              # distinct_id | $name | $email | plan
+```
+
 ### Stream Events
 
 For processing large datasets without loading everything into memory:
@@ -383,21 +397,19 @@ Once authenticated, just ask Claude questions in natural language:
 "Build me a weekly KPI dashboard for the product team."
 ```
 
-Claude will choose the right query engine (Insights, Funnels, Retention, or Flows), write and execute the Python code, and explain the results.
+Claude will choose the right query engine (Insights, Funnels, Retention, Flows, or Users), write and execute the Python code, and explain the results.
 
-### Specialist Agents
+### What's in the Plugin
 
-The plugin includes five specialist agents that Claude can invoke automatically based on your question:
+The plugin ships three skills that Claude loads automatically when relevant:
 
-| Agent | What It Does | Example Question |
-|-------|-------------|-----------------|
-| **analyst** | General-purpose orchestrator | "Show me revenue trends by plan type" |
-| **explorer** | Discovers your data schema | "What events and properties do we track?" |
-| **diagnostician** | Root cause analysis | "Why did signups drop last Tuesday?" |
-| **synthesizer** | Multi-engine cross-analysis | "Compare funnel conversion for retained vs. churned users" |
-| **narrator** | Executive summaries | "Write a weekly product report for leadership" |
+| Skill | Trigger | What It Does |
+|-------|---------|--------------|
+| **setup** | `/mixpanel-data:setup` (manual) | Installs `mixpanel_data` + analytics dependencies and verifies credentials. |
+| **mixpanelyst** | Auto-loads on analytics questions | Distilled `Workspace` API reference, discovery workflow, exploratory analysis playbook, and live `help.py` lookup for method signatures, types, and enums. |
+| **dashboard-expert** | Auto-loads on dashboard questions | Four-mode workflow (Analyze, Build, Modify, Explain) for Mixpanel dashboards, with 9 design templates, chart-type selection, and layout reference. |
 
-You don't need to invoke these manually — Claude routes to the right agent based on your question.
+The `/mixpanel-data:auth` slash command provides a guided wrapper around `mp account / project / workspace / target / session / bridge` for managing credentials without leaving the conversation.
 
 ---
 
@@ -501,6 +513,7 @@ ws.query("Event", last=30)              # Insights query
 ws.query_funnel(["A", "B", "C"])        # Funnel query
 ws.query_retention("A", "B")            # Retention query
 ws.query_flow("Event", forward=3)       # Flow query
+ws.query_user(properties=["$email"])    # User profile query
 ws.stream_events(from_date="...", to_date="...")  # Stream events
 ```
 
@@ -510,9 +523,14 @@ ws.stream_events(from_date="...", to_date="...")  # Stream events
 |----------|---------|
 | `MP_USERNAME` | Service account username |
 | `MP_SECRET` | Service account secret |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; the full service-account quad takes precedence when both sets are complete) |
 | `MP_PROJECT_ID` | Your Mixpanel project ID |
 | `MP_REGION` | Data residency region (`us`, `eu`, or `in`) |
 | `MP_WORKSPACE_ID` | Workspace ID (for dashboard and entity management) |
+| `MP_ACCOUNT` | Override the active account name |
+| `MP_TARGET` | Apply a saved target (mutually exclusive with `MP_ACCOUNT`/`MP_PROJECT_ID`/`MP_WORKSPACE_ID`) |
+| `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
+| `MP_CONFIG_PATH` | Override config file location |
 
 ### Output Formats
 

--- a/mixpanel-plugin/docs/getting-started-guide.md
+++ b/mixpanel-plugin/docs/getting-started-guide.md
@@ -73,24 +73,21 @@ You need to connect `mixpanel_data` to your Mixpanel project. There are two ways
 
 ### Option A: OAuth Login (Recommended for Personal Use)
 
-This opens your browser so you can log in with your Mixpanel credentials:
+Register an OAuth browser account, then run the PKCE login flow — the second command opens your browser so you can authenticate with Mixpanel:
 
 ```bash
-mp auth login --region us
+mp account add personal --type oauth_browser --region us
+mp account login personal
 ```
 
-After logging in, `mixpanel_data` automatically discovers your accessible projects. If you have exactly one project, it is selected for you. If you have multiple projects, you'll be prompted to choose one:
+After logging in, `mixpanel_data` automatically backfills the account's `default_project` from the post-login `/me` probe. If you have multiple accessible projects and want to switch:
 
 ```bash
-mp projects list                  # See all your projects
-mp projects switch YOUR_PROJECT_ID  # Select a project
+mp project list                # See all your accessible projects
+mp project use YOUR_PROJECT_ID # Switch to a different project
 ```
 
-You can also specify a project ID upfront if you already know it:
-
-```bash
-mp auth login --region us --project-id YOUR_PROJECT_ID
-```
+You can also pin a specific project at registration time by passing `--project YOUR_PROJECT_ID` to `mp account add`.
 
 **Region options:**
 
@@ -103,7 +100,7 @@ mp auth login --region us --project-id YOUR_PROJECT_ID
 Verify the connection:
 
 ```bash
-mp auth status
+mp session
 ```
 
 ### Option B: Service Account (Recommended for Scripts & CI/CD)
@@ -113,15 +110,16 @@ Service accounts are ideal for automation. You'll need a **service account usern
 Add the credentials (you'll be prompted for the secret securely):
 
 ```bash
-mp auth add my-project --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
+mp account add my-project --type service_account \
+    --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
 ```
 
-You'll see a hidden input prompt for the secret — paste it and press Enter.
+You'll see a hidden input prompt for the secret — paste it and press Enter. (For non-interactive use, prefer `export MP_SECRET=...` before the command, or pipe the secret via `--secret-stdin`.)
 
 Then verify the connection:
 
 ```bash
-mp auth test
+mp account test
 ```
 
 You should see a success message confirming the credentials work.
@@ -137,11 +135,11 @@ export MP_PROJECT_ID="12345"
 export MP_REGION="us"
 ```
 
-These take effect immediately for any `mp` command or Python script in the same terminal session.
+These take effect immediately for any `mp` command or Python script in the same terminal session. For an OAuth bearer token instead of a service account, set `MP_OAUTH_TOKEN` + `MP_PROJECT_ID` + `MP_REGION` (the service-account quad takes precedence when both sets are complete).
 
 ### Where Credentials Are Stored
 
-Credentials are saved to `~/.mp/config.toml`. This file is created automatically when you run `mp auth add` or `mp auth login`. You should never need to edit it by hand.
+Account records and the active session live in `~/.mp/config.toml`. OAuth browser tokens are stored per-account at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refreshed automatically on expiry. These files are created automatically when you run `mp account add` or `mp account login` — you should never need to edit them by hand.
 
 ---
 
@@ -364,10 +362,10 @@ This will:
 If the setup skill reports that no credentials are found, use the `/mixpanel-data:auth` command:
 
 ```
-/mixpanel-data:auth add my-project
+/mixpanel-data:auth account add my-project
 ```
 
-Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret.
+Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret. For OAuth, use `/mixpanel-data:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-data:auth account login personal`.
 
 ### Ask Analytics Questions
 
@@ -409,36 +407,36 @@ You don't need to invoke these manually — Claude routes to the right agent bas
 
 ### Step 1: Set Up the Credential Bridge (On Your Local Machine)
 
-Choose or create a directory to use as your Cowork workspace, then run this on your **local machine** (not inside Cowork):
+On your **local machine** (not inside Cowork), export the active account into a v2 bridge file at the default Cowork-readable path:
 
 ```bash
-mp auth cowork-setup --dir /path/to/your/workspace
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 
-This writes a `mixpanel_auth.json` bridge file into the specified directory. When you start a Cowork session, select this same directory as your workspace so the VM can access the credentials.
+This writes a v2 `auth.json` bridge file embedding your full `Account` record (and any `oauth_browser` tokens) so the Cowork session can read your credentials at startup. The default search path inside Cowork is `~/.claude/mixpanel/auth.json` — override with `MP_AUTH_FILE` if you need a custom location.
 
 **Options:**
 
 ```bash
-# Use a specific credential (if you have multiple accounts)
-mp auth cowork-setup --dir /path/to/workspace --credential production
+# Export a specific named account (defaults to the active account)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --account production
 
-# Override the project ID
-mp auth cowork-setup --dir /path/to/workspace --project-id 12345
+# Pin a project ID into the bridge (overrides the account's default_project)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --project 12345
 
-# Include a workspace ID (needed for dashboard and entity management)
-mp auth cowork-setup --dir /path/to/workspace --workspace-id 3448413
+# Pin a workspace ID into the bridge (needed for dashboard/entity management)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --workspace 3448413
 ```
 
 ### Step 2: Verify the Bridge (Anywhere)
 
-Check that the bridge file exists and is valid:
+Check that the bridge resolves correctly:
 
 ```bash
-mp auth cowork-status
+mp session --bridge
 ```
 
-This shows you the auth method, region, project ID, and whether OAuth tokens are still valid.
+This shows the resolved account, project, workspace, and any pinned headers from the bridge file.
 
 ### Step 3: Use mixpanel_data in Cowork
 
@@ -455,12 +453,13 @@ The setup script automatically detects the Cowork environment and reads credenti
 When you no longer need Cowork access, remove the bridge file:
 
 ```bash
-mp auth cowork-teardown --dir /path/to/your/workspace
+mp account remove-bridge          # removes the default ~/.claude/mixpanel/auth.json
+mp account remove-bridge --at /custom/path/auth.json
 ```
 
 ### OAuth Token Refresh
 
-If you authenticated with OAuth, the bridge file includes a refresh token. The library automatically refreshes expired tokens inside Cowork — no browser interaction needed. If the refresh token itself expires, you'll need to re-authenticate on your local machine (`mp auth login`) and re-run `mp auth cowork-setup --dir /path/to/your/workspace`.
+If you authenticated with OAuth, the bridge file embeds your refresh token. The library automatically refreshes expired access tokens inside Cowork — no browser interaction needed. If the refresh token itself is rejected (e.g., revoked at the IdP), you'll need to re-authenticate on your local machine (`mp account login <name>`) and re-run `mp account export-bridge --to ~/.claude/mixpanel/auth.json` to pick up the fresh tokens.
 
 ---
 
@@ -470,17 +469,22 @@ If you authenticated with OAuth, the bridge file includes a refresh token. The l
 
 | Command | What It Does |
 |---------|-------------|
-| `mp auth login` | Log in with OAuth (opens browser) |
-| `mp auth add <name>` | Add a service account |
-| `mp auth test` | Test your credentials |
-| `mp auth status` | Show current auth status |
+| `mp account add <name> --type oauth_browser --region us` | Register an OAuth browser account |
+| `mp account login <name>` | Run the PKCE browser flow for an OAuth account |
+| `mp account add <name> --type service_account --username ... --project ... --region ...` | Register a service account |
+| `mp account test [name]` | Test credentials for an account (defaults to active) |
+| `mp session` | Show the resolved active session (account / project / workspace) |
+| `mp account use <name>` | Switch the active account |
+| `mp project list` / `mp project use <id>` | List accessible projects / switch active project |
+| `mp workspace list` / `mp workspace use <id>` | List workspaces / pin one to the active session |
+| `mp target add <name> --account A --project P [--workspace W]` | Save a named (account, project, workspace?) cursor |
+| `mp target use <name>` | Apply a saved target atomically |
+| `mp account export-bridge --to PATH` | Write a v2 Cowork bridge file |
+| `mp account remove-bridge [--at PATH]` | Remove the bridge file |
 | `mp inspect events` | List all tracked events |
 | `mp inspect properties --event <name>` | List properties for an event |
 | `mp query segmentation --event <name> --from <date> --to <date>` | Run a segmentation query |
 | `mp query funnel <id> --from <date> --to <date>` | Query a saved funnel |
-| `mp projects list` | List accessible projects |
-| `mp projects switch <id>` | Switch active project |
-| `mp auth migrate` | Migrate v1 config to v2 format |
 | `mp --help` | Show all available commands |
 | `mp <command> --help` | Show help for a specific command |
 
@@ -547,38 +551,40 @@ If using `uv`, make sure the virtual environment is activated.
 - Double-check your service account username and secret in Mixpanel (Settings > Service Accounts)
 - Verify your project ID matches the project the service account has access to
 - Make sure the region flag matches your project's data residency
-- Run `mp auth test` to see the specific error message
+- Run `mp account test <name>` to see the specific error message
 
 ### "No credentials configured"
 
 Run one of:
 
 ```bash
-# OAuth (interactive — auto-discovers your projects)
-mp auth login --region us
+# OAuth browser (interactive PKCE flow)
+mp account add personal --type oauth_browser --region us
+mp account login personal
 
 # Service account
-mp auth add my-project --username YOUR_USERNAME --project YOUR_PROJECT_ID --region us
+mp account add my-project --type service_account \
+    --username YOUR_USERNAME --project YOUR_PROJECT_ID --region us
 ```
 
 ### OAuth Token Expired
 
 ```bash
-# Re-authenticate
-mp auth login --region us
+# Re-authenticate (refresh token revoked or expired)
+mp account login <name>
 ```
 
 ### Plugin Not Working in Claude Code
 
 1. Make sure plugins are enabled in your Claude Code settings
 2. Run `/mixpanel-data:setup` to install dependencies
-3. Check auth with `/mixpanel-data:auth status`
+3. Check auth with `/mixpanel-data:auth session`
 4. If the plugin doesn't appear, try restarting Claude Code
 
 ### Cowork VM Can't Find Credentials
 
-1. On your **local machine**, run: `mp auth cowork-setup --dir /path/to/your/workspace`
-2. Verify with: `mp auth cowork-status`
+1. On your **local machine**, run: `mp account export-bridge --to ~/.claude/mixpanel/auth.json`
+2. Verify with: `mp session --bridge`
 3. Inside the Cowork session, run: `/mixpanel-data:setup`
 
 ---

--- a/mixpanel-plugin/docs/quickstart-claude-code.md
+++ b/mixpanel-plugin/docs/quickstart-claude-code.md
@@ -47,7 +47,7 @@ You only need to do this once. Choose the method that works best for you.
 Run the `/mixpanel-data:auth` command:
 
 ```
-/mixpanel-data:auth add my-project
+/mixpanel-data:auth account add my-project
 ```
 
 Claude will walk you through it step by step:
@@ -60,20 +60,33 @@ Claude will walk you through it step by step:
 
 Your secret is never visible in the conversation.
 
-> If your account has access to multiple projects, you can switch later with `/mixpanel-data:auth switch-project <id>`. Run `/mixpanel-data:auth projects` to see what's available.
+> If your account has access to multiple projects, you can switch later with `/mixpanel-data:auth project use <id>`. Run `/mixpanel-data:auth project list` to see what's available.
 
 ### Option B: OAuth Login (Browser-Based)
 
 ```
-/mixpanel-data:auth login
+/mixpanel-data:auth account add personal --type oauth_browser --region us
+/mixpanel-data:auth account login personal
 ```
 
-Claude will ask for your region, then open a browser window where you log in with your Mixpanel credentials. After login, your projects are automatically discovered — if you have exactly one project, it's selected for you. If you have multiple, Claude will help you pick one.
+The first command registers an OAuth browser account; the second opens a browser window where you log in with your Mixpanel credentials. After login, your default project is backfilled automatically from the post-login `/me` probe. Use `/mixpanel-data:auth project list` then `/mixpanel-data:auth project use <id>` to switch if you have multiple projects.
+
+### Option C: Raw OAuth Bearer Token (CI / Agents)
+
+If a managed OAuth client (e.g., a CI pipeline) hands you a pre-obtained access token, inject it via env vars without going through the browser:
+
+```bash
+export MP_OAUTH_TOKEN="<bearer-token>"
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"  # or "eu", "in"
+```
+
+The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete.
 
 ### Verify It Worked
 
 ```
-/mixpanel-data:auth test
+/mixpanel-data:auth account test
 ```
 
 You should see confirmation that Claude connected successfully and found events in your project.
@@ -156,53 +169,55 @@ You never need to write this yourself, but it's helpful to know what's possible.
 
 ## Managing Accounts
 
-### Check current status
+### Check current session (active account / project / workspace)
 
 ```
-/mixpanel-data:auth status
+/mixpanel-data:auth session
 ```
 
 ### Switch between accounts
 
 ```
-/mixpanel-data:auth list
-/mixpanel-data:auth switch production
-```
-
-### See full context (active credential, project, workspace)
-
-```
-/mixpanel-data:auth context
+/mixpanel-data:auth account list
+/mixpanel-data:auth account use production
 ```
 
 ### Discover accessible projects
 
 ```
-/mixpanel-data:auth projects
+/mixpanel-data:auth project list
 ```
 
-### Switch projects (v2 config)
+### Switch projects
 
 ```
-/mixpanel-data:auth switch-project 67890
+/mixpanel-data:auth project use 67890
+```
+
+### Switch workspaces
+
+```
+/mixpanel-data:auth workspace list
+/mixpanel-data:auth workspace use 3448414
 ```
 
 ### Remove an account
 
 ```
-/mixpanel-data:auth remove my-old-project
+/mixpanel-data:auth account remove my-old-project
 ```
 
 ### Revoke OAuth tokens
 
 ```
-/mixpanel-data:auth logout
+/mixpanel-data:auth account logout my-account-name
 ```
 
-### Upgrade to v2 config (enables project switching)
+### Save a named target (account + project + optional workspace)
 
 ```
-/mixpanel-data:auth migrate
+/mixpanel-data:auth target add ecom --account team --project 3018488
+/mixpanel-data:auth target use ecom
 ```
 
 ---
@@ -211,18 +226,18 @@ You never need to write this yourself, but it's helpful to know what's possible.
 
 ### "No credentials configured"
 
-Run `/mixpanel-data:auth add my-project` and follow the prompts, or `/mixpanel-data:auth login` for OAuth.
+Run `/mixpanel-data:auth account add my-project` and follow the prompts, or `/mixpanel-data:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-data:auth account login personal` for OAuth.
 
 ### "Authentication failed"
 
 - Check that your service account username and secret are correct (Mixpanel Settings > Service Accounts)
 - Verify your project ID matches the project the service account has access to
 - Make sure the region matches your project's data residency
-- Run `/mixpanel-data:auth test` for detailed error information
+- Run `/mixpanel-data:auth account test` for detailed error information
 
 ### "OAuth token expired" or OAuth login stopped working
 
-Run `/mixpanel-data:auth login` again to refresh your tokens. If you switch to a service account instead, run `/mixpanel-data:auth add <name>` — service account credentials don't expire.
+Run `/mixpanel-data:auth account login <name>` again to refresh your tokens. If you switch to a service account instead, run `/mixpanel-data:auth account add <name> --type service_account ...` — service account credentials don't expire.
 
 ### Plugin not appearing
 

--- a/mixpanel-plugin/docs/quickstart-claude-code.md
+++ b/mixpanel-plugin/docs/quickstart-claude-code.md
@@ -203,14 +203,18 @@ You never need to write this yourself, but it's helpful to know what's possible.
 
 ### Remove an account
 
+The slash command focuses on read + onboarding flows; destructive lifecycle
+operations stay on the CLI. Run them in your terminal (or via the `!`
+shell prefix inside Claude Code):
+
 ```
-/mixpanel-data:auth account remove my-old-project
+! mp account remove my-old-project
 ```
 
 ### Revoke OAuth tokens
 
 ```
-/mixpanel-data:auth account logout my-account-name
+! mp account logout my-account-name
 ```
 
 ### Save a named target (account + project + optional workspace)

--- a/mixpanel-plugin/docs/quickstart-claude-cowork.md
+++ b/mixpanel-plugin/docs/quickstart-claude-cowork.md
@@ -27,17 +27,19 @@ pip install git+https://github.com/jaredmcfarland/mixpanel_data.git
 Then configure your Mixpanel credentials:
 
 ```bash
-# OAuth (opens browser, auto-discovers your projects)
-mp auth login --region us
+# OAuth browser (PKCE flow — opens browser)
+mp account add personal --type oauth_browser --region us
+mp account login personal
 
 # OR service account (prompts for secret securely)
-mp auth add my-project --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
+mp account add my-project --type service_account \
+    --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
 ```
 
 Verify the credentials work:
 
 ```bash
-mp auth test
+mp account test
 ```
 
 You should see a success message confirming the connection.
@@ -46,41 +48,33 @@ You should see a success message confirming the connection.
 
 ## Step 2: Export Credentials for Cowork
 
-On your **local machine**, choose or create a directory to use as your Cowork workspace, then export your credentials there:
+On your **local machine**, export the active account into a v2 bridge file at the default Cowork-readable path:
 
 ```bash
-mp auth cowork-setup --dir /path/to/your/workspace
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 
-This writes a `mixpanel_auth.json` bridge file into the specified directory. When you start a Cowork session, select this same directory as your workspace so the VM can access the credentials.
+This writes a v2 `auth.json` bridge file embedding your full `Account` record (and any `oauth_browser` tokens). The Cowork VM auto-discovers it on session start. Override the location with the `MP_AUTH_FILE` env var if you need a custom path.
 
-You'll see JSON output confirming what was exported:
+You'll see a brief confirmation, then the bridge is ready:
 
-```json
-{
-  "status": "cowork_setup_complete",
-  "bridge_path": "/path/to/your/workspace/mixpanel_auth.json",
-  "auth_method": "service_account",
-  "region": "us",
-  "project_id": "12345",
-  "workspace_id": null,
-  "has_custom_header": false,
-  "credentials_valid": true,
-  "test_error": null
-}
+```
+Wrote bridge: ~/.claude/mixpanel/auth.json
+  Account:  personal (oauth_browser, us)
+  Tokens:   included (refresh-capable)
 ```
 
 ### Options
 
 ```bash
-# Use a specific credential (if you have multiple accounts)
-mp auth cowork-setup --dir /path/to/workspace --credential production
+# Export a specific named account (defaults to the active account)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --account production
 
-# Override the project ID
-mp auth cowork-setup --dir /path/to/workspace --project-id 12345
+# Pin a project ID into the bridge (overrides the account's default_project)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --project 12345
 
-# Include a workspace ID (required for dashboard/entity management)
-mp auth cowork-setup --dir /path/to/workspace --workspace-id 3448413
+# Pin a workspace ID into the bridge (needed for dashboard/entity management)
+mp account export-bridge --to ~/.claude/mixpanel/auth.json --workspace 3448413
 ```
 
 ---
@@ -98,9 +92,9 @@ The setup script automatically detects the Cowork environment and reads credenti
 ```
 Cowork environment detected.
 ✓ Auth bridge file found: ~/.claude/mixpanel/auth.json
-  Auth method: service_account
-  Region: us
-  Project: 12345
+  Account:  personal (oauth_browser, us)
+  Project:  12345
+  Tokens:   included (refresh-capable)
 ```
 
 No additional configuration is needed inside Cowork.
@@ -130,17 +124,17 @@ All bridge management commands run on your **local machine**, not inside Cowork.
 Works both locally and inside Cowork:
 
 ```bash
-mp auth cowork-status
+mp session --bridge
 ```
 
-Shows whether the bridge file exists, the auth method, region, project ID, and (for OAuth) whether the token is still valid.
+Shows the bridge-resolved account, project, workspace, and any pinned headers. (For OAuth browser accounts, the library refreshes expired tokens automatically; refresh failure surfaces as `OAuthError(code="OAUTH_REFRESH_REVOKED")`.)
 
 ### Update credentials
 
-If you change your credentials or switch projects, re-export to the same workspace directory:
+If you change your credentials or switch projects, re-export to the same path:
 
 ```bash
-mp auth cowork-setup --dir /path/to/your/workspace
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 
 Then start a **new Cowork session** for the changes to take effect.
@@ -150,7 +144,8 @@ Then start a **new Cowork session** for the changes to take effect.
 When you no longer need Cowork access to your Mixpanel data:
 
 ```bash
-mp auth cowork-teardown --dir /path/to/your/workspace
+mp account remove-bridge          # removes ~/.claude/mixpanel/auth.json
+mp account remove-bridge --at /custom/path/auth.json
 ```
 
 ---
@@ -160,12 +155,12 @@ mp auth cowork-teardown --dir /path/to/your/workspace
 If you authenticated with OAuth (rather than a service account), the bridge file includes both an access token and a refresh token.
 
 - **Automatic refresh**: The `mixpanel_data` library refreshes expired OAuth tokens automatically inside Cowork — no browser needed
-- **Refresh token expired**: If the refresh token itself expires (rare), you need to re-authenticate on your local machine and re-export:
+- **Refresh token rejected**: If the refresh token itself is rejected (e.g., revoked at the IdP), the library surfaces `OAuthError(code="OAUTH_REFRESH_REVOKED")`. You need to re-authenticate on your local machine and re-export:
 
 ```bash
 # On your local machine
-mp auth login --region us
-mp auth cowork-setup --dir /path/to/your/workspace
+mp account login personal
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 
 Then start a new Cowork session.
@@ -174,32 +169,31 @@ Then start a new Cowork session.
 
 ## How the Bridge Works
 
-The credential bridge is a JSON file that maps your local credentials into a format Cowork VMs can consume:
+The credential bridge is a v2 JSON file that maps your local credentials into a format Cowork VMs can consume:
 
 ```
-Your machine                          Cowork VM
-┌─────────────────────┐               ┌──────────────────────────┐
-│ ~/.mp/config.toml   │               │ /path/to/your/workspace/ │
-│ (your credentials)  │──cowork-setup──▶│ mixpanel_auth.json       │
-│                     │   --dir ...    │ (bridge file)            │
-└─────────────────────┘               └──────────────────────────┘
-                                             │
-                                      mixpanel_data detects
-                                      Cowork + reads bridge
-                                             │
-                                      ┌──────▼──────────────┐
-                                      │ mp.Workspace()      │
-                                      │ (authenticated)     │
-                                      └─────────────────────┘
+Your machine                                         Cowork VM
+┌─────────────────────────┐                          ┌─────────────────────────┐
+│ ~/.mp/config.toml       │                          │ ~/.claude/mixpanel/     │
+│ ~/.mp/accounts/<name>/  │──account export-bridge──▶│   auth.json             │
+│ (account + tokens)      │   --to <path>            │ (v2 bridge: full        │
+│                         │                          │  Account + tokens)      │
+└─────────────────────────┘                          └─────────────────────────┘
+                                                              │
+                                                       resolve_session() reads
+                                                       bridge during construction
+                                                              │
+                                                       ┌──────▼──────────────┐
+                                                       │ mp.Workspace()      │
+                                                       │ (authenticated)     │
+                                                       └─────────────────────┘
 ```
 
 The bridge file is searched in this priority order:
 
 1. `MP_AUTH_FILE` environment variable (if set)
-2. `mixpanel_auth.json` in the current working directory
-3. `~/.claude/mixpanel/auth.json` (default location)
-4. `~/.claude/mixpanel_auth.json`
-5. `~/mnt/{folder}/mixpanel_auth.json` (bindfs mount)
+2. `~/.claude/mixpanel/auth.json` (default location)
+3. `./mixpanel_auth.json` in the current working directory
 
 ---
 
@@ -211,10 +205,10 @@ The bridge file is searched in this priority order:
 
 **Fix**: On your local machine:
 ```bash
-mp auth cowork-setup --dir /path/to/your/workspace
-mp auth cowork-status   # verify it was created
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
+mp session --bridge   # verify the bridge resolves
 ```
-Then start a **new** Cowork session using that workspace directory (existing sessions won't pick up the new file).
+Then start a **new** Cowork session (existing sessions won't pick up the new file).
 
 ### "Authentication failed" inside Cowork
 
@@ -222,22 +216,22 @@ Then start a **new** Cowork session using that workspace directory (existing ses
 
 **Fix**: On your local machine:
 ```bash
-mp auth test            # verify local credentials still work
-mp auth cowork-setup --dir /path/to/your/workspace   # re-export fresh credentials
+mp account test            # verify local credentials still work
+mp account export-bridge --to ~/.claude/mixpanel/auth.json   # re-export fresh credentials
 ```
 
 ### OAuth token expired and won't refresh
 
-**Cause**: Both the access token and refresh token have expired.
+**Cause**: The refresh token was rejected (typically `OAuthError(code="OAUTH_REFRESH_REVOKED")`).
 
 **Fix**: On your local machine:
 ```bash
-mp auth login --region us
-mp auth cowork-setup --dir /path/to/your/workspace
+mp account login personal
+mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 Then start a new Cowork session.
 
-### Can't run `mp auth cowork-setup` — "command not found"
+### Can't run `mp account export-bridge` — "command not found"
 
 **Cause**: The `mixpanel_data` package isn't installed on your local machine.
 
@@ -251,16 +245,16 @@ mp --version   # verify
 
 **Cause**: You're inside Cowork but the bridge file is missing.
 
-**Fix**: You cannot configure credentials from inside Cowork (no browser, no host terminal). Exit Cowork, run `mp auth cowork-setup --dir /path/to/your/workspace` on your local machine, then start a new Cowork session using that workspace directory.
+**Fix**: You cannot configure credentials from inside Cowork (no browser, no host terminal). Exit Cowork, run `mp account export-bridge --to ~/.claude/mixpanel/auth.json` on your local machine, then start a new Cowork session.
 
 ### Important: What Doesn't Work Inside Cowork
 
 These commands require a browser or host terminal and **should be run on your local machine**, not inside Cowork:
 
-- `mp auth login` (needs a browser for OAuth)
-- `mp auth add` (prompts for secret interactively by default; supports `--secret-stdin` and `MP_SECRET` env var for non-interactive use, but the credential bridge is the recommended approach for Cowork)
-- `mp auth cowork-setup` (reads host credentials, writes bridge file)
-- `mp auth cowork-teardown` (removes bridge file from host)
+- `mp account login <name>` (needs a browser for the PKCE OAuth flow)
+- `mp account add` for `service_account` (prompts for secret interactively by default; `--secret-stdin` and `MP_SECRET` env var work non-interactively, but the credential bridge is the recommended approach for Cowork)
+- `mp account export-bridge --to <path>` (reads host credentials, writes the bridge file)
+- `mp account remove-bridge [--at <path>]` (removes the bridge file from the host)
 
 Always run these on your **local machine** before starting a Cowork session.
 

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -81,52 +81,43 @@ echo ""
 echo "Checking Mixpanel credentials..."
 "$python_cmd" -c "
 import os, sys
-# Check environment variables first
-env_vars = ['MP_USERNAME', 'MP_SECRET', 'MP_PROJECT_ID', 'MP_REGION']
-env_set = [v for v in env_vars if os.environ.get(v)]
-if len(env_set) == len(env_vars):
-    print(f'✓ All environment variables set')
+
+# 1) Service-account env quad
+sa_quad = ['MP_USERNAME', 'MP_SECRET', 'MP_PROJECT_ID', 'MP_REGION']
+sa_set = [v for v in sa_quad if os.environ.get(v)]
+if len(sa_set) == len(sa_quad):
+    print('✓ Service-account env quad is fully set (MP_USERNAME + MP_SECRET + MP_PROJECT_ID + MP_REGION)')
     sys.exit(0)
-elif env_set:
-    missing = [v for v in env_vars if not os.environ.get(v)]
-    print(f'⚠ Partial environment config — missing: {\", \".join(missing)}')
+elif sa_set:
+    missing = [v for v in sa_quad if not os.environ.get(v)]
+    print(f'⚠ Partial service-account env config — missing: {\", \".join(missing)}')
 
-# Check config file
+# 2) OAuth-token env triple
+oauth_triple = ['MP_OAUTH_TOKEN', 'MP_PROJECT_ID', 'MP_REGION']
+oauth_set = [v for v in oauth_triple if os.environ.get(v)]
+if len(oauth_set) == len(oauth_triple):
+    print('✓ OAuth-token env triple is fully set (MP_OAUTH_TOKEN + MP_PROJECT_ID + MP_REGION)')
+    sys.exit(0)
+
+# 3) Persisted accounts in ~/.mp/config.toml
 try:
-    from mixpanel_data._internal.config import ConfigManager
-    cm = ConfigManager()
-    version = 1  # config schema version is fixed under the 0.4.0 layout
-
-    if version >= 2:
-        # v2 config: credential + project context
-        credentials = cm.list_credentials()
-        if credentials:
-            active = [c for c in credentials if c.is_active]
-            print(f'✓ Config v2: {len(credentials)} credential(s)')
-            if active:
-                print(f'  Active: {active[0].name} ({active[0].type}, {active[0].region})')
-            aliases = cm.list_project_aliases()
-            if aliases:
-                print(f'  {len(aliases)} project alias(es) configured')
+    import mixpanel_data as mp
+    accounts = mp.accounts.list()
+    if accounts:
+        active = next((a for a in accounts if a.is_active), None)
+        names = ', '.join(a.name for a in accounts)
+        print(f'✓ {len(accounts)} account(s) in ~/.mp/config.toml: {names}')
+        if active:
+            print(f'  Active: {active.name} ({active.type}, {active.region})')
         else:
-            print('⚠ Config v2 but no credentials configured.')
-            print('  Run /mixpanel-data:auth add (service account) or /mixpanel-data:auth login (OAuth)')
+            print('⚠ No active account selected. Run: mp account use <name>')
     else:
-        # v1 config: account-based
-        accounts = cm.list_accounts()
-        if accounts:
-            names = [a.name for a in accounts]
-            print(f'✓ Config v1: {len(accounts)} account(s): {\", \".join(names)}')
-            default = next((a.name for a in accounts if a.is_default), None)
-            if default:
-                print(f'  Default: {default}')
-            print(f'  Tip: Run /mixpanel-data:auth migrate to upgrade to v2 for project switching')
-        else:
-            print('⚠ No accounts configured yet.')
-            print('  Run /mixpanel-data:auth add (service account) or /mixpanel-data:auth login (OAuth)')
+        print('⚠ No accounts configured yet.')
+        print('  OAuth browser:    mp account add personal --type oauth_browser --region us && mp account login personal')
+        print('  Service account:  mp account add team --type service_account --username sa_xxx --project 12345 --region us')
 except Exception as e:
-    print(f'⚠ Could not check config file credentials: {e}')
-    print('  Set environment variables: MP_USERNAME, MP_SECRET, MP_PROJECT_ID')
+    print(f'⚠ Could not read ~/.mp/config.toml: {e}')
+    print('  Set env vars (service-account quad or OAuth triple) or run mp account add ...')
 "
 
 # Cowork detection: check for bridge file
@@ -142,15 +133,21 @@ import json, sys
 try:
     with open(sys.argv[1]) as fh:
         bridge = json.load(fh)
-    print(f'  Auth method: {bridge.get(\"auth_method\", \"unknown\")}')
-    print(f'  Region: {bridge.get(\"region\", \"unknown\")}')
-    print(f'  Project: {bridge.get(\"project_id\", \"unknown\")}')
-    ch = bridge.get('custom_header')
-    if ch:
-        print(f'  Custom header: {ch.get(\"name\", \"?\")} ✓')
-    oauth = bridge.get('oauth')
-    if oauth and oauth.get('expires_at'):
-        print(f'  Token expires: {oauth[\"expires_at\"]}')
+    if bridge.get('version') != 2:
+        print(f'  ⚠ Unexpected bridge version: {bridge.get(\"version\")} (expected 2)')
+    account = bridge.get('account', {})
+    print(f'  Account: {account.get(\"name\", \"?\")} ({account.get(\"type\", \"?\")}, {account.get(\"region\", \"?\")})')
+    project = bridge.get('project') or account.get('default_project')
+    if project:
+        print(f'  Project: {project}')
+    if bridge.get('workspace'):
+        print(f'  Workspace: {bridge[\"workspace\"]}')
+    headers = bridge.get('headers') or {}
+    if headers:
+        print(f'  Custom headers: {len(headers)} entr{\"y\" if len(headers) == 1 else \"ies\"} ✓')
+    tokens = bridge.get('tokens')
+    if tokens and tokens.get('expires_at'):
+        print(f'  Token expires: {tokens[\"expires_at\"]}')
 except Exception as e:
     print(f'  Error reading bridge file: {e}')
 " "$f"
@@ -161,7 +158,7 @@ except Exception as e:
   if [ -z "$BRIDGE_FOUND" ]; then
     echo "⚠ No auth bridge file found."
     echo "  On your HOST machine, run:"
-    echo "    mp auth cowork-setup"
+    echo "    mp account export-bridge --to ~/.claude/mixpanel/auth.json"
     echo "  Then start a new Cowork session."
   fi
 fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,8 @@ plugins:
           - getting-started/installation.md
           - getting-started/quickstart.md
           - getting-started/configuration.md
+        Migration:
+          - migration/0.4.0.md
         User Guide:
           - guide/unified-query-system.md
           - guide/discovery.md
@@ -132,6 +134,8 @@ plugins:
           - getting-started/installation.md: "Install with pip or uv"
           - getting-started/quickstart.md: "First queries in 5 minutes"
           - getting-started/configuration.md: "Accounts, env vars, config files"
+        Migration:
+          - migration/0.4.0.md: "Upgrade from 0.3.x to 0.4.0 (auth architecture redesign)"
         User Guide:
           - guide/unified-query-system.md: "Unified query system — one vocabulary, four analytics engines"
           - guide/discovery.md: "Explore schema, events, properties, cohorts"
@@ -177,6 +181,8 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
       - Configuration: getting-started/configuration.md
+  - Migration:
+      - From 0.3.x to 0.4.0: migration/0.4.0.md
   - User Guide:
       - The Unified Query System: guide/unified-query-system.md
       - Data Discovery: guide/discovery.md

--- a/scripts/qa/cli-runbook.md
+++ b/scripts/qa/cli-runbook.md
@@ -23,18 +23,18 @@ Systematic QA testing for the `mp` CLI against live Mixpanel data.
 ```bash
 uv run mp --version
 uv run mp --help
-uv run mp auth --help
+uv run mp account --help
 uv run mp fetch --help
 uv run mp query --help
 uv run mp inspect --help
 ```
 
-## 2. Auth
+## 2. Account
 ```bash
-uv run mp auth list
-uv run mp auth list --format table
-uv run mp auth show sinkapp-prod
-uv run mp auth test sinkapp-prod
+uv run mp account list
+uv run mp account list --format table
+uv run mp account show sinkapp-prod
+uv run mp account test sinkapp-prod
 ```
 
 ## 3. Inspect
@@ -82,8 +82,8 @@ uv run mp -a sinkapp-prod query segmentation-average --event "Added Entity" --on
 ## 7. Output Formats
 ```bash
 uv run mp -a sinkapp-prod inspect events --format json | head -10
-uv run mp -a sinkapp-prod auth list --format table
-uv run mp -a sinkapp-prod auth list --format csv
+uv run mp -a sinkapp-prod account list --format table
+uv run mp -a sinkapp-prod account list --format csv
 uv run mp -a sinkapp-prod inspect events --format plain | head -5
 uv run mp -a sinkapp-prod inspect events --format jsonl | head -5
 ```

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -733,8 +733,10 @@ class Workspace:
         """Resolve the workspace ID for scoped requests.
 
         Resolution order:
-        1. Explicit workspace ID (set via ``Workspace(workspace=N)`` or
-           ``Workspace.use(workspace=N)``)
+        1. Workspace ID already pinned on the resolved session (for example
+           via ``Workspace(workspace=N)``, ``Workspace.use(workspace=N)``,
+           ``MP_WORKSPACE_ID``, saved targets, bridge pins, or persisted
+           ``[active].workspace`` state)
         2. Cached auto-discovered workspace ID
         3. Auto-discover by listing workspaces and finding the default
 

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -733,7 +733,8 @@ class Workspace:
         """Resolve the workspace ID for scoped requests.
 
         Resolution order:
-        1. Explicit workspace ID (set via ``set_workspace_id()``)
+        1. Explicit workspace ID (set via ``Workspace(workspace=N)`` or
+           ``Workspace.use(workspace=N)``)
         2. Cached auto-discovered workspace ID
         3. Auto-discover by listing workspaces and finding the default
 


### PR DESCRIPTION
## Summary
- Brings `docs/`, `README.md`, and one source docstring into sync with the v3 auth surface that shipped in #126 (042-auth-architecture-redesign).
- Three first-class account types (`service_account` / `oauth_browser` / `oauth_token`), new `mp.accounts` / `mp.session` / `mp.targets` namespaces, fluent `Workspace.use()`, new CLI groups (`mp account` / `project` / `workspace` / `target` / `session`), new resolver chain (`env > param > target > bridge > [active] > default_project`).
- Adds `docs/migration/0.4.0.md` adapted from `RELEASE_NOTES_0.4.0.md`, with deep-links into the rewritten docs.

## Changes
**Full rewrites**
- `docs/getting-started/configuration.md` — three-axis hierarchy, account-types matrix, new TOML schema, CLI/Python account mgmt, resolution chain, **NEW** Saved Targets and Bridge sections.
- `docs/api/auth.md` — drops `_internal` exposures (`ConfigManager`/`OAuthStorage`/`OAuthFlow`); adds `Account` variants, `Session` axes, `Workspace.use()`, three namespaces, result types, resolver, Cowork bridge, OAuth token plumbing.

**Significant edits**
- `docs/getting-started/quickstart.md` — new Step 2 (Choose a Project) and Step 6 (in-session switching); `mp auth` → `mp account`; `ws.list_events()` → `ws.events()`.
- `docs/cli/index.md` — new global-flags table; replaced `### auth` with five new sections; updated env-vars and exit codes.
- `docs/architecture/design.md` — new resolver-chain bullets; **Immutable Credentials** → **Immutable Session**; new **Three-Axis Hierarchy** subsection; full package-structure tree rewrite.

**Targeted patches**
- `docs/api/workspace.md` — new **In-Session Switching** subsection; autodoc `members:` now lists `account`/`project`/`workspace`/`session`/`use`/`me`/`projects`/`workspaces` (drops `test_credentials`/`workspace_id`/`set_workspace_id`).
- `docs/api/index.md` — Auth Surface bullet list reframed around v3; canonical top-level imports.
- `docs/api/exceptions.md` — adds `AccountInUseError`/`ProjectNotFoundError` to hierarchy + autodoc; adds `OAUTH_REFRESH_REVOKED` row.
- `docs/index.md`, `docs/getting-started/installation.md`, `docs/guide/{entity-management,data-governance}.md` — sweep.
- `README.md` — auth section rewrite, new CLI reference paragraph, **What's new in 0.4.0** callout, three-account-types framing.

**New file + nav**
- `docs/migration/0.4.0.md` — migration recipe + before/after tables, deep-linked into the new docs.
- `mkdocs.yml` — Migration nav section + mirrored in both llmstxt sections.

**Source**
- `src/mixpanel_data/workspace.py:736` — `resolve_workspace_id` docstring no longer references the deleted `set_workspace_id()`.

## Test plan
- [x] `mkdocs build --strict` — clean (no warnings, no broken anchors)
- [x] `just lint` — all checks passed
- [x] `just typecheck` — success, no issues found in 273 source files
- [x] `uv run mp --help` — shows new global flags (`-a`/`-p`/`-w`/`-t`) and the new command groups
- [x] Auto-generated `site/cli/commands/` — shows `account`/`project`/`workspace`/`target`/`session` groups
- [x] All v3 imports resolve from the top-level `mixpanel_data` namespace
- [x] Grep zero-hits for stale refs (`mp auth`, `set_workspace_id`, `--workspace-id`, `--credential`, `ws.list_events()`) outside intentional citations in `migration/0.4.0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)