### PR TITLE
fix(ci): point Gemini workflows at pinned run-gemini-cli fork

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
-        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0
+        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
-        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0
+        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -58,7 +58,7 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
 
       - name: 'Run Gemini pull request review'
-        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0
+        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
         id: 'gemini_pr_review'
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -73,7 +73,7 @@ jobs:
         id: 'gemini_analysis'
         if: |-
           ${{ steps.get_labels.outputs.available_labels != '' }}
-        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0
+        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs


### PR DESCRIPTION
## Why

Every Gemini workflow run on the smoke-test PR (#141) failed at action download time with:

> The actions \`google-github-actions/auth@v3\` and \`actions/upload-artifact@v6\` are not allowed in mixpanel/mixpanel-headless because all actions must be pinned to a full-length commit SHA.

These two refs live **inside** \`google-github-actions/run-gemini-cli@v0.1.22\`'s \`action.yml\` (lines 221 and 435). We can't fix them by editing our workflow files — we have to fix them inside the action itself.

## Fix

Forked \`google-github-actions/run-gemini-cli\` at \`v0.1.22\` to [\`jaredmixpanel/run-gemini-cli\`](https://github.com/jaredmixpanel/run-gemini-cli/tree/pinned/v0.1.22), pinned both refs, and tagged \`v0.1.22-pinned-1\` at \`dc0f750388421b8ab57151bc6fe876dd8bebf8f6\`. This PR points all four reusable Gemini workflows at the fork.

| Action | Pinned SHA | Tag |
|---|---|---|
| \`google-github-actions/auth\` | \`7c6bc770dae815cd3e89ee6cdf493a5fab2cc093\` | \`v3\` |
| \`actions/upload-artifact\` | \`b7c566a772e6b6bfb58ed0dc250532a479d7789f\` | \`v6\` |

## Follow-up

Filing an upstream issue at \`google-github-actions/run-gemini-cli\` asking them to pin these refs directly. Once they do, we can switch back to \`google-github-actions/run-gemini-cli@<sha>\` and retire the fork.

## Test plan

- [ ] Merge
- [ ] Re-trigger the Gemini smoke tests on #141 (apply \`gemini-review\` label, post \`@gemini-cli\` comment, open a fresh test issue)
- [ ] All three should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)