### PR TITLE
Stamp client identification on outbound API requests

### DIFF
--- a/src/mixpanel_headless/_internal/CLAUDE.md
+++ b/src/mixpanel_headless/_internal/CLAUDE.md
@@ -7,7 +7,8 @@ Private infrastructure powering `mixpanel_headless`'s programmable interface to 
 | File | Purpose |
 |------|---------|
 | `config.py` | `ConfigManager` for `~/.mp/config.toml` — single schema (`[accounts.NAME]` / `[active]` / `[targets.NAME]` / `[settings]`); unknown keys are rejected with a clear error |
-| `api_client.py` | `MixpanelAPIClient` — HTTP client; takes a `Session`; preserves the underlying `httpx.Client` across in-session axis switches |
+| `api_client.py` | `MixpanelAPIClient` — HTTP client; takes a `Session`; preserves the underlying `httpx.Client` across in-session axis switches; stamps `User-Agent` and `query_origin` from `client_metadata.py` on every request |
+| `client_metadata.py` | `QUERY_ORIGIN` constant + `get_user_agent()` / `set_entry_point()` helpers — single source of truth for outbound client identification |
 | `me.py` | `MeService` + per-account `MeCache` (`~/.mp/accounts/{name}/me.json`) |
 | `pagination.py` | Cursor-based App API pagination |
 | `io_utils.py` | `atomic_write_bytes` — `O_EXCL` + `os.replace` writes with explicit mode bits |

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -37,6 +37,10 @@ from mixpanel_headless._internal.auth.session import (
     WorkspaceRef,
 )
 from mixpanel_headless._internal.auth.token_resolver import OnDiskTokenResolver
+from mixpanel_headless._internal.client_metadata import (
+    QUERY_ORIGIN,
+    get_user_agent,
+)
 from mixpanel_headless.exceptions import (
     AuthenticationError,
     JQLSyntaxError,
@@ -246,15 +250,18 @@ class MixpanelAPIClient:
         return self._client
 
     def _request_headers(self, extra: dict[str, str]) -> dict[str, str]:
-        """Compose the per-request header set: env-var → session → caller.
+        """Compose the per-request header set: defaults → env → session → caller.
 
-        Each layer overrides the prior on header-name collision:
+        Each later layer overrides the prior on header-name collision:
 
-        1. ``MP_CUSTOM_HEADER_NAME`` / ``MP_CUSTOM_HEADER_VALUE`` env pair.
-        2. ``self._session.headers`` (populated from ``[settings].custom_header``
+        1. Library defaults — currently ``User-Agent`` from
+           :func:`get_user_agent` so backend telemetry can attribute traffic
+           to this library.
+        2. ``MP_CUSTOM_HEADER_NAME`` / ``MP_CUSTOM_HEADER_VALUE`` env pair.
+        3. ``self._session.headers`` (populated from ``[settings].custom_header``
            and bridge ``headers`` per FR-014). The resolver merged env into
            the session earlier; the final session state is authoritative.
-        3. ``extra`` — typically ``{"Authorization": auth_header}`` plus any
+        4. ``extra`` — typically ``{"Authorization": auth_header}`` plus any
            per-call ``Accept-Encoding`` etc. supplied by the caller.
 
         Args:
@@ -263,7 +270,7 @@ class MixpanelAPIClient:
         Returns:
             New dict with all layers merged in precedence order.
         """
-        headers: dict[str, str] = {}
+        headers: dict[str, str] = {"User-Agent": get_user_agent()}
         custom_name = os.environ.get("MP_CUSTOM_HEADER_NAME")
         custom_value = os.environ.get("MP_CUSTOM_HEADER_VALUE")
         if custom_name and custom_value:
@@ -509,7 +516,7 @@ class MixpanelAPIClient:
         request_body = json_data or form_data
         if params is None:
             params = {}
-        params["query_origin"] = "mixpanel-headless"
+        params["query_origin"] = QUERY_ORIGIN
         request_headers = self._request_headers(headers)
 
         for attempt in range(self._max_retries + 1):

--- a/src/mixpanel_headless/_internal/client_metadata.py
+++ b/src/mixpanel_headless/_internal/client_metadata.py
@@ -1,0 +1,73 @@
+"""Client-identification metadata for outbound Mixpanel API requests.
+
+Holds the User-Agent string and ``query_origin`` value that identify
+``mixpanel-headless`` traffic. Consumed by
+:meth:`MixpanelAPIClient._request_headers` and the Query API request path.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Final, Literal
+
+QUERY_ORIGIN: Final[str] = "mixpanel-headless"
+"""Value sent as the ``query_origin`` parameter on Query API calls.
+
+Lets downstream consumers attribute analytics traffic to this library.
+"""
+
+_EntryPoint = Literal["lib", "cli"]
+_entry_point: _EntryPoint = "lib"
+
+
+def set_entry_point(value: _EntryPoint) -> None:
+    """Record how this process was launched (call once at startup).
+
+    The CLI calls this with ``"cli"`` on import so the User-Agent tag
+    reflects interactive vs programmatic use. Library callers leave the
+    default ``"lib"``.
+
+    Args:
+        value: One of ``"lib"`` or ``"cli"``.
+
+    Example:
+        ```python
+        from mixpanel_headless._internal.client_metadata import set_entry_point
+        set_entry_point("cli")
+        ```
+    """
+    global _entry_point
+    _entry_point = value
+
+
+def get_entry_point() -> _EntryPoint:
+    """Return the currently recorded entry point.
+
+    Returns:
+        ``"lib"`` (default) or ``"cli"`` once flipped.
+    """
+    return _entry_point
+
+
+def get_user_agent() -> str:
+    """Build the User-Agent string for outbound requests.
+
+    Format: ``mixpanel-headless/<version> (entry=<lib|cli>; python/<x.y>)``
+
+    Returns:
+        The User-Agent header value. Re-read on every call so an
+        entry-point change after import is reflected immediately.
+
+    Example:
+        ```python
+        get_user_agent()
+        # "mixpanel-headless/0.1.0 (entry=lib; python/3.11)"
+        ```
+    """
+    # Lazy import: mixpanel_headless/__init__.py defines __version__ after
+    # eagerly importing workspace -> api_client -> this module. Top-level
+    # import here would deadlock package initialization.
+    from mixpanel_headless import __version__
+
+    py = f"{sys.version_info.major}.{sys.version_info.minor}"
+    return f"mixpanel-headless/{__version__} (entry={_entry_point}; python/{py})"

--- a/src/mixpanel_headless/cli/main.py
+++ b/src/mixpanel_headless/cli/main.py
@@ -22,7 +22,10 @@ from typing import Annotated, Literal
 import typer
 
 import mixpanel_headless
+from mixpanel_headless._internal.client_metadata import set_entry_point
 from mixpanel_headless.cli.utils import ExitCode, err_console
+
+set_entry_point("cli")
 
 
 def _get_rich_markup_mode() -> Literal["markdown", "rich"] | None:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -18,6 +18,7 @@ from mixpanel_headless._internal.api_client import (
     MixpanelAPIClient,
     _iter_jsonl_lines,
 )
+from mixpanel_headless._internal.auth.account import ServiceAccount
 from mixpanel_headless._internal.auth.session import Session
 from mixpanel_headless.exceptions import (
     AuthenticationError,
@@ -2948,3 +2949,159 @@ class TestWithProject:
         assert isinstance(new_client._session.account, OAuthTokenAccount)
         assert new_client._session.account.token is not None
         assert new_client._session.account.token.get_secret_value() == "my-oauth-token"
+
+
+# =============================================================================
+# Client identification headers (User-Agent)
+# =============================================================================
+
+
+class TestClientIdentificationHeaders:
+    """User-Agent stamping on every outbound request path."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_entry_point(self) -> Any:
+        """Force ``"lib"`` for each test, then restore the prior value.
+
+        Other test modules may import ``cli.main``, which flips the
+        process-wide entry point to ``"cli"`` at import time. Pin to
+        ``"lib"`` for deterministic assertions; restore on teardown.
+        """
+        from mixpanel_headless._internal.client_metadata import (
+            get_entry_point,
+            set_entry_point,
+        )
+
+        original = get_entry_point()
+        set_entry_point("lib")
+        yield
+        set_entry_point(original)
+
+    def test_user_agent_set_on_standard_request(
+        self, test_credentials: Session
+    ) -> None:
+        """Standard query-API requests carry the library User-Agent."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert captured_headers["user-agent"].startswith("mixpanel-headless/")
+        assert "entry=lib" in captured_headers["user-agent"]
+        assert "python/" in captured_headers["user-agent"]
+
+    def test_user_agent_set_on_app_request(self, test_credentials: Session) -> None:
+        """App API requests carry the library User-Agent."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={"results": []})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.app_request("GET", "/projects/12345/dashboards")
+
+        assert captured_headers["user-agent"].startswith("mixpanel-headless/")
+
+    def test_user_agent_set_on_export_stream(self, test_credentials: Session) -> None:
+        """Streaming export requests carry the library User-Agent."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(
+                200, content=b'{"event":"A","properties":{"time":1}}\n'
+            )
+
+        with create_mock_client(test_credentials, handler) as client:
+            list(client.export_events("2024-01-01", "2024-01-31"))
+
+        assert captured_headers["user-agent"].startswith("mixpanel-headless/")
+
+    def test_user_agent_reflects_cli_entry_point(
+        self, test_credentials: Session
+    ) -> None:
+        """After set_entry_point("cli"), outbound UA tags entry=cli."""
+        from mixpanel_headless._internal.client_metadata import set_entry_point
+
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json=["event1"])
+
+        set_entry_point("cli")
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert "entry=cli" in captured_headers["user-agent"]
+
+    def test_session_headers_override_user_agent(self) -> None:
+        """Session.headers wins over the default User-Agent."""
+        from mixpanel_headless._internal.auth.session import Project
+
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json=["event1"])
+
+        session = Session(
+            account=ServiceAccount(
+                name="team",
+                region="us",
+                username="team.sa",
+                secret=SecretStr("team-secret"),
+            ),
+            project=Project(id="12345"),
+            headers={"User-Agent": "custom-tester/1.0"},
+        )
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(session=session, _transport=transport)
+        with client:
+            client.get_events()
+
+        assert captured_headers["user-agent"] == "custom-tester/1.0"
+
+    def test_mp_custom_header_can_override_user_agent(
+        self,
+        test_credentials: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MP_CUSTOM_HEADER_* env can override the default User-Agent."""
+        monkeypatch.setenv("MP_CUSTOM_HEADER_NAME", "User-Agent")
+        monkeypatch.setenv("MP_CUSTOM_HEADER_VALUE", "env-ua/2.0")
+
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json=["event1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events()
+
+        assert captured_headers["user-agent"] == "env-ua/2.0"
+
+    def test_caller_extra_header_overrides_default_user_agent(
+        self, test_credentials: Session
+    ) -> None:
+        """Caller-supplied User-Agent via request() wins over the default."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={})
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.request(
+                "GET",
+                "https://mixpanel.com/api/app/test",
+                headers={"User-Agent": "caller-ua/3.0"},
+            )
+
+        assert captured_headers["user-agent"] == "caller-ua/3.0"

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -6,6 +6,7 @@ Tests use httpx.MockTransport for deterministic HTTP mocking.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 import httpx
@@ -2960,7 +2961,7 @@ class TestClientIdentificationHeaders:
     """User-Agent stamping on every outbound request path."""
 
     @pytest.fixture(autouse=True)
-    def _reset_entry_point(self) -> Any:
+    def _reset_entry_point(self) -> Iterator[None]:
         """Force ``"lib"`` for each test, then restore the prior value.
 
         Other test modules may import ``cli.main``, which flips the

--- a/tests/unit/test_client_metadata.py
+++ b/tests/unit/test_client_metadata.py
@@ -1,0 +1,105 @@
+"""Unit tests for the client_metadata helper module."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from mixpanel_headless import __version__
+from mixpanel_headless._internal import client_metadata
+from mixpanel_headless._internal.client_metadata import (
+    QUERY_ORIGIN,
+    get_entry_point,
+    get_user_agent,
+    set_entry_point,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_entry_point() -> Iterator[None]:
+    """Force ``"lib"`` for each test, then restore the prior value.
+
+    The entry point is a process-wide constant that any prior CLI import
+    (in this test session or another) may have flipped to ``"cli"``. To
+    keep these tests deterministic, set ``"lib"`` at start; restore the
+    original at end so test ordering can't leak state out.
+    """
+    original = get_entry_point()
+    set_entry_point("lib")
+    yield
+    set_entry_point(original)
+
+
+class TestQueryOrigin:
+    """Static constant used to attribute Query API traffic."""
+
+    def test_query_origin_value(self) -> None:
+        """QUERY_ORIGIN identifies this library."""
+        assert QUERY_ORIGIN == "mixpanel-headless"
+
+
+class TestEntryPoint:
+    """Entry-point flag flipped by the CLI on startup."""
+
+    def test_default_entry_point_is_lib(self) -> None:
+        """Library callers see entry=lib by default."""
+        assert get_entry_point() == "lib"
+
+    def test_set_entry_point_to_cli(self) -> None:
+        """CLI startup flips the entry point."""
+        set_entry_point("cli")
+        assert get_entry_point() == "cli"
+
+    def test_set_entry_point_round_trip(self) -> None:
+        """Flipping cli then back to lib restores the default."""
+        set_entry_point("cli")
+        set_entry_point("lib")
+        assert get_entry_point() == "lib"
+
+
+class TestUserAgent:
+    """User-Agent string composition."""
+
+    def test_user_agent_starts_with_package_name(self) -> None:
+        """User-Agent leads with the package name and version."""
+        ua = get_user_agent()
+        assert ua.startswith(f"mixpanel-headless/{__version__}")
+
+    def test_user_agent_includes_entry_tag(self) -> None:
+        """User-Agent surfaces the current entry point."""
+        set_entry_point("lib")
+        assert "entry=lib" in get_user_agent()
+        set_entry_point("cli")
+        assert "entry=cli" in get_user_agent()
+
+    def test_user_agent_includes_python_version(self) -> None:
+        """User-Agent surfaces the running Python's major.minor."""
+        py = f"python/{sys.version_info.major}.{sys.version_info.minor}"
+        assert py in get_user_agent()
+
+    def test_user_agent_format(self) -> None:
+        """Full format matches: name/ver (entry=...; python/x.y)."""
+        set_entry_point("lib")
+        py = f"{sys.version_info.major}.{sys.version_info.minor}"
+        expected = f"mixpanel-headless/{__version__} (entry=lib; python/{py})"
+        assert get_user_agent() == expected
+
+    def test_user_agent_reflects_entry_point_flip(self) -> None:
+        """A flip after import is reflected on the next call (no caching)."""
+        set_entry_point("lib")
+        first = get_user_agent()
+        set_entry_point("cli")
+        second = get_user_agent()
+        assert first != second
+        assert "entry=lib" in first
+        assert "entry=cli" in second
+
+
+class TestModuleStateIsolation:
+    """The autouse fixture must force ``"lib"`` regardless of prior state."""
+
+    def test_fixture_forces_lib_during_test(self) -> None:
+        """During a test body, the entry point is ``"lib"``."""
+        assert client_metadata.get_entry_point() == "lib"


### PR DESCRIPTION
## Summary

- Add `User-Agent: mixpanel-headless/<version> (entry=<lib|cli>; python/<x.y>)` to every outbound request so downstream telemetry can attribute traffic to this library. Single source of truth lives in `_internal/client_metadata.py`; the CLI flips the entry tag on import.
- Replace the hard-coded `query_origin` literal at the request-injection site with the `QUERY_ORIGIN` constant from the same module.
- Existing override chain preserved end-to-end: `MP_CUSTOM_HEADER_*` env, `Session.headers`, and caller-supplied `extra` all override the User-Agent default.

## Test plan

- [x] `just check` green locally (6384 passed, 92.17% coverage, build artifacts produced)
- [x] `TestClientIdentificationHeaders` covers User-Agent on standard, app-API, and streaming paths plus the override chain
- [x] `tests/unit/test_client_metadata.py` covers the helper module (entry-point flip, UA format, deterministic restoration via fixture)
- [ ] Smoke against a real account: `uv run mp query segmentation -e Login --from 2024-01-01 --to 2024-12-31`
- [ ] Confirm via httpx debug log that User-Agent reports `entry=cli` from the CLI and `entry=lib` from a Python REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
