### PR TITLE
fix(ci): always post Gemini's response back to the PR/issue

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -132,3 +132,32 @@ jobs:
               }
             }
           prompt: '/gemini-invoke'
+
+      - name: 'Post Gemini response as comment'
+        # The action captures Gemini's textual response into the gemini_response
+        # output. The /gemini-invoke slash command expects Gemini to call the
+        # add_issue_comment MCP tool itself, but for many prompts (especially
+        # Q&A) Gemini answers without invoking that tool — leaving the response
+        # only in the run's step summary. This fallback always posts the
+        # captured response so users get visible output. If Gemini also posted
+        # via MCP, both will appear (rare in practice).
+        if: |-
+          ${{ steps.run_gemini.outputs.gemini_response != '' }}
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # v7
+        env:
+          GEMINI_RESPONSE: '${{ steps.run_gemini.outputs.gemini_response }}'
+        with:
+          github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          script: |
+            const issue_number =
+              context.payload.pull_request?.number ?? context.payload.issue?.number;
+            if (!issue_number) {
+              core.setFailed('Could not determine issue/PR number for comment.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: process.env.GEMINI_RESPONSE,
+            });

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -122,3 +122,31 @@ jobs:
               "https://github.com/gemini-cli-extensions/code-review"
             ]
           prompt: '/pr-code-review'
+
+      - name: 'Post Gemini review as comment'
+        # /pr-code-review (from the code-review extension) is supposed to post
+        # a pending review via the GitHub MCP server's pull_request_review_write
+        # tool. In practice it doesn't always do that — the textual review ends
+        # up only in the run's step summary. This fallback always posts the
+        # captured response as a regular PR comment so the review reaches the
+        # author. If Gemini did post a pending review via MCP, both will appear.
+        if: |-
+          ${{ steps.gemini_pr_review.outputs.gemini_response != '' }}
+        uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # v7
+        env:
+          GEMINI_RESPONSE: '${{ steps.gemini_pr_review.outputs.gemini_response }}'
+        with:
+          github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          script: |
+            const issue_number =
+              context.payload.pull_request?.number ?? context.payload.issue?.number;
+            if (!issue_number) {
+              core.setFailed('Could not determine PR number for comment.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: process.env.GEMINI_RESPONSE,
+            });


### PR DESCRIPTION
## Why

After #143 and #146 fixed the action-pinning and slash-command issues, smoke-testing on #144 showed all three Gemini workflow runs exit successfully — but only the triage path produces visible output:

| Path                          | Exit | Posted to GitHub? |
|-------------------------------|------|-------------------|
| \`gemini-review\` label         | ✅   | ❌ no review/comment |
| \`@gemini-cli\` mention (invoke)| ✅   | ❌ no comment        |
| Issue triage                  | ✅   | ✅ labels applied    |

Triage works because \`gemini-triage.yml\` has a dedicated \`label\` job that consumes the action's output (\`steps.gemini_analysis.outputs.summary\`) and applies labels via \`github.rest.issues.setLabels\`. Review and invoke rely entirely on Gemini autonomously calling the MCP \`add_issue_comment\` / \`pull_request_review_write\` tools, which in practice it often doesn't — especially for Q&A prompts. The response ends up captured in the action's \`gemini_response\` step output and the run's step summary, but never reaches the user.

## Fix

Add an unconditional post-step at the end of \`gemini-invoke.yml\` and \`gemini-review.yml\` that consumes \`steps.<run-step>.outputs.gemini_response\` and posts it as an issue comment via \`github.rest.issues.createComment\`. Mirrors the pattern used by \`codex-review.yml\` and \`codex.yml\`.

## Trade-off

If Gemini *does* post via MCP, both will appear (duplicated). In our smoke tests it never did, but if it becomes noisy we can revisit (e.g. detect existing bot comment from the same run, or stop using the MCP-posting tools entirely).

## Test plan

- [ ] Merge
- [ ] Re-trigger \`gemini-review\` label on a fresh test PR → confirm a Gemini review comment appears
- [ ] Comment \`@gemini-cli <question>\` → confirm a Gemini response comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)