### PR TITLE
fix(ci): bump pinned run-gemini-cli to v0.1.22-pinned-2 (slash-command fix)

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
-        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
+        uses: 'jaredmixpanel/run-gemini-cli@c45abde456b44f04791097f631931f36a334655d' # v0.1.22-pinned-2
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'
-        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
+        uses: 'jaredmixpanel/run-gemini-cli@c45abde456b44f04791097f631931f36a334655d' # v0.1.22-pinned-2
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -58,7 +58,7 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
 
       - name: 'Run Gemini pull request review'
-        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
+        uses: 'jaredmixpanel/run-gemini-cli@c45abde456b44f04791097f631931f36a334655d' # v0.1.22-pinned-2
         id: 'gemini_pr_review'
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -73,7 +73,7 @@ jobs:
         id: 'gemini_analysis'
         if: |-
           ${{ steps.get_labels.outputs.available_labels != '' }}
-        uses: 'jaredmixpanel/run-gemini-cli@dc0f750388421b8ab57151bc6fe876dd8bebf8f6' # v0.1.22-pinned-1
+        uses: 'jaredmixpanel/run-gemini-cli@c45abde456b44f04791097f631931f36a334655d' # v0.1.22-pinned-2
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs


### PR DESCRIPTION
## Why

Smoke-test on PR #144 (after #143 landed) showed:

| Path | Result |
|---|---|
| \`gemini-review\` label | ✅ works |
| \`@gemini-cli\` (invoke) | ❌ \"Blocked command: echo \$ADDITIONAL_CONTEXT. Reason: Blocked by policy\" |
| Issue triage | ❌ same |

The v0.1.22-shipped \`.github/commands/{gemini-invoke,gemini-triage,gemini-plan-execute}.toml\` use Gemini CLI's \`!{echo \$VAR}\` syntax to expand env vars at prompt time. The workflow's \`tools.core: []\` setting blocks the shell tool, so the expansion fails. Upstream's \`examples/workflows/\` directory has newer \`.toml\` versions that use \`@{.gemini/context.json}\` (file-injection) — backed by the \"Prepare prompt context\" step our workflows already include — but those updates haven't been ported to the auto-installed copies.

## Fix

[v0.1.22-pinned-2](https://github.com/jaredmixpanel/run-gemini-cli/releases/tag/v0.1.22-pinned-2) of the fork ports the example \`.toml\` files into \`.github/commands/\`. This PR bumps all four reusable Gemini workflows to that SHA (\`c45abde456b44f04791097f631931f36a334655d\`).

## Test plan

- [ ] Merge
- [ ] Re-trigger Gemini smoke tests on #144 (apply \`gemini-review\`, post \`@gemini-cli\`, open a fresh test issue)
- [ ] All three should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)