### PR TITLE
docs: lead with `mp login` across docs and plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ just mutate-check        # Check score meets 80% threshold
 - **Streaming data access**: API returns iterators for memory-efficient processing of large datasets
 - **Account → Project → Workspace hierarchy** (042 redesign): every CLI verb and Python namespace maps to one of those three axes; `Workspace.use(account=, project=, workspace=)` is the single in-session switching method.
 - **Three first-class account types**: `service_account` (Basic Auth), `oauth_browser` (PKCE, tokens auto-refreshed), `oauth_token` (static bearer for CI/agents). All managed through one unified surface.
+- **Frictionless login** (043): `mp login` (CLI) and `accounts.login_unified()` (Python) collapse the old two-step `mp account add` + `mp account login` flow into one call. Auth-type detection is env-driven: `MP_USERNAME`+`MP_SECRET` → `service_account`; `MP_OAUTH_TOKEN` → `oauth_token`; otherwise `oauth_browser`. Region auto-probes `us → eu → in` when `--region` is not supplied. Project, account name, and default workspace derive from the post-login `/me` response.
 - **Single resolver**: `resolve_session(...)` consults env → param → target → bridge → config in priority order; no silent cross-axis fallback.
 - **Connection-pool preservation**: `ws.use(account=...)` rebuilds the auth header but reuses the underlying `httpx.Client` (same Python instance — verified by `id()` equality in `tests/integration/test_cross_project_iteration.py`).
 - **Dependency injection**: Services accept dependencies as constructor arguments for testing.
@@ -199,14 +200,16 @@ just mutate-check        # Check score meets 80% threshold
 
 | Variable | Purpose |
 |----------|---------|
-| `MP_USERNAME` | Service account username |
+| `MP_USERNAME` | Service account username (also triggers `mp login` SA detection when paired with `MP_SECRET`) |
 | `MP_SECRET` | Service account secret |
-| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; ignored only when the full service-account env-var set — `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` — is also present) |
+| `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; triggers `mp login` `oauth_token` detection when set; ignored only when the full service-account env-var set — `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` — is also present) |
 | `MP_PROJECT_ID` | Project ID |
-| `MP_REGION` | Data residency (us, eu, in) |
+| `MP_REGION` | Data residency (us, eu, in); when unset, `mp login` probes us → eu → in |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file location |
+
+Recommended starter command: `mp login` (one-shot orchestrator covering region probe, `/me`-driven project pick, and account-name derivation; backed by `mp.accounts.login_unified()` in Python).
 
 Config file: `~/.mp/config.toml`
 OAuth browser tokens: `~/.mp/accounts/{account_name}/tokens.json` (per-account, atomic 0o600 writes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ just mutate-check        # Check score meets 80% threshold
 - **Streaming data access**: API returns iterators for memory-efficient processing of large datasets
 - **Account → Project → Workspace hierarchy** (042 redesign): every CLI verb and Python namespace maps to one of those three axes; `Workspace.use(account=, project=, workspace=)` is the single in-session switching method.
 - **Three first-class account types**: `service_account` (Basic Auth), `oauth_browser` (PKCE, tokens auto-refreshed), `oauth_token` (static bearer for CI/agents). All managed through one unified surface.
-- **Frictionless login** (043): `mp login` (CLI) and `accounts.login_unified()` (Python) collapse the old two-step `mp account add` + `mp account login` flow into one call. Auth-type detection is env-driven: `MP_USERNAME`+`MP_SECRET` → `service_account`; `MP_OAUTH_TOKEN` → `oauth_token`; otherwise `oauth_browser`. Region auto-probes `us → eu → in` when `--region` is not supplied. Project, account name, and default workspace derive from the post-login `/me` response.
+- **Frictionless login** (043): `mp login` (CLI) and `accounts.login_unified()` (Python) collapse the old two-step `mp account add` + `mp account login` flow into one call. Auth-type detection is env-driven: `MP_USERNAME`+`MP_SECRET` → `service_account`; `MP_OAUTH_TOKEN` → `oauth_token`; otherwise `oauth_browser`. Region behavior is auth-type-specific: SA and `oauth_token` paths probe `us → eu → in` when `--region` is omitted; `oauth_browser` defaults to `us` (PKCE commits to a region before the post-login `/me` probe runs, so EU / India users must pass `--region eu|in` explicitly). Project and account name derive from the post-login `/me` response; workspace stays lazy and resolves on first workspace-scoped call.
 - **Single resolver**: `resolve_session(...)` consults env → param → target → bridge → config in priority order; no silent cross-axis fallback.
 - **Connection-pool preservation**: `ws.use(account=...)` rebuilds the auth header but reuses the underlying `httpx.Client` (same Python instance — verified by `id()` equality in `tests/integration/test_cross_project_iteration.py`).
 - **Dependency injection**: Services accept dependencies as constructor arguments for testing.
@@ -204,7 +204,7 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_SECRET` | Service account secret |
 | `MP_OAUTH_TOKEN` | Raw OAuth 2.0 bearer token (alternative to service account; requires `MP_PROJECT_ID` + `MP_REGION`; triggers `mp login` `oauth_token` detection when set; ignored only when the full service-account env-var set — `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` — is also present) |
 | `MP_PROJECT_ID` | Project ID |
-| `MP_REGION` | Data residency (us, eu, in); when unset, `mp login` probes us → eu → in |
+| `MP_REGION` | Data residency (us, eu, in); when unset, `mp login` probes us → eu → in for SA / oauth_token paths and defaults to us for the browser PKCE path |
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file location |

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ mp --version
 
 ```bash
 mp login
-# Probes us → eu → in for the right region.
-# Opens browser for PKCE; derives the account name from your /me org;
+# Opens browser for PKCE (default region: us).
+# Derives the account name from your /me org;
 # auto-picks your project (or shows a picker when you have several).
 mp session                    # Verify resolved state
 ```
 
 `mp login` reads your environment first and picks the right auth path:
 
-- `MP_USERNAME` + `MP_SECRET` set → service account (no browser).
-- `MP_OAUTH_TOKEN` set → static bearer (no browser, no persistence).
-- Neither → OAuth browser flow.
+- `MP_USERNAME` + `MP_SECRET` set → service account (no browser, region auto-probes us → eu → in).
+- `MP_OAUTH_TOKEN` set → static bearer (no browser, region auto-probes us → eu → in; the token is persisted inline to `~/.mp/config.toml`).
+- Neither → OAuth browser flow (region defaults to **us**; pass `--region eu|in` for other clusters).
 
-Pass `--region us|eu|in` to skip the probe, `--project ID` to skip the picker, or `--name NAME` to override the derived account name.
+Pass `--region us|eu|in` to set the region explicitly, `--project ID` to skip the project picker, or `--name NAME` to override the derived account name.
 
 **Service Account (scripts, CI/CD)**
 
@@ -64,9 +64,11 @@ mp inspect events
 Or persist the credentials to a named account so the secret lives on disk (mode `0o600`) instead of every shell:
 
 ```bash
+export MP_USERNAME="sa_xxx"
 export MP_SECRET="your-secret-here"
 mp login --service-account --name team
-# Or, for explicit control over the username:
+# `mp login --service-account` reads MP_USERNAME + MP_SECRET from env;
+# both must be set or it errors. For explicit control over the username:
 echo "$MP_SECRET" | mp account add team --type service_account \
     --username sa_xxx --project 12345 --region us --secret-stdin
 ```

--- a/README.md
+++ b/README.md
@@ -31,37 +31,49 @@ mp --version
 
 ### 1. Authenticate
 
-**Option A: OAuth Login (interactive, recommended)**
+**Recommended: `mp login`**
 
 ```bash
-mp account add personal --type oauth_browser --region us
-mp account login personal     # Opens browser for PKCE flow
+mp login
+# Probes us → eu → in for the right region.
+# Opens browser for PKCE; derives the account name from your /me org;
+# auto-picks your project (or shows a picker when you have several).
 mp session                    # Verify resolved state
 ```
 
-**Option B: Service Account (scripts, CI/CD)**
+`mp login` reads your environment first and picks the right auth path:
+
+- `MP_USERNAME` + `MP_SECRET` set → service account (no browser).
+- `MP_OAUTH_TOKEN` set → static bearer (no browser, no persistence).
+- Neither → OAuth browser flow.
+
+Pass `--region us|eu|in` to skip the probe, `--project ID` to skip the picker, or `--name NAME` to override the derived account name.
+
+**Service Account (scripts, CI/CD)**
+
+For unattended automation, set the four env vars and run any `mp` command:
 
 ```bash
-# Set the secret via env var (preferred)
+export MP_USERNAME="sa_xxx"
 export MP_SECRET="your-secret-here"
-mp account add team --type service_account --username sa_xxx --project 12345 --region us
-# Added account 'team' (service_account, us). Set as active.
-
-mp account test team          # Verify connection
+export MP_PROJECT_ID="12345"
+export MP_REGION="us"
+mp inspect events
 ```
 
-For CI/CD environments where the secret lives in a shell variable, pipe it via stdin:
+Or persist the credentials to a named account so the secret lives on disk (mode `0o600`) instead of every shell:
 
 ```bash
-echo "$SECRET" | mp account add team --type service_account \
+export MP_SECRET="your-secret-here"
+mp login --service-account --name team
+# Or, for explicit control over the username:
+echo "$MP_SECRET" | mp account add team --type service_account \
     --username sa_xxx --project 12345 --region us --secret-stdin
 ```
 
-Or set all credentials as environment variables: `MP_USERNAME`, `MP_SECRET`, `MP_PROJECT_ID`, `MP_REGION`
+**Raw OAuth Bearer Token (CI / agents)**
 
-**Option C: Raw OAuth Bearer Token (CI / agents)**
-
-If a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) already gave you an access token, inject it via env vars without going through the browser flow:
+If a managed OAuth client (a Claude Code plugin, CI pipeline) hands you a pre-obtained access token, inject it via env vars without going through the browser flow:
 
 ```bash
 export MP_OAUTH_TOKEN="<bearer-token>"
@@ -70,6 +82,20 @@ export MP_REGION="us"  # or "eu", "in"
 ```
 
 The full service-account env-var set (`MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION`) takes precedence when both sets are complete, so this is safe to add to a shell that already exports the service-account vars.
+
+<details><summary>Advanced: explicit account creation (two-step)</summary>
+
+For users who want full control over the account name, region, and type at registration time:
+
+```bash
+# Register first, then run the PKCE flow
+mp account add personal --type oauth_browser --region us
+mp account login personal
+```
+
+`mp login --name personal --region us` is the one-line equivalent.
+
+</details>
 
 ### 2. Explore Your Data
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -193,7 +193,7 @@ Account lifecycle: register, switch, probe, OAuth flows, bridge export. The `log
 
 #### Frictionless login (`login_unified`)
 
-Composes region probe, `/me` lookup, project picker, and account-name derivation into one call. Backs the CLI's `mp login` command.
+Composes auth-type detection, region resolution, `/me` lookup, project picker, and account-name derivation into one call. Backs the CLI's `mp login` command.
 
 ```python
 import mixpanel_headless as mp
@@ -226,7 +226,9 @@ Auth-type detection ladder (priority order):
 3. `MP_OAUTH_TOKEN` set → `oauth_token`.
 4. Otherwise → `oauth_browser` (PKCE).
 
-Raises `RegionProbeError` / `RegionProbeNetworkError` if no region accepts the credential, `InvalidArgumentError` for mutually-incompatible flag combinations, `ProjectNotFoundError` for an explicit `--project` not visible to `/me`, and `AccountExistsError` when the derived name collides on the browser path. See [Exceptions](exceptions.md#oauth-exceptions) for the full set.
+Region behavior is auth-type-specific. `service_account` and `oauth_token` paths probe `us → eu → in` against `/me` when `region=` is not passed, returning the first 200. `oauth_browser` commits to the supplied `region` (or defaults to `"us"`) before the PKCE redirect, then cross-checks the picked project's domain after the callback. EU and India browser users must pass `region="eu"` or `region="in"` explicitly.
+
+Raises `RegionProbeError` / `RegionProbeNetworkError` if no region accepts the credential (SA / token paths only), `InvalidArgumentError` for mutually-incompatible flag combinations, `ProjectNotFoundError` for an explicit `project=` not visible to `/me`, and `AccountExistsError` when the derived name collides on the browser path. See [Exceptions](exceptions.md#oauth-exceptions) for the full set.
 
 ### `mp.session`
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -170,7 +170,7 @@ The auth surface exposes three module-level namespaces re-exported from `mixpane
 
 ### `mp.accounts`
 
-Account lifecycle: register, switch, probe, OAuth flows, bridge export.
+Account lifecycle: register, switch, probe, OAuth flows, bridge export. The `login_unified` orchestrator below collapses the explicit `add` + `login` pair into a single conversational call (the Python entry point behind `mp login`).
 
 ::: mixpanel_headless.accounts
     options:
@@ -185,10 +185,48 @@ Account lifecycle: register, switch, probe, OAuth flows, bridge export.
         - show
         - test
         - login
+        - login_unified
         - logout
         - token
         - export_bridge
         - remove_bridge
+
+#### Frictionless login (`login_unified`)
+
+Composes region probe, `/me` lookup, project picker, and account-name derivation into one call. Backs the CLI's `mp login` command.
+
+```python
+import mixpanel_headless as mp
+
+# Browser PKCE — derives region, name, project from /me.
+summary = mp.accounts.login_unified()
+print(summary.user_email, summary.project_id, summary.project_name)
+
+# Service account from env, region auto-probed (us → eu → in):
+import os
+os.environ["MP_USERNAME"] = "sa_xxx"
+os.environ["MP_SECRET"] = "..."
+summary = mp.accounts.login_unified()
+
+# Re-login: refresh tokens for an existing account.
+summary = mp.accounts.login_unified(name="acme-corp")
+
+# Multi-project — supply a picker callback for non-CLI contexts.
+def picker(me, sorted_projects):
+    """Return the project_id you want to bind."""
+    return sorted_projects[0][0]
+
+summary = mp.accounts.login_unified(project_picker=picker)
+```
+
+Auth-type detection ladder (priority order):
+
+1. Explicit `account_type=` (or the CLI's `--service-account` / `--token-env`).
+2. `MP_USERNAME` + `MP_SECRET` set → `service_account`.
+3. `MP_OAUTH_TOKEN` set → `oauth_token`.
+4. Otherwise → `oauth_browser` (PKCE).
+
+Raises `RegionProbeError` / `RegionProbeNetworkError` if no region accepts the credential, `InvalidArgumentError` for mutually-incompatible flag combinations, `ProjectNotFoundError` for an explicit `--project` not visible to `/me`, and `AccountExistsError` when the derived name collides on the browser path. See [Exceptions](exceptions.md#oauth-exceptions) for the full set.
 
 ### `mp.session`
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -15,6 +15,7 @@ MixpanelHeadlessError
 │   ├── AccountNotFoundError
 │   ├── AccountExistsError
 │   ├── AccountInUseError
+│   ├── InvalidArgumentError
 │   └── ProjectNotFoundError
 ├── APIError
 │   ├── AuthenticationError
@@ -23,6 +24,8 @@ MixpanelHeadlessError
 │   ├── ServerError
 │   └── JQLSyntaxError
 ├── OAuthError
+│   └── RegionProbeError
+│       └── RegionProbeNetworkError
 ├── WorkspaceScopeError
 └── BusinessContextValidationError
 ```
@@ -115,21 +118,69 @@ except mp.MixpanelHeadlessError as e:
       show_root_heading: true
       show_root_toc_entry: true
 
+### InvalidArgumentError
+
+Raised by `accounts.login_unified` (and the CLI's `mp login`) when a public-API call combines mutually incompatible arguments. Subclass of `ConfigError`. The CLI maps this to exit code 3 (`INVALID_ARGS`) instead of the generic 1.
+
+| `violation` | Raised When |
+|-------------|-------------|
+| `mutually_exclusive` | `--service-account` + `--token-env` (or equivalent kwargs) |
+| `no_browser_misuse` | `--no-browser` against a non-browser auth type |
+| `secret_stdin_misuse` | `--secret-stdin` against a non-SA auth type |
+
+The `details` dict carries `violation` and (when detection ran) `detected_auth_type`. Pattern-match by class so non-CLI callers (Cowork's `auth_manager.py`, JSON consumers) can dispatch without parsing the human message.
+
+::: mixpanel_headless.InvalidArgumentError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## OAuth Exceptions
 
-Raised during OAuth 2.0 PKCE authentication flows.
+Raised during OAuth 2.0 PKCE authentication flows and the `mp login` region probe.
 
 | Error Code | Raised When |
 |------------|-------------|
 | `OAUTH_TOKEN_ERROR` | Token exchange fails |
 | `OAUTH_REFRESH_ERROR` | Token refresh fails (transient) |
-| `OAUTH_REFRESH_REVOKED` | Refresh token rejected by IdP as `invalid_grant` (re-run `mp account login NAME`) |
+| `OAUTH_REFRESH_REVOKED` | Refresh token rejected by IdP as `invalid_grant` (re-run `mp login --name NAME`) |
 | `OAUTH_REGISTRATION_ERROR` | Dynamic client registration fails |
 | `OAUTH_TIMEOUT` | Callback server times out waiting for authorization |
 | `OAUTH_PORT_ERROR` | Cannot bind to a local port for the callback server |
 | `OAUTH_BROWSER_ERROR` | Cannot open the authorization URL in the browser |
+| `OAUTH_REGION_PROBE_FAILED` | `mp login` probed every region and none accepted the credential — see `RegionProbeError` below |
+| `OAUTH_NETWORK_UNREACHABLE` | Every region probe failed at the network layer (DNS / TLS / connect refused) — see `RegionProbeNetworkError` below |
 
 ::: mixpanel_headless.OAuthError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+### RegionProbeError
+
+Raised by `mp login` (and `accounts.login_unified`) when the `us → eu → in` region probe fails for every region. Subclass of `OAuthError`. The `attempts` attribute carries the full `(region, status_code, error_body)` list; status `0` indicates a network-layer failure (DNS / TLS / connect refused) — those cases raise `RegionProbeNetworkError` (subclass) so the CLI can render a different remediation hint.
+
+```python
+import mixpanel_headless as mp
+
+try:
+    mp.accounts.login_unified()
+except mp.RegionProbeNetworkError as exc:
+    print("Could not reach any Mixpanel region. Check connectivity.")
+    for region, status, body in exc.attempts:
+        print(f"  {region}: {body}")
+except mp.RegionProbeError as exc:
+    print("Credential not valid in any region.")
+    for region, status, body in exc.attempts:
+        print(f"  {region}: {status} {body}")
+```
+
+::: mixpanel_headless.RegionProbeError
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
+::: mixpanel_headless.RegionProbeNetworkError
     options:
       show_root_heading: true
       show_root_toc_entry: true

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -40,15 +40,15 @@ These resolve via the priority chain `env > param > target > bridge > [active] >
 
 ### login — Frictionless Authentication
 
-`mp login` is the recommended starter command. It composes region probe, `/me` lookup, project picker, and account-name derivation into a single call:
+`mp login` is the recommended starter command. It composes auth-type detection, `/me` lookup, project picker, and account-name derivation into a single call:
 
 | Command | Description |
 |---------|-------------|
 | `mp login` | One-shot login (browser PKCE by default; auto-detects SA / static-bearer paths from env) |
 
-Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path, `--no-browser` prints the authorization URL instead of launching a browser, `--secret-stdin` reads the SA secret from stdin.
+Useful flags: `--region {us\|eu\|in}` sets the region (required for EU / India when using the browser path; SA and oauth_token paths probe automatically when `--region` is omitted), `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path, `--no-browser` prints the authorization URL instead of launching a browser, `--secret-stdin` reads the SA secret from stdin.
 
-The auth-type detection ladder (in priority order): explicit `--service-account` / `--token-env` flag → `MP_USERNAME` + `MP_SECRET` set → `MP_OAUTH_TOKEN` set → otherwise `oauth_browser`. See [Configuration → Quick Start](../getting-started/configuration.md#quick-start-mp-login) for examples.
+The auth-type detection ladder (in priority order): explicit `--service-account` / `--token-env` flag → `MP_USERNAME` + `MP_SECRET` set → `MP_OAUTH_TOKEN` set → otherwise `oauth_browser`. Region behavior: SA and oauth_token paths probe `us → eu → in` when `--region` is omitted; the browser path defaults to `us`. See [Configuration → Quick Start](../getting-started/configuration.md#quick-start-mp-login) for examples.
 
 ### account — Account Management
 
@@ -533,7 +533,7 @@ These resolve via `env > param > target > bridge > [active] > default_project` �
 ### Complete Workflow
 
 ```bash
-# 1. Authenticate (probes region, picks project, derives name from /me)
+# 1. Authenticate (browser PKCE; picks project, derives name from /me)
 mp login
 
 # 2. Explore schema

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -38,9 +38,21 @@ These resolve via the priority chain `env > param > target > bridge > [active] >
 
 ## Command Groups
 
+### login — Frictionless Authentication
+
+`mp login` is the recommended starter command. It composes region probe, `/me` lookup, project picker, and account-name derivation into a single call:
+
+| Command | Description |
+|---------|-------------|
+| `mp login` | One-shot login (browser PKCE by default; auto-detects SA / static-bearer paths from env) |
+
+Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path, `--no-browser` prints the authorization URL instead of launching a browser, `--secret-stdin` reads the SA secret from stdin.
+
+The auth-type detection ladder (in priority order): explicit `--service-account` / `--token-env` flag → `MP_USERNAME` + `MP_SECRET` set → `MP_OAUTH_TOKEN` set → otherwise `oauth_browser`. See [Configuration → Quick Start](../getting-started/configuration.md#quick-start-mp-login) for examples.
+
 ### account — Account Management
 
-Manage configured accounts (service accounts, OAuth browser, OAuth token) and the active account.
+Manage configured accounts (service accounts, OAuth browser, OAuth token) and the active account. For first-time setup, prefer `mp login` above; the `account` group is for explicit registration, rotation, and lifecycle management.
 
 | Command | Description |
 |---------|-------------|
@@ -51,7 +63,7 @@ Manage configured accounts (service accounts, OAuth browser, OAuth token) and th
 | `mp account use` | Switch the active account (clears workspace) |
 | `mp account show` | Display account metadata (omit name for active) |
 | `mp account test` | Probe `/me`; returns `AccountTestResult` |
-| `mp account login` | Run the OAuth browser PKCE flow (oauth_browser only) |
+| `mp account login` | Run the OAuth browser PKCE flow (oauth_browser only) — `mp login --name NAME` is the unified equivalent |
 | `mp account logout` | Delete on-disk OAuth tokens (oauth_browser only) |
 | `mp account token` | Print the bearer token (for piping to curl etc.) |
 | `mp account export-bridge` | Write a v2 Cowork bridge file |
@@ -521,9 +533,8 @@ These resolve via `env > param > target > bridge > [active] > default_project` �
 ### Complete Workflow
 
 ```bash
-# 1. Set up credentials (prompts for secret securely)
-mp account add personal --type oauth_browser --region us
-mp account login personal       # opens browser for PKCE flow
+# 1. Authenticate (probes region, picks project, derives name from /me)
+mp login
 
 # 2. Explore schema
 mp inspect events
@@ -532,6 +543,8 @@ mp inspect properties --event Purchase
 # 3. Run live queries
 mp query segmentation --event Purchase --from 2025-01-01 --to 2025-01-31 --format table
 ```
+
+For explicit account names or non-browser flows, use `mp login --name personal --region us` or the two-step `mp account add` + `mp account login` (see [account — Account Management](#account-account-management) above).
 
 ### Piping and Scripting
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -13,6 +13,26 @@ In-session switching is a one-line operation: `Workspace.use(account=..., projec
 
     Ask questions about service accounts, OAuth, environment variables, or multi-account configuration.
 
+## Quick Start: `mp login`
+
+The fastest way to authenticate is the top-level `mp login` command. It probes regions, runs the right auth flow for your environment, derives an account name from `/me`, and pins a default project — all in one call:
+
+```bash
+mp login
+# Logged in as jared@example.com → acme · AI Demo
+```
+
+Auth-type detection is env-driven (`accounts.py:_detect_login_type`):
+
+1. Explicit `--service-account` / `--token-env VAR` flag.
+2. `MP_USERNAME` + `MP_SECRET` set → `service_account`.
+3. `MP_OAUTH_TOKEN` set → `oauth_token`.
+4. Otherwise → `oauth_browser` (PKCE).
+
+Useful flags: `--region {us|eu|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived name.
+
+The rest of this page covers the underlying account model, env-var precedence, and the explicit setup paths for users who want more control than `mp login` provides.
+
 ## Account Types
 
 | Type | Best For | Storage |
@@ -44,6 +64,9 @@ These map onto the [credential resolution chain](#credential-resolution-chain) b
 !!! note "Service-account env quad takes precedence over `MP_OAUTH_TOKEN`"
     If `MP_USERNAME` + `MP_SECRET` + `MP_PROJECT_ID` + `MP_REGION` are all set, the service-account quad wins even when `MP_OAUTH_TOKEN` is also present. This is safe to add to a shell that already exports the service-account vars.
 
+!!! note "`mp login` auth-type detection"
+    The same env presence drives `mp login`'s auth-type detection: `MP_USERNAME` + `MP_SECRET` set → `service_account`; `MP_OAUTH_TOKEN` set → `oauth_token`; otherwise the browser PKCE flow. Pass `--service-account` or `--token-env VAR` to force a non-browser path.
+
 ## Setting Up an Account
 
 ### Service account (Basic Auth)
@@ -74,6 +97,19 @@ mp account test team
 
 ### OAuth (browser, PKCE)
 
+The recommended path is `mp login` (see [Quick Start](#quick-start-mp-login) above), which probes the region for you and derives a name from `/me`:
+
+```bash
+mp login --name personal
+# Logged in as jared@example.com → personal · AI Demo
+```
+
+Tokens land at `~/.mp/accounts/personal/tokens.json` (mode `0o600`) and refresh automatically before each call. The `default_project` is set from the post-login `/me` probe.
+
+<details><summary>Advanced: explicit account creation (two-step)</summary>
+
+For full control over the account name and region at registration time:
+
 ```bash
 mp account add personal --type oauth_browser --region us
 # Added account 'personal' (oauth_browser, us). Set as active.
@@ -83,7 +119,9 @@ mp account login personal
 # ✓ Authenticated as jared@example.com
 ```
 
-The PKCE flow opens your browser for Mixpanel authorization. Tokens land at `~/.mp/accounts/personal/tokens.json` (mode `0o600`) and refresh automatically before each call. The `default_project` field on the account is backfilled from the post-login `/me` probe.
+`mp account add` registers the account; `mp account login` runs the PKCE flow. `mp login --name personal --region us` collapses both into one call.
+
+</details>
 
 ### OAuth (static bearer / CI)
 
@@ -210,7 +248,7 @@ OAuth browser tokens are stored per account; OAuth client metadata (Dynamic Clie
     └── client_in.json
 ```
 
-Tokens auto-refresh on expiry. If the refresh token is rejected (e.g., revoked at the IdP), the next call raises `OAuthError(code="OAUTH_REFRESH_REVOKED")` — re-run `mp account login NAME` to recover.
+Tokens auto-refresh on expiry. If the refresh token is rejected (e.g., revoked at the IdP), the next call raises `OAuthError(code="OAUTH_REFRESH_REVOKED")` — re-run `mp login --name NAME` to recover (or the legacy `mp account login NAME`).
 
 ```bash
 mp account token personal                          # Print the active access token

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -15,21 +15,26 @@ In-session switching is a one-line operation: `Workspace.use(account=..., projec
 
 ## Quick Start: `mp login`
 
-The fastest way to authenticate is the top-level `mp login` command. It probes regions, runs the right auth flow for your environment, derives an account name from `/me`, and pins a default project — all in one call:
+The fastest way to authenticate is the top-level `mp login` command. It runs the right auth flow for your environment, derives an account name from `/me`, and pins a default project — all in one call:
 
 ```bash
 mp login
 # Logged in as jared@example.com → acme · AI Demo
 ```
 
-Auth-type detection is env-driven (`accounts.py:_detect_login_type`):
+Auth-type detection is env-driven:
 
 1. Explicit `--service-account` / `--token-env VAR` flag.
 2. `MP_USERNAME` + `MP_SECRET` set → `service_account`.
 3. `MP_OAUTH_TOKEN` set → `oauth_token`.
 4. Otherwise → `oauth_browser` (PKCE).
 
-Useful flags: `--region {us|eu|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived name.
+Region behavior depends on the auth type:
+
+- `service_account` and `oauth_token`: probes `us → eu → in` against `/me` and uses the first 200.
+- `oauth_browser`: defaults to `us` when `--region` is not passed. EU and India users must pass `--region eu` or `--region in` explicitly (the PKCE flow commits to a single region before the post-login `/me` probe runs).
+
+Useful flags: `--region {us|eu|in}` sets the region explicitly, `--project ID` skips the picker, `--name NAME` overrides the derived name.
 
 The rest of this page covers the underlying account model, env-var precedence, and the explicit setup paths for users who want more control than `mp login` provides.
 
@@ -97,7 +102,7 @@ mp account test team
 
 ### OAuth (browser, PKCE)
 
-The recommended path is `mp login` (see [Quick Start](#quick-start-mp-login) above), which probes the region for you and derives a name from `/me`:
+The recommended path is `mp login` (see [Quick Start](#quick-start-mp-login) above), which derives a name from `/me`. The browser path defaults to `us`; pass `--region eu|in` for other clusters:
 
 ```bash
 mp login --name personal

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -21,8 +21,8 @@ You'll need:
 
 ```bash
 mp login
-# Probing regions for /me access ...
-# ✓ us
+# Opens browser for PKCE...
+# Authenticated as jared@example.com
 #
 # Found 2 project(s) across 1 organization(s):
 #   1) Acme · AI Demo            (id 3713224, mixpanel.com)
@@ -32,17 +32,19 @@ mp login
 # Logged in as jared@example.com → acme · AI Demo
 ```
 
-`mp login` is the one-shot path — it probes `us` → `eu` → `in` for the right region, hits `/me` to discover what you can access, derives the account name from your org, and pins a default project (auto-picks when you have one, prompts when you have several). Tokens land at `~/.mp/accounts/{name}/tokens.json` (mode `0o600`) and refresh automatically on expiry.
+`mp login` is the one-shot path — it picks the right auth flow for your environment, hits `/me` to discover what you can access, derives the account name from your org, and pins a default project (auto-picks when you have one, prompts when you have several). For browser PKCE, tokens land at `~/.mp/accounts/{name}/tokens.json` (mode `0o600`) and refresh automatically on expiry.
 
-The command also auto-detects your auth type from the environment:
+The command auto-detects your auth type from the environment:
 
-| Env vars set | Auth type used |
-|---|---|
-| `MP_USERNAME` + `MP_SECRET` | `service_account` (no browser) |
-| `MP_OAUTH_TOKEN` | `oauth_token` (no browser, no persistence) |
-| Neither | `oauth_browser` (PKCE flow) |
+| Env vars set | Auth type used | Region behavior | Persistence |
+|---|---|---|---|
+| `MP_USERNAME` + `MP_SECRET` | `service_account` | probes `us → eu → in` | username + secret persisted to `~/.mp/config.toml` |
+| `MP_OAUTH_TOKEN` | `oauth_token` | probes `us → eu → in` | bearer persisted inline to `~/.mp/config.toml` (use `--token-env VAR` to persist a pointer instead) |
+| Neither | `oauth_browser` (PKCE) | defaults to `us` (pass `--region eu\|in` for other clusters) | refresh-capable tokens at `~/.mp/accounts/{name}/tokens.json` |
 
-Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
+For a truly non-persistent path (env-only with no account record), set the env vars and skip `mp login` entirely — the resolver picks them up directly. See the "Other auth paths" tabs below.
+
+Useful flags: `--region {us\|eu\|in}` sets the region explicitly (skips the probe for SA / token paths), `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
 
 ### Other auth paths
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,70 +17,73 @@ You'll need:
 
 ## Step 1: Set Up Credentials
 
-### Option A: Environment Variables (Service Account)
+### Recommended: `mp login`
 
 ```bash
-export MP_USERNAME="sa_abc123..."
-export MP_SECRET="your-secret-here"
-export MP_PROJECT_ID="12345"
-export MP_REGION="us"
+mp login
+# Probing regions for /me access ...
+# ✓ us
+#
+# Found 2 project(s) across 1 organization(s):
+#   1) Acme · AI Demo            (id 3713224, mixpanel.com)
+#   2) Acme · E-Commerce         (id 3018488, mixpanel.com)
+# Which project? [1]: 1
+#
+# Logged in as jared@example.com → acme · AI Demo
 ```
 
-### Option B: Config File (Service Account)
+`mp login` is the one-shot path — it probes `us` → `eu` → `in` for the right region, hits `/me` to discover what you can access, derives the account name from your org, and pins a default project (auto-picks when you have one, prompts when you have several). Tokens land at `~/.mp/accounts/{name}/tokens.json` (mode `0o600`) and refresh automatically on expiry.
 
-```bash
-# Set the secret via env var (preferred)
-export MP_SECRET="your-secret-here"
-mp account add production --type service_account \
-    --username sa_abc123... \
-    --project 12345 \
-    --region us
-# Added account 'production' (service_account, us). Set as active.
-```
+The command also auto-detects your auth type from the environment:
 
-This stores credentials in `~/.mp/config.toml` and sets `production` as the active account.
+| Env vars set | Auth type used |
+|---|---|
+| `MP_USERNAME` + `MP_SECRET` | `service_account` (no browser) |
+| `MP_OAUTH_TOKEN` | `oauth_token` (no browser, no persistence) |
+| Neither | `oauth_browser` (PKCE flow) |
 
-For CI/CD environments where the secret lives in a shell variable, pipe it via stdin:
+Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
 
-```bash
-echo "$SECRET" | mp account add production --type service_account \
-    --username sa_abc123... --project 12345 --region us --secret-stdin
-```
+### Other auth paths
 
-### Option C: OAuth Login (Interactive)
+=== "Service-account env vars"
 
-For interactive use without managing service account credentials:
+    For unattended automation, set the four env vars and skip account registration entirely — the resolver picks them up directly:
 
-```bash
-# Register an OAuth account
-mp account add personal --type oauth_browser --region us
+    ```bash
+    export MP_USERNAME="sa_abc123..."
+    export MP_SECRET="your-secret-here"
+    export MP_PROJECT_ID="12345"
+    export MP_REGION="us"
+    ```
 
-# Run the PKCE browser flow
-mp account login personal
-# Opening browser...
-# ✓ Authenticated as jared@example.com
+=== "Raw OAuth bearer (CI / agents)"
 
-# Inspect resolved state
-mp session
-```
+    If a managed OAuth client hands you a pre-obtained access token, inject it via env vars (the library sends `Authorization: Bearer <token>`):
 
-OAuth tokens are stored at `~/.mp/accounts/personal/tokens.json` and automatically refreshed when expired. The active project is backfilled from the post-login `/me` probe. See [Configuration → OAuth (browser) — token storage](configuration.md#oauth-browser-token-storage) for details.
+    ```bash
+    export MP_OAUTH_TOKEN="<bearer-token>"
+    export MP_PROJECT_ID="12345"
+    export MP_REGION="us"  # or "eu", "in"
+    ```
 
-### Option D: Raw OAuth Bearer Token (CI / Agents)
+    Tokens injected this way are not persisted (no refresh — pass a fresh token when the previous one expires). The full service-account env-var set takes precedence when both sets are complete.
 
-If a managed OAuth client (e.g., a Claude Code plugin or CI pipeline) hands you a pre-obtained access token, inject it via env vars without going through the browser flow:
+=== "Advanced: explicit two-step add"
 
-```bash
-export MP_OAUTH_TOKEN="<bearer-token>"
-export MP_PROJECT_ID="12345"
-export MP_REGION="us"  # or "eu", "in"
-```
+    For full control over the account name and region at registration time:
 
-The library sends `Authorization: Bearer <token>` on every Mixpanel endpoint. Tokens injected this way are not persisted (no refresh — pass a fresh token when the previous one expires). See [Configuration → OAuth (static bearer / CI)](configuration.md#oauth-static-bearer-ci) and the precedence note under [Environment Variables](configuration.md#environment-variables).
+    ```bash
+    mp account add personal --type oauth_browser --region us
+    mp account login personal
+    # ✓ Authenticated as jared@example.com
+    ```
 
-## Step 2: Choose a Project
+    `mp login --name personal --region us` is the one-line equivalent. See [Configuration → OAuth (browser) — token storage](configuration.md#oauth-browser-token-storage) for the persistence details.
 
-After authenticating with a registered account (Options B or C above), select which Mixpanel project to query:
+## Step 2: Switch Projects (Optional)
+
+`mp login` already pinned the project shown in its success line. This step is for *changing* it later — pointing the same account at a different project, or swapping in-session.
 
 === "CLI"
 
@@ -90,8 +93,8 @@ After authenticating with a registered account (Options B or C above), select wh
     # 3713224   AI Demo           Acme      ✓
     # 3018488   E-Commerce Demo   Acme      ✓
 
-    mp project use 3713224
-    # Active project: AI Demo (3713224)
+    mp project use 3018488
+    # Active project: E-Commerce Demo (3018488)
     ```
 
 === "Python"
@@ -103,13 +106,13 @@ After authenticating with a registered account (Options B or C above), select wh
     for project in ws.projects():
         print(project.id, project.name)
 
-    ws.use(project="3713224", persist=True)
+    ws.use(project="3018488", persist=True)
     ```
 
 `mp project use` writes to the active account's `default_project`. To override per-call without persisting, pass `--project` / `-p` on the CLI or `Workspace(project="...")` in Python.
 
 !!! note "Env-only paths skip this step"
-    `mp project use` requires an active account in `~/.mp/config.toml`. If you set up via Option A (`MP_USERNAME`/`MP_SECRET`/...) or Option D (`MP_OAUTH_TOKEN`/...) without registering an account, set the project via `MP_PROJECT_ID` directly (already required by both env-only paths) or pass `--project` / `Workspace(project=...)` per call. Don't run `mp project use` — it errors with "No active account configured."
+    `mp project use` requires an active account in `~/.mp/config.toml`. If you set up via the service-account env quad or `MP_OAUTH_TOKEN` without registering an account, set the project via `MP_PROJECT_ID` directly (already required by both env-only paths) or pass `--project` / `Workspace(project=...)` per call. Don't run `mp project use` — it errors with "No active account configured."
 
 ## Step 3: Test Your Connection
 

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -131,9 +131,12 @@ All entity methods require a workspace ID. Use `ws.resolve_workspace_id()` to au
 
 Three account types — `service_account` (Basic Auth), `oauth_browser` (PKCE
 browser flow), and `oauth_token` (static bearer for CI / agents) — managed
-through a single Account → Project → Workspace hierarchy. Run
-`/mixpanel-headless:setup` for first-time configuration, or `/mixpanel-headless:auth`
-to switch accounts, projects, workspaces, or saved targets after initial setup.
+through a single Account → Project → Workspace hierarchy. The recommended
+starter command is `mp login`: it probes regions (`us → eu → in`), detects
+the right auth path from the environment, derives the account name from
+`/me`, and pins a default project in one call. Run `/mixpanel-headless:setup`
+for first-time configuration, or `/mixpanel-headless:auth` to switch
+accounts, projects, workspaces, or saved targets after initial setup.
 
 ## Installation
 

--- a/mixpanel-plugin/README.md
+++ b/mixpanel-plugin/README.md
@@ -132,9 +132,11 @@ All entity methods require a workspace ID. Use `ws.resolve_workspace_id()` to au
 Three account types — `service_account` (Basic Auth), `oauth_browser` (PKCE
 browser flow), and `oauth_token` (static bearer for CI / agents) — managed
 through a single Account → Project → Workspace hierarchy. The recommended
-starter command is `mp login`: it probes regions (`us → eu → in`), detects
-the right auth path from the environment, derives the account name from
-`/me`, and pins a default project in one call. Run `/mixpanel-headless:setup`
+starter command is `mp login`: it detects the right auth path from the
+environment, derives the account name from `/me`, and pins a default
+project in one call. SA and oauth_token paths probe `us → eu → in` for
+the region; the browser PKCE path defaults to `us` (pass `--region
+eu|in` for other clusters). Run `/mixpanel-headless:setup`
 for first-time configuration, or `/mixpanel-headless:auth` to switch
 accounts, projects, workspaces, or saved targets after initial setup.
 

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -1,7 +1,7 @@
 ---
 name: mixpanel-headless:auth
-description: Manage Mixpanel authentication — check session, list/add/use accounts, OAuth login, switch projects/workspaces, manage targets, check the Cowork bridge. Use with no arguments for a one-line session summary.
-argument-hint: [session|account|project|workspace|target|bridge] [...]
+description: Manage Mixpanel authentication — check session, list/add/use accounts, OAuth login (frictionless `mp login` or two-step), switch projects/workspaces, manage targets, check the Cowork bridge. Use with no arguments for a one-line session summary.
+argument-hint: [session|login|account|project|workspace|target|bridge] [...]
 ---
 
 # Mixpanel Authentication Management
@@ -27,6 +27,28 @@ stdout (exit 0) so you can `json.loads` unconditionally — no try/except needed
 Parse `$ARGUMENTS` and route to the appropriate subcommand. With no
 arguments, run `session`.
 
+### "login"
+
+For first-time setup, the frictionless one-shot path is `mp login`. It
+probes regions (`us → eu → in`), runs the right auth flow for the
+environment, derives the account name from `/me`, and pins a default
+project. Tell the user to run:
+
+```
+! mp login
+```
+
+Optional flags they may want:
+- `--name NAME` — override the derived account name
+- `--region us|eu|in` — skip the region probe
+- `--project ID` — skip the project picker
+- `--service-account` — force the SA path (requires `MP_USERNAME` + `MP_SECRET` in env)
+- `--token-env VAR` — force the static-bearer path (reads token from `$VAR`)
+- `--no-browser` — print the authorization URL instead of launching a browser
+
+After the user confirms they ran it, verify with `account test`:
+`python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py account test`
+
 ### No arguments or "session"
 
 Run: `python3 ${CLAUDE_PLUGIN_ROOT}/skills/mixpanelyst/scripts/auth_manager.py session`
@@ -37,10 +59,10 @@ Switch on `state`:
   `/mixpanel-headless:auth account list` and `/mixpanel-headless:auth project list`
   exist if the user wants to switch.
 - **`needs_account`** — no account configured. Show the first
-  `next[0].command` as the recommended onboarding step (OAuth browser flow);
-  list the alternatives in `next[1]` (service account) and `next[2]`
-  (`MP_OAUTH_TOKEN` env triple — best for non-interactive contexts like CI
-  or agents).
+  `next[0].command` as the recommended onboarding step (the frictionless
+  `mp login` orchestrator); list the alternatives in `next[1]` (explicit
+  account add) and `next[2]` (`MP_OAUTH_TOKEN` env triple — best for
+  non-interactive contexts like CI or agents).
 - **`needs_project`** — account configured but no project pinned. Tell the
   user to run `mp project list` then `mp project use <id>`.
 - **`error`** — show `error.message`. If `error.actionable` is true, the
@@ -76,7 +98,15 @@ Now run this command — it will prompt for your service account secret with hid
 ! mp account add <NAME> --type service_account --username <USERNAME> --project <PROJECT_ID> --region <REGION>
 ```
 
-For OAuth browser:
+For OAuth browser, prefer the one-shot `mp login` (covered by the "login"
+branch above):
+
+```
+! mp login --name <NAME> --region <REGION>
+```
+
+For full control over registration before the PKCE flow, the explicit
+two-step is still available:
 
 ```
 ! mp account add <NAME> --type oauth_browser --region <REGION>

--- a/mixpanel-plugin/commands/auth.md
+++ b/mixpanel-plugin/commands/auth.md
@@ -30,17 +30,22 @@ arguments, run `session`.
 ### "login"
 
 For first-time setup, the frictionless one-shot path is `mp login`. It
-probes regions (`us → eu → in`), runs the right auth flow for the
-environment, derives the account name from `/me`, and pins a default
-project. Tell the user to run:
+runs the right auth flow for the environment, derives the account name
+from `/me`, and pins a default project. Tell the user to run:
 
 ```
 ! mp login
 ```
 
+Region behavior is auth-type-specific:
+- `service_account` and `oauth_token` paths: probes `us → eu → in` and
+  uses the first 200.
+- `oauth_browser` path (the bare-`mp login` default): commits to `us`
+  unless the user passes `--region eu` or `--region in`.
+
 Optional flags they may want:
 - `--name NAME` — override the derived account name
-- `--region us|eu|in` — skip the region probe
+- `--region us|eu|in` — set the region explicitly (required for EU / India browser users)
 - `--project ID` — skip the project picker
 - `--service-account` — force the SA path (requires `MP_USERNAME` + `MP_SECRET` in env)
 - `--token-env VAR` — force the static-bearer path (reads token from `$VAR`)

--- a/mixpanel-plugin/docs/getting-started-guide.md
+++ b/mixpanel-plugin/docs/getting-started-guide.md
@@ -69,33 +69,27 @@ python3 -m mixpanel_headless --version
 
 ## Part 2: Authenticate with Mixpanel
 
-You need to connect `mixpanel_headless` to your Mixpanel project. There are two ways to do this: **OAuth login** (interactive, opens your browser) or **service account** (for scripts and automation).
+You need to connect `mixpanel_headless` to your Mixpanel project. The recommended path is the one-shot `mp login`; service accounts and env-var setups are also supported.
 
-### Option A: OAuth Login (Recommended for Personal Use)
+### Option A: `mp login` (Recommended)
 
-Register an OAuth browser account, then run the PKCE login flow — the second command opens your browser so you can authenticate with Mixpanel:
-
-```bash
-mp account add personal --type oauth_browser --region us
-mp account login personal
-```
-
-After logging in, `mixpanel_headless` automatically backfills the account's `default_project` from the post-login `/me` probe. If you have multiple accessible projects and want to switch:
+Run one command and follow the prompts:
 
 ```bash
-mp project list                # See all your accessible projects
-mp project use YOUR_PROJECT_ID # Switch to a different project
+mp login
 ```
 
-You can also pin a specific project at registration time by passing `--project YOUR_PROJECT_ID` to `mp account add`.
+`mp login` probes your region (`us → eu → in`), opens your browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. If you have several accessible projects, it shows a numbered picker; if you have one, it auto-picks. Tokens land at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refresh automatically on expiry.
 
-**Region options:**
+The command also auto-detects your auth type from the environment:
 
-| Region | Flag | When to use |
-|--------|------|-------------|
-| United States | `--region us` | Most projects (default) |
-| Europe | `--region eu` | EU data residency |
-| India | `--region in` | India data residency |
+| Env vars present | Auth type used |
+|---|---|
+| `MP_USERNAME` + `MP_SECRET` | `service_account` (no browser) |
+| `MP_OAUTH_TOKEN` | `oauth_token` (no browser, no persistence) |
+| Neither | `oauth_browser` (PKCE flow) |
+
+Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
 
 Verify the connection:
 
@@ -107,14 +101,15 @@ mp session
 
 Service accounts are ideal for automation. You'll need a **service account username** and **secret** from your Mixpanel project settings (Settings > Service Accounts).
 
-Add the credentials (you'll be prompted for the secret securely):
+For a registered account on disk, set `MP_SECRET` and run:
 
 ```bash
+export MP_SECRET="your-service-account-secret"
 mp account add my-project --type service_account \
     --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
 ```
 
-You'll see a hidden input prompt for the secret — paste it and press Enter. (For non-interactive use, prefer `export MP_SECRET=...` before the command, or pipe the secret via `--secret-stdin`.)
+(For non-interactive contexts, pipe the secret via `--secret-stdin` instead of exporting it.)
 
 Then verify the connection:
 
@@ -126,7 +121,7 @@ You should see a success message confirming the credentials work.
 
 ### Option C: Environment Variables (Quick Setup)
 
-For a quick, temporary setup (useful for trying things out), you can export environment variables:
+For a quick, temporary setup (useful for trying things out), you can export environment variables — the resolver picks them up directly without account registration:
 
 ```bash
 export MP_USERNAME="your-service-account-username"
@@ -139,7 +134,7 @@ These take effect immediately for any `mp` command or Python script in the same 
 
 ### Where Credentials Are Stored
 
-Account records and the active session live in `~/.mp/config.toml`. OAuth browser tokens are stored per-account at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refreshed automatically on expiry. These files are created automatically when you run `mp account add` or `mp account login` — you should never need to edit them by hand.
+Account records and the active session live in `~/.mp/config.toml`. OAuth browser tokens are stored per-account at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refreshed automatically on expiry. These files are created automatically when you run `mp login` (or the explicit `mp account add` + `mp account login`) — you should never need to edit them by hand.
 
 ---
 
@@ -379,7 +374,7 @@ If the setup skill reports that no credentials are found, use the `/mixpanel-hea
 /mixpanel-headless:auth account add my-project
 ```
 
-Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret. For OAuth, use `/mixpanel-headless:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-headless:auth account login personal`.
+Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret. For OAuth, the simplest path is `! mp login` — it probes the region, opens the browser, derives the account name, and pins a project. Use `/mixpanel-headless:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-headless:auth account login personal` if you need explicit control over the account name and region.
 
 ### Ask Analytics Questions
 
@@ -471,7 +466,7 @@ mp account remove-bridge --at /custom/path/auth.json
 
 ### OAuth Token Refresh
 
-If you authenticated with OAuth, the bridge file embeds your refresh token. The library automatically refreshes expired access tokens inside Cowork — no browser interaction needed. If the refresh token itself is rejected (e.g., revoked at the IdP), you'll need to re-authenticate on your local machine (`mp account login <name>`) and re-run `mp account export-bridge --to ~/.claude/mixpanel/auth.json` to pick up the fresh tokens.
+If you authenticated with OAuth, the bridge file embeds your refresh token. The library automatically refreshes expired access tokens inside Cowork — no browser interaction needed. If the refresh token itself is rejected (e.g., revoked at the IdP), you'll need to re-authenticate on your local machine (`mp login --name <name>` or the legacy `mp account login <name>`) and re-run `mp account export-bridge --to ~/.claude/mixpanel/auth.json` to pick up the fresh tokens.
 
 ---
 
@@ -481,8 +476,9 @@ If you authenticated with OAuth, the bridge file embeds your refresh token. The 
 
 | Command | What It Does |
 |---------|-------------|
-| `mp account add <name> --type oauth_browser --region us` | Register an OAuth browser account |
-| `mp account login <name>` | Run the PKCE browser flow for an OAuth account |
+| `mp login` | One-shot frictionless login (region probe + project picker + name derivation) |
+| `mp account add <name> --type oauth_browser --region us` | Register an OAuth browser account explicitly (advanced) |
+| `mp account login <name>` | Run the PKCE browser flow for an explicitly-registered account (advanced) |
 | `mp account add <name> --type service_account --username ... --project ... --region ...` | Register a service account |
 | `mp account test [name]` | Test credentials for an account (defaults to active) |
 | `mp session` | Show the resolved active session (account / project / workspace) |
@@ -576,20 +572,24 @@ If using `uv`, make sure the virtual environment is activated.
 Run one of:
 
 ```bash
-# OAuth browser (interactive PKCE flow)
-mp account add personal --type oauth_browser --region us
-mp account login personal
+# Frictionless one-shot login (covers PKCE, region probe, project picker)
+mp login
 
-# Service account
+# Service account (set MP_SECRET first, then register)
+export MP_SECRET="your-secret-here"
 mp account add my-project --type service_account \
     --username YOUR_USERNAME --project YOUR_PROJECT_ID --region us
+
+# Advanced: explicit OAuth browser two-step
+mp account add personal --type oauth_browser --region us
+mp account login personal
 ```
 
 ### OAuth Token Expired
 
 ```bash
 # Re-authenticate (refresh token revoked or expired)
-mp account login <name>
+mp login --name <name>            # or `mp account login <name>` (legacy)
 ```
 
 ### Plugin Not Working in Claude Code

--- a/mixpanel-plugin/docs/getting-started-guide.md
+++ b/mixpanel-plugin/docs/getting-started-guide.md
@@ -79,17 +79,19 @@ Run one command and follow the prompts:
 mp login
 ```
 
-`mp login` probes your region (`us → eu → in`), opens your browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. If you have several accessible projects, it shows a numbered picker; if you have one, it auto-picks. Tokens land at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refresh automatically on expiry.
+`mp login` opens your browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. If you have several accessible projects, it shows a numbered picker; if you have one, it auto-picks. Tokens land at `~/.mp/accounts/<name>/tokens.json` (mode `0o600`) and refresh automatically on expiry.
 
-The command also auto-detects your auth type from the environment:
+The command auto-detects your auth type from the environment:
 
-| Env vars present | Auth type used |
-|---|---|
-| `MP_USERNAME` + `MP_SECRET` | `service_account` (no browser) |
-| `MP_OAUTH_TOKEN` | `oauth_token` (no browser, no persistence) |
-| Neither | `oauth_browser` (PKCE flow) |
+| Env vars present | Auth type used | Region behavior | Persistence |
+|---|---|---|---|
+| `MP_USERNAME` + `MP_SECRET` | `service_account` | probes `us → eu → in` | username + secret saved to `~/.mp/config.toml` |
+| `MP_OAUTH_TOKEN` | `oauth_token` | probes `us → eu → in` | bearer saved inline to `~/.mp/config.toml` (use `--token-env VAR` to save a pointer instead) |
+| Neither | `oauth_browser` (PKCE) | defaults to `us` (pass `--region eu\|in` for other clusters) | refresh-capable tokens at `~/.mp/accounts/<name>/tokens.json` |
 
-Useful flags: `--region {us\|eu\|in}` skips the probe, `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
+For a truly non-persistent flow, set the env vars and skip `mp login` — see Option C below.
+
+Useful flags: `--region {us\|eu\|in}` sets the region explicitly (skips the probe for SA / token paths), `--project ID` skips the picker, `--name NAME` overrides the derived account name, `--service-account` / `--token-env VAR` force a non-browser path.
 
 Verify the connection:
 
@@ -374,7 +376,7 @@ If the setup skill reports that no credentials are found, use the `/mixpanel-hea
 /mixpanel-headless:auth account add my-project
 ```
 
-Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret. For OAuth, the simplest path is `! mp login` — it probes the region, opens the browser, derives the account name, and pins a project. Use `/mixpanel-headless:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-headless:auth account login personal` if you need explicit control over the account name and region.
+Claude will guide you through entering your service account username, project ID, and region. You'll be prompted to run a shell command that securely collects your secret. For OAuth, the simplest path is `! mp login` — it opens the browser, derives the account name, and pins a project. The browser path defaults to the `us` region; EU and India users should pass `--region eu` or `--region in`. Use `/mixpanel-headless:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-headless:auth account login personal` if you need explicit control over the account name at registration time.
 
 ### Ask Analytics Questions
 

--- a/mixpanel-plugin/docs/quickstart-claude-code.md
+++ b/mixpanel-plugin/docs/quickstart-claude-code.md
@@ -70,7 +70,7 @@ The frictionless one-shot path:
 ! mp login
 ```
 
-`mp login` probes regions (`us → eu → in`), opens a browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. If you have several accessible projects, you'll see a numbered picker. Override the derived name with `--name personal`, skip the probe with `--region us`, or skip the picker with `--project 3018488`.
+`mp login` opens a browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. The browser path defaults to the `us` region; EU and India users must pass `--region eu` or `--region in` (the SA / oauth_token paths probe `us → eu → in` automatically when env vars trigger them). If you have several accessible projects, you'll see a numbered picker. Override the derived name with `--name personal` or skip the picker with `--project 3018488`.
 
 <details><summary>Advanced: explicit two-step</summary>
 

--- a/mixpanel-plugin/docs/quickstart-claude-code.md
+++ b/mixpanel-plugin/docs/quickstart-claude-code.md
@@ -64,12 +64,28 @@ Your secret is never visible in the conversation.
 
 ### Option B: OAuth Login (Browser-Based)
 
+The frictionless one-shot path:
+
+```
+! mp login
+```
+
+`mp login` probes regions (`us → eu → in`), opens a browser for the PKCE flow, derives the account name from your Mixpanel org, and pins a default project. If you have several accessible projects, you'll see a numbered picker. Override the derived name with `--name personal`, skip the probe with `--region us`, or skip the picker with `--project 3018488`.
+
+<details><summary>Advanced: explicit two-step</summary>
+
+For full control over the account name and region at registration time:
+
 ```
 /mixpanel-headless:auth account add personal --type oauth_browser --region us
 /mixpanel-headless:auth account login personal
 ```
 
-The first command registers an OAuth browser account; the second opens a browser window where you log in with your Mixpanel credentials. After login, your default project is backfilled automatically from the post-login `/me` probe. Use `/mixpanel-headless:auth project list` then `/mixpanel-headless:auth project use <id>` to switch if you have multiple projects.
+The first command registers an OAuth browser account; the second opens a browser window where you log in. After login, the default project is backfilled from the post-login `/me` probe.
+
+</details>
+
+Use `/mixpanel-headless:auth project list` then `/mixpanel-headless:auth project use <id>` to switch if you have multiple projects.
 
 ### Option C: Raw OAuth Bearer Token (CI / Agents)
 
@@ -230,7 +246,7 @@ shell prefix inside Claude Code):
 
 ### "No credentials configured"
 
-Run `/mixpanel-headless:auth account add my-project` and follow the prompts, or `/mixpanel-headless:auth account add personal --type oauth_browser --region us` followed by `/mixpanel-headless:auth account login personal` for OAuth.
+Run `! mp login` for the one-shot frictionless path, or `/mixpanel-headless:auth account add my-project` and follow the prompts for the guided wizard.
 
 ### "Authentication failed"
 
@@ -241,7 +257,7 @@ Run `/mixpanel-headless:auth account add my-project` and follow the prompts, or 
 
 ### "OAuth token expired" or OAuth login stopped working
 
-Run `/mixpanel-headless:auth account login <name>` again to refresh your tokens. If you switch to a service account instead, run `/mixpanel-headless:auth account add <name> --type service_account ...` — service account credentials don't expire.
+Run `! mp login --name <name>` (or the legacy `/mixpanel-headless:auth account login <name>`) to refresh your tokens. If you switch to a service account instead, set `MP_USERNAME` + `MP_SECRET` and re-run `! mp login`, or use `/mixpanel-headless:auth account add <name> --type service_account ...` for explicit registration — service account credentials don't expire.
 
 ### Plugin not appearing
 

--- a/mixpanel-plugin/docs/quickstart-claude-cowork.md
+++ b/mixpanel-plugin/docs/quickstart-claude-cowork.md
@@ -24,16 +24,25 @@ On your **local machine** (not inside Cowork), install the `mp` command-line too
 pip install git+https://github.com/mixpanel/mixpanel-headless.git
 ```
 
-Then configure your Mixpanel credentials:
+Then configure your Mixpanel credentials. The recommended path is the one-shot `mp login`:
 
 ```bash
-# OAuth browser (PKCE flow — opens browser)
-mp account add personal --type oauth_browser --region us
-mp account login personal
+mp login
+# Probes us → eu → in, opens browser for PKCE, derives the
+# account name from /me, and pins your default project.
+```
 
-# OR service account (prompts for secret securely)
+For explicit control over the account name, type, or region, use the two-step add instead:
+
+```bash
+# Service account (set MP_SECRET first, then register)
+export MP_SECRET="your-secret-here"
 mp account add my-project --type service_account \
     --username YOUR_SA_USERNAME --project YOUR_PROJECT_ID --region us
+
+# Or explicit OAuth browser registration
+mp account add personal --type oauth_browser --region us
+mp account login personal
 ```
 
 Verify the credentials work:
@@ -159,7 +168,7 @@ If you authenticated with OAuth (rather than a service account), the bridge file
 
 ```bash
 # On your local machine
-mp account login personal
+mp login --name personal             # or `mp account login personal` (legacy)
 mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 
@@ -226,7 +235,7 @@ mp account export-bridge --to ~/.claude/mixpanel/auth.json   # re-export fresh c
 
 **Fix**: On your local machine:
 ```bash
-mp account login personal
+mp login --name personal             # or `mp account login personal` (legacy)
 mp account export-bridge --to ~/.claude/mixpanel/auth.json
 ```
 Then start a new Cowork session.
@@ -251,7 +260,7 @@ mp --version   # verify
 
 These commands require a browser or host terminal and **should be run on your local machine**, not inside Cowork:
 
-- `mp account login <name>` (needs a browser for the PKCE OAuth flow)
+- `mp login` and `mp account login <name>` (need a browser for the PKCE OAuth flow)
 - `mp account add` for `service_account` (prompts for secret interactively by default; `--secret-stdin` and `MP_SECRET` env var work non-interactively, but the credential bridge is the recommended approach for Cowork)
 - `mp account export-bridge --to <path>` (reads host credentials, writes the bridge file)
 - `mp account remove-bridge [--at <path>]` (removes the bridge file from the host)

--- a/mixpanel-plugin/docs/quickstart-claude-cowork.md
+++ b/mixpanel-plugin/docs/quickstart-claude-cowork.md
@@ -28,8 +28,9 @@ Then configure your Mixpanel credentials. The recommended path is the one-shot `
 
 ```bash
 mp login
-# Probes us → eu → in, opens browser for PKCE, derives the
-# account name from /me, and pins your default project.
+# Opens browser for PKCE (defaults to us; pass --region eu|in for other
+# clusters), derives the account name from /me, and pins your default
+# project.
 ```
 
 For explicit control over the account name, type, or region, use the two-step add instead:

--- a/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
+++ b/mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py
@@ -40,8 +40,8 @@ SCHEMA_VERSION = 1
 
 # fmt: off
 _ONBOARDING = [
-    {"command": "mp account add personal --type oauth_browser --region us", "label": "OAuth (recommended)"},  # noqa: E501
-    {"command": "mp account add team --type service_account --username '<service-account-username>' --region us", "label": "Service account"},  # noqa: E501
+    {"command": "mp login", "label": "Frictionless login (recommended)"},
+    {"command": "mp account add team --type service_account --username '<service-account-username>' --region us", "label": "Service account (explicit add)"},  # noqa: E501
     {"command": "export MP_OAUTH_TOKEN=<bearer> MP_REGION=us MP_PROJECT_ID=<id>", "label": "Static bearer (CI)"},  # noqa: E501
 ]
 _PROJECT_NEXT = [

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -47,12 +47,18 @@ The frictionless one-shot path. Tell the user to run:
 ! mp login
 ```
 
-`mp login` probes regions (`us → eu → in`), runs the right auth flow for
-the environment, derives the account name from `/me`, and pins a default
-project. For laptops with a usable browser, this opens the PKCE flow;
-for environments with `MP_USERNAME` + `MP_SECRET` set, it skips the
-browser and uses the service-account path; for `MP_OAUTH_TOKEN` set, it
-uses the static bearer.
+`mp login` runs the right auth flow for the environment, derives the
+account name from `/me`, and pins a default project. For laptops with a
+usable browser, this opens the PKCE flow; for environments with
+`MP_USERNAME` + `MP_SECRET` set, it skips the browser and uses the
+service-account path; for `MP_OAUTH_TOKEN` set, it uses the static
+bearer.
+
+Region behavior:
+- `service_account` and `oauth_token` paths probe `us → eu → in` when
+  `--region` is omitted.
+- `oauth_browser` (the bare-`mp login` default) defaults to `us`. EU and
+  India browser users must pass `--region eu` or `--region in`.
 
 Useful flags: `--name NAME`, `--region us|eu|in`, `--project ID`,
 `--service-account`, `--token-env VAR`, `--no-browser`, `--secret-stdin`.

--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -39,29 +39,37 @@ Parse the JSON `state` field:
 
 If no credentials are configured, guide the user to one of these methods:
 
-### Recommended: Guided Setup
+### Recommended: `mp login`
 
-Tell the user to run `/mixpanel-headless:auth account add` for a step-by-step
-walkthrough that securely collects credentials. The slash command never
-prompts for secrets in conversation — it instructs the user to run
-`! mp account add ...` themselves so the secret is read with hidden input.
-
-### Alternative: OAuth Login
-
-For OAuth browser auth (laptops with a usable browser):
+The frictionless one-shot path. Tell the user to run:
 
 ```
-! mp account add personal --type oauth_browser --region us
-! mp account login personal     # opens browser for PKCE flow
+! mp login
 ```
 
-The first `mp account add` registers the account; `mp account login` runs
-the PKCE dance, persists tokens to `~/.mp/accounts/personal/tokens.json`,
-and backfills the account's default project from the post-login `/me` probe.
+`mp login` probes regions (`us → eu → in`), runs the right auth flow for
+the environment, derives the account name from `/me`, and pins a default
+project. For laptops with a usable browser, this opens the PKCE flow;
+for environments with `MP_USERNAME` + `MP_SECRET` set, it skips the
+browser and uses the service-account path; for `MP_OAUTH_TOKEN` set, it
+uses the static bearer.
+
+Useful flags: `--name NAME`, `--region us|eu|in`, `--project ID`,
+`--service-account`, `--token-env VAR`, `--no-browser`, `--secret-stdin`.
+
+### Alternative: Guided Setup (explicit account add)
+
+Tell the user to run `/mixpanel-headless:auth account add` for a
+step-by-step walkthrough. The slash command never prompts for secrets in
+conversation — it instructs the user to run `! mp account add ...`
+themselves so the secret is read with hidden input. Use this path when
+the user wants explicit control over the account name, region, and type
+at registration time.
 
 ### Alternative: Service-Account Environment Variables (temporary)
 
-For quick testing, set all four variables in the shell:
+For quick testing, set all four variables in the shell — the resolver
+picks them up directly without account registration:
 
 ```bash
 export MP_USERNAME="service-account-username"
@@ -118,7 +126,7 @@ token (no browser needed). If refresh fails:
 > Your OAuth session has expired and could not be refreshed.
 > On your host machine, run:
 > ```
-> mp account login personal           # re-authenticate
+> mp login --name personal             # re-authenticate (or `mp account login personal`)
 > mp account export-bridge --to ~/.claude/mixpanel/auth.json
 > ```
 > Then start a new Cowork session.

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -113,11 +113,11 @@ try:
             print('⚠ No active account selected. Run: mp account use <name>')
     else:
         print('⚠ No accounts configured yet.')
-        print('  OAuth browser:    mp account add personal --type oauth_browser --region us && mp account login personal')
+        print('  Recommended:      mp login                                   # one-shot frictionless login')
         print('  Service account:  mp account add team --type service_account --username sa_xxx --project 12345 --region us')
 except Exception as e:
     print(f'⚠ Could not read ~/.mp/config.toml: {e}')
-    print('  Set env vars (service-account quad or OAuth triple) or run mp account add ...')
+    print('  Run `mp login`, set env vars (service-account quad or OAuth triple), or run mp account add ...')
 "
 
 # Cowork detection: check for bridge file

--- a/tests/integration/test_plugin_auth_manager.py
+++ b/tests/integration/test_plugin_auth_manager.py
@@ -154,8 +154,10 @@ class TestSessionSubcommand:
         assert payload["state"] == "needs_account"
         assert isinstance(payload.get("next"), list)
         assert payload["next"], "needs_account should suggest a next command"
-        # First suggestion must be a usable mp command per § 2.2.
-        assert payload["next"][0]["command"].startswith("mp account add")
+        # First suggestion must be a usable mp command per § 2.2. Post-043,
+        # ``mp login`` replaces the multi-step ``mp account add`` as the
+        # frictionless onboarding default.
+        assert payload["next"][0]["command"].startswith("mp login")
 
     def test_populated_config_returns_ok(self, populated_home: Path) -> None:
         """A configured account + default_project yields ``state="ok"``."""


### PR DESCRIPTION
## Summary

- Doc updates only — no library code changes. Reflects the 043 frictionless-auth surface (`mp login` / `accounts.login_unified`) across every doc that previously taught the two-step `mp account add` + `mp account login` flow as primary.
- 15 doc files reorganized to lead with `mp login`, with the explicit two-step preserved under collapsible "Advanced" disclosures.
- One integration test in `tests/integration/test_plugin_auth_manager.py` pinned `next[0].command.startswith("mp account add")`; updated to expect `"mp login"` to match the new `auth_manager.py` `_ONBOARDING` default.

## Files touched

Core docs:
- `README.md`, `CLAUDE.md`
- `docs/getting-started/{quickstart,configuration}.md`
- `docs/cli/index.md` (new "login" command-group entry)
- `docs/api/auth.md` (adds `login_unified` to `mp.accounts` namespace + frictionless login subsection)
- `docs/api/exceptions.md` (adds `RegionProbeError`, `RegionProbeNetworkError`, `InvalidArgumentError` with hierarchy and error-code rows)

Plugin:
- `mixpanel-plugin/{README,commands/auth,skills/setup/SKILL,docs/getting-started-guide,docs/quickstart-claude-code,docs/quickstart-claude-cowork}.md`
- `mixpanel-plugin/skills/setup/scripts/setup.sh`
- `mixpanel-plugin/skills/mixpanelyst/scripts/auth_manager.py` (`_ONBOARDING[0]` → `mp login`)

## Test plan

- [x] `just check` — 6362 passed, 92.17% coverage
- [x] `uv run mkdocs build --strict` — builds clean
- [ ] Reviewer spot-check: render `docs/getting-started/{quickstart,configuration}.md` to confirm the `<details>` blocks display correctly under mkdocs-material
- [ ] Reviewer spot-check: invoke `/mixpanel-headless:auth` and `/mixpanel-headless:setup` in a fresh Claude Code session and confirm the new copy renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)