### PR TITLE
Widen events() listing defaults + retry on date-range 403

### DIFF
--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -1896,21 +1896,23 @@ class MixpanelAPIClient:
     ) -> list[str]:
         """List event names in the project.
 
-        Defaults aim at the widest possible window: ``limit`` is the
-        server-side ceiling (5000), ``from_date`` reaches back to the
-        Unix epoch, and ``to_date`` is today. The Mixpanel
-        ``/events/names`` endpoint is gated by the per-project
-        ``max_data_history_days`` feature; if the wide ``from_date`` is
-        rejected with HTTP 403, the failing response carries a
-        "Date range exceeds N days into the past" message, and this
-        method automatically retries with ``today - N days``.
+        Defaults aim at the widest window the endpoint will accept:
+        ``limit`` is the server-side ceiling (5000), ``from_date`` is
+        ``2000-01-01`` (the earliest year the API accepts — pre-2000
+        values come back as ``"invalid date, bad year"``), and
+        ``to_date`` is today (UTC). The ``/events/names`` endpoint is
+        gated by the per-project ``max_data_history_days`` feature; if
+        the wide ``from_date`` is rejected with HTTP 403 "Date range
+        exceeds N days into the past", this method automatically
+        retries once with ``today - N days``.
 
         Args:
             limit: Maximum events to return. Capped server-side at
                 5000; values above are silently clamped.
             from_date: ``YYYY-MM-DD`` lower bound. Defaults to
-                ``1970-01-01`` and falls back to the project's
-                ``max_data_history_days`` ceiling when rejected.
+                ``2000-01-01`` (the API's earliest accepted year) and
+                falls back to the project's ``max_data_history_days``
+                ceiling when rejected.
             to_date: ``YYYY-MM-DD`` upper bound. Defaults to today
                 (UTC).
 
@@ -1923,8 +1925,10 @@ class MixpanelAPIClient:
                 any other 4xx the endpoint emits.
         """
         url = self._build_url("query", "/events/names")
-        resolved_from = from_date or self._EVENTS_NAMES_WIDE_FROM_DATE
-        resolved_to = to_date or date.today().isoformat()
+        resolved_from = (
+            from_date if from_date is not None else self._EVENTS_NAMES_WIDE_FROM_DATE
+        )
+        resolved_to = to_date if to_date is not None else date.today().isoformat()
         params: dict[str, Any] = {
             "type": "general",
             "limit": limit,
@@ -1935,7 +1939,7 @@ class MixpanelAPIClient:
             response = self._request("GET", url, params=params)
         except QueryError as exc:
             match = re.search(r"exceeds\s+(\d+)\s+days", str(exc))
-            if not match or from_date is not None:
+            if not match or from_date is not None or exc.status_code != 403:
                 raise
             allowed_days = int(match.group(1))
             params["from_date"] = (

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -1900,9 +1900,9 @@ class MixpanelAPIClient:
         ``limit`` is the server-side ceiling (5000), ``from_date`` is
         ``2000-01-01`` (the earliest year the API accepts — pre-2000
         values come back as ``"invalid date, bad year"``), and
-        ``to_date`` is today (UTC). The ``/events/names`` endpoint is
-        gated by the per-project ``max_data_history_days`` feature; if
-        the wide ``from_date`` is rejected with HTTP 403 "Date range
+        ``to_date`` is today. The ``/events/names`` endpoint is gated
+        by the per-project ``max_data_history_days`` feature; if the
+        wide ``from_date`` is rejected with HTTP 403 "Date range
         exceeds N days into the past", this method automatically
         retries once with ``today - N days``.
 
@@ -1914,7 +1914,8 @@ class MixpanelAPIClient:
                 falls back to the project's ``max_data_history_days``
                 ceiling when rejected.
             to_date: ``YYYY-MM-DD`` upper bound. Defaults to today
-                (UTC).
+                (system local date, consistent with the rest of the
+                library's date-default convention).
 
         Returns:
             List of event name strings.
@@ -1925,10 +1926,14 @@ class MixpanelAPIClient:
                 any other 4xx the endpoint emits.
         """
         url = self._build_url("query", "/events/names")
+        # Capture today once so the initial to_date and the retry's
+        # from_date can't diverge if the host crosses midnight between
+        # the two requests.
+        today = date.today()
         resolved_from = (
             from_date if from_date is not None else self._EVENTS_NAMES_WIDE_FROM_DATE
         )
-        resolved_to = to_date if to_date is not None else date.today().isoformat()
+        resolved_to = to_date if to_date is not None else today.isoformat()
         params: dict[str, Any] = {
             "type": "general",
             "limit": limit,
@@ -1938,13 +1943,18 @@ class MixpanelAPIClient:
         try:
             response = self._request("GET", url, params=params)
         except QueryError as exc:
+            # Matches the per-project lookback gate error text observed
+            # at the time of writing: "Date range exceeds N days into
+            # the past". Kept loose (no anchor on "Date range" / "into
+            # the past") so minor rewordings don't silently disable the
+            # retry. Combined with the status_code == 403 gate and the
+            # from_date is None short-circuit, false positives are not
+            # constructable from any other known backend code path.
             match = re.search(r"exceeds\s+(\d+)\s+days", str(exc))
             if not match or from_date is not None or exc.status_code != 403:
                 raise
             allowed_days = int(match.group(1))
-            params["from_date"] = (
-                date.today() - timedelta(days=allowed_days)
-            ).isoformat()
+            params["from_date"] = (today - timedelta(days=allowed_days)).isoformat()
             response = self._request("GET", url, params=params)
         if isinstance(response, list):
             return [str(e) for e in response]

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -16,9 +16,10 @@ import json
 import logging
 import os
 import random
+import re
 import time
 from collections.abc import Callable, Iterator
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote
 
@@ -1875,18 +1876,72 @@ class MixpanelAPIClient:
     # Discovery API
     # =========================================================================
 
-    def get_events(self) -> list[str]:
-        """List all event names in the project.
+    # Server-side ceiling on the /events/names ``limit`` parameter;
+    # higher values are silently clamped server-side.
+    _EVENTS_NAMES_MAX_LIMIT = 5000
+    # Widest ``from_date`` the server accepts — pre-2000 dates are
+    # rejected with "Error in from_date: invalid date, bad year". On
+    # projects whose ``max_data_history_days`` window is shorter than
+    # (today − 2000-01-01), the resulting 403 ("Date range exceeds N
+    # days into the past") triggers a single retry with
+    # ``today − N days``.
+    _EVENTS_NAMES_WIDE_FROM_DATE = "2000-01-01"
+
+    def get_events(
+        self,
+        *,
+        limit: int = _EVENTS_NAMES_MAX_LIMIT,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[str]:
+        """List event names in the project.
+
+        Defaults aim at the widest possible window: ``limit`` is the
+        server-side ceiling (5000), ``from_date`` reaches back to the
+        Unix epoch, and ``to_date`` is today. The Mixpanel
+        ``/events/names`` endpoint is gated by the per-project
+        ``max_data_history_days`` feature; if the wide ``from_date`` is
+        rejected with HTTP 403, the failing response carries a
+        "Date range exceeds N days into the past" message, and this
+        method automatically retries with ``today - N days``.
+
+        Args:
+            limit: Maximum events to return. Capped server-side at
+                5000; values above are silently clamped.
+            from_date: ``YYYY-MM-DD`` lower bound. Defaults to
+                ``1970-01-01`` and falls back to the project's
+                ``max_data_history_days`` ceiling when rejected.
+            to_date: ``YYYY-MM-DD`` upper bound. Defaults to today
+                (UTC).
 
         Returns:
             List of event name strings.
 
         Raises:
             AuthenticationError: Invalid credentials.
+            QueryError: 403 errors unrelated to date-range gating, or
+                any other 4xx the endpoint emits.
         """
         url = self._build_url("query", "/events/names")
-        response = self._request("GET", url, params={"type": "general"})
-        # Response is a list of event names
+        resolved_from = from_date or self._EVENTS_NAMES_WIDE_FROM_DATE
+        resolved_to = to_date or date.today().isoformat()
+        params: dict[str, Any] = {
+            "type": "general",
+            "limit": limit,
+            "from_date": resolved_from,
+            "to_date": resolved_to,
+        }
+        try:
+            response = self._request("GET", url, params=params)
+        except QueryError as exc:
+            match = re.search(r"exceeds\s+(\d+)\s+days", str(exc))
+            if not match or from_date is not None:
+                raise
+            allowed_days = int(match.group(1))
+            params["from_date"] = (
+                date.today() - timedelta(days=allowed_days)
+            ).isoformat()
+            response = self._request("GET", url, params=params)
         if isinstance(response, list):
             return [str(e) for e in response]
         return []

--- a/src/mixpanel_headless/_internal/services/discovery.py
+++ b/src/mixpanel_headless/_internal/services/discovery.py
@@ -408,17 +408,18 @@ class DiscoveryService:
     ) -> list[str]:
         """List event names in the project.
 
-        Defaults to the widest range supported by the underlying
-        ``/events/names`` endpoint (``limit=5000``, ``from_date``
-        reaching back to the Unix epoch, ``to_date=today``). Results
-        for each unique ``(limit, from_date, to_date)`` triple are
-        cached separately for the lifetime of this service instance.
+        Defaults to the widest range the underlying ``/events/names``
+        endpoint will accept (``limit=5000``, ``from_date=2000-01-01``
+        — the API's earliest accepted year — and ``to_date=today``).
+        Results for each unique ``(limit, from_date, to_date)`` triple
+        are cached separately for the lifetime of this service
+        instance.
 
         Args:
             limit: Maximum events to return. ``None`` defers to the
                 API client's default (5000, the server-side ceiling).
             from_date: ``YYYY-MM-DD`` lower bound. ``None`` defers to
-                the API client's wide default.
+                the API client's default of ``2000-01-01``.
             to_date: ``YYYY-MM-DD`` upper bound. ``None`` defers to
                 the API client's default (today).
 

--- a/src/mixpanel_headless/_internal/services/discovery.py
+++ b/src/mixpanel_headless/_internal/services/discovery.py
@@ -428,6 +428,8 @@ class DiscoveryService:
 
         Raises:
             AuthenticationError: Invalid credentials.
+            QueryError: 403 errors unrelated to date-range gating, or
+                any other 4xx the ``/events/names`` endpoint emits.
         """
         cache_key: tuple[str | int | None, ...] = (
             "list_events",

--- a/src/mixpanel_headless/_internal/services/discovery.py
+++ b/src/mixpanel_headless/_internal/services/discovery.py
@@ -399,23 +399,52 @@ class DiscoveryService:
         # Internal cache: tuple keys map to cached results
         self._cache: dict[tuple[str | int | None, ...], list[Any]] = {}
 
-    def list_events(self) -> list[str]:
-        """List all event names in the project.
+    def list_events(
+        self,
+        *,
+        limit: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[str]:
+        """List event names in the project.
+
+        Defaults to the widest range supported by the underlying
+        ``/events/names`` endpoint (``limit=5000``, ``from_date``
+        reaching back to the Unix epoch, ``to_date=today``). Results
+        for each unique ``(limit, from_date, to_date)`` triple are
+        cached separately for the lifetime of this service instance.
+
+        Args:
+            limit: Maximum events to return. ``None`` defers to the
+                API client's default (5000, the server-side ceiling).
+            from_date: ``YYYY-MM-DD`` lower bound. ``None`` defers to
+                the API client's wide default.
+            to_date: ``YYYY-MM-DD`` upper bound. ``None`` defers to
+                the API client's default (today).
 
         Returns:
             Alphabetically sorted list of event names.
 
         Raises:
             AuthenticationError: Invalid credentials.
-
-        Note:
-            Results are cached for the lifetime of this service instance.
         """
-        cache_key = ("list_events",)
+        cache_key: tuple[str | int | None, ...] = (
+            "list_events",
+            limit,
+            from_date,
+            to_date,
+        )
         if cache_key in self._cache:
             return list(self._cache[cache_key])
 
-        result = self._api_client.get_events()
+        kwargs: dict[str, Any] = {}
+        if limit is not None:
+            kwargs["limit"] = limit
+        if from_date is not None:
+            kwargs["from_date"] = from_date
+        if to_date is not None:
+            kwargs["to_date"] = to_date
+        result = self._api_client.get_events(**kwargs)
         sorted_result = sorted(result)
         self._cache[cache_key] = sorted_result
         return list(sorted_result)

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -974,6 +974,8 @@ class Workspace:
         Raises:
             ConfigError: If API credentials not available.
             AuthenticationError: If credentials are invalid.
+            QueryError: 403 errors unrelated to date-range gating, or
+                any other 4xx the ``/events/names`` endpoint emits.
         """
         return self._discovery_service.list_events(
             limit=limit,

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -943,12 +943,13 @@ class Workspace:
 
         Defaults to the widest window the underlying
         ``/events/names`` endpoint will accept: ``limit=5000`` (the
-        server-side ceiling), ``from_date`` reaching back to the Unix
-        epoch, and ``to_date`` set to today. The endpoint is gated by
-        the per-project ``max_data_history_days`` feature; if the
-        wide ``from_date`` is rejected (HTTP 403, "Date range exceeds
-        N days into the past"), the call automatically retries with
-        ``today - N days``.
+        server-side ceiling), ``from_date=2000-01-01`` (the API's
+        earliest accepted year — pre-2000 values come back as
+        ``"invalid date, bad year"``), and ``to_date`` set to today.
+        The endpoint is gated by the per-project
+        ``max_data_history_days`` feature; if the wide ``from_date``
+        is rejected (HTTP 403, "Date range exceeds N days into the
+        past"), the call automatically retries with ``today - N days``.
 
         Note that this method reflects events seen during the queried
         window — it is not the schema registry. Events that were
@@ -962,8 +963,8 @@ class Workspace:
         Args:
             limit: Maximum events to return. Defaults to the
                 server-side ceiling (5000).
-            from_date: ``YYYY-MM-DD`` lower bound. Defaults to a wide
-                value that will fall back to the project's
+            from_date: ``YYYY-MM-DD`` lower bound. Defaults to
+                ``2000-01-01`` and falls back to the project's
                 ``max_data_history_days`` ceiling on rejection.
             to_date: ``YYYY-MM-DD`` upper bound. Defaults to today.
 

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -932,10 +932,40 @@ class Workspace:
     # DISCOVERY METHODS
     # =========================================================================
 
-    def events(self) -> list[str]:
-        """List all event names in the Mixpanel project.
+    def events(
+        self,
+        *,
+        limit: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[str]:
+        """List event names in the Mixpanel project.
 
-        Results are cached for the lifetime of the Workspace.
+        Defaults to the widest window the underlying
+        ``/events/names`` endpoint will accept: ``limit=5000`` (the
+        server-side ceiling), ``from_date`` reaching back to the Unix
+        epoch, and ``to_date`` set to today. The endpoint is gated by
+        the per-project ``max_data_history_days`` feature; if the
+        wide ``from_date`` is rejected (HTTP 403, "Date range exceeds
+        N days into the past"), the call automatically retries with
+        ``today - N days``.
+
+        Note that this method reflects events seen during the queried
+        window — it is not the schema registry. Events that were
+        registered in Lexicon but never fired in the window are
+        absent. For the full registered schema, use the Lexicon
+        endpoints (e.g. :meth:`get_event_definitions`).
+
+        Results are cached per ``(limit, from_date, to_date)`` triple
+        for the lifetime of the Workspace.
+
+        Args:
+            limit: Maximum events to return. Defaults to the
+                server-side ceiling (5000).
+            from_date: ``YYYY-MM-DD`` lower bound. Defaults to a wide
+                value that will fall back to the project's
+                ``max_data_history_days`` ceiling on rejection.
+            to_date: ``YYYY-MM-DD`` upper bound. Defaults to today.
 
         Returns:
             Alphabetically sorted list of event names.
@@ -944,7 +974,11 @@ class Workspace:
             ConfigError: If API credentials not available.
             AuthenticationError: If credentials are invalid.
         """
-        return self._discovery_service.list_events()
+        return self._discovery_service.list_events(
+            limit=limit,
+            from_date=from_date,
+            to_date=to_date,
+        )
 
     def properties(self, event: str) -> list[str]:
         """List all property names for an event.

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -6,6 +6,7 @@ Tests use httpx.MockTransport for deterministic HTTP mocking.
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 from typing import Any
 
 import httpx
@@ -765,8 +766,6 @@ class TestDiscovery:
         self, test_credentials: Session
     ) -> None:
         """A 403 'Date range exceeds N days' should retry with today - N days."""
-        from datetime import date, timedelta
-
         captured_from_dates: list[str] = []
         call_count = 0
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -831,6 +831,54 @@ class TestDiscovery:
 
         assert call_count == 1
 
+    def test_get_events_does_not_retry_on_non_403_with_matching_text(
+        self, test_credentials: Session
+    ) -> None:
+        """A 400 whose message coincidentally matches the gate text must not retry.
+
+        Guards against an over-eager retry triggered by any QueryError whose
+        message happens to contain ``exceeds N days``.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(
+                400,
+                json={"error": "Query exceeds 90 days lookback in custom filter"},
+            )
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(QueryError),
+        ):
+            client.get_events()
+
+        assert call_count == 1
+
+    def test_get_events_empty_string_from_date_is_not_replaced(
+        self, test_credentials: Session
+    ) -> None:
+        """``from_date=""`` is passed through as-is, not silently defaulted.
+
+        Locks the ``is None`` check: callers who pass a falsy-but-non-None
+        value should get whatever the server returns (probably a 400), not
+        the library's default ``2000-01-01``.
+        """
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json=[])
+
+        with create_mock_client(test_credentials, handler) as client:
+            client.get_events(from_date="", to_date="")
+
+        assert captured_params["from_date"] == ""
+        assert captured_params["to_date"] == ""
+
     def test_get_event_properties(self, test_credentials: Session) -> None:
         """Should list event properties from /events/properties/top endpoint."""
         captured_params: dict[str, Any] = {}

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -723,7 +723,7 @@ class TestDiscovery:
     """Test discovery APIs (US5)."""
 
     def test_get_events(self, test_credentials: Session) -> None:
-        """Should list events with type=general parameter."""
+        """Should list events with widest defaults (type=general, limit=5000, wide date range)."""
         captured_params: dict[str, Any] = {}
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -736,6 +736,100 @@ class TestDiscovery:
 
         assert events == ["event1", "event2", "event3"]
         assert captured_params["type"] == "general"
+        assert captured_params["limit"] == "5000"
+        assert captured_params["from_date"] == "2000-01-01"
+        # to_date defaults to today; just assert it's present and well-formed.
+        assert "to_date" in captured_params
+        assert len(captured_params["to_date"]) == 10
+
+    def test_get_events_caller_overrides(self, test_credentials: Session) -> None:
+        """Caller-supplied limit/from_date/to_date should override the wide defaults."""
+        captured_params: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for key, value in request.url.params.items():
+                captured_params[key] = value
+            return httpx.Response(200, json=["a", "b"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            events = client.get_events(
+                limit=42, from_date="2024-01-01", to_date="2024-12-31"
+            )
+
+        assert events == ["a", "b"]
+        assert captured_params["limit"] == "42"
+        assert captured_params["from_date"] == "2024-01-01"
+        assert captured_params["to_date"] == "2024-12-31"
+
+    def test_get_events_falls_back_on_date_range_403(
+        self, test_credentials: Session
+    ) -> None:
+        """A 403 'Date range exceeds N days' should retry with today - N days."""
+        from datetime import date, timedelta
+
+        captured_from_dates: list[str] = []
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            captured_from_dates.append(request.url.params["from_date"])
+            if call_count == 1:
+                return httpx.Response(
+                    403,
+                    json={"error": "Date range exceeds 90 days into the past"},
+                )
+            return httpx.Response(200, json=["e1"])
+
+        with create_mock_client(test_credentials, handler) as client:
+            events = client.get_events()
+
+        assert events == ["e1"]
+        assert call_count == 2
+        assert captured_from_dates[0] == "2000-01-01"
+        expected_retry = (date.today() - timedelta(days=90)).isoformat()
+        assert captured_from_dates[1] == expected_retry
+
+    def test_get_events_does_not_retry_when_caller_set_from_date(
+        self, test_credentials: Session
+    ) -> None:
+        """Explicit from_date should not be silently overridden on a 403."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(
+                403,
+                json={"error": "Date range exceeds 30 days into the past"},
+            )
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(QueryError),
+        ):
+            client.get_events(from_date="1999-01-01")
+
+        assert call_count == 1
+
+    def test_get_events_does_not_retry_on_unrelated_403(
+        self, test_credentials: Session
+    ) -> None:
+        """A 403 unrelated to the date-range gate should propagate as QueryError."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(403, json={"error": "Permission denied"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(QueryError),
+        ):
+            client.get_events()
+
+        assert call_count == 1
 
     def test_get_event_properties(self, test_credentials: Session) -> None:
         """Should list event properties from /events/properties/top endpoint."""

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -173,6 +173,60 @@ class TestListEvents:
 
         assert events == []
 
+    def test_list_events_caches_per_args_triple(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """Cache key is the (limit, from_date, to_date) triple.
+
+        Calls with the same triple share a cache slot; calls with
+        different triples each hit the API.
+        """
+        call_count = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=[f"E{call_count}"])
+
+        discovery = discovery_factory(handler)
+
+        discovery.list_events(limit=10)
+        discovery.list_events(limit=10)
+        assert call_count == 1  # second call cached
+
+        discovery.list_events(limit=20)
+        assert call_count == 2  # different triple, new HTTP call
+
+        discovery.list_events()  # all-None triple, distinct from above
+        assert call_count == 3
+
+    def test_list_events_forwards_kwargs_to_api_client(
+        self,
+        discovery_factory: Callable[
+            [Callable[[httpx.Request], httpx.Response]], DiscoveryService
+        ],
+    ) -> None:
+        """Caller-supplied limit/from_date/to_date reach the outbound request.
+
+        Guards against accidental drop of the kwargs-filtering block.
+        """
+        captured_params: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            for k, v in request.url.params.items():
+                captured_params[k] = v
+            return httpx.Response(200, json=["e1"])
+
+        discovery = discovery_factory(handler)
+        discovery.list_events(limit=7, from_date="2024-01-01", to_date="2024-12-31")
+
+        assert captured_params["limit"] == "7"
+        assert captured_params["from_date"] == "2024-01-01"
+        assert captured_params["to_date"] == "2024-12-31"
+
 
 # =============================================================================
 # User Story 2: list_properties() Tests


### PR DESCRIPTION
## Summary

- `Workspace.events()` / `DiscoveryService.list_events()` / `MixpanelAPIClient.get_events()` now default to the widest window the `/events/names` endpoint will accept: `limit=5000` (server-side ceiling), `from_date=2000-01-01`, `to_date=today`. Callers can still pass any of the three to narrow the window.
- On HTTP 403 "Date range exceeds N days into the past" (driven by `max_data_history_days`), the call retries once with `today - N days` parsed from the error.
- Explicit caller-supplied `from_date` is never silently overridden. Unrelated 403s propagate as `QueryError`.
- `DiscoveryService` caches results per `(limit, from_date, to_date)` triple for the lifetime of the service.

## Test plan

- [x] `just check` green locally (6371 passed, 92.14% coverage, build artifacts produced)
- [x] `test_get_events` locks the wide defaults (`limit=5000`, `from_date=2000-01-01`, `to_date=today`)
- [x] `test_get_events_caller_overrides` confirms caller params win over the defaults
- [x] `test_get_events_falls_back_on_date_range_403` confirms the retry with `today - N days`
- [x] `test_get_events_does_not_retry_when_caller_set_from_date` confirms explicit `from_date` is preserved on 403
- [x] `test_get_events_does_not_retry_on_unrelated_403` confirms only date-range 403s trigger the retry
- [ ] Smoke against a real account with a short data-history window: `uv run mp inspect events` should return up to 5000 events without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
