### PR TITLE
feat(business-context): add read/write support for org and project business context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ src/mixpanel_data/
     │                        # + query, inspect, dashboards, reports, cohorts, flags,
     │                        # experiments, alerts, annotations, webhooks, lexicon,
     │                        # drop-filters, custom-properties, custom-events,
-    │                        # lookup-tables, schemas
+    │                        # lookup-tables, schemas, business-context
     ├── formatters.py        # JSON, JSONL, Table, CSV, Plain output
     └── utils.py             # Error handling, console helpers
 ```

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -23,7 +23,8 @@ MixpanelDataError
 │   ├── ServerError
 │   └── JQLSyntaxError
 ├── OAuthError
-└── WorkspaceScopeError
+├── WorkspaceScopeError
+└── BusinessContextValidationError
 ```
 
 ## Catching Errors
@@ -144,6 +145,21 @@ Raised when workspace resolution fails for App API endpoints.
 | `WORKSPACE_NOT_FOUND` | Specified workspace ID does not exist |
 
 ::: mixpanel_data.WorkspaceScopeError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+## Business Context Exceptions
+
+Raised by `Workspace.set_business_context()` when content exceeds the 50,000-character cap. The check runs **before** the HTTP call, so callers fail fast and don't waste a round-trip; the server enforces the same limit and would otherwise return `QueryError` (HTTP 400). See the [Business Context guide](../guide/business-context.md) for usage.
+
+| Error Code | Raised When |
+|------------|-------------|
+| `BUSINESS_CONTEXT_TOO_LONG` | `len(content) > BUSINESS_CONTEXT_MAX_CHARS` (50,000) |
+
+The `details` dict carries `length` (the actual content length) and `max` (the configured limit) for programmatic recovery.
+
+::: mixpanel_data.BusinessContextValidationError
     options:
       show_root_heading: true
       show_root_toc_entry: true

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -134,15 +134,16 @@ Raised during OAuth 2.0 PKCE authentication flows.
       show_root_heading: true
       show_root_toc_entry: true
 
-## Workspace Exceptions
+## Workspace / Organization Scope Exceptions
 
-Raised when workspace resolution fails for App API endpoints.
+Raised when an auth-axis identifier (workspace or organization) cannot be resolved during App API requests.
 
 | Error Code | Raised When |
 |------------|-------------|
 | `NO_WORKSPACES` | No workspaces found for the project |
 | `AMBIGUOUS_WORKSPACE` | Multiple workspaces found and none is marked as default |
 | `WORKSPACE_NOT_FOUND` | Specified workspace ID does not exist |
+| `ORGANIZATION_AMBIGUOUS` | An org-scoped business-context call could not auto-resolve the organization (active project absent from `/me` AND >1 accessible organization). `details` carries `project_id` and `available_organizations`. Pass `organization_id=N` explicitly to bypass auto-resolution. |
 
 ::: mixpanel_data.WorkspaceScopeError
     options:

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1012,3 +1012,19 @@ Types for managing event deletion requests.
     options:
       show_root_heading: true
       show_root_toc_entry: true
+
+## Business Context Types
+
+Types for the markdown documentation that grounds AI assistants — see the [Business Context guide](../guide/business-context.md). Both org and project scopes return the same `BusinessContext` model; `BusinessContextChain` bundles both for the convenience `get_business_context_chain()` round-trip.
+
+The 50,000-character cap is exposed as the constant `mixpanel_data.BUSINESS_CONTEXT_MAX_CHARS` and enforced both client-side (before any HTTP call) and server-side.
+
+::: mixpanel_data.BusinessContext
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_data.BusinessContextChain
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -18,6 +18,7 @@ Workspace orchestrates internal services and provides direct App API access:
 - **Feature Management** — Create, read, update, delete feature flags and experiments via Mixpanel App API (project-scoped)
 - **Operational Tooling** — Manage alerts, annotations, and webhooks via Mixpanel App API (workspace-scoped)
 - **Data Governance** — Manage Lexicon definitions, drop filters, custom properties, custom events, lookup tables, schema registry, schema enforcement, data auditing, volume anomalies, and event deletion requests via Mixpanel App API (workspace-scoped)
+- **Business Context** — Read and write the markdown documentation that grounds AI assistants (org and project scopes, 50,000-char cap)
 
 ## Key Features
 
@@ -115,6 +116,29 @@ events = ws.list_custom_events()
 ```
 
 See the [Data Governance guide](../guide/data-governance.md) for complete coverage.
+
+### Business Context
+
+Read and write the markdown documentation that grounds AI assistants. Two scopes (`level="organization"` shared across the org, `level="project"` per-project), 50,000-character cap enforced client-side before any HTTP call.
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+
+# Read
+project_ctx = ws.get_business_context(level="project")
+org_ctx = ws.get_business_context(level="organization")     # auto-resolves org_id
+
+# Read both in one round-trip
+chain = ws.get_business_context_chain()
+
+# Write (full-replace; pass "" to clear)
+ws.set_business_context("# About Acme\n…", level="project")
+ws.clear_business_context(level="organization")
+```
+
+Project-scope writes require `edit_project_info` permission; org-scope writes require `edit_project_info` at the org level. See the [Business Context guide](../guide/business-context.md) for full coverage of input modes, error handling, and cross-project audit patterns.
 
 !!! note "`workspaces()` vs `list_workspaces()`"
     Both methods are exposed. `workspaces()` (recommended) returns `list[WorkspaceRef]` from the cached `/me` response — fast, typed, and consistent with `events()` / `properties()` / `funnels()` / `cohorts()`. `list_workspaces()` is a lower-level escape hatch that calls `GET /api/app/projects/{pid}/workspaces/public` directly and returns `list[PublicWorkspace]`.

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -198,6 +198,10 @@ See [Auth → Workspace.use()](auth.md#workspaceuse-in-session-switching) for th
         - clear_discovery_cache
         - stream_events
         - stream_profiles
+        - get_business_context
+        - set_business_context
+        - clear_business_context
+        - get_business_context_chain
         - query
         - build_params
         - query_funnel

--- a/docs/guide/business-context.md
+++ b/docs/guide/business-context.md
@@ -1,0 +1,336 @@
+# Business Context
+
+Read and write the markdown documentation that grounds AI assistants in your organization's structure and goals, exposed as a Python API and `mp business-context` CLI group.
+
+!!! info "What is Business Context?"
+    Business Context is plain markdown text (up to **50,000 characters per scope**) that you attach to a Mixpanel organization or project. AI assistants read it before answering questions, so they know *what your product does*, *what your events mean*, *which dashboards are canonical*, and *how your team defines key metrics*. See the [official Mixpanel Business Context docs](https://docs.mixpanel.com/docs/business-context) for the broader product picture.
+
+!!! note "Prerequisites"
+    Business Context requires **authentication**. Project-level reads work with any account that has project access; project-level writes additionally require `edit_project_info` permission. Org-level operations require org membership (read) plus `edit_project_info` at the org level (write). Service accounts can read/write at the project level for projects they're attached to; for org-level operations or for org-id auto-resolution, an OAuth account (`oauth_browser` or `oauth_token`) is the cleanest path.
+
+## Two scopes
+
+| Scope | Lives at | Shared by |
+|---|---|---|
+| `organization` | The Mixpanel organization | Every project in the org |
+| `project` | A single project | That project only |
+
+`mixpanel_data` exposes both scopes through the same API, gated by a `level: Literal["organization", "project"]` argument.
+
+## Quick reference
+
+=== "Python"
+
+    ```python
+    import mixpanel_data as mp
+
+    ws = mp.Workspace()
+
+    # Read
+    project_ctx = ws.get_business_context(level="project")
+    org_ctx = ws.get_business_context(level="organization")
+
+    # Read both at once (single round-trip via /business-context/chain)
+    chain = ws.get_business_context_chain()
+
+    # Write
+    ws.set_business_context("# About Acme\n…", level="project")
+    ws.set_business_context("# Org-wide context", level="organization")
+
+    # Clear (equivalent to set_business_context(""))
+    ws.clear_business_context(level="project")
+    ```
+
+=== "CLI"
+
+    ```bash
+    # Read
+    mp business-context get --level project
+    mp business-context get --level organization
+    mp business-context chain                       # both at once
+
+    # Write — three input modes
+    mp business-context set --level project --content "# About Acme..."
+    mp business-context set --level project --file context.md
+    cat context.md | mp business-context set --level project
+
+    # Clear
+    mp business-context clear --level project
+    ```
+
+## Reading context
+
+### Project scope
+
+Project-scope reads use the active session's project ID. If no context has been set, the API returns the empty string — no special "not found" error to handle.
+
+=== "Python"
+
+    ```python
+    ctx = ws.get_business_context(level="project")
+    print(f"{ctx.character_count} chars")
+    if ctx.is_empty:
+        print("No project context configured.")
+    else:
+        print(ctx.content)
+    ```
+
+=== "CLI"
+
+    ```bash
+    # Pretty-printed JSON (default)
+    mp business-context get --level project
+
+    # Just the markdown body via jq
+    mp business-context get --level project --jq '.content'
+
+    # Compact rich table
+    mp business-context get --level project --format table
+    ```
+
+### Organization scope
+
+Organization-scope reads default to the org that owns the active session's project. The org ID is auto-resolved from the cached `/me` response (24-hour TTL). To read context from a different org without switching projects, pass `organization_id` explicitly.
+
+=== "Python"
+
+    ```python
+    # Auto-resolve org_id from the active project's organization
+    org_ctx = ws.get_business_context(level="organization")
+    print(f"org={org_ctx.organization_id}: {org_ctx.character_count} chars")
+
+    # Explicit override (skips the /me lookup)
+    other = ws.get_business_context(level="organization", organization_id=42)
+    ```
+
+=== "CLI"
+
+    ```bash
+    # Auto-resolve from active project
+    mp business-context get --level organization
+
+    # Explicit org id
+    mp business-context get --level organization --organization-id 42
+    ```
+
+If auto-resolution can't determine the org (e.g. the active project isn't in the cached `/me` and the user belongs to multiple orgs), the call raises `WorkspaceScopeError` with `code="ORGANIZATION_AMBIGUOUS"` and lists the accessible org IDs.
+
+### Both scopes in one call
+
+The server exposes a `/business-context/chain` endpoint that returns both org and project context together, scoped to the active project. Use `get_business_context_chain()` (Python) or `mp business-context chain` (CLI) to avoid two round-trips.
+
+=== "Python"
+
+    ```python
+    chain = ws.get_business_context_chain()
+    print("ORG:    ", chain.organization.content)
+    print("PROJECT:", chain.project.content)
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp business-context chain
+    mp business-context chain --jq '.project.content'
+    ```
+
+## Writing context
+
+`set_business_context` is **full-replace** semantics — what you pass becomes the entire stored content for that scope. There is no append, no patch, no diff. Pass the empty string to clear, or use `clear_business_context` for clarity.
+
+=== "Python"
+
+    ```python
+    new_content = """# Acme Analytics
+
+    ## Product overview
+
+    Acme is a SaaS dashboard for SMBs.
+
+    ## Event taxonomy
+
+    - `signup_completed` — user creates an account
+    - `subscription_started` — paid plan begins
+    - `feature_X_used` — pattern for feature engagement
+
+    ## Definitions
+
+    - **Active user**: any user with ≥1 event in the last 28 days
+    """
+
+    ws.set_business_context(new_content, level="project")
+    ws.set_business_context("# Org-wide standards…", level="organization")
+    ws.set_business_context("", level="project")  # clear
+    ws.clear_business_context(level="project")    # same thing, more explicit
+    ```
+
+=== "CLI"
+
+    The `set` command accepts content from three sources, in priority order:
+
+    1. `--content TEXT` — inline markdown (best for short content)
+    2. `--file PATH` — read from a file on disk
+    3. **stdin** — when no flags are given and stdin is not a TTY
+
+    `--content` and `--file` are mutually exclusive. Stdin is only consulted when neither flag is provided.
+
+    ```bash
+    # Inline
+    mp business-context set --level project --content "# Quick note"
+
+    # From file (typical for version-controlled context)
+    mp business-context set --level project --file ./context.md
+
+    # From stdin (works well in scripts)
+    cat ./context.md | mp business-context set --level project
+
+    # Heredoc
+    mp business-context set --level project <<'EOF'
+    # Acme Analytics
+
+    Updated by deploy job at $(date).
+    EOF
+    ```
+
+### Validation
+
+`set_business_context` validates `len(content) <= 50_000` **client-side, before** making any HTTP call. Oversize input raises `BusinessContextValidationError` with `details={"length": N, "max": 50_000}` so you fail fast and don't waste a round-trip. The server enforces the same cap and would otherwise return HTTP 400.
+
+=== "Python"
+
+    ```python
+    from mixpanel_data import BUSINESS_CONTEXT_MAX_CHARS
+    print(BUSINESS_CONTEXT_MAX_CHARS)  # 50000
+
+    try:
+        ws.set_business_context("x" * 60_000)
+    except mp.BusinessContextValidationError as e:
+        print(f"Too long: {e.details['length']} > {e.details['max']}")
+    ```
+
+=== "CLI"
+
+    ```bash
+    # Oversize content from a file
+    mp business-context set --level project --file too_big.md
+    # → exits with code 1 (GENERAL_ERROR) and a clear message,
+    #   without making a network request
+    ```
+
+### Clearing
+
+`clear_business_context()` is a thin convenience over `set_business_context("")`. Use whichever reads better at the call site.
+
+=== "Python"
+
+    ```python
+    ws.clear_business_context(level="project")
+    ws.clear_business_context(level="organization")
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp business-context clear --level project
+    mp business-context clear --level organization
+    ```
+
+## Common workflows
+
+### Version-control project context as a file
+
+Treat `context.md` like any other source file in your repo, and re-apply it as part of deploy:
+
+```bash
+# In CI or a deploy hook
+mp business-context set --level project --file ./context.md
+```
+
+### Bootstrap a new project from the org default
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+chain = ws.get_business_context_chain()
+
+# Seed the project with the org content (e.g. for a new project that should
+# inherit org standards as a starting point)
+if chain.project.is_empty and not chain.organization.is_empty:
+    ws.set_business_context(chain.organization.content, level="project")
+```
+
+### Audit context across many projects
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+for project in ws.projects():
+    ws.use(project=project.id)
+    ctx = ws.get_business_context(level="project")
+    if ctx.is_empty:
+        print(f"⚠️  {project.id} ({project.name}) has no project context")
+    else:
+        print(f"✅ {project.id} ({project.name}) — {ctx.character_count} chars")
+```
+
+## Result types
+
+`get_business_context` and `set_business_context` return [`BusinessContext`](../api/types.md#mixpanel_data.BusinessContext) — a frozen Pydantic model with the markdown content plus the scope-appropriate identifier:
+
+| Field | Project scope | Org scope |
+|---|---|---|
+| `level` | `"project"` | `"organization"` |
+| `content` | markdown body (or `""`) | markdown body (or `""`) |
+| `project_id` | active project ID | `None` |
+| `organization_id` | `None` | resolved org ID |
+
+Two convenience properties (Python only — not in `model_dump()`):
+
+- `is_empty: bool` — `True` when `content == ""`
+- `character_count: int` — `len(content)`; compare against `BUSINESS_CONTEXT_MAX_CHARS`
+
+`get_business_context_chain()` returns [`BusinessContextChain`](../api/types.md#mixpanel_data.BusinessContextChain), which is just `{organization: BusinessContext, project: BusinessContext}`.
+
+## Error handling
+
+| Exception | Raised when |
+|---|---|
+| [`BusinessContextValidationError`](../api/exceptions.md#mixpanel_data.BusinessContextValidationError) | Client-side: content > 50,000 chars (no HTTP call made) |
+| [`QueryError`](../api/exceptions.md#mixpanel_data.QueryError) | Server-side 400 (malformed body, server-side oversize), 403 (missing `edit_project_info`), 404 (org/project not visible) |
+| [`AuthenticationError`](../api/exceptions.md#mixpanel_data.AuthenticationError) | 401 — credentials are invalid |
+| [`WorkspaceScopeError`](../api/exceptions.md#mixpanel_data.WorkspaceScopeError) | `level="organization"` and the org ID could not be auto-resolved (`code="ORGANIZATION_AMBIGUOUS"`) |
+| [`ServerError`](../api/exceptions.md#mixpanel_data.ServerError) | 5xx |
+
+```python
+import mixpanel_data as mp
+
+ws = mp.Workspace()
+try:
+    ws.set_business_context("…", level="organization")
+except mp.BusinessContextValidationError as e:
+    print(f"Too long ({e.details['length']} chars), max {e.details['max']}")
+except mp.WorkspaceScopeError as e:
+    print(f"Cannot resolve org: {e.message}")
+except mp.QueryError as e:
+    print(f"API rejected the write: {e.status_code} {e.message}")
+```
+
+## Permissions summary
+
+| Operation | Required permission |
+|---|---|
+| Project-level read | Project access (read) |
+| Project-level write | Project access + `edit_project_info` |
+| Org-level read | Org membership |
+| Org-level write | Org membership + `edit_project_info` at the org level |
+
+Service accounts attached to a project can read and write that project's context. Org-level writes typically require an OAuth account (`oauth_browser` or `oauth_token`) whose principal has org-level edit permissions. The 50,000-character cap is enforced both client-side (before any HTTP call) and server-side.
+
+## Next steps
+
+- Reference: [Workspace API](../api/workspace.md) for the full method surface.
+- Reference: [Result Types — Business Context](../api/types.md#business-context-types) and [Exceptions — Business Context](../api/exceptions.md#business-context-exceptions).
+- CLI: [`mp business-context` command reference](../cli/commands.md) (auto-generated from the Typer app).
+- Product docs: the [Mixpanel Business Context product page](https://docs.mixpanel.com/docs/business-context) for organization-level rollout guidance.

--- a/docs/guide/business-context.md
+++ b/docs/guide/business-context.md
@@ -119,6 +119,8 @@ If auto-resolution can't determine the org (e.g. the active project isn't in the
 
 The server exposes a `/business-context/chain` endpoint that returns both org and project context together, scoped to the active project. Use `get_business_context_chain()` (Python) or `mp business-context chain` (CLI) to avoid two round-trips.
 
+`organization.organization_id` on the returned chain is populated **best-effort** from the cached `/me` response (in-memory or disk). When the cache is cold the field is left as `None` — the chain endpoint deliberately does *not* trigger an extra `/me` fetch, preserving its single-network-round-trip property. Callers that need a guaranteed org ID should call `get_business_context(level="organization")`, which performs full resolution.
+
 === "Python"
 
     ```python
@@ -168,11 +170,11 @@ The server exposes a `/business-context/chain` endpoint that returns both org an
 
     The `set` command accepts content from three sources, in priority order:
 
-    1. `--content TEXT` — inline markdown (best for short content)
+    1. `--content TEXT` — inline markdown (best for short content; pass `""` to clear)
     2. `--file PATH` — read from a file on disk
     3. **stdin** — when no flags are given and stdin is not a TTY
 
-    `--content` and `--file` are mutually exclusive. Stdin is only consulted when neither flag is provided.
+    `--content` and `--file` are mutually exclusive. Stdin is only consulted when neither flag is provided. **Empty / whitespace-only stdin is rejected** (exit code 3) — use `mp business-context clear` to deliberately clear, so a CI/cron run with `</dev/null` can never silently wipe stored content.
 
     ```bash
     # Inline
@@ -213,7 +215,7 @@ The server exposes a `/business-context/chain` endpoint that returns both org an
     ```bash
     # Oversize content from a file
     mp business-context set --level project --file too_big.md
-    # → exits with code 1 (GENERAL_ERROR) and a clear message,
+    # → exits with code 3 (INVALID_ARGS) and a clear message,
     #   without making a network request
     ```
 
@@ -286,7 +288,7 @@ for project in ws.projects():
 | `project_id` | active project ID | `None` |
 | `organization_id` | `None` | resolved org ID |
 
-Two convenience properties (Python only — not in `model_dump()`):
+Two computed fields are also exposed and **appear in `model_dump()`** (so `--jq '.is_empty'` and `--jq '.character_count'` work directly from the CLI):
 
 - `is_empty: bool` — `True` when `content == ""`
 - `character_count: int` — `len(content)`; compare against `BUSINESS_CONTEXT_MAX_CHARS`

--- a/docs/index.md
+++ b/docs/index.md
@@ -307,4 +307,5 @@ For interactive exploration of the codebase itself, see [DeepWiki](https://deepw
 - [API Reference](api/index.md) — Complete Python API documentation
 - [Entity Management](guide/entity-management.md) — Manage dashboards, reports, cohorts, feature flags, experiments, alerts, annotations, and webhooks
 - [Data Governance](guide/data-governance.md) — Manage Lexicon definitions, drop filters, custom properties, custom events, and lookup tables
+- [Business Context](guide/business-context.md) — Read and write the markdown business context that grounds AI assistants (org and project scopes)
 - [CLI Reference](cli/index.md) — Command-line interface documentation

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mixpanel-data",
-  "version": "5.0.0",
-  "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_data auth surface (Account → Project → Workspace hierarchy) and API (5 query engines, discovery, entity CRUD) with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
+  "version": "5.1.0",
+  "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_data auth surface (Account → Project → Workspace hierarchy), API (5 query engines, discovery, entity CRUD), and Business Context read/write (the markdown documentation that grounds AI assistants, at org and project scopes), with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",
     "email": "jaredcolin@gmail.com",

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -123,8 +123,9 @@ The plugin also provides full entity CRUD via the Mixpanel App API:
 - **Alerts & Annotations** — monitoring and timeline markers
 - **Webhooks** — event-driven integrations
 - **Data Governance** — Lexicon definitions, drop filters, custom properties, custom events, lookup tables, schema registry
+- **Business Context** — read/write the markdown documentation that grounds AI assistants (org and project scopes, 50,000-char cap)
 
-All entity methods require a workspace ID. Use `ws.resolve_workspace_id()` to auto-discover it.
+All entity methods require a workspace ID. Use `ws.resolve_workspace_id()` to auto-discover it. Business context lives at the project + org level, so it is **not** workspace-scoped — it works as soon as a project is set.
 
 ## Authentication
 

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mixpanelyst
-description: This skill should be used when the user asks about Mixpanel product analytics, event data, funnel analysis, retention curves, cohort analysis, segmentation queries, user behavior, conversion rates, churn, DAU/MAU, ARPU, revenue metrics, feature adoption, A/B test results, user paths, flow analysis, or any request to query, explore, visualize, or analyze Mixpanel data using Python.
+description: This skill should be used when the user asks about Mixpanel product analytics, event data, funnel analysis, retention curves, cohort analysis, segmentation queries, user behavior, conversion rates, churn, DAU/MAU, ARPU, revenue metrics, feature adoption, A/B test results, user paths, flow analysis, or any request to query, explore, visualize, or analyze Mixpanel data using Python. Also use when the user asks to read, write, or manage Mixpanel "business context" — the markdown documentation that grounds AI assistants in an organization's structure and goals.
 allowed-tools: Bash Read Write WebFetch
 ---
 
@@ -922,6 +922,49 @@ User Guide: `WebFetch(url="https://jaredmcfarland.github.io/mixpanel_data/guide/
 
 **Other:** `get_tracking_metadata`
 
+### Business Context
+
+Read and write the markdown documentation that grounds AI assistants in your organization's structure and goals, exposed as a typed Python API.
+
+Two scopes — `level="organization"` (shared across the whole org) and `level="project"` (per-project). 50,000-character cap enforced **client-side before any HTTP call** so oversize input fails fast. Org-level operations auto-resolve `organization_id` from the cached `/me` response; pass `organization_id=N` to override.
+
+Run `python3 ${CLAUDE_SKILL_DIR}/scripts/help.py search business_context` to see all four methods, two types, and one exception.
+
+```python
+from mixpanel_data import BUSINESS_CONTEXT_MAX_CHARS  # 50_000
+
+# Read
+project_ctx = ws.get_business_context(level="project")
+org_ctx = ws.get_business_context(level="organization")  # auto-resolves org_id
+explicit = ws.get_business_context(level="organization", organization_id=42)
+
+# Read both at once (single round-trip via /business-context/chain)
+chain = ws.get_business_context_chain()
+print(chain.organization.content)
+print(chain.project.content)
+
+# Write (full-replace; pass "" to clear, or use clear_business_context())
+ws.set_business_context("# About Acme\n…", level="project")
+ws.set_business_context("# Org-wide standards", level="organization")
+ws.clear_business_context(level="project")
+
+# All return BusinessContext with: level, content, organization_id, project_id
+# Plus convenience .is_empty and .character_count properties (Python only)
+print(f"{project_ctx.character_count}/{BUSINESS_CONTEXT_MAX_CHARS} chars; "
+      f"empty={project_ctx.is_empty}")
+```
+
+**When to reach for this:**
+
+- User asks "what's the business context for this project/org?" → `get_business_context_chain()`
+- User wants to version-control project context as a `.md` file → `ws.set_business_context(Path("ctx.md").read_text(), level="project")` in CI
+- User asks to "audit which projects have AI context configured" → iterate `ws.projects()` + `ws.use(project=...)` + `ws.get_business_context(level="project")` and check `.is_empty`
+- User asks to seed a new project from the org default → `chain = ws.get_business_context_chain(); ws.set_business_context(chain.organization.content, level="project")`
+
+**Permissions:** project-scope reads need any project access; project-scope writes need `edit_project_info` on the project. Org-scope writes need `edit_project_info` at the org level (typically OAuth, not service account). The `BusinessContextValidationError` exception is raised client-side BEFORE any HTTP call when content exceeds 50,000 chars, so use it to detect oversize input without burning a round-trip.
+
+User Guide: `WebFetch(url="https://jaredmcfarland.github.io/mixpanel_data/guide/business-context/index.md")`
+
 ## Key Types
 
 Run `python3 ${CLAUDE_SKILL_DIR}/scripts/help.py types` for the full list of all types. Use `help.py <TypeName>` for fields, constructors, and enum values.
@@ -1008,6 +1051,7 @@ Full reference: `WebFetch(url="https://jaredmcfarland.github.io/mixpanel_data/ap
 | `BookmarkValidationError` | Params failed validation |
 | `RateLimitError` | Rate limit exceeded (429) |
 | `ServerError` | Mixpanel server error (5xx) |
-| `WorkspaceScopeError` | Workspace resolution error |
+| `WorkspaceScopeError` | Workspace resolution error (also raised when org_id can't be auto-resolved for `level="organization"` business-context calls) |
 | `DateRangeTooLargeError` | Date range exceeds API maximum |
 | `OAuthError` | OAuth flow error |
+| `BusinessContextValidationError` | Business context content exceeds 50,000 chars (client-side, before HTTP) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ plugins:
           - guide/streaming.md
           - guide/entity-management.md
           - guide/data-governance.md
+          - guide/business-context.md
         API Reference:
           - api/index.md
           - api/workspace.md
@@ -148,6 +149,7 @@ plugins:
           - guide/streaming.md: "Stream events and profiles for ETL"
           - guide/entity-management.md: "Create, update, delete dashboards, reports, and cohorts"
           - guide/data-governance.md: "Manage Lexicon definitions, drop filters, custom properties, custom events, lookup tables, schema registry, enforcement, auditing, anomalies, and event deletion requests"
+          - guide/business-context.md: "Read and write the markdown business context that grounds AI assistants (org and project scopes, 50,000-char cap)"
         API Reference:
           - api/index.md: "Python API overview"
           - api/workspace.md: "Workspace class - main entry point"
@@ -195,6 +197,7 @@ nav:
       - Streaming Data: guide/streaming.md
       - Entity Management: guide/entity-management.md
       - Data Governance: guide/data-governance.md
+      - Business Context: guide/business-context.md
   - API Reference:
       - Overview: api/index.md
       - Workspace: api/workspace.md

--- a/src/mixpanel_data/CLAUDE.md
+++ b/src/mixpanel_data/CLAUDE.md
@@ -138,6 +138,8 @@ with mp.Workspace() as ws:
 
 **Data Governance — Custom Events**: `list_custom_events()`, `create_custom_event()`, `update_custom_event()`, `delete_custom_event()`
 
+**Business Context**: `get_business_context()`, `set_business_context()`, `clear_business_context()`, `get_business_context_chain()` — read/write the markdown documentation that grounds AI assistants (org and project scopes, 50,000-char cap)
+
 **Escape Hatches**: `api` (MixpanelAPIClient)
 
 ## Exception Hierarchy

--- a/src/mixpanel_data/__init__.py
+++ b/src/mixpanel_data/__init__.py
@@ -59,6 +59,7 @@ from mixpanel_data.exceptions import (
     APIError,
     AuthenticationError,
     BookmarkValidationError,
+    BusinessContextValidationError,
     ConfigError,
     DateRangeTooLargeError,
     EventNotFoundError,
@@ -73,6 +74,8 @@ from mixpanel_data.exceptions import (
     WorkspaceScopeError,
 )
 from mixpanel_data.types import (
+    # Business Context (AIE-147)
+    BUSINESS_CONTEXT_MAX_CHARS,
     # Auth redesign (042) types
     AccountSummary,
     AccountTestResult,
@@ -116,6 +119,8 @@ from mixpanel_data.types import (
     BulkUpdateCohortEntry,
     BulkUpdateEventsParams,
     BulkUpdatePropertiesParams,
+    BusinessContext,
+    BusinessContextChain,
     Cohort,
     CohortBreakdown,
     CohortCreator,
@@ -367,6 +372,7 @@ __all__ = [
     "DateRangeTooLargeError",
     "OAuthError",
     "WorkspaceScopeError",
+    "BusinessContextValidationError",
     # Result types
     "SegmentationResult",
     "FunnelResult",
@@ -532,6 +538,10 @@ __all__ = [
     "CustomEvent",
     "CustomEventAlternative",
     "CreateCustomEventParams",
+    # Business Context (AIE-147)
+    "BUSINESS_CONTEXT_MAX_CHARS",
+    "BusinessContext",
+    "BusinessContextChain",
     # Query API types (Phase 029)
     "MathType",
     "PerUserAggregation",

--- a/src/mixpanel_data/_internal/api_client.py
+++ b/src/mixpanel_data/_internal/api_client.py
@@ -7929,3 +7929,159 @@ class MixpanelAPIClient:
                 f"expected list, got {type(result).__name__}",
             )
         return result
+
+    # =========================================================================
+    # Business Context (AIE-147)
+    # =========================================================================
+
+    def get_business_context(
+        self, *, organization_id: int | None = None
+    ) -> dict[str, Any]:
+        """Fetch business context content for an organization or project.
+
+        Calls ``GET /api/app/projects/{pid}/business-context`` (project
+        scope) or ``GET /api/app/organizations/{org_id}/business-context``
+        (organization scope). The endpoint always returns 200 with
+        ``{"content": ""}`` when no context has been set.
+
+        Path is constructed directly (NOT via ``maybe_scoped_path``)
+        because the endpoint is project-scoped, not workspace-scoped.
+
+        Args:
+            organization_id: When provided, fetches the org-level context
+                under ``/organizations/{organization_id}/business-context``.
+                When omitted, fetches the project-level context under
+                ``/projects/{pid}/business-context`` for the current
+                session's project.
+
+        Returns:
+            Dictionary of the form ``{"content": "<markdown>"}``. The
+            ``content`` field is the empty string when no context is set.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Caller lacks access to the project / organization
+                (403, 404).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors or unexpected
+                response shape.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(session=sess) as client:
+                # Project-level context for the active project.
+                project = client.get_business_context()
+                print(project["content"])
+
+                # Org-level context for org id 100.
+                org = client.get_business_context(organization_id=100)
+                print(org["content"])
+            ```
+        """
+        if organization_id is not None:
+            path = f"/organizations/{organization_id}/business-context"
+        else:
+            path = f"/projects/{self._session.project.id}/business-context"
+        result = self.app_request("GET", path)
+        if not isinstance(result, dict):
+            raise MixpanelDataError(
+                f"Unexpected response from get_business_context: "
+                f"expected dict, got {type(result).__name__}",
+            )
+        return result
+
+    def set_business_context(
+        self, content: str, *, organization_id: int | None = None
+    ) -> dict[str, Any]:
+        """Replace business context content at the given scope.
+
+        Calls ``PUT /api/app/projects/{pid}/business-context`` (project
+        scope) or ``PUT /api/app/organizations/{org_id}/business-context``
+        (organization scope). The PUT is full-replace — pass an empty
+        string to clear.
+
+        The Mixpanel server enforces a 50,000-character limit and
+        returns HTTP 400 ``"content exceeds maximum length of 50000
+        characters"`` above that threshold; callers should validate
+        client-side first to avoid the wasted round-trip (the
+        ``Workspace`` facade does this automatically).
+
+        Path is constructed directly (NOT via ``maybe_scoped_path``)
+        because the endpoint is project-scoped, not workspace-scoped.
+
+        Args:
+            content: New markdown content. Empty string clears the
+                context at this scope.
+            organization_id: When provided, writes the org-level context.
+                When omitted, writes the project-level context for the
+                current session's project.
+
+        Returns:
+            Dictionary of the form ``{"content": "<saved markdown>"}``
+            echoing what the server stored.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Content exceeds 50,000 chars (400), caller lacks
+                ``edit_project_info`` permission (403), or invalid JSON
+                body (400).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors or unexpected
+                response shape.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(session=sess) as client:
+                client.set_business_context("# About Acme\\n...")
+                client.set_business_context("", organization_id=100)  # clear org
+            ```
+        """
+        if organization_id is not None:
+            path = f"/organizations/{organization_id}/business-context"
+        else:
+            path = f"/projects/{self._session.project.id}/business-context"
+        result = self.app_request("PUT", path, json_body={"content": content})
+        if not isinstance(result, dict):
+            raise MixpanelDataError(
+                f"Unexpected response from set_business_context: "
+                f"expected dict, got {type(result).__name__}",
+            )
+        return result
+
+    def get_business_context_chain(self) -> dict[str, Any]:
+        """Fetch both organization and project business context together.
+
+        Calls ``GET /api/app/projects/{pid}/business-context/chain`` —
+        a server-side convenience that returns both scopes in a single
+        round-trip, scoped to the current session's project. The org
+        context returned is the one that owns the project.
+
+        Returns:
+            Dictionary of the form
+            ``{"org_context": "<markdown>", "project_context": "<markdown>"}``.
+            Either field may be the empty string when no context is set
+            at that scope.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Caller lacks project access (403, 404).
+            ServerError: Server-side errors (5xx).
+            MixpanelDataError: Network/connection errors or unexpected
+                response shape.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(session=sess) as client:
+                chain = client.get_business_context_chain()
+                print("ORG:", chain["org_context"])
+                print("PROJECT:", chain["project_context"])
+            ```
+        """
+        path = f"/projects/{self._session.project.id}/business-context/chain"
+        result = self.app_request("GET", path)
+        if not isinstance(result, dict):
+            raise MixpanelDataError(
+                f"Unexpected response from get_business_context_chain: "
+                f"expected dict, got {type(result).__name__}",
+            )
+        return result

--- a/src/mixpanel_data/_internal/me.py
+++ b/src/mixpanel_data/_internal/me.py
@@ -431,6 +431,33 @@ class MeService:
         self._region = region
         self._cached_response: MeResponse | None = None
 
+    def peek(self) -> MeResponse | None:
+        """Return the cached /me response without triggering a network call.
+
+        Checks the in-memory cache first, then the on-disk cache.
+        Returns ``None`` if neither is available — does NOT call the
+        API, even if the cache is empty or expired. Used by callers
+        that want best-effort enrichment without giving up the
+        single-round-trip property of an unrelated request (e.g.,
+        ``Workspace.get_business_context_chain()``).
+
+        Returns:
+            Cached MeResponse or None if both caches are empty.
+
+        Example:
+            ```python
+            svc = MeService(api_client, cache, "us")
+            me = svc.peek()
+            org_id = me.organizations["100"].id if me else None
+            ```
+        """
+        if self._cached_response is not None:
+            return self._cached_response
+        cached = self._cache.get()
+        if cached is not None:
+            self._cached_response = cached
+        return cached
+
     def fetch(self, *, force_refresh: bool = False) -> MeResponse:
         """Fetch the /me response, using cache when available.
 

--- a/src/mixpanel_data/cli/CLAUDE.md
+++ b/src/mixpanel_data/cli/CLAUDE.md
@@ -21,6 +21,7 @@ state-change verb.
 | `reports` | Report/bookmark CRUD (list, create, get, update, delete, bulk ops, history) |
 | `cohorts` | Cohort CRUD (list, create, get, update, delete, bulk ops) |
 | `flags` / `experiments` / `alerts` / `annotations` / `webhooks` / `lexicon` / `drop-filters` / `custom-properties` / `custom-events` / `lookup-tables` / `schemas` | Entity CRUD + data governance for the matching App API surface |
+| `business-context` | Read/write markdown business context at org or project scope (`get`, `set`, `clear`, `chain`) |
 
 **Removed (no shim):** `mp auth`, `mp projects`, `mp workspaces`, `mp context`,
 `mp config`. See `RELEASE_NOTES_0.4.0.md` for the legacy → v3 verb map.

--- a/src/mixpanel_data/cli/commands/CLAUDE.md
+++ b/src/mixpanel_data/cli/commands/CLAUDE.md
@@ -31,6 +31,7 @@ flags.
 | `custom_events.py` | `mp custom-events` | Custom-event CRUD (data governance) |
 | `lookup_tables.py` | `mp lookup-tables` | Lookup-table CRUD + upload/download (data governance) |
 | `schemas.py` | `mp schemas` | Project / workspace JSON schemas |
+| `business_context.py` | `mp business-context` | Read/write markdown business context at org or project scope (`get`, `set`, `clear`, `chain`) |
 
 **Removed (no shim):** `mp auth`, `mp projects`, `mp workspaces`, `mp context`,
 `mp config`. See `RELEASE_NOTES_0.4.0.md` for the legacy → v3 verb map.

--- a/src/mixpanel_data/cli/commands/business_context.py
+++ b/src/mixpanel_data/cli/commands/business_context.py
@@ -1,0 +1,274 @@
+"""Business context commands.
+
+This module provides commands for reading and writing the markdown
+documentation that grounds AI assistants in your organization's
+structure and goals — the same content the official Mixpanel MCP
+server's ``Get-Business-Context`` and ``Update-Business-Context``
+tools manage.
+
+Subcommands:
+
+- ``get``:   Read context at a given scope (org or project).
+- ``set``:   Replace context at a given scope. Accepts content from
+  ``--content``, ``--file``, or stdin (mutually exclusive).
+- ``clear``: Convenience for ``set`` with empty content.
+- ``chain``: Read both org-level and project-level context together
+  in a single round-trip via the ``/business-context/chain`` endpoint.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated, Literal, cast
+
+import typer
+
+from mixpanel_data.cli.options import FormatOption, JqOption
+from mixpanel_data.cli.utils import (
+    ExitCode,
+    err_console,
+    get_workspace,
+    handle_errors,
+    output_result,
+    status_spinner,
+)
+
+business_context_app = typer.Typer(
+    name="business-context",
+    help="Read and write project / organization business context.",
+    no_args_is_help=True,
+)
+
+
+_LEVEL_HELP = "Which scope to operate on: 'project' (default) or 'organization'."
+_ORG_ID_HELP = (
+    "Organization ID for --level organization. When omitted, auto-resolved "
+    "from the current session's project via the cached /me response."
+)
+
+
+def _coerce_level(value: str) -> Literal["organization", "project"]:
+    """Validate and narrow a CLI ``--level`` value to the literal type.
+
+    Args:
+        value: Raw string value from the CLI option.
+
+    Returns:
+        The same value typed as ``Literal["organization", "project"]``.
+
+    Raises:
+        typer.Exit: ``value`` was not one of the two valid options.
+            Exits with ``ExitCode.INVALID_ARGS``.
+    """
+    if value not in ("organization", "project"):
+        err_console.print(
+            f"[red]Invalid --level value:[/red] {value!r}. "
+            "Must be 'organization' or 'project'."
+        )
+        raise typer.Exit(code=ExitCode.INVALID_ARGS)
+    return cast("Literal['organization', 'project']", value)
+
+
+def _read_set_content(
+    content: str | None,
+    file: Path | None,
+) -> str:
+    """Resolve the markdown content to send for the ``set`` command.
+
+    Precedence: ``--content`` > ``--file`` > stdin. ``--content`` and
+    ``--file`` are mutually exclusive — passing both is a usage error.
+    Stdin is read only when both flags are absent and stdin is not a
+    TTY (i.e. content was actually piped in).
+
+    Args:
+        content: Inline content from ``--content``, or ``None``.
+        file: Path from ``--file``, or ``None``.
+
+    Returns:
+        The markdown content to send to the API.
+
+    Raises:
+        typer.Exit: Both ``--content`` and ``--file`` were provided,
+            the file does not exist, or no content source was supplied
+            (no flags AND stdin is a TTY). Exits with
+            ``ExitCode.INVALID_ARGS``.
+    """
+    if content is not None and file is not None:
+        err_console.print("[red]--content and --file are mutually exclusive.[/red]")
+        raise typer.Exit(code=ExitCode.INVALID_ARGS)
+
+    if content is not None:
+        return content
+    if file is not None:
+        if not file.exists():
+            err_console.print(f"[red]File not found:[/red] {file}")
+            raise typer.Exit(code=ExitCode.INVALID_ARGS)
+        return file.read_text(encoding="utf-8")
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    err_console.print(
+        "[red]No content provided.[/red] Pass --content TEXT, --file PATH, "
+        "or pipe content via stdin."
+    )
+    raise typer.Exit(code=ExitCode.INVALID_ARGS)
+
+
+@business_context_app.command("get")
+@handle_errors
+def business_context_get(
+    ctx: typer.Context,
+    level: Annotated[
+        str,
+        typer.Option("--level", help=_LEVEL_HELP),
+    ] = "project",
+    organization_id: Annotated[
+        int | None,
+        typer.Option("--organization-id", help=_ORG_ID_HELP),
+    ] = None,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Read business context content at the given scope.
+
+    Outputs a ``BusinessContext`` JSON document with ``level``,
+    ``content``, and the matching ``organization_id`` or ``project_id``.
+
+    Args:
+        ctx: Typer context with global options.
+        level: ``project`` (default) or ``organization``.
+        organization_id: Optional explicit org ID for org-level reads.
+        format: Output format.
+        jq_filter: Optional jq filter expression.
+    """
+    typed_level = _coerce_level(level)
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, f"Fetching {typed_level} business context..."):
+        result = workspace.get_business_context(
+            level=typed_level,
+            organization_id=organization_id,
+        )
+    output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)
+
+
+@business_context_app.command("set")
+@handle_errors
+def business_context_set(
+    ctx: typer.Context,
+    level: Annotated[
+        str,
+        typer.Option("--level", help=_LEVEL_HELP),
+    ] = "project",
+    organization_id: Annotated[
+        int | None,
+        typer.Option("--organization-id", help=_ORG_ID_HELP),
+    ] = None,
+    content: Annotated[
+        str | None,
+        typer.Option(
+            "--content",
+            help="Inline markdown content. Mutually exclusive with --file / stdin.",
+        ),
+    ] = None,
+    file: Annotated[
+        Path | None,
+        typer.Option(
+            "--file",
+            help="Read markdown content from a file. Mutually exclusive with --content / stdin.",
+        ),
+    ] = None,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Replace business context content at the given scope.
+
+    Content can come from ``--content``, ``--file``, or stdin (when
+    neither flag is given and stdin is not a TTY). Pass an empty
+    string to clear (or use ``mp business-context clear`` for clarity).
+
+    The 50,000-character limit is enforced client-side BEFORE the HTTP
+    call so over-long input fails immediately rather than wasting a
+    round-trip.
+
+    Args:
+        ctx: Typer context with global options.
+        level: ``project`` (default) or ``organization``.
+        organization_id: Optional explicit org ID for org-level writes.
+        content: Inline content. Mutually exclusive with ``--file`` / stdin.
+        file: Path to a file containing the content. Mutually exclusive
+            with ``--content`` / stdin.
+        format: Output format.
+        jq_filter: Optional jq filter expression.
+    """
+    typed_level = _coerce_level(level)
+    payload = _read_set_content(content, file)
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, f"Updating {typed_level} business context..."):
+        result = workspace.set_business_context(
+            payload,
+            level=typed_level,
+            organization_id=organization_id,
+        )
+    output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)
+
+
+@business_context_app.command("clear")
+@handle_errors
+def business_context_clear(
+    ctx: typer.Context,
+    level: Annotated[
+        str,
+        typer.Option("--level", help=_LEVEL_HELP),
+    ] = "project",
+    organization_id: Annotated[
+        int | None,
+        typer.Option("--organization-id", help=_ORG_ID_HELP),
+    ] = None,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Clear business context at the given scope.
+
+    Equivalent to ``mp business-context set --content ""``. Documents
+    intent and avoids accidental clearing when stdin is unexpectedly
+    empty.
+
+    Args:
+        ctx: Typer context with global options.
+        level: ``project`` (default) or ``organization``.
+        organization_id: Optional explicit org ID for org-level clears.
+        format: Output format.
+        jq_filter: Optional jq filter expression.
+    """
+    typed_level = _coerce_level(level)
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, f"Clearing {typed_level} business context..."):
+        result = workspace.clear_business_context(
+            level=typed_level,
+            organization_id=organization_id,
+        )
+    output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)
+
+
+@business_context_app.command("chain")
+@handle_errors
+def business_context_chain(
+    ctx: typer.Context,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Read both org-level and project-level context in one call.
+
+    Calls the project-scoped ``/business-context/chain`` endpoint and
+    returns a ``BusinessContextChain`` JSON document with both scopes
+    populated.
+
+    Args:
+        ctx: Typer context with global options.
+        format: Output format.
+        jq_filter: Optional jq filter expression.
+    """
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, "Fetching business context chain..."):
+        result = workspace.get_business_context_chain()
+    output_result(ctx, result.model_dump(), format=format, jq_filter=jq_filter)

--- a/src/mixpanel_data/cli/commands/business_context.py
+++ b/src/mixpanel_data/cli/commands/business_context.py
@@ -2,15 +2,14 @@
 
 This module provides commands for reading and writing the markdown
 documentation that grounds AI assistants in your organization's
-structure and goals — the same content the official Mixpanel MCP
-server's ``Get-Business-Context`` and ``Update-Business-Context``
-tools manage.
+structure and goals.
 
 Subcommands:
 
 - ``get``:   Read context at a given scope (org or project).
 - ``set``:   Replace context at a given scope. Accepts content from
-  ``--content``, ``--file``, or stdin (mutually exclusive).
+  ``--content``, ``--file``, or stdin (mutually exclusive). Empty
+  stdin is rejected — use ``clear`` to deliberately clear.
 - ``clear``: Convenience for ``set`` with empty content.
 - ``chain``: Read both org-level and project-level context together
   in a single round-trip via the ``/business-context/chain`` endpoint.
@@ -22,6 +21,7 @@ import sys
 from pathlib import Path
 from typing import Annotated, Literal, cast
 
+import click
 import typer
 
 from mixpanel_data.cli.options import FormatOption, JqOption
@@ -41,33 +41,24 @@ business_context_app = typer.Typer(
 )
 
 
-_LEVEL_HELP = "Which scope to operate on: 'project' (default) or 'organization'."
+# ``LevelOption`` mirrors the codebase pattern in ``cli/options.py::FormatOption``:
+# accept a ``str`` with ``click_type=click.Choice([...])`` so Click validates the
+# value and produces nice ``--help`` like ``[organization|project]``. We use
+# this here rather than a Python ``Enum`` because some Typer versions raise on
+# ``Literal`` annotations and the project already standardizes on ``click.Choice``.
+LevelOption = Annotated[
+    str,
+    typer.Option(
+        "--level",
+        help="Which scope to operate on.",
+        click_type=click.Choice(["organization", "project"]),
+    ),
+]
+
 _ORG_ID_HELP = (
     "Organization ID for --level organization. When omitted, auto-resolved "
     "from the current session's project via the cached /me response."
 )
-
-
-def _coerce_level(value: str) -> Literal["organization", "project"]:
-    """Validate and narrow a CLI ``--level`` value to the literal type.
-
-    Args:
-        value: Raw string value from the CLI option.
-
-    Returns:
-        The same value typed as ``Literal["organization", "project"]``.
-
-    Raises:
-        typer.Exit: ``value`` was not one of the two valid options.
-            Exits with ``ExitCode.INVALID_ARGS``.
-    """
-    if value not in ("organization", "project"):
-        err_console.print(
-            f"[red]Invalid --level value:[/red] {value!r}. "
-            "Must be 'organization' or 'project'."
-        )
-        raise typer.Exit(code=ExitCode.INVALID_ARGS)
-    return cast("Literal['organization', 'project']", value)
 
 
 def _read_set_content(
@@ -76,10 +67,14 @@ def _read_set_content(
 ) -> str:
     """Resolve the markdown content to send for the ``set`` command.
 
-    Precedence: ``--content`` > ``--file`` > stdin. ``--content`` and
-    ``--file`` are mutually exclusive — passing both is a usage error.
-    Stdin is read only when both flags are absent and stdin is not a
-    TTY (i.e. content was actually piped in).
+    Precedence: ``--content`` > ``--file`` > stdin (when piped).
+    ``--content`` and ``--file`` are mutually exclusive — passing both
+    is a usage error. Stdin is read only when both flags are absent
+    AND stdin is not a TTY (i.e. content was actually piped in). An
+    empty / whitespace-only stdin is rejected — clearing context must
+    be explicit (``mp business-context clear`` or
+    ``--content ""``) to prevent silent data loss in CI / cron where
+    stdin may be redirected from ``/dev/null``.
 
     Args:
         content: Inline content from ``--content``, or ``None``.
@@ -90,9 +85,9 @@ def _read_set_content(
 
     Raises:
         typer.Exit: Both ``--content`` and ``--file`` were provided,
-            the file does not exist, or no content source was supplied
-            (no flags AND stdin is a TTY). Exits with
-            ``ExitCode.INVALID_ARGS``.
+            the file does not exist, no content source was supplied,
+            or the piped stdin was empty / whitespace-only. Exits
+            with ``ExitCode.INVALID_ARGS``.
     """
     if content is not None and file is not None:
         err_console.print("[red]--content and --file are mutually exclusive.[/red]")
@@ -106,7 +101,19 @@ def _read_set_content(
             raise typer.Exit(code=ExitCode.INVALID_ARGS)
         return file.read_text(encoding="utf-8")
     if not sys.stdin.isatty():
-        return sys.stdin.read()
+        payload = sys.stdin.read()
+        if not payload.strip():
+            # Defend against the CI/cron `</dev/null` footgun: an empty
+            # stdin would otherwise full-replace the stored context with
+            # the empty string — a silent destructive write. Force the
+            # caller to be explicit.
+            err_console.print(
+                "[red]Empty stdin.[/red] Refusing to write empty content "
+                "implicitly. To clear, use `mp business-context clear` "
+                'or pass `--content ""` explicitly.'
+            )
+            raise typer.Exit(code=ExitCode.INVALID_ARGS)
+        return payload
     err_console.print(
         "[red]No content provided.[/red] Pass --content TEXT, --file PATH, "
         "or pipe content via stdin."
@@ -118,10 +125,7 @@ def _read_set_content(
 @handle_errors
 def business_context_get(
     ctx: typer.Context,
-    level: Annotated[
-        str,
-        typer.Option("--level", help=_LEVEL_HELP),
-    ] = "project",
+    level: LevelOption = "project",
     organization_id: Annotated[
         int | None,
         typer.Option("--organization-id", help=_ORG_ID_HELP),
@@ -141,7 +145,9 @@ def business_context_get(
         format: Output format.
         jq_filter: Optional jq filter expression.
     """
-    typed_level = _coerce_level(level)
+    # ``LevelOption`` (click.Choice) guarantees one of the two literals at
+    # runtime, so the cast is safe.
+    typed_level = cast("Literal['organization', 'project']", level)
     workspace = get_workspace(ctx)
     with status_spinner(ctx, f"Fetching {typed_level} business context..."):
         result = workspace.get_business_context(
@@ -155,10 +161,7 @@ def business_context_get(
 @handle_errors
 def business_context_set(
     ctx: typer.Context,
-    level: Annotated[
-        str,
-        typer.Option("--level", help=_LEVEL_HELP),
-    ] = "project",
+    level: LevelOption = "project",
     organization_id: Annotated[
         int | None,
         typer.Option("--organization-id", help=_ORG_ID_HELP),
@@ -182,9 +185,11 @@ def business_context_set(
 ) -> None:
     """Replace business context content at the given scope.
 
-    Content can come from ``--content``, ``--file``, or stdin (when
-    neither flag is given and stdin is not a TTY). Pass an empty
-    string to clear (or use ``mp business-context clear`` for clarity).
+    Content can come from ``--content``, ``--file``, or piped stdin
+    (when neither flag is given and stdin is not a TTY). Empty /
+    whitespace-only stdin is rejected — use ``mp business-context clear``
+    or pass ``--content ""`` explicitly to clear, to prevent silent
+    destructive writes in CI / cron.
 
     The 50,000-character limit is enforced client-side BEFORE the HTTP
     call so over-long input fails immediately rather than wasting a
@@ -200,7 +205,7 @@ def business_context_set(
         format: Output format.
         jq_filter: Optional jq filter expression.
     """
-    typed_level = _coerce_level(level)
+    typed_level = cast("Literal['organization', 'project']", level)
     payload = _read_set_content(content, file)
     workspace = get_workspace(ctx)
     with status_spinner(ctx, f"Updating {typed_level} business context..."):
@@ -216,10 +221,7 @@ def business_context_set(
 @handle_errors
 def business_context_clear(
     ctx: typer.Context,
-    level: Annotated[
-        str,
-        typer.Option("--level", help=_LEVEL_HELP),
-    ] = "project",
+    level: LevelOption = "project",
     organization_id: Annotated[
         int | None,
         typer.Option("--organization-id", help=_ORG_ID_HELP),
@@ -240,7 +242,7 @@ def business_context_clear(
         format: Output format.
         jq_filter: Optional jq filter expression.
     """
-    typed_level = _coerce_level(level)
+    typed_level = cast("Literal['organization', 'project']", level)
     workspace = get_workspace(ctx)
     with status_spinner(ctx, f"Clearing {typed_level} business context..."):
         result = workspace.clear_business_context(
@@ -261,7 +263,9 @@ def business_context_chain(
 
     Calls the project-scoped ``/business-context/chain`` endpoint and
     returns a ``BusinessContextChain`` JSON document with both scopes
-    populated.
+    populated. ``organization.organization_id`` is populated only when
+    a cached ``/me`` response is available — this preserves the chain
+    endpoint's single-network-round-trip guarantee.
 
     Args:
         ctx: Typer context with global options.

--- a/src/mixpanel_data/cli/main.py
+++ b/src/mixpanel_data/cli/main.py
@@ -170,6 +170,7 @@ def _register_commands() -> None:
     from mixpanel_data.cli.commands.account import account_app
     from mixpanel_data.cli.commands.alerts import alerts_app
     from mixpanel_data.cli.commands.annotations import annotations_app
+    from mixpanel_data.cli.commands.business_context import business_context_app
     from mixpanel_data.cli.commands.cohorts import cohorts_app
     from mixpanel_data.cli.commands.custom_events import custom_events_app
     from mixpanel_data.cli.commands.custom_properties import custom_properties_app
@@ -227,6 +228,11 @@ def _register_commands() -> None:
         lookup_tables_app,
         name="lookup-tables",
         help="Manage lookup tables.",
+    )
+    app.add_typer(
+        business_context_app,
+        name="business-context",
+        help="Read and write project / organization business context.",
     )
 
 

--- a/src/mixpanel_data/cli/utils.py
+++ b/src/mixpanel_data/cli/utils.py
@@ -29,6 +29,7 @@ from mixpanel_data.exceptions import (
     AccountExistsError,
     AccountNotFoundError,
     AuthenticationError,
+    BusinessContextValidationError,
     ConfigError,
     DateRangeTooLargeError,
     EventNotFoundError,
@@ -291,6 +292,14 @@ def handle_errors(func: F) -> F:
                 f"[red]Configuration error:[/red] {rich_escape(e.message)}"
             )
             raise typer.Exit(ExitCode.GENERAL_ERROR) from None
+        except BusinessContextValidationError as e:
+            # Client-side input validation rejection (oversize content) —
+            # map to INVALID_ARGS (3) rather than GENERAL_ERROR (1) since
+            # the failure was the caller's input, not an unknown error.
+            err_console.print(
+                f"[red]Business context too long:[/red] {rich_escape(e.message)}"
+            )
+            raise typer.Exit(ExitCode.INVALID_ARGS) from None
         except MixpanelDataError as e:
             err_console.print(f"[red]Error:[/red] {rich_escape(e.message)}")
             raise typer.Exit(ExitCode.GENERAL_ERROR) from None

--- a/src/mixpanel_data/exceptions.py
+++ b/src/mixpanel_data/exceptions.py
@@ -1026,6 +1026,49 @@ class WorkspaceScopeError(MixpanelDataError):
         super().__init__(message, code=code, details=details)
 
 
+# Business Context Validation
+
+
+class BusinessContextValidationError(MixpanelDataError):
+    """Business context content failed client-side validation.
+
+    Raised by ``Workspace.set_business_context()`` when the supplied
+    content exceeds ``BUSINESS_CONTEXT_MAX_CHARS`` (50,000 characters).
+    The check runs before the HTTP call so callers can fail fast and
+    avoid a wasted round-trip — the server enforces the same limit
+    server-side and would otherwise return ``QueryError`` (HTTP 400).
+
+    The ``details`` dict carries ``length`` (the actual content length)
+    and ``max`` (the configured limit) for programmatic recovery.
+
+    Example:
+        ```python
+        try:
+            ws.set_business_context("x" * 60_000, level="project")
+        except BusinessContextValidationError as e:
+            print(f"Too long: {e.details['length']} > {e.details['max']}")
+        ```
+    """
+
+    def __init__(
+        self,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize BusinessContextValidationError.
+
+        Args:
+            message: Human-readable error message.
+            details: Additional structured data — typically ``length``
+                and ``max``.
+        """
+        super().__init__(
+            message,
+            code="BUSINESS_CONTEXT_TOO_LONG",
+            details=details,
+        )
+
+
 # Bookmark Validation
 
 

--- a/src/mixpanel_data/exceptions.py
+++ b/src/mixpanel_data/exceptions.py
@@ -988,24 +988,29 @@ class OAuthError(MixpanelDataError):
 
 
 class WorkspaceScopeError(MixpanelDataError):
-    """Workspace resolution error.
+    """Scope resolution error (workspace or organization).
 
-    Raised when workspace resolution fails during App API requests.
-    This can occur when no workspaces are found, multiple workspaces
-    exist without a clear default, or an explicit workspace ID doesn't
-    match any available workspace.
+    Raised when an auth-axis identifier cannot be resolved during App
+    API requests. Originally introduced for workspace resolution; also
+    raised when the organization ID for an org-scoped business-context
+    call cannot be auto-derived from the cached ``/me`` response.
 
     Error codes:
     - NO_WORKSPACES: Project has no accessible workspaces
     - AMBIGUOUS_WORKSPACE: Multiple workspaces, none default; must specify --workspace-id
     - WORKSPACE_NOT_FOUND: Explicit workspace ID doesn't match any workspace
+    - ORGANIZATION_AMBIGUOUS: Cannot auto-resolve the organization for an
+      org-scoped call (active project absent from /me AND >1 accessible
+      organization). The ``details`` dict carries ``project_id`` and
+      ``available_organizations``. Pass ``organization_id=N`` explicitly
+      to bypass auto-resolution.
 
     Example:
         ```python
         try:
             workspace_id = ws.resolve_workspace_id()
         except WorkspaceScopeError as e:
-            print(f"Workspace issue: {e.message} (code: {e.code})")
+            print(f"Scope issue: {e.message} (code: {e.code})")
         ```
     """
 
@@ -1020,7 +1025,8 @@ class WorkspaceScopeError(MixpanelDataError):
         Args:
             message: Human-readable error message.
             code: Machine-readable error code. One of: NO_WORKSPACES,
-                AMBIGUOUS_WORKSPACE, WORKSPACE_NOT_FOUND.
+                AMBIGUOUS_WORKSPACE, WORKSPACE_NOT_FOUND,
+                ORGANIZATION_AMBIGUOUS.
             details: Additional structured data about the error.
         """
         super().__init__(message, code=code, details=details)

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -12150,6 +12150,118 @@ class UserQueryResult(ResultWithDataFrame):
 
 
 # =============================================================================
+# Business Context (AIE-147)
+# =============================================================================
+# Markdown documentation that grounds AI assistants in an organization's
+# structure and goals. Two scopes — "organization" (shared across all projects)
+# and "project" (per-project). Stored as plain markdown text (no images,
+# structured data, or links). The 50,000-character cap is enforced both
+# server-side and client-side; the same constant ships in
+# webapp/business_context/mutations.py::MAX_CONTENT_LENGTH.
+
+
+BUSINESS_CONTEXT_MAX_CHARS: int = 50_000
+"""Maximum allowed content length for business context, in characters.
+
+Mirrors ``MAX_CONTENT_LENGTH`` in
+``analytics/webapp/business_context/mutations.py`` — the server returns
+HTTP 400 with ``"content exceeds maximum length of 50000 characters"``
+above this threshold."""
+
+
+class BusinessContext(BaseModel):
+    """Business context content at a single scope.
+
+    Returned by ``Workspace.get_business_context()`` and
+    ``Workspace.set_business_context()``. The ``organization_id`` field
+    is populated for ``level="organization"`` and ``project_id`` for
+    ``level="project"`` so callers can identify which scope a value
+    came from when handling both in the same code path.
+
+    Attributes:
+        level: ``"organization"`` (org-wide) or ``"project"``
+            (project-specific).
+        content: The markdown content. Empty string when no context is
+            set at this scope.
+        organization_id: Owning organization ID — populated when
+            ``level="organization"``, ``None`` otherwise.
+        project_id: Owning project ID — populated when ``level="project"``,
+            ``None`` otherwise.
+
+    Example:
+        ```python
+        ws = Workspace()
+        ctx = ws.get_business_context(level="project")
+        if not ctx.is_empty:
+            print(ctx.content[:200], "...")
+            print(f"({ctx.character_count} characters)")
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    level: Literal["organization", "project"]
+    """Which scope this context belongs to."""
+
+    content: str
+    """Markdown content. Empty string when no context is set."""
+
+    organization_id: int | None = None
+    """Owning organization ID (set when ``level="organization"``)."""
+
+    project_id: str | None = None
+    """Owning project ID (set when ``level="project"``)."""
+
+    @property
+    def is_empty(self) -> bool:
+        """``True`` when no content has been set at this scope.
+
+        Returns:
+            ``True`` if ``content`` is the empty string, ``False`` otherwise.
+        """
+        return not self.content
+
+    @property
+    def character_count(self) -> int:
+        """Length of ``content`` in characters.
+
+        Returns:
+            Number of Unicode characters in ``content``. Compare against
+            ``BUSINESS_CONTEXT_MAX_CHARS`` (50,000) to check headroom.
+        """
+        return len(self.content)
+
+
+class BusinessContextChain(BaseModel):
+    """Both organization and project business context returned together.
+
+    Returned by ``Workspace.get_business_context_chain()``, which calls
+    the project-scoped ``/business-context/chain`` endpoint and resolves
+    both scopes in a single round-trip.
+
+    Attributes:
+        organization: Organization-level context (shared across projects).
+        project: Project-level context (specific to the active project).
+
+    Example:
+        ```python
+        ws = Workspace()
+        chain = ws.get_business_context_chain()
+        print("ORG:", chain.organization.content)
+        print("PROJECT:", chain.project.content)
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    organization: BusinessContext
+    """Organization-level context (``level="organization"``)."""
+
+    project: BusinessContext
+    """Project-level context (``level="project"``)."""
+
+
+# =============================================================================
 # Auth Architecture Redesign Types (Phase 042)
 # =============================================================================
 # Read-only summary types for the redesigned auth subsystem. These are the

--- a/src/mixpanel_data/types.py
+++ b/src/mixpanel_data/types.py
@@ -69,7 +69,14 @@ from mixpanel_data.auth_types import (
 if TYPE_CHECKING:
     import networkx as nx
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
 T = TypeVar("T")
@@ -12150,21 +12157,19 @@ class UserQueryResult(ResultWithDataFrame):
 
 
 # =============================================================================
-# Business Context (AIE-147)
+# Business Context
 # =============================================================================
 # Markdown documentation that grounds AI assistants in an organization's
 # structure and goals. Two scopes — "organization" (shared across all projects)
 # and "project" (per-project). Stored as plain markdown text (no images,
 # structured data, or links). The 50,000-character cap is enforced both
-# server-side and client-side; the same constant ships in
-# webapp/business_context/mutations.py::MAX_CONTENT_LENGTH.
+# server-side and client-side.
 
 
 BUSINESS_CONTEXT_MAX_CHARS: int = 50_000
 """Maximum allowed content length for business context, in characters.
 
-Mirrors ``MAX_CONTENT_LENGTH`` in
-``analytics/webapp/business_context/mutations.py`` — the server returns
+Mirrors the server's ``MAX_CONTENT_LENGTH`` constant — the API returns
 HTTP 400 with ``"content exceeds maximum length of 50000 characters"``
 above this threshold."""
 
@@ -12187,6 +12192,12 @@ class BusinessContext(BaseModel):
             ``level="organization"``, ``None`` otherwise.
         project_id: Owning project ID — populated when ``level="project"``,
             ``None`` otherwise.
+        is_empty: Computed — ``True`` when ``content == ""``. Visible
+            in ``model_dump()`` output so JSON consumers can use it
+            directly (no need to recompute).
+        character_count: Computed — ``len(content)``. Visible in
+            ``model_dump()`` output. Compare against
+            ``BUSINESS_CONTEXT_MAX_CHARS`` (50,000) to check headroom.
 
     Example:
         ```python
@@ -12212,18 +12223,26 @@ class BusinessContext(BaseModel):
     project_id: str | None = None
     """Owning project ID (set when ``level="project"``)."""
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def is_empty(self) -> bool:
         """``True`` when no content has been set at this scope.
+
+        Computed field — appears in ``model_dump()`` so JSON / CLI
+        consumers can ``--jq '.is_empty'`` directly.
 
         Returns:
             ``True`` if ``content`` is the empty string, ``False`` otherwise.
         """
         return not self.content
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def character_count(self) -> int:
         """Length of ``content`` in characters.
+
+        Computed field — appears in ``model_dump()`` so JSON / CLI
+        consumers can ``--jq '.character_count'`` directly.
 
         Returns:
             Number of Unicode characters in ``content``. Compare against

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -119,14 +119,17 @@ from mixpanel_data._literal_types import (
 from mixpanel_data.exceptions import (
     AuthenticationError,
     BookmarkValidationError,
+    BusinessContextValidationError,
     ConfigError,
     MixpanelDataError,
     QueryError,
     RateLimitError,
     ServerError,
     ValidationError,
+    WorkspaceScopeError,
 )
 from mixpanel_data.types import (
+    BUSINESS_CONTEXT_MAX_CHARS,
     ActivityFeedResult,
     AlertCount,
     AlertHistoryResponse,
@@ -150,6 +153,8 @@ from mixpanel_data.types import (
     BulkUpdateCohortEntry,
     BulkUpdateEventsParams,
     BulkUpdatePropertiesParams,
+    BusinessContext,
+    BusinessContextChain,
     Cohort,
     CohortBreakdown,
     CohortDefinition,
@@ -9944,3 +9949,301 @@ class Workspace:
             val = params["distinct_ids"]
             kwargs["distinct_ids"] = json.loads(val) if isinstance(val, str) else val
         return kwargs
+
+    # =========================================================================
+    # BUSINESS CONTEXT (AIE-147)
+    # =========================================================================
+    # Markdown documentation that grounds AI assistants in the
+    # organization's structure and goals. Two scopes:
+    #   - "organization": shared across all projects
+    #   - "project":      specific to the active project
+    # Backed by /api/app/projects/{pid}/business-context and
+    # /api/app/organizations/{org_id}/business-context. The /chain
+    # endpoint returns both at once. Server enforces a 50,000-char limit
+    # (mirrored client-side as BUSINESS_CONTEXT_MAX_CHARS).
+
+    def _resolve_organization_id(self, explicit: int | None = None) -> int:
+        """Resolve the organization ID for org-scoped business context calls.
+
+        Resolution order:
+
+        1. ``explicit`` argument when not ``None`` (no I/O).
+        2. ``MeResponse.projects[<active project id>].organization_id``
+           via the cached ``/me`` response (24h ``MeCache``).
+        3. The single org in ``MeResponse.organizations`` when exactly
+           one is accessible.
+        4. Raise ``WorkspaceScopeError`` listing the available org IDs.
+
+        Args:
+            explicit: Optional explicit organization ID. When provided,
+                no /me lookup is performed and this value is returned
+                as-is.
+
+        Returns:
+            Numeric organization ID for use in
+            ``/organizations/{org_id}/business-context`` paths.
+
+        Raises:
+            ConfigError: ``/me`` cannot be fetched (e.g. credentials
+                lack /me permission).
+            WorkspaceScopeError: ``explicit`` was not provided AND the
+                current project is not present in ``/me`` AND there is
+                not exactly one accessible organization to fall back to.
+
+        Example:
+            ```python
+            ws = Workspace()
+            org_id = ws._resolve_organization_id()         # auto-resolve
+            org_id = ws._resolve_organization_id(42)       # explicit
+            ```
+        """
+        if explicit is not None:
+            return explicit
+        me = self._me_svc.fetch()
+        project_info = me.projects.get(self._session.project.id)
+        if project_info is not None:
+            return project_info.organization_id
+        if len(me.organizations) == 1:
+            sole = next(iter(me.organizations.values()))
+            return sole.id
+        raise WorkspaceScopeError(
+            f"Cannot auto-resolve organization for project "
+            f"{self._session.project.id!r}. Pass organization_id explicitly. "
+            f"Available organizations: {sorted(me.organizations.keys())}",
+            code="ORGANIZATION_AMBIGUOUS",
+            details={
+                "project_id": self._session.project.id,
+                "available_organizations": sorted(me.organizations.keys()),
+            },
+        )
+
+    def get_business_context(
+        self,
+        *,
+        level: Literal["organization", "project"] = "project",
+        organization_id: int | None = None,
+    ) -> BusinessContext:
+        """Read business context content at the given scope.
+
+        Calls ``GET /api/app/projects/{pid}/business-context`` (when
+        ``level="project"``) or
+        ``GET /api/app/organizations/{org_id}/business-context``
+        (when ``level="organization"``). Returns a populated
+        ``BusinessContext`` with ``content=""`` when no context is set.
+
+        Args:
+            level: ``"project"`` (default) reads the project-level
+                context for the active session's project.
+                ``"organization"`` reads the org-level context shared
+                across all projects in the organization.
+            organization_id: Optional explicit org ID, only honored
+                when ``level="organization"``. When omitted, the org ID
+                is auto-resolved from the cached ``/me`` response — see
+                :meth:`_resolve_organization_id`.
+
+        Returns:
+            ``BusinessContext`` whose ``content`` reflects the server's
+            current state. ``organization_id`` is populated for
+            org-level returns; ``project_id`` for project-level.
+
+        Raises:
+            ConfigError: Credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400, 403, 404).
+            ServerError: Server-side errors (5xx).
+            WorkspaceScopeError: ``level="organization"`` and the org
+                ID could not be auto-resolved.
+
+        Example:
+            ```python
+            ws = Workspace()
+            project_ctx = ws.get_business_context(level="project")
+            org_ctx = ws.get_business_context(
+                level="organization", organization_id=100,
+            )
+            print(project_ctx.content)
+            ```
+        """
+        client = self._require_api_client()
+        if level == "organization":
+            org_id = self._resolve_organization_id(organization_id)
+            raw = client.get_business_context(organization_id=org_id)
+            return BusinessContext(
+                level="organization",
+                content=raw.get("content", ""),
+                organization_id=org_id,
+            )
+        raw = client.get_business_context()
+        return BusinessContext(
+            level="project",
+            content=raw.get("content", ""),
+            project_id=self._session.project.id,
+        )
+
+    def set_business_context(
+        self,
+        content: str,
+        *,
+        level: Literal["organization", "project"] = "project",
+        organization_id: int | None = None,
+    ) -> BusinessContext:
+        """Replace business context content at the given scope.
+
+        Validates ``len(content) <= BUSINESS_CONTEXT_MAX_CHARS`` (50,000)
+        client-side BEFORE the HTTP call so callers fail fast and avoid
+        a wasted round-trip to the server (which enforces the same limit
+        and returns 400 above it). Then calls
+        ``PUT /api/app/projects/{pid}/business-context`` (project) or
+        ``PUT /api/app/organizations/{org_id}/business-context`` (org).
+
+        The PUT is full-replace — pass an empty string to clear (or use
+        :meth:`clear_business_context` for clarity).
+
+        Args:
+            content: New markdown content. Empty string clears the
+                context at this scope.
+            level: ``"project"`` (default) or ``"organization"``.
+            organization_id: Optional explicit org ID, only honored
+                when ``level="organization"``. Auto-resolved from
+                ``/me`` when omitted.
+
+        Returns:
+            ``BusinessContext`` echoing the server's saved content.
+
+        Raises:
+            BusinessContextValidationError: ``len(content) > 50_000``
+                (client-side check, no HTTP call made).
+            ConfigError: Credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Caller lacks ``edit_project_info`` permission
+                (403) or other API error (400).
+            ServerError: Server-side errors (5xx).
+            WorkspaceScopeError: ``level="organization"`` and the org
+                ID could not be auto-resolved.
+
+        Example:
+            ```python
+            ws = Workspace()
+            ws.set_business_context("# Acme Corp\\n...", level="project")
+            ws.set_business_context(
+                "# Org-wide context", level="organization",
+            )
+            ```
+        """
+        if len(content) > BUSINESS_CONTEXT_MAX_CHARS:
+            raise BusinessContextValidationError(
+                f"content exceeds maximum length of "
+                f"{BUSINESS_CONTEXT_MAX_CHARS} characters (got {len(content)})",
+                details={
+                    "length": len(content),
+                    "max": BUSINESS_CONTEXT_MAX_CHARS,
+                },
+            )
+        client = self._require_api_client()
+        if level == "organization":
+            org_id = self._resolve_organization_id(organization_id)
+            raw = client.set_business_context(content, organization_id=org_id)
+            return BusinessContext(
+                level="organization",
+                content=raw.get("content", ""),
+                organization_id=org_id,
+            )
+        raw = client.set_business_context(content)
+        return BusinessContext(
+            level="project",
+            content=raw.get("content", ""),
+            project_id=self._session.project.id,
+        )
+
+    def clear_business_context(
+        self,
+        *,
+        level: Literal["organization", "project"] = "project",
+        organization_id: int | None = None,
+    ) -> BusinessContext:
+        """Clear business context at the given scope.
+
+        Convenience wrapper that calls
+        ``set_business_context("", level=..., organization_id=...)``.
+        Useful for documenting intent — equivalent to passing an empty
+        string explicitly.
+
+        Args:
+            level: ``"project"`` (default) or ``"organization"``.
+            organization_id: Optional explicit org ID for
+                ``level="organization"``.
+
+        Returns:
+            ``BusinessContext`` with ``content=""`` (the cleared state
+            echoed back from the server).
+
+        Raises:
+            ConfigError: Credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Caller lacks ``edit_project_info`` permission
+                (403) or other API error (400).
+            ServerError: Server-side errors (5xx).
+            WorkspaceScopeError: ``level="organization"`` and the org
+                ID could not be auto-resolved.
+
+        Example:
+            ```python
+            ws = Workspace()
+            ws.clear_business_context(level="project")
+            ```
+        """
+        return self.set_business_context(
+            "",
+            level=level,
+            organization_id=organization_id,
+        )
+
+    def get_business_context_chain(self) -> BusinessContextChain:
+        """Read both organization and project business context together.
+
+        Calls ``GET /api/app/projects/{pid}/business-context/chain`` —
+        a server-side convenience that returns both scopes for the
+        active project in a single round-trip. The returned
+        ``organization`` field reflects the org that owns the active
+        project; its ``organization_id`` is auto-resolved via the same
+        path as :meth:`_resolve_organization_id`.
+
+        Returns:
+            ``BusinessContextChain`` with populated ``organization`` and
+            ``project`` fields. Either ``content`` may be empty when no
+            context is set at that scope.
+
+        Raises:
+            ConfigError: Credentials are not available.
+            AuthenticationError: Invalid credentials (401).
+            QueryError: Caller lacks project access (403, 404) or
+                other API error (400).
+            ServerError: Server-side errors (5xx).
+            WorkspaceScopeError: Org ID could not be auto-resolved
+                (the chain endpoint returns content but the response
+                does not echo the org ID, so we resolve it ourselves
+                to populate ``organization.organization_id``).
+
+        Example:
+            ```python
+            ws = Workspace()
+            chain = ws.get_business_context_chain()
+            print("ORG:", chain.organization.content)
+            print("PROJECT:", chain.project.content)
+            ```
+        """
+        client = self._require_api_client()
+        raw = client.get_business_context_chain()
+        org_id = self._resolve_organization_id()
+        return BusinessContextChain(
+            organization=BusinessContext(
+                level="organization",
+                content=raw.get("org_context", ""),
+                organization_id=org_id,
+            ),
+            project=BusinessContext(
+                level="project",
+                content=raw.get("project_context", ""),
+                project_id=self._session.project.id,
+            ),
+        )

--- a/src/mixpanel_data/workspace.py
+++ b/src/mixpanel_data/workspace.py
@@ -9951,7 +9951,7 @@ class Workspace:
         return kwargs
 
     # =========================================================================
-    # BUSINESS CONTEXT (AIE-147)
+    # BUSINESS CONTEXT
     # =========================================================================
     # Markdown documentation that grounds AI assistants in the
     # organization's structure and goals. Two scopes:
@@ -9962,6 +9962,28 @@ class Workspace:
     # endpoint returns both at once. Server enforces a 50,000-char limit
     # (mirrored client-side as BUSINESS_CONTEXT_MAX_CHARS).
 
+    @staticmethod
+    def _validate_level(level: str) -> None:
+        """Reject any ``level`` value other than the two documented literals.
+
+        Python's ``Literal[...]`` type annotations are erased at runtime,
+        so without this check a caller passing ``level="org"`` would
+        silently take the project-scope branch. We validate explicitly
+        so the error surfaces at the call site.
+
+        Args:
+            level: The ``level`` argument from a public business-context
+                method.
+
+        Raises:
+            ValueError: ``level`` is not ``"organization"`` or
+                ``"project"``.
+        """
+        if level not in ("organization", "project"):
+            raise ValueError(
+                f"level must be 'organization' or 'project', got {level!r}"
+            )
+
     def _resolve_organization_id(self, explicit: int | None = None) -> int:
         """Resolve the organization ID for org-scoped business context calls.
 
@@ -9969,10 +9991,13 @@ class Workspace:
 
         1. ``explicit`` argument when not ``None`` (no I/O).
         2. ``MeResponse.projects[<active project id>].organization_id``
-           via the cached ``/me`` response (24h ``MeCache``).
+           via the cached ``/me`` response (24h ``MeCache``). This step
+           may trigger a ``/me`` API call when both in-memory and disk
+           caches miss.
         3. The single org in ``MeResponse.organizations`` when exactly
            one is accessible.
-        4. Raise ``WorkspaceScopeError`` listing the available org IDs.
+        4. Raise ``WorkspaceScopeError`` (``code="ORGANIZATION_AMBIGUOUS"``)
+           listing the available org IDs.
 
         Args:
             explicit: Optional explicit organization ID. When provided,
@@ -9989,13 +10014,6 @@ class Workspace:
             WorkspaceScopeError: ``explicit`` was not provided AND the
                 current project is not present in ``/me`` AND there is
                 not exactly one accessible organization to fall back to.
-
-        Example:
-            ```python
-            ws = Workspace()
-            org_id = ws._resolve_organization_id()         # auto-resolve
-            org_id = ws._resolve_organization_id(42)       # explicit
-            ```
         """
         if explicit is not None:
             return explicit
@@ -10016,6 +10034,72 @@ class Workspace:
                 "available_organizations": sorted(me.organizations.keys()),
             },
         )
+
+    def _cached_organization_id(self) -> int | None:
+        """Return ``organization_id`` from cached ``/me``, never fetching.
+
+        Used by ``get_business_context_chain()`` to enrich the response
+        with ``organization_id`` *only when free* — preserving the
+        chain endpoint's single-network-round-trip guarantee. If the
+        cache is cold (neither in-memory nor on-disk), returns ``None``
+        rather than triggering a ``/me`` API call. Callers that need a
+        guaranteed org ID should use ``get_business_context(level=
+        "organization")`` instead.
+
+        Returns:
+            Cached organization ID for the active project, the sole
+            accessible org if exactly one exists, or ``None`` when the
+            cache is cold or the project is not in the cached ``/me``
+            and there are multiple orgs.
+        """
+        if self._me_service is None:
+            return None
+        me = self._me_service.peek()
+        if me is None:
+            return None
+        project_info = me.projects.get(self._session.project.id)
+        if project_info is not None:
+            return int(project_info.organization_id)
+        if len(me.organizations) == 1:
+            sole = next(iter(me.organizations.values()))
+            return int(sole.id)
+        return None
+
+    @staticmethod
+    def _require_str_field(raw: dict[str, Any], key: str, *, method: str) -> str:
+        """Read a required string field from an App API response.
+
+        Treats a missing key as a server-contract violation (raises
+        ``MixpanelDataError``) rather than silently substituting the
+        empty string, which would mask renames or schema drift on the
+        server side.
+
+        Args:
+            raw: The unwrapped ``results`` dict returned by ``app_request``.
+            key: Field name expected in ``raw``.
+            method: Caller method name, embedded in the error message.
+
+        Returns:
+            The string value at ``raw[key]``. Empty strings are valid
+            (unset business context returns ``""``).
+
+        Raises:
+            MixpanelDataError: ``key`` is absent from ``raw`` or its
+                value is not a string.
+        """
+        if key not in raw:
+            raise MixpanelDataError(
+                f"Unexpected response from {method}: missing required field {key!r}",
+                details={"missing_field": key, "response": raw},
+            )
+        value = raw[key]
+        if not isinstance(value, str):
+            raise MixpanelDataError(
+                f"Unexpected response from {method}: field {key!r} "
+                f"is {type(value).__name__}, expected str",
+                details={"field": key, "response": raw},
+            )
+        return value
 
     def get_business_context(
         self,
@@ -10038,8 +10122,9 @@ class Workspace:
                 across all projects in the organization.
             organization_id: Optional explicit org ID, only honored
                 when ``level="organization"``. When omitted, the org ID
-                is auto-resolved from the cached ``/me`` response — see
-                :meth:`_resolve_organization_id`.
+                is auto-resolved from the cached ``/me`` response
+                (which may trigger a ``/me`` API call when the cache
+                is cold).
 
         Returns:
             ``BusinessContext`` whose ``content`` reflects the server's
@@ -10047,12 +10132,15 @@ class Workspace:
             org-level returns; ``project_id`` for project-level.
 
         Raises:
+            ValueError: ``level`` is not ``"organization"`` or ``"project"``.
             ConfigError: Credentials are not available.
             AuthenticationError: Invalid credentials (401).
             QueryError: API error (400, 403, 404).
             ServerError: Server-side errors (5xx).
             WorkspaceScopeError: ``level="organization"`` and the org
                 ID could not be auto-resolved.
+            MixpanelDataError: API response is missing the ``content``
+                field.
 
         Example:
             ```python
@@ -10064,19 +10152,28 @@ class Workspace:
             print(project_ctx.content)
             ```
         """
+        self._validate_level(level)
         client = self._require_api_client()
         if level == "organization":
             org_id = self._resolve_organization_id(organization_id)
             raw = client.get_business_context(organization_id=org_id)
             return BusinessContext(
                 level="organization",
-                content=raw.get("content", ""),
+                content=self._require_str_field(
+                    raw,
+                    "content",
+                    method="get_business_context",
+                ),
                 organization_id=org_id,
             )
         raw = client.get_business_context()
         return BusinessContext(
             level="project",
-            content=raw.get("content", ""),
+            content=self._require_str_field(
+                raw,
+                "content",
+                method="get_business_context",
+            ),
             project_id=self._session.project.id,
         )
 
@@ -10097,7 +10194,7 @@ class Workspace:
         ``PUT /api/app/organizations/{org_id}/business-context`` (org).
 
         The PUT is full-replace — pass an empty string to clear (or use
-        :meth:`clear_business_context` for clarity).
+        ``clear_business_context`` for clarity).
 
         Args:
             content: New markdown content. Empty string clears the
@@ -10111,6 +10208,7 @@ class Workspace:
             ``BusinessContext`` echoing the server's saved content.
 
         Raises:
+            ValueError: ``level`` is not ``"organization"`` or ``"project"``.
             BusinessContextValidationError: ``len(content) > 50_000``
                 (client-side check, no HTTP call made).
             ConfigError: Credentials are not available.
@@ -10120,6 +10218,8 @@ class Workspace:
             ServerError: Server-side errors (5xx).
             WorkspaceScopeError: ``level="organization"`` and the org
                 ID could not be auto-resolved.
+            MixpanelDataError: API response is missing the ``content``
+                field.
 
         Example:
             ```python
@@ -10130,6 +10230,7 @@ class Workspace:
             )
             ```
         """
+        self._validate_level(level)
         if len(content) > BUSINESS_CONTEXT_MAX_CHARS:
             raise BusinessContextValidationError(
                 f"content exceeds maximum length of "
@@ -10145,13 +10246,21 @@ class Workspace:
             raw = client.set_business_context(content, organization_id=org_id)
             return BusinessContext(
                 level="organization",
-                content=raw.get("content", ""),
+                content=self._require_str_field(
+                    raw,
+                    "content",
+                    method="set_business_context",
+                ),
                 organization_id=org_id,
             )
         raw = client.set_business_context(content)
         return BusinessContext(
             level="project",
-            content=raw.get("content", ""),
+            content=self._require_str_field(
+                raw,
+                "content",
+                method="set_business_context",
+            ),
             project_id=self._session.project.id,
         )
 
@@ -10178,6 +10287,7 @@ class Workspace:
             echoed back from the server).
 
         Raises:
+            ValueError: ``level`` is not ``"organization"`` or ``"project"``.
             ConfigError: Credentials are not available.
             AuthenticationError: Invalid credentials (401).
             QueryError: Caller lacks ``edit_project_info`` permission
@@ -10201,17 +10311,22 @@ class Workspace:
     def get_business_context_chain(self) -> BusinessContextChain:
         """Read both organization and project business context together.
 
-        Calls ``GET /api/app/projects/{pid}/business-context/chain`` —
+        Issues exactly one App API request to
+        ``GET /api/app/projects/{pid}/business-context/chain`` —
         a server-side convenience that returns both scopes for the
-        active project in a single round-trip. The returned
-        ``organization`` field reflects the org that owns the active
-        project; its ``organization_id`` is auto-resolved via the same
-        path as :meth:`_resolve_organization_id`.
+        active project. ``organization.organization_id`` is populated
+        on a best-effort basis from the cached ``/me`` response (in-memory
+        or disk); when the cache is cold it is left as ``None`` rather
+        than triggering an extra ``/me`` round-trip. Callers that need a
+        guaranteed org ID should use ``get_business_context(level=
+        "organization")``, which performs full resolution.
 
         Returns:
             ``BusinessContextChain`` with populated ``organization`` and
             ``project`` fields. Either ``content`` may be empty when no
             context is set at that scope.
+            ``organization.organization_id`` may be ``None`` when the
+            ``/me`` cache is cold (see method description).
 
         Raises:
             ConfigError: Credentials are not available.
@@ -10219,10 +10334,8 @@ class Workspace:
             QueryError: Caller lacks project access (403, 404) or
                 other API error (400).
             ServerError: Server-side errors (5xx).
-            WorkspaceScopeError: Org ID could not be auto-resolved
-                (the chain endpoint returns content but the response
-                does not echo the org ID, so we resolve it ourselves
-                to populate ``organization.organization_id``).
+            MixpanelDataError: API response is missing ``org_context``
+                or ``project_context``.
 
         Example:
             ```python
@@ -10234,16 +10347,26 @@ class Workspace:
         """
         client = self._require_api_client()
         raw = client.get_business_context_chain()
-        org_id = self._resolve_organization_id()
+        org_content = self._require_str_field(
+            raw,
+            "org_context",
+            method="get_business_context_chain",
+        )
+        project_content = self._require_str_field(
+            raw,
+            "project_context",
+            method="get_business_context_chain",
+        )
+        org_id = self._cached_organization_id()
         return BusinessContextChain(
             organization=BusinessContext(
                 level="organization",
-                content=raw.get("org_context", ""),
+                content=org_content,
                 organization_id=org_id,
             ),
             project=BusinessContext(
                 level="project",
-                content=raw.get("project_context", ""),
+                content=project_content,
                 project_id=self._session.project.id,
             ),
         )

--- a/tests/pbt/test_business_context_pbt.py
+++ b/tests/pbt/test_business_context_pbt.py
@@ -1,0 +1,131 @@
+"""Property-based tests for business context (AIE-147).
+
+Locks down three invariants that must hold for arbitrary inputs:
+
+1. ``Workspace.set_business_context(content)`` sends exactly
+   ``{"content": content}`` to the project endpoint for any text
+   payload up to ``BUSINESS_CONTEXT_MAX_CHARS`` chars.
+2. Round-trip GET-after-SET (mocked echo) preserves the content
+   verbatim across arbitrary unicode strings.
+3. ``set_business_context`` rejects any content with
+   ``len(content) > BUSINESS_CONTEXT_MAX_CHARS`` BEFORE making any
+   HTTP call (the mock transport's request count stays at zero).
+"""
+
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data.exceptions import BusinessContextValidationError
+from mixpanel_data.types import BUSINESS_CONTEXT_MAX_CHARS, BusinessContext
+from mixpanel_data.workspace import Workspace
+from tests.conftest import make_session
+
+
+def _build_workspace(handler: Any) -> Workspace:
+    """Build a Workspace whose API client routes through ``handler``.
+
+    Args:
+        handler: ``httpx.MockTransport`` handler.
+
+    Returns:
+        Workspace bound to the mock transport with project 12345.
+    """
+    sess = make_session(project_id="12345", region="us", oauth_token="token")
+    transport = httpx.MockTransport(handler)
+    client = MixpanelAPIClient(session=sess, _transport=transport)
+    return Workspace(session=sess, _api_client=client)
+
+
+# Valid-content strategy: any unicode text up to the cap.
+_valid_content = st.text(min_size=0, max_size=BUSINESS_CONTEXT_MAX_CHARS)
+
+
+@given(content=_valid_content)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_set_sends_exact_content_body(content: str) -> None:
+    """For any valid content, set sends ``{"content": <content>}``."""
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Capture body, echo content back."""
+        body: dict[str, Any] = json.loads(request.content)
+        captured.append(body)
+        return httpx.Response(
+            200, json={"status": "ok", "results": {"content": body["content"]}}
+        )
+
+    ws = _build_workspace(handler)
+    ws.set_business_context(content, level="project")
+    assert captured == [{"content": content}]
+
+
+@given(content=_valid_content)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_round_trip_preserves_content(content: str) -> None:
+    """Echo handler: SET then GET returns the same content."""
+
+    storage: dict[str, str] = {"content": ""}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Mock storage: PUT updates, GET returns current state."""
+        if request.method == "PUT":
+            body: dict[str, Any] = json.loads(request.content)
+            storage["content"] = body["content"]
+        return httpx.Response(
+            200, json={"status": "ok", "results": {"content": storage["content"]}}
+        )
+
+    ws = _build_workspace(handler)
+    ws.set_business_context(content, level="project")
+    fetched = ws.get_business_context(level="project")
+
+    assert isinstance(fetched, BusinessContext)
+    assert fetched.content == content
+    assert fetched.character_count == len(content)
+
+
+@given(
+    overflow=st.integers(min_value=1, max_value=128),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_oversize_content_blocks_http_call(overflow: int) -> None:
+    """``len(content) > MAX`` raises BEFORE any HTTP request is made."""
+
+    request_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Bump counter; should never run when validation rejects."""
+        request_count["n"] += 1
+        return httpx.Response(200, json={"status": "ok", "results": {"content": ""}})
+
+    ws = _build_workspace(handler)
+    payload = "x" * (BUSINESS_CONTEXT_MAX_CHARS + overflow)
+
+    with pytest.raises(BusinessContextValidationError) as exc_info:
+        ws.set_business_context(payload, level="project")
+
+    assert request_count["n"] == 0
+    assert exc_info.value.details["length"] == len(payload)
+    assert exc_info.value.details["max"] == BUSINESS_CONTEXT_MAX_CHARS

--- a/tests/unit/cli/test_business_context.py
+++ b/tests/unit/cli/test_business_context.py
@@ -1,0 +1,446 @@
+# ruff: noqa: ARG001, ARG005
+"""Tests for ``mp business-context`` CLI commands.
+
+Covers all four subcommands plus the input-source mutex on ``set``:
+
+- ``get``:   project + organization, --organization-id forwarding,
+  error mapping, --jq smoke test
+- ``set``:   --content / --file / stdin input modes, mutual exclusion,
+  oversize content, error mapping
+- ``clear``: forwards level + organization_id; outputs cleared state
+- ``chain``: returns BusinessContextChain JSON with both scopes
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import typer.testing
+
+from mixpanel_data.cli.main import app
+from mixpanel_data.exceptions import (
+    AuthenticationError,
+    BusinessContextValidationError,
+    QueryError,
+    WorkspaceScopeError,
+)
+
+runner = typer.testing.CliRunner()
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _ctx_mock(
+    *,
+    level: str = "project",
+    content: str = "# Hello",
+    organization_id: int | None = None,
+    project_id: str | None = "12345",
+) -> MagicMock:
+    """Build a MagicMock that mimics a BusinessContext.model_dump()."""
+    payload: dict[str, object] = {
+        "level": level,
+        "content": content,
+        "organization_id": organization_id,
+        "project_id": project_id,
+    }
+    mock = MagicMock()
+    mock.model_dump = lambda: payload
+    return mock
+
+
+def _chain_mock() -> MagicMock:
+    """Build a MagicMock that mimics a BusinessContextChain.model_dump()."""
+    payload: dict[str, object] = {
+        "organization": {
+            "level": "organization",
+            "content": "# Org",
+            "organization_id": 100,
+            "project_id": None,
+        },
+        "project": {
+            "level": "project",
+            "content": "# Project",
+            "organization_id": None,
+            "project_id": "12345",
+        },
+    }
+    mock = MagicMock()
+    mock.model_dump = lambda: payload
+    return mock
+
+
+# =============================================================================
+# get
+# =============================================================================
+
+
+class TestGet:
+    """``mp business-context get`` behavior."""
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_default_level_is_project(self, mock_get_ws: MagicMock) -> None:
+        """No --level → project-scope GET, JSON includes project_id."""
+        ws = MagicMock()
+        ws.get_business_context.return_value = _ctx_mock(level="project")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "get"])
+        assert result.exit_code == 0
+        ws.get_business_context.assert_called_once_with(
+            level="project",
+            organization_id=None,
+        )
+        data = json.loads(result.stdout)
+        assert data["level"] == "project"
+        assert data["project_id"] == "12345"
+        assert data["content"] == "# Hello"
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_organization_level_with_explicit_id(self, mock_get_ws: MagicMock) -> None:
+        """--level organization --organization-id forwards both."""
+        ws = MagicMock()
+        ws.get_business_context.return_value = _ctx_mock(
+            level="organization",
+            content="# Org info",
+            organization_id=42,
+            project_id=None,
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            [
+                "business-context",
+                "get",
+                "--level",
+                "organization",
+                "--organization-id",
+                "42",
+            ],
+        )
+        assert result.exit_code == 0
+        ws.get_business_context.assert_called_once_with(
+            level="organization",
+            organization_id=42,
+        )
+        data = json.loads(result.stdout)
+        assert data["organization_id"] == 42
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_jq_filter_extracts_content(self, mock_get_ws: MagicMock) -> None:
+        """--jq '.content' produces the markdown body only."""
+        ws = MagicMock()
+        ws.get_business_context.return_value = _ctx_mock(content="markdown!")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "get", "--jq", ".content"],
+        )
+        assert result.exit_code == 0
+        assert "markdown!" in result.stdout
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_invalid_level_exits_3(self, mock_get_ws: MagicMock) -> None:
+        """Bogus --level value exits with INVALID_ARGS (3)."""
+        mock_get_ws.return_value = MagicMock()
+
+        result = runner.invoke(
+            app,
+            ["business-context", "get", "--level", "bogus"],
+        )
+        assert result.exit_code == 3
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_auth_error_exits_2(self, mock_get_ws: MagicMock) -> None:
+        """AuthenticationError from workspace → AUTH_ERROR (2)."""
+        ws = MagicMock()
+        ws.get_business_context.side_effect = AuthenticationError(
+            "bad token", request_url="/api/app/projects/12345/business-context"
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "get"])
+        assert result.exit_code == 2
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_workspace_scope_error_exits_1(self, mock_get_ws: MagicMock) -> None:
+        """WorkspaceScopeError → GENERAL_ERROR (1)."""
+        ws = MagicMock()
+        ws.get_business_context.side_effect = WorkspaceScopeError(
+            "ambiguous org",
+            code="ORGANIZATION_AMBIGUOUS",
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "get", "--level", "organization"],
+        )
+        assert result.exit_code == 1
+
+
+# =============================================================================
+# set
+# =============================================================================
+
+
+class TestSet:
+    """``mp business-context set`` behavior."""
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_inline_content(self, mock_get_ws: MagicMock) -> None:
+        """--content forwards the literal string to set_business_context."""
+        ws = MagicMock()
+        ws.set_business_context.return_value = _ctx_mock(content="# Inline")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set", "--content", "# Inline"],
+        )
+        assert result.exit_code == 0
+        ws.set_business_context.assert_called_once_with(
+            "# Inline",
+            level="project",
+            organization_id=None,
+        )
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_file_input(self, mock_get_ws: MagicMock, tmp_path: Path) -> None:
+        """--file reads from disk and forwards content."""
+        ws = MagicMock()
+        ws.set_business_context.return_value = _ctx_mock(content="from file")
+        mock_get_ws.return_value = ws
+
+        ctx_file = tmp_path / "ctx.md"
+        ctx_file.write_text("from file", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set", "--file", str(ctx_file)],
+        )
+        assert result.exit_code == 0
+        ws.set_business_context.assert_called_once_with(
+            "from file",
+            level="project",
+            organization_id=None,
+        )
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_stdin_input(self, mock_get_ws: MagicMock) -> None:
+        """Piped stdin (no flags, non-tty) is forwarded as content."""
+        ws = MagicMock()
+        ws.set_business_context.return_value = _ctx_mock(content="from stdin")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set"],
+            input="from stdin",
+        )
+        assert result.exit_code == 0
+        ws.set_business_context.assert_called_once_with(
+            "from stdin",
+            level="project",
+            organization_id=None,
+        )
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_content_and_file_mutex_exits_3(
+        self, mock_get_ws: MagicMock, tmp_path: Path
+    ) -> None:
+        """--content + --file together → INVALID_ARGS (3)."""
+        mock_get_ws.return_value = MagicMock()
+        ctx_file = tmp_path / "ctx.md"
+        ctx_file.write_text("hi", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            [
+                "business-context",
+                "set",
+                "--content",
+                "x",
+                "--file",
+                str(ctx_file),
+            ],
+        )
+        assert result.exit_code == 3
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_no_content_no_pipe_exits_3(self, mock_get_ws: MagicMock) -> None:
+        """No flags + TTY stdin → INVALID_ARGS (3)."""
+        mock_get_ws.return_value = MagicMock()
+
+        # CliRunner without `input` simulates a TTY-like empty stdin;
+        # explicitly pass input=None to keep stdin a TTY for the tool.
+        result = runner.invoke(app, ["business-context", "set"])
+        # In CliRunner, sys.stdin is replaced by a non-tty buffer when
+        # input is None. We expect either INVALID_ARGS (3) or success
+        # with empty content (set "" — equivalent to clear). Document
+        # the current behavior: when CliRunner supplies an empty
+        # stream, isatty() returns False so we treat it as piped empty
+        # input — which is "" — and the call goes through.
+        assert result.exit_code in (0, 3)
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_missing_file_exits_3(self, mock_get_ws: MagicMock) -> None:
+        """--file pointing at a non-existent path → INVALID_ARGS (3)."""
+        mock_get_ws.return_value = MagicMock()
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set", "--file", "/nonexistent/ctx.md"],
+        )
+        assert result.exit_code == 3
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_oversize_content_exits_via_handle_errors(
+        self, mock_get_ws: MagicMock
+    ) -> None:
+        """BusinessContextValidationError from set → GENERAL_ERROR (1)."""
+        ws = MagicMock()
+        ws.set_business_context.side_effect = BusinessContextValidationError(
+            "too long",
+            details={"length": 60_000, "max": 50_000},
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set", "--content", "x" * 60_000],
+        )
+        # BusinessContextValidationError inherits from MixpanelDataError →
+        # the @handle_errors decorator's MixpanelDataError branch maps to
+        # GENERAL_ERROR (1).
+        assert result.exit_code == 1
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_org_level_set_forwards_org_id(self, mock_get_ws: MagicMock) -> None:
+        """--level organization --organization-id forwards the int."""
+        ws = MagicMock()
+        ws.set_business_context.return_value = _ctx_mock(
+            level="organization",
+            content="# Org",
+            organization_id=42,
+            project_id=None,
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            [
+                "business-context",
+                "set",
+                "--level",
+                "organization",
+                "--organization-id",
+                "42",
+                "--content",
+                "# Org",
+            ],
+        )
+        assert result.exit_code == 0
+        ws.set_business_context.assert_called_once_with(
+            "# Org",
+            level="organization",
+            organization_id=42,
+        )
+
+
+# =============================================================================
+# clear
+# =============================================================================
+
+
+class TestClear:
+    """``mp business-context clear`` behavior."""
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_clear_default_level(self, mock_get_ws: MagicMock) -> None:
+        """clear with no flags clears project-level."""
+        ws = MagicMock()
+        ws.clear_business_context.return_value = _ctx_mock(content="")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "clear"])
+        assert result.exit_code == 0
+        ws.clear_business_context.assert_called_once_with(
+            level="project",
+            organization_id=None,
+        )
+        data = json.loads(result.stdout)
+        assert data["content"] == ""
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_clear_organization(self, mock_get_ws: MagicMock) -> None:
+        """clear --level organization --organization-id forwards both."""
+        ws = MagicMock()
+        ws.clear_business_context.return_value = _ctx_mock(
+            level="organization",
+            content="",
+            organization_id=42,
+            project_id=None,
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            [
+                "business-context",
+                "clear",
+                "--level",
+                "organization",
+                "--organization-id",
+                "42",
+            ],
+        )
+        assert result.exit_code == 0
+        ws.clear_business_context.assert_called_once_with(
+            level="organization",
+            organization_id=42,
+        )
+
+
+# =============================================================================
+# chain
+# =============================================================================
+
+
+class TestChain:
+    """``mp business-context chain`` behavior."""
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_chain_returns_both_scopes(self, mock_get_ws: MagicMock) -> None:
+        """chain returns JSON with `organization` and `project` blocks."""
+        ws = MagicMock()
+        ws.get_business_context_chain.return_value = _chain_mock()
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "chain"])
+        assert result.exit_code == 0
+        ws.get_business_context_chain.assert_called_once_with()
+        data = json.loads(result.stdout)
+        assert data["organization"]["organization_id"] == 100
+        assert data["project"]["project_id"] == "12345"
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_chain_query_error_exits_3(self, mock_get_ws: MagicMock) -> None:
+        """QueryError from chain → INVALID_ARGS (3)."""
+        ws = MagicMock()
+        ws.get_business_context_chain.side_effect = QueryError(
+            "boom",
+            status_code=400,
+            request_url="/api/app/projects/12345/business-context/chain",
+        )
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "chain"])
+        assert result.exit_code == 3

--- a/tests/unit/cli/test_business_context.py
+++ b/tests/unit/cli/test_business_context.py
@@ -147,15 +147,22 @@ class TestGet:
         assert "markdown!" in result.stdout
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
-    def test_invalid_level_exits_3(self, mock_get_ws: MagicMock) -> None:
-        """Bogus --level value exits with INVALID_ARGS (3)."""
+    def test_invalid_level_exits_2(self, mock_get_ws: MagicMock) -> None:
+        """Bogus --level value exits with Click's usage error code (2).
+
+        ``--level`` is now a ``click.Choice`` so Click validates it
+        before our handler runs and exits with its standard usage-error
+        code 2 (``UsageError`` → ``SystemExit(2)``), matching every
+        other ``click.Choice``-validated option in the CLI (e.g.
+        ``--format``).
+        """
         mock_get_ws.return_value = MagicMock()
 
         result = runner.invoke(
             app,
             ["business-context", "get", "--level", "bogus"],
         )
-        assert result.exit_code == 3
+        assert result.exit_code == 2
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
     def test_auth_error_exits_2(self, mock_get_ws: MagicMock) -> None:
@@ -275,20 +282,43 @@ class TestSet:
         assert result.exit_code == 3
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
-    def test_no_content_no_pipe_exits_3(self, mock_get_ws: MagicMock) -> None:
-        """No flags + TTY stdin → INVALID_ARGS (3)."""
-        mock_get_ws.return_value = MagicMock()
+    def test_empty_stdin_refuses_silent_clear(self, mock_get_ws: MagicMock) -> None:
+        """Empty / whitespace-only stdin → INVALID_ARGS (3) deterministically.
 
-        # CliRunner without `input` simulates a TTY-like empty stdin;
-        # explicitly pass input=None to keep stdin a TTY for the tool.
-        result = runner.invoke(app, ["business-context", "set"])
-        # In CliRunner, sys.stdin is replaced by a non-tty buffer when
-        # input is None. We expect either INVALID_ARGS (3) or success
-        # with empty content (set "" — equivalent to clear). Document
-        # the current behavior: when CliRunner supplies an empty
-        # stream, isatty() returns False so we treat it as piped empty
-        # input — which is "" — and the call goes through.
-        assert result.exit_code in (0, 3)
+        Regression guard for the CI/cron `</dev/null` footgun: we must
+        never silently send `{"content": ""}` from an empty stdin.
+        Clearing context must be explicit (`clear` subcommand, or
+        `--content ""`).
+        """
+        ws = MagicMock()
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(app, ["business-context", "set"], input="")
+        assert result.exit_code == 3
+        ws.set_business_context.assert_not_called()
+
+        # Whitespace-only stdin is also rejected (no real intent to write).
+        result = runner.invoke(app, ["business-context", "set"], input="   \n")
+        assert result.exit_code == 3
+        ws.set_business_context.assert_not_called()
+
+    @patch("mixpanel_data.cli.commands.business_context.get_workspace")
+    def test_explicit_empty_content_clears(self, mock_get_ws: MagicMock) -> None:
+        """`--content ""` is the explicit way to clear via `set`."""
+        ws = MagicMock()
+        ws.set_business_context.return_value = _ctx_mock(content="")
+        mock_get_ws.return_value = ws
+
+        result = runner.invoke(
+            app,
+            ["business-context", "set", "--content", ""],
+        )
+        assert result.exit_code == 0
+        ws.set_business_context.assert_called_once_with(
+            "",
+            level="project",
+            organization_id=None,
+        )
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
     def test_missing_file_exits_3(self, mock_get_ws: MagicMock) -> None:
@@ -302,10 +332,14 @@ class TestSet:
         assert result.exit_code == 3
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
-    def test_oversize_content_exits_via_handle_errors(
-        self, mock_get_ws: MagicMock
-    ) -> None:
-        """BusinessContextValidationError from set → GENERAL_ERROR (1)."""
+    def test_oversize_content_exits_invalid_args(self, mock_get_ws: MagicMock) -> None:
+        """BusinessContextValidationError from set → INVALID_ARGS (3).
+
+        @handle_errors has an explicit branch for
+        BusinessContextValidationError that maps to INVALID_ARGS,
+        because the failure is client-side input validation rather
+        than an unknown library error.
+        """
         ws = MagicMock()
         ws.set_business_context.side_effect = BusinessContextValidationError(
             "too long",
@@ -317,10 +351,7 @@ class TestSet:
             app,
             ["business-context", "set", "--content", "x" * 60_000],
         )
-        # BusinessContextValidationError inherits from MixpanelDataError →
-        # the @handle_errors decorator's MixpanelDataError branch maps to
-        # GENERAL_ERROR (1).
-        assert result.exit_code == 1
+        assert result.exit_code == 3
 
     @patch("mixpanel_data.cli.commands.business_context.get_workspace")
     def test_org_level_set_forwards_org_id(self, mock_get_ws: MagicMock) -> None:

--- a/tests/unit/test_workspace_business_context.py
+++ b/tests/unit/test_workspace_business_context.py
@@ -1,0 +1,463 @@
+"""Unit tests for Workspace business context methods (AIE-147).
+
+Covers all four facade methods plus the ``_resolve_organization_id``
+helper. Each method delegates to MixpanelAPIClient via httpx.MockTransport
+and returns typed BusinessContext / BusinessContextChain instances.
+
+Verifies:
+
+- Project- and org-level GET / SET / CLEAR
+- Org ID auto-resolution from /me cache (project lookup, sole-org fallback)
+- Org ID explicit override (no /me fetch)
+- Ambiguous-org raises WorkspaceScopeError
+- 50,000-character boundary on set (client-side validation)
+- Chain endpoint parses both fields and populates org_id + project_id
+- Server-side 400 surfaces as QueryError
+"""
+
+# ruff: noqa: ARG001, ARG005
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from mixpanel_data._internal.api_client import MixpanelAPIClient
+from mixpanel_data._internal.auth.session import Session
+from mixpanel_data._internal.me import MeOrgInfo, MeProjectInfo, MeResponse
+from mixpanel_data.exceptions import (
+    BusinessContextValidationError,
+    QueryError,
+    WorkspaceScopeError,
+)
+from mixpanel_data.types import (
+    BUSINESS_CONTEXT_MAX_CHARS,
+    BusinessContext,
+    BusinessContextChain,
+)
+from mixpanel_data.workspace import Workspace
+from tests.conftest import make_session
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _session() -> Session:
+    """Return a Session bound to test project 12345.
+
+    Returns:
+        A Session usable for ``MixpanelAPIClient(session=...)``.
+    """
+    return make_session(project_id="12345", region="us", oauth_token="test-token")
+
+
+def _make_workspace(handler: Any) -> Workspace:
+    """Build a Workspace whose API client routes through ``handler``.
+
+    Args:
+        handler: ``httpx.MockTransport`` handler accepting ``Request``.
+
+    Returns:
+        A Workspace wired to the mock transport.
+    """
+    sess = _session()
+    transport = httpx.MockTransport(handler)
+    client = MixpanelAPIClient(session=sess, _transport=transport)
+    return Workspace(session=sess, _api_client=client)
+
+
+def _stub_me(
+    ws: Workspace,
+    *,
+    project_org: int | None = 100,
+    extra_orgs: dict[str, int] | None = None,
+    no_active_project: bool = False,
+) -> None:
+    """Pre-populate ``ws._me_service`` with a canned MeResponse.
+
+    Args:
+        ws: Workspace whose MeService should be replaced.
+        project_org: Owning organization ID for the active project
+            (12345). Set to ``None`` to omit the project from the
+            ``/me`` payload (forces fallback paths).
+        extra_orgs: Additional ``{org_id: int_id}`` entries to add to
+            ``MeResponse.organizations``. The active project's org is
+            always present (when ``project_org`` is set) plus these.
+        no_active_project: When True, omit the active project entirely
+            (combine with empty ``extra_orgs`` to test ambiguous-org
+            failure, or with one ``extra_orgs`` to test sole-org
+            fallback).
+    """
+
+    class _StubMeSvc:
+        """Minimal MeService stand-in returning a canned MeResponse."""
+
+        def __init__(self, response: MeResponse) -> None:
+            """Store the canned response."""
+            self._response = response
+
+        def fetch(self, *, force_refresh: bool = False) -> MeResponse:
+            """Return the canned response (cache parameters ignored)."""
+            del force_refresh
+            return self._response
+
+    orgs: dict[str, MeOrgInfo] = {}
+    projects: dict[str, MeProjectInfo] = {}
+
+    if project_org is not None and not no_active_project:
+        orgs[str(project_org)] = MeOrgInfo(id=project_org, name=f"Org {project_org}")
+        projects["12345"] = MeProjectInfo(name="Active", organization_id=project_org)
+
+    if extra_orgs:
+        for key, oid in extra_orgs.items():
+            orgs[key] = MeOrgInfo(id=oid, name=f"Org {oid}")
+
+    response = MeResponse(organizations=orgs, projects=projects)
+    ws._me_service = _StubMeSvc(response)  # type: ignore[assignment]
+
+
+def _ok(results: dict[str, Any]) -> httpx.Response:
+    """Build a 200 OK App-API response wrapping ``results``."""
+    return httpx.Response(200, json={"status": "ok", "results": results})
+
+
+# =============================================================================
+# Project-scoped GET
+# =============================================================================
+
+
+class TestGetBusinessContextProject:
+    """get_business_context(level='project') behavior."""
+
+    def test_returns_populated_context(self, temp_dir: Path) -> None:
+        """GET returns BusinessContext with project_id and content."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL + method, return canned content."""
+            seen.append(f"{request.method} {request.url.path}")
+            return _ok({"content": "# Project context\n\nHello."})
+
+        ws = _make_workspace(handler)
+        ctx = ws.get_business_context(level="project")
+
+        assert isinstance(ctx, BusinessContext)
+        assert ctx.level == "project"
+        assert ctx.project_id == "12345"
+        assert ctx.organization_id is None
+        assert ctx.content == "# Project context\n\nHello."
+        assert ctx.is_empty is False
+        assert ctx.character_count == len("# Project context\n\nHello.")
+        assert seen == ["GET /api/app/projects/12345/business-context"]
+
+    def test_default_level_is_project(self, temp_dir: Path) -> None:
+        """Calling without ``level`` defaults to 'project'."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return empty content."""
+            return _ok({"content": ""})
+
+        ws = _make_workspace(handler)
+        ctx = ws.get_business_context()
+        assert ctx.level == "project"
+        assert ctx.is_empty is True
+
+    def test_empty_content_yields_is_empty(self, temp_dir: Path) -> None:
+        """Empty string from API → BusinessContext.is_empty is True."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return the unset state."""
+            return _ok({"content": ""})
+
+        ws = _make_workspace(handler)
+        ctx = ws.get_business_context(level="project")
+        assert ctx.content == ""
+        assert ctx.is_empty is True
+        assert ctx.character_count == 0
+
+
+# =============================================================================
+# Project-scoped SET / CLEAR
+# =============================================================================
+
+
+class TestSetBusinessContextProject:
+    """set_business_context(level='project') behavior."""
+
+    def test_sends_put_with_correct_body(self, temp_dir: Path) -> None:
+        """SET issues PUT with ``{"content": ...}`` body."""
+        seen: list[tuple[str, str, dict[str, Any]]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture method, path, body and echo content back."""
+            body: dict[str, Any] = json.loads(request.content)
+            seen.append((request.method, request.url.path, body))
+            return _ok({"content": body["content"]})
+
+        ws = _make_workspace(handler)
+        ctx = ws.set_business_context("# New content", level="project")
+
+        assert ctx.level == "project"
+        assert ctx.project_id == "12345"
+        assert ctx.content == "# New content"
+        assert seen == [
+            (
+                "PUT",
+                "/api/app/projects/12345/business-context",
+                {"content": "# New content"},
+            ),
+        ]
+
+    def test_validation_blocks_oversize_before_http(self, temp_dir: Path) -> None:
+        """50_001 chars → BusinessContextValidationError, no HTTP call."""
+        called = False
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Should never be called when validation rejects input."""
+            nonlocal called
+            called = True
+            return _ok({"content": ""})
+
+        ws = _make_workspace(handler)
+        with pytest.raises(BusinessContextValidationError) as exc_info:
+            ws.set_business_context("x" * (BUSINESS_CONTEXT_MAX_CHARS + 1))
+
+        assert called is False
+        details = exc_info.value.details
+        assert details["length"] == BUSINESS_CONTEXT_MAX_CHARS + 1
+        assert details["max"] == BUSINESS_CONTEXT_MAX_CHARS
+        assert exc_info.value.code == "BUSINESS_CONTEXT_TOO_LONG"
+
+    def test_exact_max_length_is_accepted(self, temp_dir: Path) -> None:
+        """Exactly 50,000 chars passes client-side validation."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Echo content back to caller."""
+            body: dict[str, Any] = json.loads(request.content)
+            return _ok({"content": body["content"]})
+
+        ws = _make_workspace(handler)
+        payload = "x" * BUSINESS_CONTEXT_MAX_CHARS
+        ctx = ws.set_business_context(payload, level="project")
+        assert ctx.character_count == BUSINESS_CONTEXT_MAX_CHARS
+
+    def test_server_400_surfaces_as_query_error(self, temp_dir: Path) -> None:
+        """A 400 from the API is mapped to QueryError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return the server-side rejection shape."""
+            return httpx.Response(
+                400,
+                json={
+                    "status": "error",
+                    "error": "content exceeds maximum length of 50000 characters",
+                },
+            )
+
+        ws = _make_workspace(handler)
+        with pytest.raises(QueryError):
+            ws.set_business_context("# legal here", level="project")
+
+
+class TestClearBusinessContextProject:
+    """clear_business_context delegates to set with empty content."""
+
+    def test_clear_sends_empty_content_put(self, temp_dir: Path) -> None:
+        """CLEAR issues PUT with ``{"content": ""}``."""
+        seen: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture body, echo cleared state."""
+            body: dict[str, Any] = json.loads(request.content)
+            seen.append(body)
+            return _ok({"content": body["content"]})
+
+        ws = _make_workspace(handler)
+        ctx = ws.clear_business_context(level="project")
+
+        assert ctx.level == "project"
+        assert ctx.is_empty is True
+        assert seen == [{"content": ""}]
+
+
+# =============================================================================
+# Org-scoped GET / SET (with org-id resolution)
+# =============================================================================
+
+
+class TestGetBusinessContextOrganization:
+    """get_business_context(level='organization') behavior."""
+
+    def test_explicit_org_id_skips_me_fetch(self, temp_dir: Path) -> None:
+        """Passing organization_id avoids any /me lookup."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL and return canned org content."""
+            seen.append(f"{request.method} {request.url.path}")
+            return _ok({"content": "# Org content"})
+
+        ws = _make_workspace(handler)
+
+        class _ExplodingMeSvc:
+            """Stand-in that raises if fetch() is called."""
+
+            def fetch(self, *, force_refresh: bool = False) -> MeResponse:
+                """Should never be invoked when organization_id is explicit."""
+                raise AssertionError("MeService.fetch should not be called")
+
+        ws._me_service = _ExplodingMeSvc()  # type: ignore[assignment]
+
+        ctx = ws.get_business_context(level="organization", organization_id=42)
+        assert ctx.level == "organization"
+        assert ctx.organization_id == 42
+        assert ctx.project_id is None
+        assert ctx.content == "# Org content"
+        assert seen == ["GET /api/app/organizations/42/business-context"]
+
+    def test_auto_resolve_from_active_project(self, temp_dir: Path) -> None:
+        """Without explicit org_id, derives it from /me.projects[pid]."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL and return canned org content."""
+            seen.append(request.url.path)
+            return _ok({"content": "# Auto-resolved"})
+
+        ws = _make_workspace(handler)
+        _stub_me(ws, project_org=100)
+
+        ctx = ws.get_business_context(level="organization")
+        assert ctx.organization_id == 100
+        assert seen == ["/api/app/organizations/100/business-context"]
+
+    def test_auto_resolve_falls_through_to_sole_org(self, temp_dir: Path) -> None:
+        """When project missing from /me but only one org exists, use it."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return canned content."""
+            seen.append(request.url.path)
+            return _ok({"content": ""})
+
+        ws = _make_workspace(handler)
+        _stub_me(
+            ws,
+            project_org=None,
+            extra_orgs={"77": 77},
+            no_active_project=True,
+        )
+
+        ctx = ws.get_business_context(level="organization")
+        assert ctx.organization_id == 77
+        assert seen == ["/api/app/organizations/77/business-context"]
+
+    def test_ambiguous_org_raises_workspace_scope_error(self, temp_dir: Path) -> None:
+        """Multiple orgs + project not in /me → WorkspaceScopeError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Should never be called when resolution fails first."""
+            raise AssertionError("HTTP call should not happen on resolution failure")
+
+        ws = _make_workspace(handler)
+        _stub_me(
+            ws,
+            project_org=None,
+            extra_orgs={"1": 1, "2": 2},
+            no_active_project=True,
+        )
+
+        with pytest.raises(WorkspaceScopeError) as exc_info:
+            ws.get_business_context(level="organization")
+
+        assert exc_info.value.code == "ORGANIZATION_AMBIGUOUS"
+        assert exc_info.value.details["project_id"] == "12345"
+        assert exc_info.value.details["available_organizations"] == ["1", "2"]
+
+
+class TestSetBusinessContextOrganization:
+    """set_business_context(level='organization') behavior."""
+
+    def test_set_org_uses_org_path(self, temp_dir: Path) -> None:
+        """Org SET hits /organizations/{id}/business-context."""
+        seen: list[tuple[str, str, dict[str, Any]]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture method, path, body."""
+            body: dict[str, Any] = json.loads(request.content)
+            seen.append((request.method, request.url.path, body))
+            return _ok({"content": body["content"]})
+
+        ws = _make_workspace(handler)
+        ctx = ws.set_business_context(
+            "# Org-wide",
+            level="organization",
+            organization_id=100,
+        )
+
+        assert ctx.level == "organization"
+        assert ctx.organization_id == 100
+        assert ctx.content == "# Org-wide"
+        assert seen == [
+            (
+                "PUT",
+                "/api/app/organizations/100/business-context",
+                {"content": "# Org-wide"},
+            ),
+        ]
+
+
+# =============================================================================
+# Chain endpoint
+# =============================================================================
+
+
+class TestGetBusinessContextChain:
+    """get_business_context_chain() behavior."""
+
+    def test_chain_parses_both_scopes(self, temp_dir: Path) -> None:
+        """Chain returns BusinessContextChain with org + project content."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture URL, return both fields."""
+            seen.append(f"{request.method} {request.url.path}")
+            return _ok(
+                {
+                    "org_context": "# Org info",
+                    "project_context": "# Project info",
+                }
+            )
+
+        ws = _make_workspace(handler)
+        _stub_me(ws, project_org=100)
+
+        chain = ws.get_business_context_chain()
+
+        assert isinstance(chain, BusinessContextChain)
+        assert chain.organization.level == "organization"
+        assert chain.organization.organization_id == 100
+        assert chain.organization.content == "# Org info"
+        assert chain.project.level == "project"
+        assert chain.project.project_id == "12345"
+        assert chain.project.content == "# Project info"
+        assert seen == ["GET /api/app/projects/12345/business-context/chain"]
+
+    def test_chain_with_empty_scopes(self, temp_dir: Path) -> None:
+        """Empty strings in chain response yield is_empty BusinessContexts."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return the unset state for both scopes."""
+            return _ok({"org_context": "", "project_context": ""})
+
+        ws = _make_workspace(handler)
+        _stub_me(ws, project_org=100)
+
+        chain = ws.get_business_context_chain()
+        assert chain.organization.is_empty is True
+        assert chain.project.is_empty is True

--- a/tests/unit/test_workspace_business_context.py
+++ b/tests/unit/test_workspace_business_context.py
@@ -1,8 +1,9 @@
-"""Unit tests for Workspace business context methods (AIE-147).
+"""Unit tests for Workspace business context methods.
 
 Covers all four facade methods plus the ``_resolve_organization_id``
-helper. Each method delegates to MixpanelAPIClient via httpx.MockTransport
-and returns typed BusinessContext / BusinessContextChain instances.
+and ``_cached_organization_id`` helpers. Each method delegates to
+MixpanelAPIClient via httpx.MockTransport and returns typed
+BusinessContext / BusinessContextChain instances.
 
 Verifies:
 
@@ -10,17 +11,19 @@ Verifies:
 - Org ID auto-resolution from /me cache (project lookup, sole-org fallback)
 - Org ID explicit override (no /me fetch)
 - Ambiguous-org raises WorkspaceScopeError
+- Invalid ``level`` raises ValueError before any HTTP call
 - 50,000-character boundary on set (client-side validation)
-- Chain endpoint parses both fields and populates org_id + project_id
+- Chain endpoint truly single-round-trip — no /me fetch
+- Chain populates org_id from cached /me on a best-effort basis
+- Cold-cache chain leaves organization_id=None
 - Server-side 400 surfaces as QueryError
+- Missing ``content`` / ``org_context`` / ``project_context`` raises
+  MixpanelDataError instead of being silently treated as empty
 """
-
-# ruff: noqa: ARG001, ARG005
 
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -31,6 +34,7 @@ from mixpanel_data._internal.auth.session import Session
 from mixpanel_data._internal.me import MeOrgInfo, MeProjectInfo, MeResponse
 from mixpanel_data.exceptions import (
     BusinessContextValidationError,
+    MixpanelDataError,
     QueryError,
     WorkspaceScopeError,
 )
@@ -80,6 +84,10 @@ def _stub_me(
 ) -> None:
     """Pre-populate ``ws._me_service`` with a canned MeResponse.
 
+    The stub implements both ``fetch()`` and ``peek()`` — ``fetch()``
+    is what ``_resolve_organization_id`` calls, ``peek()`` is what
+    ``_cached_organization_id`` (used by the chain endpoint) calls.
+
     Args:
         ws: Workspace whose MeService should be replaced.
         project_org: Owning organization ID for the active project
@@ -104,6 +112,10 @@ def _stub_me(
         def fetch(self, *, force_refresh: bool = False) -> MeResponse:
             """Return the canned response (cache parameters ignored)."""
             del force_refresh
+            return self._response
+
+        def peek(self) -> MeResponse:
+            """Return the canned response without triggering a fetch."""
             return self._response
 
     orgs: dict[str, MeOrgInfo] = {}
@@ -134,7 +146,7 @@ def _ok(results: dict[str, Any]) -> httpx.Response:
 class TestGetBusinessContextProject:
     """get_business_context(level='project') behavior."""
 
-    def test_returns_populated_context(self, temp_dir: Path) -> None:
+    def test_returns_populated_context(self) -> None:
         """GET returns BusinessContext with project_id and content."""
         seen: list[str] = []
 
@@ -155,11 +167,12 @@ class TestGetBusinessContextProject:
         assert ctx.character_count == len("# Project context\n\nHello.")
         assert seen == ["GET /api/app/projects/12345/business-context"]
 
-    def test_default_level_is_project(self, temp_dir: Path) -> None:
+    def test_default_level_is_project(self) -> None:
         """Calling without ``level`` defaults to 'project'."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Return empty content."""
+            del request
             return _ok({"content": ""})
 
         ws = _make_workspace(handler)
@@ -167,11 +180,12 @@ class TestGetBusinessContextProject:
         assert ctx.level == "project"
         assert ctx.is_empty is True
 
-    def test_empty_content_yields_is_empty(self, temp_dir: Path) -> None:
+    def test_empty_content_yields_is_empty(self) -> None:
         """Empty string from API → BusinessContext.is_empty is True."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Return the unset state."""
+            del request
             return _ok({"content": ""})
 
         ws = _make_workspace(handler)
@@ -179,6 +193,33 @@ class TestGetBusinessContextProject:
         assert ctx.content == ""
         assert ctx.is_empty is True
         assert ctx.character_count == 0
+
+    def test_invalid_level_raises_value_error(self) -> None:
+        """``level="org"`` (or any other non-literal) raises ValueError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Should never run when validation rejects input."""
+            del request
+            raise AssertionError("HTTP must not be called for invalid level")
+
+        ws = _make_workspace(handler)
+        with pytest.raises(
+            ValueError, match=r"level must be 'organization' or 'project'"
+        ):
+            ws.get_business_context(level="org")  # type: ignore[arg-type]
+
+    def test_missing_content_raises_mixpanel_data_error(self) -> None:
+        """API response without ``content`` field → MixpanelDataError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a malformed response (no ``content`` field)."""
+            del request
+            return _ok({"unexpected": "shape"})
+
+        ws = _make_workspace(handler)
+        with pytest.raises(MixpanelDataError) as exc_info:
+            ws.get_business_context(level="project")
+        assert "missing required field 'content'" in str(exc_info.value)
 
 
 # =============================================================================
@@ -189,7 +230,7 @@ class TestGetBusinessContextProject:
 class TestSetBusinessContextProject:
     """set_business_context(level='project') behavior."""
 
-    def test_sends_put_with_correct_body(self, temp_dir: Path) -> None:
+    def test_sends_put_with_correct_body(self) -> None:
         """SET issues PUT with ``{"content": ...}`` body."""
         seen: list[tuple[str, str, dict[str, Any]]] = []
 
@@ -213,12 +254,13 @@ class TestSetBusinessContextProject:
             ),
         ]
 
-    def test_validation_blocks_oversize_before_http(self, temp_dir: Path) -> None:
+    def test_validation_blocks_oversize_before_http(self) -> None:
         """50_001 chars → BusinessContextValidationError, no HTTP call."""
         called = False
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Should never be called when validation rejects input."""
+            del request
             nonlocal called
             called = True
             return _ok({"content": ""})
@@ -233,7 +275,7 @@ class TestSetBusinessContextProject:
         assert details["max"] == BUSINESS_CONTEXT_MAX_CHARS
         assert exc_info.value.code == "BUSINESS_CONTEXT_TOO_LONG"
 
-    def test_exact_max_length_is_accepted(self, temp_dir: Path) -> None:
+    def test_exact_max_length_is_accepted(self) -> None:
         """Exactly 50,000 chars passes client-side validation."""
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -246,11 +288,12 @@ class TestSetBusinessContextProject:
         ctx = ws.set_business_context(payload, level="project")
         assert ctx.character_count == BUSINESS_CONTEXT_MAX_CHARS
 
-    def test_server_400_surfaces_as_query_error(self, temp_dir: Path) -> None:
+    def test_server_400_surfaces_as_query_error(self) -> None:
         """A 400 from the API is mapped to QueryError."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Return the server-side rejection shape."""
+            del request
             return httpx.Response(
                 400,
                 json={
@@ -263,11 +306,25 @@ class TestSetBusinessContextProject:
         with pytest.raises(QueryError):
             ws.set_business_context("# legal here", level="project")
 
+    def test_invalid_level_raises_value_error_before_http(self) -> None:
+        """``set`` with bogus ``level`` raises ValueError, no HTTP."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Should never run when validation rejects input."""
+            del request
+            raise AssertionError("HTTP must not be called for invalid level")
+
+        ws = _make_workspace(handler)
+        with pytest.raises(
+            ValueError, match=r"level must be 'organization' or 'project'"
+        ):
+            ws.set_business_context("x", level="oops")  # type: ignore[arg-type]
+
 
 class TestClearBusinessContextProject:
     """clear_business_context delegates to set with empty content."""
 
-    def test_clear_sends_empty_content_put(self, temp_dir: Path) -> None:
+    def test_clear_sends_empty_content_put(self) -> None:
         """CLEAR issues PUT with ``{"content": ""}``."""
         seen: list[dict[str, Any]] = []
 
@@ -293,7 +350,7 @@ class TestClearBusinessContextProject:
 class TestGetBusinessContextOrganization:
     """get_business_context(level='organization') behavior."""
 
-    def test_explicit_org_id_skips_me_fetch(self, temp_dir: Path) -> None:
+    def test_explicit_org_id_skips_me_fetch(self) -> None:
         """Passing organization_id avoids any /me lookup."""
         seen: list[str] = []
 
@@ -309,7 +366,12 @@ class TestGetBusinessContextOrganization:
 
             def fetch(self, *, force_refresh: bool = False) -> MeResponse:
                 """Should never be invoked when organization_id is explicit."""
+                del force_refresh
                 raise AssertionError("MeService.fetch should not be called")
+
+            def peek(self) -> MeResponse | None:
+                """Should never be invoked for an explicit-org-id call."""
+                raise AssertionError("MeService.peek should not be called")
 
         ws._me_service = _ExplodingMeSvc()  # type: ignore[assignment]
 
@@ -320,7 +382,7 @@ class TestGetBusinessContextOrganization:
         assert ctx.content == "# Org content"
         assert seen == ["GET /api/app/organizations/42/business-context"]
 
-    def test_auto_resolve_from_active_project(self, temp_dir: Path) -> None:
+    def test_auto_resolve_from_active_project(self) -> None:
         """Without explicit org_id, derives it from /me.projects[pid]."""
         seen: list[str] = []
 
@@ -336,7 +398,7 @@ class TestGetBusinessContextOrganization:
         assert ctx.organization_id == 100
         assert seen == ["/api/app/organizations/100/business-context"]
 
-    def test_auto_resolve_falls_through_to_sole_org(self, temp_dir: Path) -> None:
+    def test_auto_resolve_falls_through_to_sole_org(self) -> None:
         """When project missing from /me but only one org exists, use it."""
         seen: list[str] = []
 
@@ -357,11 +419,12 @@ class TestGetBusinessContextOrganization:
         assert ctx.organization_id == 77
         assert seen == ["/api/app/organizations/77/business-context"]
 
-    def test_ambiguous_org_raises_workspace_scope_error(self, temp_dir: Path) -> None:
+    def test_ambiguous_org_raises_workspace_scope_error(self) -> None:
         """Multiple orgs + project not in /me → WorkspaceScopeError."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Should never be called when resolution fails first."""
+            del request
             raise AssertionError("HTTP call should not happen on resolution failure")
 
         ws = _make_workspace(handler)
@@ -383,7 +446,7 @@ class TestGetBusinessContextOrganization:
 class TestSetBusinessContextOrganization:
     """set_business_context(level='organization') behavior."""
 
-    def test_set_org_uses_org_path(self, temp_dir: Path) -> None:
+    def test_set_org_uses_org_path(self) -> None:
         """Org SET hits /organizations/{id}/business-context."""
         seen: list[tuple[str, str, dict[str, Any]]] = []
 
@@ -420,7 +483,7 @@ class TestSetBusinessContextOrganization:
 class TestGetBusinessContextChain:
     """get_business_context_chain() behavior."""
 
-    def test_chain_parses_both_scopes(self, temp_dir: Path) -> None:
+    def test_chain_parses_both_scopes(self) -> None:
         """Chain returns BusinessContextChain with org + project content."""
         seen: list[str] = []
 
@@ -446,13 +509,15 @@ class TestGetBusinessContextChain:
         assert chain.project.level == "project"
         assert chain.project.project_id == "12345"
         assert chain.project.content == "# Project info"
+        # Single round-trip — the chain endpoint is the only HTTP call.
         assert seen == ["GET /api/app/projects/12345/business-context/chain"]
 
-    def test_chain_with_empty_scopes(self, temp_dir: Path) -> None:
+    def test_chain_with_empty_scopes(self) -> None:
         """Empty strings in chain response yield is_empty BusinessContexts."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Return the unset state for both scopes."""
+            del request
             return _ok({"org_context": "", "project_context": ""})
 
         ws = _make_workspace(handler)
@@ -461,3 +526,58 @@ class TestGetBusinessContextChain:
         chain = ws.get_business_context_chain()
         assert chain.organization.is_empty is True
         assert chain.project.is_empty is True
+
+    def test_chain_does_not_fetch_me_when_cache_cold(self) -> None:
+        """Chain leaves organization_id=None when /me cache is cold.
+
+        Regression guard for the "single round-trip" guarantee — the
+        chain endpoint must not call ``_resolve_organization_id`` (which
+        would trigger a /me fetch). Best-effort enrichment via
+        ``peek()`` returns None on cold cache, so org_id stays None.
+        """
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Capture method+path; would 404 a /me call if reached."""
+            seen.append(f"{request.method} {request.url.path}")
+            if request.url.path.endswith("/me"):
+                raise AssertionError("Chain endpoint must not trigger /me fetch")
+            return _ok({"org_context": "# Org", "project_context": "# Project"})
+
+        ws = _make_workspace(handler)
+        # Do NOT call _stub_me — leaves the real MeService with cold cache.
+        # The real MeService.peek() will check disk; in tests temp HOME isn't
+        # set so it would miss too. Either way: org_id should be None.
+
+        chain = ws.get_business_context_chain()
+        assert chain.organization.organization_id is None
+        assert chain.organization.content == "# Org"
+        assert chain.project.content == "# Project"
+        # Only the chain endpoint was hit — no /me.
+        assert seen == ["GET /api/app/projects/12345/business-context/chain"]
+
+    def test_chain_missing_org_context_raises(self) -> None:
+        """API response without ``org_context`` → MixpanelDataError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a malformed chain response."""
+            del request
+            return _ok({"project_context": "# Project"})
+
+        ws = _make_workspace(handler)
+        with pytest.raises(MixpanelDataError) as exc_info:
+            ws.get_business_context_chain()
+        assert "missing required field 'org_context'" in str(exc_info.value)
+
+    def test_chain_missing_project_context_raises(self) -> None:
+        """API response without ``project_context`` → MixpanelDataError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a malformed chain response."""
+            del request
+            return _ok({"org_context": "# Org"})
+
+        ws = _make_workspace(handler)
+        with pytest.raises(MixpanelDataError) as exc_info:
+            ws.get_business_context_chain()
+        assert "missing required field 'project_context'" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Adds full Python + CLI support for **Business Context** — the markdown documentation (up to 50,000 chars per scope) attached to a Mixpanel project or organization that grounds AI assistants in business goals and conventions.
- Four new public \`Workspace\` methods (\`get/set/clear_business_context\`, \`get_business_context_chain\`), two new types (\`BusinessContext\`, \`BusinessContextChain\`), one new exception (\`BusinessContextValidationError\`), one constant (\`BUSINESS_CONTEXT_MAX_CHARS = 50_000\`), and a new \`mp business-context\` CLI group with \`get|set|clear|chain\` subcommands.
- Establishes the first **org-scoped** capability in the codebase, with a reusable \`_resolve_organization_id\` helper that auto-resolves the org via the existing 24h \`/me\` cache (with explicit override).

## API surface

\`\`\`python
ws.get_business_context(level="project")                     # → BusinessContext
ws.get_business_context(level="organization")                # auto-resolves org_id
ws.get_business_context(level="organization", organization_id=42)
ws.set_business_context(content, level="project")            # full-replace
ws.clear_business_context(level="organization")              # convenience for set("")
ws.get_business_context_chain()                              # → BusinessContextChain
\`\`\`

\`\`\`bash
mp business-context get   [--level project|organization] [--organization-id N]
mp business-context set   [--level ...] [--content TEXT | --file PATH | <stdin>]
mp business-context clear [--level ...]
mp business-context chain
\`\`\`

The 50,000-char cap is enforced **client-side BEFORE any HTTP call** — oversize content raises \`BusinessContextValidationError\` with no round-trip wasted.

## Implementation notes

- API client methods (\`get/set_business_context\`, \`get_business_context_chain\`) construct paths directly (NOT via \`maybe_scoped_path\`) because the endpoint is project-scoped, not workspace-scoped.
- Org ID resolution: explicit param → cached \`MeResponse.projects[active].organization_id\` → sole org in \`MeResponse.organizations\` → \`WorkspaceScopeError(code="ORGANIZATION_AMBIGUOUS")\`.
- Live-QA'd end-to-end against project 4014559 in AK's org: project + org reads, all three \`set\` input modes, chain endpoint, error paths (invalid level, inaccessible org, mutex violation, oversize), \`--format table\`, \`--jq\`, full Python API. Test data cleared after.

## Test plan

- [x] \`just check\` — lint + format + mypy --strict + 6230 tests + 92.22% coverage + wheel build (all green)
- [x] 15 unit tests for the \`Workspace\` facade (project + org GET/SET/CLEAR, auto-resolve, explicit override, ambiguous-org, validation boundary, chain, server 400)
- [x] 18 CLI tests (all 4 subcommands, \`--content\`/\`--file\`/stdin handling, mutex errors, \`--organization-id\` forwarding, error mapping, \`--jq\`/\`--format\`)
- [x] 3 Hypothesis property-based tests (body shape, round-trip preservation, validation blocks HTTP)
- [x] Docs build cleanly (\`just docs\`); \`help.py search business_context\` finds all 7 new surfaces

## Docs

- New guide: [\`docs/guide/business-context.md\`](docs/guide/business-context.md)
- API reference updates: types, exceptions, Workspace overview, home page Next Steps, mkdocs nav (3 places)
- Plugin updates: \`mixpanelyst/SKILL.md\` (description + new section + exceptions table), README, plugin.json bumped 5.0.0 → 5.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)