### PR TITLE
Close out CodeQL findings: stricter atomic_write_bytes mode + codex-review gate

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -6,14 +6,22 @@ on:
 
 jobs:
   codex:
-    # Only run when the "codex-review" label is applied to a non-fork PR.
-    # GitHub gates label application on triage permission (granted with write
-    # access), which serves as the implicit access gate. The fork check stops a
-    # forked branch from supplying a hostile prompt file and avoids noisy
-    # failures (fork PRs don't have access to repo secrets like OPENAI_API_KEY).
+    # Three gates, all required:
+    #   1. The "codex-review" label was the one just applied. (Label
+    #      application requires triage permission, but that grant is too
+    #      coarse for spending OPENAI_API_KEY on arbitrary PR code.)
+    #   2. The PR head is in this repo, not a fork. Fork PRs would not get
+    #      the secret anyway, and rejecting them up front avoids noisy
+    #      failure runs.
+    #   3. The user who applied the label is on the explicit ai-engine
+    #      allow-list below. This is the actual access gate — only humans
+    #      authorized to spend Codex budget can trigger a run on otherwise
+    #      arbitrary PR code. Refresh from `gh api orgs/mixpanel/teams/
+    #      ai-engine/members --jq '.[].login'` when the team changes.
     if: |
       github.event.label.name == 'codex-review' &&
-      github.event.pull_request.head.repo.fork == false
+      github.event.pull_request.head.repo.fork == false &&
+      contains(fromJSON('["xxx","sumitngupta","msiebert","gslopez","micaww","jaredmixpanel","joshua-koehler"]'), github.event.sender.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -40,6 +40,18 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
+      - name: Restore trusted Codex config from base
+        # The PR's checkout includes any PR-supplied changes to the Codex
+        # prompt and config. A malicious same-repo PR could rewrite
+        # `.github/codex/prompts/review.md` to instruct the LLM to
+        # exfiltrate `OPENAI_API_KEY` or take other unauthorized actions
+        # the moment an ai-engine reviewer applies the label without
+        # noticing the prompt diff. Restore the entire `.github/codex/`
+        # tree from the merge target so codex always reads the trusted
+        # base copy regardless of what the PR changed.
+        run: |
+          git checkout "origin/${{ github.event.pull_request.base.ref }}" -- .github/codex/
+
       - name: Run Codex
         id: run_codex
         uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1

--- a/src/mixpanel_headless/_internal/io_utils.py
+++ b/src/mixpanel_headless/_internal/io_utils.py
@@ -58,15 +58,29 @@ def atomic_write_bytes(path: Path, data: bytes, *, mode: int = 0o600) -> None:
     Parent directories are NOT created — callers are responsible for
     ensuring ``path.parent`` exists with appropriate permissions.
 
+    The tmp file is always created with mode ``0o600`` (owner-only)
+    regardless of the requested ``mode`` — only the final file picks up
+    ``mode`` via :func:`os.fchmod`. This guarantees the on-disk view is
+    never wider than ``0o600`` for the brief window the tmp file exists,
+    even if the caller asked for a more restrictive final mode like
+    ``0o400``.
+
     Args:
         path: Destination file path. Will be created or replaced.
         data: Bytes to write.
         mode: POSIX file mode applied to the final file. Defaults to
             ``0o600`` (owner read/write only) — the right default for
-            credential / config material. Ignored on Windows where
-            POSIX modes have no real-world effect.
+            credential / config material. Must NOT grant any group or
+            world bits (``mode & 0o077`` must be ``0``); this helper
+            only ever writes credential-bearing files. Ignored on
+            Windows where POSIX modes have no real-world effect.
 
     Raises:
+        ValueError: If ``mode`` grants any group or world access (any
+            bit in ``0o077`` is set). Defense-in-depth: every internal
+            caller passes ``0o600``, but the API is private to
+            ``_internal`` and a future caller asking for ``0o644``
+            would silently leak a credential file.
         FileExistsError: If a stale tmp file from the same pid+tid is
             already present at the computed tmp path. The target is not
             touched.
@@ -74,8 +88,18 @@ def atomic_write_bytes(path: Path, data: bytes, *, mode: int = 0o600) -> None:
         OSError: If the underlying write or rename fails (disk full,
             permission denied, cross-device link, etc.).
     """
+    if mode & 0o077:
+        raise ValueError(
+            f"atomic_write_bytes mode must not grant group/world access; "
+            f"got {oct(mode)}"
+        )
     tmp_path = path.parent / f"{path.name}.tmp.{os.getpid()}.{threading.get_ident()}"
-    fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    # Always create the tmp file owner-only (literal 0o600). The caller's
+    # requested ``mode`` is applied via fchmod below, after we've validated
+    # it and proved we own the fd. Passing a literal here keeps the
+    # ``os.open`` mode statically bounded, which both makes intent obvious
+    # and stops static analyzers from flagging this as overly permissive.
+    fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         try:
             if hasattr(os, "fchmod"):

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -8,7 +8,8 @@ crash without leaving the on-disk file in a partial state, and
 
 Verifies:
 - Writes bytes to a fresh path with default 0o600 mode
-- Writes bytes with a custom mode
+- Accepts owner-only restrictive modes (0o400, 0o600)
+- Rejects modes that grant group/world access (0o644, 0o660, 0o604)
 - Atomically replaces existing file content
 - Tmp file is cleaned up after a successful write
 - Tmp file is cleaned up after a failed write (no leak)
@@ -69,11 +70,26 @@ class TestAtomicWriteBytes:
         platform.system() == "Windows",
         reason="POSIX file permissions not available on Windows",
     )
-    def test_writes_bytes_with_custom_mode(self, temp_dir: Path) -> None:
-        """An explicit mode is honored on the final file."""
+    def test_writes_bytes_with_owner_only_mode(self, temp_dir: Path) -> None:
+        """A restrictive owner-only mode (0o400) is honored on the final file."""
         target = temp_dir / "config.toml"
-        atomic_write_bytes(target, b"x", mode=0o644)
-        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+        atomic_write_bytes(target, b"x", mode=0o400)
+        assert stat.S_IMODE(target.stat().st_mode) == 0o400
+
+    @pytest.mark.parametrize("bad_mode", [0o644, 0o660, 0o604, 0o666, 0o777])
+    def test_rejects_group_or_world_bits(self, temp_dir: Path, bad_mode: int) -> None:
+        """Modes granting group or world access are rejected before any I/O.
+
+        Defense-in-depth: every internal caller passes 0o600, but the API
+        is private to ``_internal`` and a future caller asking for 0o644
+        would silently leak a credential file. The check fires at function
+        entry, so no tmp file is created on rejection.
+        """
+        target = temp_dir / "config.toml"
+        with pytest.raises(ValueError, match="group/world access"):
+            atomic_write_bytes(target, b"x", mode=bad_mode)
+        assert not target.exists()
+        assert _tmp_glob(target) == []
 
     def test_replaces_existing_file_atomically(self, temp_dir: Path) -> None:
         """Writing to an existing path swaps content; old content is gone."""


### PR DESCRIPTION
## Summary

Resolves the open CodeQL code-scanning findings on `mixpanel/mixpanel-headless` after a per-alert assessment. Of 20 open alerts, 17 were dismissed via the API as false positives (paths logged in cleanup-recovery hints; URL substring matches in test mocks/assertions) and 3 are addressed by code changes here.

- **`atomic_write_bytes` (`src/mixpanel_headless/_internal/io_utils.py`)** — validates that `mode` does not grant any group/world bits (rejects with `ValueError` otherwise) and passes a literal `0o600` to `os.open`, then `fchmod`s to the requested mode. Every existing internal caller passes `0o600` so behavior is unchanged in practice; this is defense-in-depth against a future caller asking for `0o644` on a credential file. Closes alert #20 (`py/overly-permissive-file`).
- **`codex-review.yml`** — adds a third gate to the `codex` job's `if:`: the user who applied the `codex-review` label must be on the `mixpanel/ai-engine` team. The existing label gate alone trusted anyone with triage permission to spend `OPENAI_API_KEY` on otherwise arbitrary PR code. Closes alerts #2 and #26 (`actions/untrusted-checkout/medium`).
- **Tests** — replaces the `mode=0o644` success case in `tests/unit/test_io_utils.py` with a `mode=0o400` success case plus a parametrized rejection test covering `0o644`, `0o660`, `0o604`, `0o666`, `0o777`.

## Test plan

- [x] `just check` passes (lint, format, mypy --strict, 6367 tests, 92.16% coverage, build).
- [x] New `test_rejects_group_or_world_bits` test confirms `ValueError` fires before any tmp file is created.
- [ ] After merge, watch CodeQL re-scan and confirm alerts #20, #2, #26 transition to `fixed`.
- [ ] After merge, label a benign PR with `codex-review` from a team member to confirm the workflow still triggers; confirm a non-team-member label application does not trigger the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)