### PR TITLE
fix(ci): correct MCP tool list for review + always-post fallback

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -134,18 +134,22 @@ jobs:
           prompt: '/gemini-invoke'
 
       - name: 'Post Gemini response as comment'
-        # The action captures Gemini's textual response into the gemini_response
-        # output. The /gemini-invoke slash command expects Gemini to call the
-        # add_issue_comment MCP tool itself, but for many prompts (especially
-        # Q&A) Gemini answers without invoking that tool — leaving the response
-        # only in the run's step summary. This fallback always posts the
-        # captured response so users get visible output. If Gemini also posted
-        # via MCP, both will appear (rare in practice).
+        # Always post a visible comment. The /gemini-invoke slash command is
+        # supposed to call add_issue_comment via the GitHub MCP server, but
+        # in practice Gemini often answers without invoking that tool — so
+        # the response only ends up in the run's step summary. This step
+        # ensures the user always sees something in the conversation. If
+        # gemini_response is empty (Gemini posted via MCP, errored silently,
+        # or returned no textual content), post a brief notice with a link to
+        # the run logs.
+        # See: https://github.com/google-github-actions/run-gemini-cli/issues/277
+        #      https://github.com/google-github-actions/run-gemini-cli/issues/278
         if: |-
-          ${{ steps.run_gemini.outputs.gemini_response != '' }}
+          ${{ always() && !cancelled() }}
         uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # v7
         env:
           GEMINI_RESPONSE: '${{ steps.run_gemini.outputs.gemini_response }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         with:
           github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           script: |
@@ -155,9 +159,14 @@ jobs:
               core.setFailed('Could not determine issue/PR number for comment.');
               return;
             }
+            const response = (process.env.GEMINI_RESPONSE || '').trim();
+            const runUrl = process.env.RUN_URL;
+            const body = response
+              ? `${response}\n\n<sub>— Gemini · [run logs](${runUrl})</sub>`
+              : `🤖 Gemini ran but didn't return a textual response. It may have posted via the GitHub MCP tools above, or you can check the [run logs](${runUrl}) for details.`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number,
-              body: process.env.GEMINI_RESPONSE,
+              body,
             });

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -105,8 +105,9 @@ jobs:
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "pull_request_review_write"
+                    "submit_pending_pull_request_review"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
@@ -124,17 +125,23 @@ jobs:
           prompt: '/pr-code-review'
 
       - name: 'Post Gemini review as comment'
-        # /pr-code-review (from the code-review extension) is supposed to post
-        # a pending review via the GitHub MCP server's pull_request_review_write
-        # tool. In practice it doesn't always do that — the textual review ends
-        # up only in the run's step summary. This fallback always posts the
-        # captured response as a regular PR comment so the review reaches the
-        # author. If Gemini did post a pending review via MCP, both will appear.
+        # Always post a visible comment. /pr-code-review (from the code-review
+        # extension) is supposed to create + submit a pending review via the
+        # GitHub MCP server, but the upstream's `includeTools` list shipped
+        # with the wrong tool names for github-mcp-server >= v0.18 (we use
+        # v0.27), so the MCP path silently no-ops. We've fixed the tool list
+        # above (create_pending_pull_request_review, submit_pending_pull_request_review),
+        # but keep this fallback as a belt-and-suspenders so the response
+        # always reaches the PR even if MCP fails. If gemini_response is empty,
+        # post a brief notice with a link to the run logs.
+        # See: https://github.com/google-github-actions/run-gemini-cli/issues/353
+        #      https://github.com/google-github-actions/run-gemini-cli/issues/277
         if: |-
-          ${{ steps.gemini_pr_review.outputs.gemini_response != '' }}
+          ${{ always() && !cancelled() }}
         uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # v7
         env:
           GEMINI_RESPONSE: '${{ steps.gemini_pr_review.outputs.gemini_response }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         with:
           github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           script: |
@@ -144,9 +151,14 @@ jobs:
               core.setFailed('Could not determine PR number for comment.');
               return;
             }
+            const response = (process.env.GEMINI_RESPONSE || '').trim();
+            const runUrl = process.env.RUN_URL;
+            const body = response
+              ? `${response}\n\n<sub>— Gemini review · [run logs](${runUrl})</sub>`
+              : `🤖 Gemini ran but didn't return a textual response. It may have posted a pending review via the GitHub MCP tools above, or you can check the [run logs](${runUrl}) for details.`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number,
-              body: process.env.GEMINI_RESPONSE,
+              body,
             });


### PR DESCRIPTION
## Why

After #143, #146, and #148, every Gemini workflow run on the smoke-test PR (#144) exits successfully but only the triage path delivers visible output. Web search turned up multiple closed-but-unfixed upstream bugs:

| Issue | Symptom | Root cause |
|---|---|---|
| [#277](https://github.com/google-github-actions/run-gemini-cli/issues/277) | Review runs succeed, no comments posted | Duplicate of #278; never properly fixed |
| [#278](https://github.com/google-github-actions/run-gemini-cli/issues/278) | Same | Closed as \"not reproducible\" — workaround was to allow shell tools |
| [#353](https://github.com/google-github-actions/run-gemini-cli/issues/353) | \`/review\` not posting since github-mcp-server v0.18+ | Upstream example's \`includeTools\` references removed/renamed tools |

## Fix

### 1. MCP tool names (gemini-review.yml)

\`\`\`diff
   \"includeTools\": [
     \"add_comment_to_pending_review\",
+    \"create_pending_pull_request_review\",
     \"pull_request_read\",
-    \"pull_request_review_write\"
+    \"submit_pending_pull_request_review\"
   ],
\`\`\`

The replaced tool name is what upstream's example ships with — but it doesn't exist in github-mcp-server v0.18+ (we pin v0.27.0). Without \`create_pending_pull_request_review\` + \`submit_pending_pull_request_review\`, Gemini can't actually submit a review even when it tries.

### 2. Always-post fallback (gemini-invoke.yml + gemini-review.yml)

The existing fallback step from #148 only fires when \`gemini_response != ''\`. In our last test, invoke's \`gemini_response\` came back empty — likely Gemini called MCP tools (which silently no-op'd) and didn't print a textual summary. So the fallback was skipped and nothing reached the user.

This PR makes the fallback run unconditionally and handle the empty-response case explicitly:

- **Non-empty response** → post the response with a footer linking to the run logs
- **Empty response** → post a brief notice: \"🤖 Gemini ran but didn't return a textual response. … check the [run logs](…) for details.\"

Either way, the PR/issue conversation always has visible feedback.

### Trade-off

If Gemini *does* successfully post via MCP, the user will see two messages (MCP-posted + fallback). Hasn't happened in our tests; can be revisited if noisy.

## Test plan

- [ ] Merge
- [ ] Merge \`main\` into \`test/gemini-retry\` so the test PR's branch picks up the fix (PRs from same-repo branches use the head branch's workflow file)
- [ ] Re-trigger \`gemini-review\` label and \`@gemini-cli\` mention on #144
- [ ] Confirm both produce a visible comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)