### PR TITLE
test: re-exercise Gemini workflows; remove throwaway smoke-test file

### DIFF
--- a/.github/AI_REVIEWER_TEST.md
+++ b/.github/AI_REVIEWER_TEST.md
@@ -1,4 +1,0 @@
-# AI reviewer smoke test
-
-Throwaway file used to open a PR that exercises the Codex and Gemini reviewer
-workflows added in #140. Safe to delete after the test PR is closed.


### PR DESCRIPTION
## Purpose

#141 was merged unintentionally, leaving the throwaway \`.github/AI_REVIEWER_TEST.md\` on main. This PR removes it and serves as a fresh test bed to re-verify the Gemini workflows now that #143 (fork-pinned \`run-gemini-cli\`) is on main.

Will be merged once the Gemini smoke tests pass.

## Test plan

- [ ] Apply \`gemini-review\` label → Gemini posts a pending review
- [ ] Comment \`@gemini-cli <question>\` → Gemini invoke responds
- [ ] (separate fresh issue) Open issue → Gemini triage applies labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)