### PR TITLE
Bump urllib3 2.6.3 -> 2.7.0 (GHSA-qccp-gfcp-xxvc)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-07T23:44:29.929192Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -3055,11 +3055,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps transitive `urllib3` from `2.6.3` → `2.7.0` in `uv.lock` to clear Dependabot alert [#12](https://github.com/mixpanel/mixpanel-headless/security/dependabot/12) (GHSA-qccp-gfcp-xxvc / CVE-2026-44431, high severity).
- The advisory: `Authorization`, `Cookie`, and `Proxy-Authorization` headers were forwarded across origins on cross-origin redirects when using the low-level `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)` path. 2.7.0 strips them, matching the high-level API behavior.
- Runtime impact for `mixpanel_headless` users is nil — urllib3 only enters via `mkdocs-material → requests` in the `docs` extra; the library itself uses `httpx`. This is lockfile hygiene.

## Dependency chain
```
urllib3 v2.6.3
└── requests v2.33.1
    └── mkdocs-material v9.7.6
        └── mixpanel-headless (extra: docs)
```

No `pyproject.toml` change required — `requests` has no upper bound on urllib3, so `uv lock --upgrade-package urllib3` was enough. Diff is 4 lines.

## Test plan
- [x] `just check` passes locally (6362 tests, 92.16% coverage, build green)
- [ ] CI green
- [ ] Dependabot alert auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)