### PR TITLE
Reject symlinks on credential file reads (SEC-331)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dev = [
     "pandas-stubs>=2.0",
     "mutmut>=3.0",
     "interrogate>=1.7",
+    "psutil>=7.2.0",
+    "types-psutil>=7.2.0.20251228",
 ]
 docs = [
     "mkdocs>=1.5",

--- a/src/mixpanel_headless/_internal/auth/bridge.py
+++ b/src/mixpanel_headless/_internal/auth/bridge.py
@@ -48,7 +48,10 @@ from mixpanel_headless._internal.auth.account import (
 )
 from mixpanel_headless._internal.auth.storage import account_dir
 from mixpanel_headless._internal.auth.token import OAuthTokens
-from mixpanel_headless._internal.io_utils import atomic_write_bytes
+from mixpanel_headless._internal.io_utils import (
+    atomic_write_bytes,
+    read_credential_text,
+)
 from mixpanel_headless.exceptions import ConfigError, OAuthError
 
 logger = logging.getLogger(__name__)
@@ -163,7 +166,7 @@ def load_bridge(path: Path | None = None) -> BridgeFile | None:
         if not candidate.exists():
             continue
         try:
-            payload = json.loads(candidate.read_text(encoding="utf-8"))
+            payload = json.loads(read_credential_text(candidate))
         except (OSError, json.JSONDecodeError) as exc:
             raise ConfigError(
                 f"Could not read bridge file at {candidate}: {exc}",
@@ -210,7 +213,7 @@ def _read_browser_tokens(name: str) -> OAuthTokens:
             details={"account_name": name, "path": str(path)},
         )
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(read_credential_text(path))
     except (OSError, json.JSONDecodeError) as exc:
         raise OAuthError(
             f"Could not read OAuth tokens for account '{name}' from {path}: {exc}",

--- a/src/mixpanel_headless/_internal/auth/bridge.py
+++ b/src/mixpanel_headless/_internal/auth/bridge.py
@@ -51,6 +51,7 @@ from mixpanel_headless._internal.auth.token import OAuthTokens
 from mixpanel_headless._internal.io_utils import (
     atomic_write_bytes,
     read_credential_text,
+    reject_if_symlink,
 )
 from mixpanel_headless.exceptions import ConfigError, OAuthError
 
@@ -163,6 +164,16 @@ def load_bridge(path: Path | None = None) -> BridgeFile | None:
         candidates.extend(default_bridge_search_paths())
 
     for candidate in candidates:
+        # Probe for a symlink BEFORE the existence check — Path.exists()
+        # follows symlinks and silently returns False for dangling
+        # links, hiding the attack signal.
+        try:
+            reject_if_symlink(candidate)
+        except OSError as exc:
+            raise ConfigError(
+                f"Could not read bridge file at {candidate}: {exc}",
+                details={"path": str(candidate)},
+            ) from exc
         if not candidate.exists():
             continue
         try:
@@ -205,6 +216,15 @@ def _read_browser_tokens(name: str) -> OAuthTokens:
             refresh attempt.
     """
     path = account_dir(name) / "tokens.json"
+    # Probe for symlink before existence check — see ``load_bridge``.
+    try:
+        reject_if_symlink(path)
+    except OSError as exc:
+        raise OAuthError(
+            f"Could not read OAuth tokens for account '{name}' from {path}: {exc}",
+            code="OAUTH_TOKEN_ERROR",
+            details={"account_name": name, "path": str(path)},
+        ) from exc
     if not path.exists():
         raise OAuthError(
             f"No OAuth tokens found for account '{name}' at {path}. "

--- a/src/mixpanel_headless/_internal/auth/storage.py
+++ b/src/mixpanel_headless/_internal/auth/storage.py
@@ -37,7 +37,11 @@ from typing import Any
 from pydantic import SecretStr
 
 from mixpanel_headless._internal.auth.token import OAuthClientInfo, OAuthTokens
-from mixpanel_headless._internal.io_utils import atomic_write_bytes
+from mixpanel_headless._internal.io_utils import (
+    CredentialPathError,
+    atomic_write_bytes,
+    read_credential_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -236,15 +240,35 @@ class OAuthStorage:
 
         Verifies that the storage directory has ``0o700`` permissions and
         the specified file has ``0o600`` permissions. Attempts to repair
-        incorrect permissions via ``os.chmod()``. Logs a warning to stderr
-        if repair fails.
+        incorrect permissions via ``os.chmod()``. Logs a warning if
+        repair fails.
+
+        Symlink handling: uses ``lstat`` and refuses to chmod through a
+        symlink. The chmod would otherwise operate on the symlink's
+        target, which an attacker controls by choosing where the
+        symlink points — turning a "fix permissions" routine into a
+        primitive that auto-tightens an attacker file to 0o600 right
+        before we read it. The read itself is later rejected by
+        :func:`read_credential_text` via ``O_NOFOLLOW``, so this
+        method just has to avoid leaving a chmod side effect on a
+        symlinked target.
 
         Args:
             path: File path whose permissions (and parent directory) to check.
         """
-        # Check directory permissions
-        if self._storage_dir.exists():
-            dir_mode = stat.S_IMODE(self._storage_dir.stat().st_mode)
+        # Check directory permissions. Use lstat so a symlinked storage dir
+        # doesn't get its target silently chmodded.
+        try:
+            dir_st = self._storage_dir.lstat()
+        except FileNotFoundError:
+            dir_st = None
+        if dir_st is not None and stat.S_ISLNK(dir_st.st_mode):
+            logger.warning(
+                "Refusing to chmod through symlinked storage directory %s.",
+                self._storage_dir,
+            )
+        elif dir_st is not None:
+            dir_mode = stat.S_IMODE(dir_st.st_mode)
             if dir_mode != 0o700:
                 try:
                     self._storage_dir.chmod(stat.S_IRWXU)
@@ -258,21 +282,32 @@ class OAuthStorage:
                         self._storage_dir,
                     )
 
-        # Check file permissions
-        if path.exists():
-            file_mode = stat.S_IMODE(path.stat().st_mode)
-            if file_mode != 0o600:
-                try:
-                    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-                except OSError:
-                    logger.warning(
-                        "Cannot repair file permissions on %s. "
-                        "Expected 0o600, got %s. "
-                        "Run: chmod 600 %s",
-                        path,
-                        oct(file_mode),
-                        path,
-                    )
+        # Check file permissions. lstat for the same reason as the dir branch.
+        try:
+            file_st = path.lstat()
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(file_st.st_mode):
+            logger.warning(
+                "Refusing to chmod through symlink at %s. "
+                "The subsequent read will reject the symlink and the cache "
+                "will be re-fetched.",
+                path,
+            )
+            return
+        file_mode = stat.S_IMODE(file_st.st_mode)
+        if file_mode != 0o600:
+            try:
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                logger.warning(
+                    "Cannot repair file permissions on %s. "
+                    "Expected 0o600, got %s. "
+                    "Run: chmod 600 %s",
+                    path,
+                    oct(file_mode),
+                    path,
+                )
 
     def _write_file(self, path: Path, data: dict[str, Any]) -> None:
         """Atomically write JSON data to ``path`` with mode ``0o600``.
@@ -307,8 +342,15 @@ class OAuthStorage:
             return None
         self._check_and_fix_permissions(path)
         try:
-            content = path.read_text(encoding="utf-8")
+            content = read_credential_text(path)
             parsed = json.loads(content)
+        except CredentialPathError as exc:
+            # Symlink or lax mode rejected by the read helper. WARNING
+            # (not the lower-severity "corrupted JSON" log below) so a
+            # symlink-attack signal isn't swallowed in the same-shape
+            # "ignore this file" path.
+            logger.warning("Refusing to read credential file %s: %s", path, exc)
+            return None
         except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
             logger.warning("Corrupted or invalid JSON in %s — ignoring file.", path)
             return None

--- a/src/mixpanel_headless/_internal/auth/storage.py
+++ b/src/mixpanel_headless/_internal/auth/storage.py
@@ -170,6 +170,10 @@ def _fchmod_no_follow(
             be applied (file vanished, permission denied, etc.).
         fallback_args: Args interpolated into ``fallback_message``.
     """
+    if not hasattr(os, "fchmod"):
+        # Windows / non-POSIX. POSIX modes have no meaning here;
+        # skip silently rather than crash with AttributeError.
+        return
     try:
         fd = os.open(str(path), open_flags)
     except OSError:
@@ -297,9 +301,18 @@ class OAuthStorage:
         method just has to avoid leaving a chmod side effect on a
         symlinked target.
 
+        Windows: POSIX modes don't apply; Windows uses ACLs. Skip
+        silently — ``os.O_NOFOLLOW``, ``os.O_DIRECTORY``, and
+        ``os.fchmod`` don't exist on the platform, and evaluating
+        their bitwise OR at the call site would raise
+        ``AttributeError`` before this function even runs.
+
         Args:
             path: File path whose permissions (and parent directory) to check.
         """
+        if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "fchmod"):
+            # Windows / non-POSIX. No-op.
+            return
         # Check directory permissions. Use lstat so a symlinked storage dir
         # doesn't get its target silently chmodded.
         try:
@@ -314,10 +327,13 @@ class OAuthStorage:
         elif dir_st is not None:
             dir_mode = stat.S_IMODE(dir_st.st_mode)
             if dir_mode != 0o700:
+                dir_open_flags = os.O_RDONLY | os.O_NOFOLLOW
+                if hasattr(os, "O_DIRECTORY"):
+                    dir_open_flags |= os.O_DIRECTORY
                 _fchmod_no_follow(
                     self._storage_dir,
                     stat.S_IRWXU,
-                    open_flags=os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    open_flags=dir_open_flags,
                     fallback_message=(
                         "Cannot repair directory permissions on %s. "
                         "Expected 0o700, got %s. Run: chmod 700 %s"

--- a/src/mixpanel_headless/_internal/auth/storage.py
+++ b/src/mixpanel_headless/_internal/auth/storage.py
@@ -41,6 +41,7 @@ from mixpanel_headless._internal.io_utils import (
     CredentialPathError,
     atomic_write_bytes,
     read_credential_text,
+    reject_if_symlink,
 )
 
 logger = logging.getLogger(__name__)
@@ -137,6 +138,52 @@ def ensure_account_dir(name: str) -> Path:
     # Defensive chmod so a pre-existing dir with looser permissions gets locked down.
     path.chmod(stat.S_IRWXU)
     return path
+
+
+def _fchmod_no_follow(
+    path: Path,
+    mode: int,
+    *,
+    open_flags: int,
+    fallback_message: str,
+    fallback_args: tuple[object, ...],
+) -> None:
+    """Chmod ``path`` to ``mode`` without following symlinks.
+
+    Opens ``path`` with ``open_flags`` (caller supplies the right
+    combination: ``O_RDONLY | O_NOFOLLOW`` for regular files,
+    ``O_RDONLY | O_DIRECTORY | O_NOFOLLOW`` for directories), then
+    applies ``mode`` via :func:`os.fchmod`. The fd pins the inode, so
+    the chmod is TOCTOU-free w.r.t. the open.
+
+    If the open fails because ``path`` became a symlink between the
+    earlier ``lstat`` and now (ELOOP, or ENOTDIR on macOS when paired
+    with ``O_DIRECTORY``), logs and returns. Other ``OSError``s emit
+    the ``fallback_message`` (matching the historic chmod-failure log
+    shape) so users get the same actionable message they did before.
+
+    Args:
+        path: File or directory to chmod.
+        mode: Target POSIX mode bits.
+        open_flags: ``os.open`` flags. Must include ``O_NOFOLLOW``.
+        fallback_message: Log format string used when chmod cannot
+            be applied (file vanished, permission denied, etc.).
+        fallback_args: Args interpolated into ``fallback_message``.
+    """
+    try:
+        fd = os.open(str(path), open_flags)
+    except OSError:
+        # Race: file disappeared or became a symlink. Bail without
+        # touching the target.
+        logger.warning(*((fallback_message,) + fallback_args))
+        return
+    try:
+        try:
+            os.fchmod(fd, mode)
+        except OSError:
+            logger.warning(*((fallback_message,) + fallback_args))
+    finally:
+        os.close(fd)
 
 
 class OAuthStorage:
@@ -240,15 +287,12 @@ class OAuthStorage:
 
         Verifies that the storage directory has ``0o700`` permissions and
         the specified file has ``0o600`` permissions. Attempts to repair
-        incorrect permissions via ``os.chmod()``. Logs a warning if
-        repair fails.
+        incorrect permissions via ``fchmod`` on an ``O_NOFOLLOW``-opened
+        fd (NOT ``path.chmod()``, which follows symlinks even after the
+        lstat check). The fd pins the inode, so the chmod is TOCTOU-free.
 
-        Symlink handling: uses ``lstat`` and refuses to chmod through a
-        symlink. The chmod would otherwise operate on the symlink's
-        target, which an attacker controls by choosing where the
-        symlink points — turning a "fix permissions" routine into a
-        primitive that auto-tightens an attacker file to 0o600 right
-        before we read it. The read itself is later rejected by
+        Symlink handling: uses ``lstat`` and refuses to even open a fd
+        through a symlink. The read itself is later rejected by
         :func:`read_credential_text` via ``O_NOFOLLOW``, so this
         method just has to avoid leaving a chmod side effect on a
         symlinked target.
@@ -270,17 +314,16 @@ class OAuthStorage:
         elif dir_st is not None:
             dir_mode = stat.S_IMODE(dir_st.st_mode)
             if dir_mode != 0o700:
-                try:
-                    self._storage_dir.chmod(stat.S_IRWXU)
-                except OSError:
-                    logger.warning(
+                _fchmod_no_follow(
+                    self._storage_dir,
+                    stat.S_IRWXU,
+                    open_flags=os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    fallback_message=(
                         "Cannot repair directory permissions on %s. "
-                        "Expected 0o700, got %s. "
-                        "Run: chmod 700 %s",
-                        self._storage_dir,
-                        oct(dir_mode),
-                        self._storage_dir,
-                    )
+                        "Expected 0o700, got %s. Run: chmod 700 %s"
+                    ),
+                    fallback_args=(self._storage_dir, oct(dir_mode), self._storage_dir),
+                )
 
         # Check file permissions. lstat for the same reason as the dir branch.
         try:
@@ -297,17 +340,16 @@ class OAuthStorage:
             return
         file_mode = stat.S_IMODE(file_st.st_mode)
         if file_mode != 0o600:
-            try:
-                path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                logger.warning(
+            _fchmod_no_follow(
+                path,
+                stat.S_IRUSR | stat.S_IWUSR,
+                open_flags=os.O_RDONLY | os.O_NOFOLLOW,
+                fallback_message=(
                     "Cannot repair file permissions on %s. "
-                    "Expected 0o600, got %s. "
-                    "Run: chmod 600 %s",
-                    path,
-                    oct(file_mode),
-                    path,
-                )
+                    "Expected 0o600, got %s. Run: chmod 600 %s"
+                ),
+                fallback_args=(path, oct(file_mode), path),
+            )
 
     def _write_file(self, path: Path, data: dict[str, Any]) -> None:
         """Atomically write JSON data to ``path`` with mode ``0o600``.
@@ -338,6 +380,13 @@ class OAuthStorage:
             Parsed dictionary, or None if the file does not exist or
             contains invalid/non-JSON data.
         """
+        # Probe for symlink before existence check — see the analogous
+        # pattern in ``me.MeCache.get`` and ``bridge.load_bridge``.
+        try:
+            reject_if_symlink(path)
+        except CredentialPathError as exc:
+            logger.warning("Refusing to read credential file %s: %s", path, exc)
+            return None
         if not path.exists():
             return None
         self._check_and_fix_permissions(path)

--- a/src/mixpanel_headless/_internal/auth/token_resolver.py
+++ b/src/mixpanel_headless/_internal/auth/token_resolver.py
@@ -29,7 +29,10 @@ from mixpanel_headless._internal.auth.account import (
 )
 from mixpanel_headless._internal.auth.storage import account_dir
 from mixpanel_headless._internal.auth.token import OAuthTokens, token_payload_bytes
-from mixpanel_headless._internal.io_utils import atomic_write_bytes
+from mixpanel_headless._internal.io_utils import (
+    atomic_write_bytes,
+    read_credential_bytes,
+)
 from mixpanel_headless.exceptions import OAuthError
 
 
@@ -100,7 +103,7 @@ class OnDiskTokenResolver(TokenResolver):
                 details={"account_name": name, "path": str(path)},
             )
         try:
-            raw = path.read_bytes()
+            raw = read_credential_bytes(path)
         except OSError as exc:
             raise OAuthError(
                 f"Could not read OAuth tokens for account '{name}' from {path}: {exc}",

--- a/src/mixpanel_headless/_internal/auth/token_resolver.py
+++ b/src/mixpanel_headless/_internal/auth/token_resolver.py
@@ -32,6 +32,7 @@ from mixpanel_headless._internal.auth.token import OAuthTokens, token_payload_by
 from mixpanel_headless._internal.io_utils import (
     atomic_write_bytes,
     read_credential_bytes,
+    reject_if_symlink,
 )
 from mixpanel_headless.exceptions import OAuthError
 
@@ -93,6 +94,21 @@ class OnDiskTokenResolver(TokenResolver):
                 without a refresh token, or refresh fails.
         """
         path = _account_tokens_path(name)
+        # Probe for symlink before existence check. A dangling symlink at
+        # this path would otherwise silently pass through ``exists()`` and
+        # then hit ``read_credential_bytes`` with no signal that the path
+        # itself was symlinked. ``reject_if_symlink`` raises
+        # ``CredentialPathError``, which the OSError catch below converts
+        # to ``OAuthError``.
+        try:
+            reject_if_symlink(path)
+        except OSError as exc:
+            raise OAuthError(
+                f"OAuth tokens path is a symlink at {path}: {exc}. "
+                f"Remove the symlink and re-run `mp account login {name}`.",
+                code="OAUTH_TOKEN_ERROR",
+                details={"account_name": name, "path": str(path)},
+            ) from exc
         if not path.exists():
             raise OAuthError(
                 (

--- a/src/mixpanel_headless/_internal/config.py
+++ b/src/mixpanel_headless/_internal/config.py
@@ -43,7 +43,10 @@ from mixpanel_headless._internal.auth.account import (
     ServiceAccount,
 )
 from mixpanel_headless._internal.auth.session import ActiveSession
-from mixpanel_headless._internal.io_utils import atomic_write_bytes
+from mixpanel_headless._internal.io_utils import (
+    atomic_write_bytes,
+    read_credential_text,
+)
 from mixpanel_headless.exceptions import (
     AccountInUseError,
     ConfigError,
@@ -172,7 +175,7 @@ class ConfigManager:
         if not self._path.exists():
             return {}
         try:
-            raw: dict[str, Any] = tomllib.loads(self._path.read_text(encoding="utf-8"))
+            raw: dict[str, Any] = tomllib.loads(read_credential_text(self._path))
         except (tomllib.TOMLDecodeError, OSError) as exc:
             raise ConfigError(f"Could not parse config at {self._path}: {exc}") from exc
         return raw

--- a/src/mixpanel_headless/_internal/config.py
+++ b/src/mixpanel_headless/_internal/config.py
@@ -46,6 +46,7 @@ from mixpanel_headless._internal.auth.session import ActiveSession
 from mixpanel_headless._internal.io_utils import (
     atomic_write_bytes,
     read_credential_text,
+    reject_if_symlink,
 )
 from mixpanel_headless.exceptions import (
     AccountInUseError,
@@ -172,6 +173,14 @@ class ConfigManager:
                 expected to delete the file and re-add via ``mp account
                 add``.
         """
+        # Probe for symlink BEFORE the existence check — Path.exists()
+        # follows symlinks and silently returns False for dangling links,
+        # hiding the attack signal. CredentialPathError surfaces as
+        # ConfigError below via the existing OSError catch.
+        try:
+            reject_if_symlink(self._path)
+        except OSError as exc:
+            raise ConfigError(f"Could not parse config at {self._path}: {exc}") from exc
         if not self._path.exists():
             return {}
         try:

--- a/src/mixpanel_headless/_internal/io_utils.py
+++ b/src/mixpanel_headless/_internal/io_utils.py
@@ -1,4 +1,4 @@
-"""Atomic on-disk write primitive + bounded stdin reader.
+"""Atomic on-disk write primitive, credential-read helpers, and bounded stdin reader.
 
 Every persisted credential / config write goes through
 :func:`atomic_write_bytes` so a SIGKILL or power loss between
@@ -12,6 +12,17 @@ guarantees atomicity-on-success, not survival across power loss
 mid-write. Adding ``fsync`` would cost 5–50 ms per CLI invocation
 for no win in the realistic failure modes for a desktop CLI.
 
+:func:`read_credential_bytes` / :func:`read_credential_text` are the
+read-side mirror. On POSIX they open with ``O_NOFOLLOW`` so the
+kernel refuses to traverse a symlink at the final path component,
+then verify via ``fstat`` that the file mode is owner-only. Same-UID
+symlink attacks (CI runners with shared ``$HOME``, container images
+with shared mounts, compromised local tooling running as the user)
+are the threat model — see :class:`CredentialPathError` for what
+gets raised and the helper docstrings for what's deliberately out of
+scope (hard links, intermediate-component symlinks under ``0o700``
+ancestors, attacker-controlled ``$HOME``).
+
 :func:`read_capped_secret_from_stdin` is the shared stdin reader for
 service-account secrets and OAuth bearers. The cap rejects multi-MB
 pastes (e.g. an SSH key piped by mistake) before the value reaches
@@ -20,14 +31,22 @@ the credential store.
 
 from __future__ import annotations
 
+import errno
 import os
+import stat
 import sys
 import threading
 from pathlib import Path
 
 from mixpanel_headless.exceptions import ConfigError
 
-__all__ = ["atomic_write_bytes", "read_capped_secret_from_stdin"]
+__all__ = [
+    "CredentialPathError",
+    "atomic_write_bytes",
+    "read_capped_secret_from_stdin",
+    "read_credential_bytes",
+    "read_credential_text",
+]
 
 
 SECRET_STDIN_MAX_BYTES = 64 * 1024
@@ -120,6 +139,170 @@ def atomic_write_bytes(path: Path, data: bytes, *, mode: int = 0o600) -> None:
     except BaseException:
         Path(tmp_path).unlink(missing_ok=True)
         raise
+
+
+class CredentialPathError(OSError):
+    """Raised when a credential file fails a structural safety check.
+
+    Subclass of :class:`OSError` so existing ``except OSError`` handlers
+    at the credential call sites (``config.py``, ``bridge.py``,
+    ``token_resolver.py``, ``storage.py``, ``me.py``) continue to catch
+    it and translate to their domain exceptions (``ConfigError``,
+    ``OAuthError``) without code changes. Call sites that want to
+    distinguish a deliberate refusal (symlink, lax mode) from incidental
+    I/O failure (missing file, EACCES on a legit file) can
+    ``except CredentialPathError`` separately and log at WARNING — the
+    silent-degradation sites in ``storage.py`` and ``me.py`` use this
+    distinction so a symlink-attack signal isn't lost in a
+    "corrupted cache, ignoring" path.
+    """
+
+
+def _open_credential_fd(path: Path) -> int:
+    """Open ``path`` read-only, refusing to traverse a final-component symlink.
+
+    On POSIX, uses ``os.open(O_RDONLY | O_NOFOLLOW)`` so the kernel
+    surfaces ``ELOOP`` when the final component is a symlink. We catch
+    that ``ELOOP`` and re-raise as :class:`CredentialPathError` with a
+    message naming the path explicitly so logs don't show the bare
+    "Too many levels of symbolic links" the kernel emits.
+
+    On platforms without ``O_NOFOLLOW`` (Windows), falls back to
+    :meth:`Path.is_symlink` before opening. TOCTOU-vulnerable in
+    theory; not in the threat model.
+
+    Args:
+        path: File to open.
+
+    Returns:
+        The open file descriptor. Caller MUST close.
+
+    Raises:
+        CredentialPathError: The final path component is a symlink.
+        FileNotFoundError: The path does not exist (non-symlink case).
+        OSError: Any other open failure (EACCES, EISDIR, ...).
+    """
+    if hasattr(os, "O_NOFOLLOW"):
+        try:
+            return os.open(str(path), os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise CredentialPathError(
+                    errno.ELOOP,
+                    f"Refusing to read credential at symlink: {path}",
+                    str(path),
+                ) from exc
+            raise
+    # Windows fallback. The ``is_symlink`` check is TOCTOU-vulnerable —
+    # an attacker could swap a regular file for a symlink between this
+    # check and the open. Windows is not in the threat model for the
+    # same-UID-attacker scenario (creating symlinks requires elevated
+    # privileges or developer mode), so we accept the residual risk.
+    if path.is_symlink():
+        raise CredentialPathError(
+            errno.ELOOP,
+            f"Refusing to read credential at symlink: {path}",
+            str(path),
+        )
+    return os.open(str(path), os.O_RDONLY)
+
+
+def _enforce_owner_only_mode(fd: int, path: Path) -> None:
+    """Raise ``CredentialPathError`` if the open file's mode has group/world bits.
+
+    The check runs on ``fstat(fd)``, NOT a fresh ``path.stat()``. The fd
+    pins the inode at the moment of open, so an attacker cannot swap
+    the file out from under the check — there is no TOCTOU window.
+
+    Skipped on platforms without :func:`os.fstat` mode semantics
+    (Windows reports a stub mode).
+
+    Args:
+        fd: Open file descriptor.
+        path: The path used at open time (for the error message only).
+
+    Raises:
+        CredentialPathError: Mode has any of the ``0o077`` bits set.
+    """
+    if not hasattr(os, "fchmod"):  # Windows proxy — no real POSIX mode.
+        return
+    file_mode = stat.S_IMODE(os.fstat(fd).st_mode)
+    if file_mode & 0o077:
+        raise CredentialPathError(
+            errno.EPERM,
+            (
+                f"Refusing to read credential with mode {oct(file_mode)} "
+                f"(group/world bits set): {path}"
+            ),
+            str(path),
+        )
+
+
+def read_credential_bytes(path: Path) -> bytes:
+    """Read bytes from ``path`` while refusing symlinks and lax modes.
+
+    POSIX: opens with ``O_NOFOLLOW`` so the kernel rejects a symlinked
+    final component (``ELOOP``); then ``fstat``s the fd and rejects any
+    file mode with the ``0o077`` bits set. Both rejections raise
+    :class:`CredentialPathError` (an :class:`OSError` subclass).
+
+    Out of scope:
+        - Hard links. ``O_NOFOLLOW`` does not detect them. A hard-link
+          attack requires write access to a directory in the target
+          path AND read access to the target file, which is strictly
+          stronger than the same-UID symlink threat we're defending.
+        - Intermediate symlinks in ancestor paths. Ancestor dirs are
+          managed at ``0o700`` by ``ensure_account_dir`` and
+          ``_ensure_dir``, which excludes the insertion vector.
+        - Attacker-controlled ``$HOME``. If :meth:`Path.home` itself
+          is influenced (some CI setups override ``$HOME``), the leaf
+          check is moot. That's a deployment posture, not an
+          in-process check.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file contents as bytes.
+
+    Raises:
+        CredentialPathError: ``path`` is a symlink, or the file mode
+            has group/world bits set.
+        FileNotFoundError: ``path`` does not exist (non-symlink case).
+        OSError: Any other I/O failure (EACCES, EISDIR, ...).
+    """
+    fd = _open_credential_fd(path)
+    try:
+        _enforce_owner_only_mode(fd, path)
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+def read_credential_text(path: Path, *, encoding: str = "utf-8") -> str:
+    """UTF-8 (by default) wrapper around :func:`read_credential_bytes`.
+
+    Args:
+        path: File to read.
+        encoding: Text encoding. Defaults to ``utf-8``; every credential
+            file in this codebase is UTF-8 by construction.
+
+    Returns:
+        Decoded file contents.
+
+    Raises:
+        CredentialPathError: ``path`` fails a structural safety check.
+        UnicodeDecodeError: File bytes are not valid in ``encoding``.
+        FileNotFoundError: ``path`` does not exist.
+        OSError: Any other I/O failure.
+    """
+    return read_credential_bytes(path).decode(encoding)
 
 
 def read_capped_secret_from_stdin() -> str:

--- a/src/mixpanel_headless/_internal/io_utils.py
+++ b/src/mixpanel_headless/_internal/io_utils.py
@@ -13,15 +13,17 @@ mid-write. Adding ``fsync`` would cost 5–50 ms per CLI invocation
 for no win in the realistic failure modes for a desktop CLI.
 
 :func:`read_credential_bytes` / :func:`read_credential_text` are the
-read-side mirror. On POSIX they open with ``O_NOFOLLOW`` so the
-kernel refuses to traverse a symlink at the final path component,
-then verify via ``fstat`` that the file mode is owner-only. Same-UID
-symlink attacks (CI runners with shared ``$HOME``, container images
-with shared mounts, compromised local tooling running as the user)
-are the threat model — see :class:`CredentialPathError` for what
-gets raised and the helper docstrings for what's deliberately out of
-scope (hard links, intermediate-component symlinks under ``0o700``
-ancestors, attacker-controlled ``$HOME``).
+read-side mirror. On POSIX they walk every path component with
+``openat(O_NOFOLLOW | O_CLOEXEC)`` so the kernel refuses to traverse
+a symlink at any component (final OR intermediate). After open, the
+fd is ``fstat``ed for three structural invariants: regular file
+(rejects FIFOs/devices), owner-only mode (no group/world bits), and
+size at most :data:`MAX_CREDENTIAL_BYTES`. Same-UID symlink attacks
+(CI runners with shared ``$HOME``, container images with shared
+mounts, compromised local tooling running as the user) are the
+threat model — see :class:`CredentialPathError` for what gets raised
+and the helper docstrings for what's deliberately out of scope (hard
+links, attacker-controlled ``$HOME``).
 
 :func:`read_capped_secret_from_stdin` is the shared stdin reader for
 service-account secrets and OAuth bearers. The cap rejects multi-MB
@@ -41,11 +43,13 @@ from pathlib import Path
 from mixpanel_headless.exceptions import ConfigError
 
 __all__ = [
+    "MAX_CREDENTIAL_BYTES",
     "CredentialPathError",
     "atomic_write_bytes",
     "read_capped_secret_from_stdin",
     "read_credential_bytes",
     "read_credential_text",
+    "reject_if_symlink",
 ]
 
 
@@ -56,6 +60,23 @@ Real service-account secrets are < 1 KiB and OAuth bearers are < 8 KiB.
 A larger payload is almost always the wrong file being piped — a key
 bundle, a JSON dump, a tarball. Reject loudly rather than silently
 swallowing it into a credential field.
+"""
+
+
+MAX_CREDENTIAL_BYTES = 1 << 20
+"""Hard ceiling on a credential file's size.
+
+Realistic credential files in this codebase:
+
+* ``config.toml`` — < 5 KB
+* per-account ``tokens.json`` — < 2 KB
+* per-region ``oauth/tokens_<region>.json`` and ``client_<region>.json`` — < 2 KB
+* per-account ``me.json`` — < 10 KB
+* Cowork bridge ``auth.json`` — < 5 KB
+
+1 MiB is 100× the largest realistic file. Anything larger is either
+a runaway write, a corrupted file, or an attacker-planted blob aimed
+at OOM-ing the CLI. Reject before reading the bytes.
 """
 
 
@@ -158,61 +179,219 @@ class CredentialPathError(OSError):
     """
 
 
-def _open_credential_fd(path: Path) -> int:
-    """Open ``path`` read-only, refusing to traverse a final-component symlink.
+def reject_if_symlink(path: Path) -> None:
+    """Raise :class:`CredentialPathError` if ``path`` itself is a symlink.
 
-    On POSIX, uses ``os.open(O_RDONLY | O_NOFOLLOW)`` so the kernel
-    surfaces ``ELOOP`` when the final component is a symlink. We catch
-    that ``ELOOP`` and re-raise as :class:`CredentialPathError` with a
-    message naming the path explicitly so logs don't show the bare
-    "Too many levels of symbolic links" the kernel emits.
+    Companion to :func:`read_credential_bytes` for call sites that check
+    path existence (``Path.exists()``) before reading. ``Path.exists``
+    follows symlinks and returns ``False`` for dangling links, so a
+    dangling symlink at the credential path short-circuits the read
+    helper entirely — the symlink-attack signal disappears.
 
-    On platforms without ``O_NOFOLLOW`` (Windows), falls back to
-    :meth:`Path.is_symlink` before opening. TOCTOU-vulnerable in
-    theory; not in the threat model.
+    This helper restores the signal: ``lstat`` the path, raise if it's
+    a symlink (dangling or live), return silently otherwise. Missing
+    paths (``FileNotFoundError`` from ``lstat``) are intentionally a
+    no-op — the existence check is the caller's concern.
 
     Args:
-        path: File to open.
-
-    Returns:
-        The open file descriptor. Caller MUST close.
+        path: Credential file path to probe.
 
     Raises:
-        CredentialPathError: The final path component is a symlink.
-        FileNotFoundError: The path does not exist (non-symlink case).
-        OSError: Any other open failure (EACCES, EISDIR, ...).
+        CredentialPathError: ``path`` is a symlink.
     """
-    if hasattr(os, "O_NOFOLLOW"):
-        try:
-            return os.open(str(path), os.O_RDONLY | os.O_NOFOLLOW)
-        except OSError as exc:
-            if exc.errno == errno.ELOOP:
-                raise CredentialPathError(
-                    errno.ELOOP,
-                    f"Refusing to read credential at symlink: {path}",
-                    str(path),
-                ) from exc
-            raise
-    # Windows fallback. The ``is_symlink`` check is TOCTOU-vulnerable —
-    # an attacker could swap a regular file for a symlink between this
-    # check and the open. Windows is not in the threat model for the
-    # same-UID-attacker scenario (creating symlinks requires elevated
-    # privileges or developer mode), so we accept the residual risk.
-    if path.is_symlink():
+    try:
+        st = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(st.st_mode):
         raise CredentialPathError(
             errno.ELOOP,
             f"Refusing to read credential at symlink: {path}",
             str(path),
         )
-    return os.open(str(path), os.O_RDONLY)
 
 
-def _enforce_owner_only_mode(fd: int, path: Path) -> None:
-    """Raise ``CredentialPathError`` if the open file's mode has group/world bits.
+_LEAF_OPEN_FLAGS = (
+    (os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK)
+    if hasattr(os, "O_NOFOLLOW")
+    else os.O_RDONLY
+)
+"""Flags used when opening the leaf component of a credential path.
 
-    The check runs on ``fstat(fd)``, NOT a fresh ``path.stat()``. The fd
-    pins the inode at the moment of open, so an attacker cannot swap
-    the file out from under the check — there is no TOCTOU window.
+``O_NOFOLLOW`` rejects a symlinked leaf with ``ELOOP``. ``O_CLOEXEC``
+prevents a forked subprocess from inheriting the live credential fd.
+``O_NONBLOCK`` prevents a FIFO-at-the-credential-path attack from
+hanging the open (POSIX ignores ``O_NONBLOCK`` on regular files; we
+clear it after open as hygiene).
+"""
+
+_DIR_OPEN_FLAGS = (
+    (os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC)
+    if hasattr(os, "O_NOFOLLOW") and hasattr(os, "O_DIRECTORY")
+    else os.O_RDONLY
+)
+"""Flags used for every intermediate dirfd opened during the walk."""
+
+
+def _open_credential_fd(path: Path) -> int:
+    """Open ``path`` read-only with symlink defense scoped to the user's home tree.
+
+    Threat model: a same-UID attacker can plant symlinks anywhere they
+    have write access — practically, anywhere under :func:`Path.home`
+    (or the configured ``MP_OAUTH_STORAGE_DIR`` / ``MP_CONFIG_PATH`` /
+    ``MP_AUTH_FILE`` trees, if those env vars point inside their reach).
+    Outside those trees, paths typically traverse system-owned dirs
+    (``/var``, ``/private``, ``/Users``) that the user trusts the OS to
+    have set up correctly.
+
+    Strategy:
+
+    * If ``path`` is under :func:`Path.home`: dirfd-walk from ``home``
+      down to the leaf, with ``O_NOFOLLOW`` at every component. A
+      symlink anywhere in the walk raises :class:`CredentialPathError`.
+    * Otherwise: open the leaf only, with ``O_NOFOLLOW`` (same as the
+      original PR's behavior). The user has explicitly configured an
+      out-of-home credential path and accepts that intermediate-symlink
+      defense doesn't apply there.
+
+    The dirfd walk uses Python's ``os.open(part, ..., dir_fd=parent)``
+    (``openat`` semantics). Each step is atomic w.r.t. the previously
+    pinned dirfd, so the walk is TOCTOU-free.
+
+    All opens — root, intermediate, and leaf — use ``O_CLOEXEC`` so
+    no descendant subprocess can inherit a live credential fd.
+
+    Windows fallback (no ``O_NOFOLLOW``): single :meth:`Path.is_symlink`
+    probe before opening. TOCTOU-vulnerable in theory; not in the
+    threat model.
+
+    Args:
+        path: File to open.
+
+    Returns:
+        The open file descriptor for the credential file. Caller MUST close.
+
+    Raises:
+        CredentialPathError: A component of the path (under home) is a
+            symlink, or the leaf is a symlink.
+        FileNotFoundError: A component does not exist.
+        OSError: Any other open failure (EACCES, EISDIR, ...).
+    """
+    if not hasattr(os, "O_NOFOLLOW"):
+        # Windows fallback.
+        if path.is_symlink():
+            raise CredentialPathError(
+                errno.ELOOP,
+                f"Refusing to read credential at symlink: {path}",
+                str(path),
+            )
+        return os.open(str(path), os.O_RDONLY)
+
+    abs_path = path if path.is_absolute() else Path.cwd() / path
+    home = Path.home()
+    try:
+        relative_parts = abs_path.relative_to(home).parts
+    except ValueError:
+        # Path is outside HOME — out-of-tree configured path. Apply
+        # leaf-only O_NOFOLLOW.
+        return _open_leaf_only(abs_path)
+
+    if not relative_parts:
+        # ``abs_path`` IS the home dir — degenerate case (no credential
+        # file lives there). Apply leaf-only and let the structural
+        # checks downstream sort it out.
+        return _open_leaf_only(abs_path)
+
+    # Walk from HOME down with O_NOFOLLOW at every step.
+    home_fd = os.open(str(home), os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    current_dirfd = home_fd
+    try:
+        for i, part in enumerate(relative_parts):
+            is_leaf = i == len(relative_parts) - 1
+            flags = _LEAF_OPEN_FLAGS if is_leaf else _DIR_OPEN_FLAGS
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_dirfd)
+            except OSError as exc:
+                # Linux: O_NOFOLLOW on a symlink → ELOOP.
+                # macOS: O_NOFOLLOW + O_DIRECTORY on a symlink → ENOTDIR
+                # (the symlink itself isn't a directory file type, so the
+                # O_DIRECTORY check fires before any symlink-resolution
+                # logic). Verify via lstat before claiming "symlink".
+                if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                    bad_path = home / Path(*relative_parts[: i + 1])
+                    try:
+                        st = bad_path.lstat()
+                    except FileNotFoundError:
+                        raise
+                    if stat.S_ISLNK(st.st_mode):
+                        raise CredentialPathError(
+                            errno.ELOOP,
+                            (f"Refusing to read credential at symlink: {bad_path}"),
+                            str(path),
+                        ) from exc
+                raise
+            if is_leaf:
+                os.close(current_dirfd)
+                current_dirfd = -1
+                return next_fd
+            os.close(current_dirfd)
+            current_dirfd = next_fd
+        # Unreachable — the loop always returns when is_leaf is True.
+        raise CredentialPathError(  # pragma: no cover
+            errno.ENOENT, f"Path walk did not reach a leaf: {path}", str(path)
+        )
+    except BaseException:
+        if current_dirfd != -1:
+            os.close(current_dirfd)
+        raise
+
+
+def _open_leaf_only(path: Path) -> int:
+    """Open ``path`` with ``O_NOFOLLOW`` on the leaf component only.
+
+    Used when the path is outside :func:`Path.home` — typically an
+    explicit env-var override (``MP_CONFIG_PATH``, ``MP_AUTH_FILE``,
+    ``MP_OAUTH_STORAGE_DIR``) where the user has opted into a non-home
+    location. Same protection level as the original PR.
+
+    Args:
+        path: File to open.
+
+    Returns:
+        The open file descriptor.
+
+    Raises:
+        CredentialPathError: The leaf component is a symlink.
+        OSError: Any other open failure.
+    """
+    try:
+        return os.open(str(path), _LEAF_OPEN_FLAGS)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise CredentialPathError(
+                errno.ELOOP,
+                f"Refusing to read credential at symlink: {path}",
+                str(path),
+            ) from exc
+        raise
+
+
+def _enforce_credential_file_invariants(fd: int, path: Path) -> None:
+    """Raise :class:`CredentialPathError` if the open file fails any structural check.
+
+    Three invariants, all evaluated against ``os.fstat(fd)`` (NOT a
+    fresh ``path.stat()``). The fd pins the inode at the moment of
+    open, so an attacker cannot swap the file out from under any of
+    the checks — there is no TOCTOU window.
+
+    1. Regular file (``S_ISREG``). Rejects FIFOs, devices, sockets,
+       directories — anything an attacker might substitute to either
+       hang the CLI (FIFO with no writer) or feed it an unbounded
+       byte stream.
+    2. Owner-only mode (no bits in ``0o077``). Rejects files with
+       group or world read/write/execute permission.
+    3. Size at most :data:`MAX_CREDENTIAL_BYTES`. Rejects oversized
+       files that would OOM the read loop.
 
     Skipped on platforms without :func:`os.fstat` mode semantics
     (Windows reports a stub mode).
@@ -222,11 +401,18 @@ def _enforce_owner_only_mode(fd: int, path: Path) -> None:
         path: The path used at open time (for the error message only).
 
     Raises:
-        CredentialPathError: Mode has any of the ``0o077`` bits set.
+        CredentialPathError: Any invariant fails.
     """
-    if not hasattr(os, "fchmod"):  # Windows proxy — no real POSIX mode.
+    if not hasattr(os, "fstat"):  # Windows proxy — no real POSIX stat.
         return
-    file_mode = stat.S_IMODE(os.fstat(fd).st_mode)
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise CredentialPathError(
+            errno.EINVAL,
+            f"Refusing to read credential: not a regular file: {path}",
+            str(path),
+        )
+    file_mode = stat.S_IMODE(st.st_mode)
     if file_mode & 0o077:
         raise CredentialPathError(
             errno.EPERM,
@@ -236,28 +422,42 @@ def _enforce_owner_only_mode(fd: int, path: Path) -> None:
             ),
             str(path),
         )
+    if st.st_size > MAX_CREDENTIAL_BYTES:
+        raise CredentialPathError(
+            errno.EFBIG,
+            (
+                f"Refusing to read credential: size {st.st_size} exceeds "
+                f"cap {MAX_CREDENTIAL_BYTES}: {path}"
+            ),
+            str(path),
+        )
 
 
 def read_credential_bytes(path: Path) -> bytes:
-    """Read bytes from ``path`` while refusing symlinks and lax modes.
+    """Read bytes from ``path`` while refusing every known structural attack.
 
-    POSIX: opens with ``O_NOFOLLOW`` so the kernel rejects a symlinked
-    final component (``ELOOP``); then ``fstat``s the fd and rejects any
-    file mode with the ``0o077`` bits set. Both rejections raise
-    :class:`CredentialPathError` (an :class:`OSError` subclass).
+    POSIX: opens via :func:`_open_credential_fd` (dirfd-walked
+    ``openat`` with ``O_NOFOLLOW`` at every component, plus
+    ``O_CLOEXEC`` and ``O_NONBLOCK`` on the leaf), then enforces three
+    invariants via :func:`_enforce_credential_file_invariants` (regular
+    file, owner-only mode, size at most :data:`MAX_CREDENTIAL_BYTES`).
+    Any failure raises :class:`CredentialPathError`.
+
+    After the regular-file check passes, ``O_NONBLOCK`` is cleared on
+    the fd via ``fcntl`` so the read loop has standard blocking
+    semantics. (``O_NONBLOCK`` is ignored on regular files per POSIX,
+    but clearing it is hygiene against future refactors that might
+    swap the fd to something the flag matters for.)
 
     Out of scope:
         - Hard links. ``O_NOFOLLOW`` does not detect them. A hard-link
           attack requires write access to a directory in the target
           path AND read access to the target file, which is strictly
           stronger than the same-UID symlink threat we're defending.
-        - Intermediate symlinks in ancestor paths. Ancestor dirs are
-          managed at ``0o700`` by ``ensure_account_dir`` and
-          ``_ensure_dir``, which excludes the insertion vector.
         - Attacker-controlled ``$HOME``. If :meth:`Path.home` itself
-          is influenced (some CI setups override ``$HOME``), the leaf
-          check is moot. That's a deployment posture, not an
-          in-process check.
+          is influenced (some CI setups override ``$HOME``), the
+          dirfd walk starts from a root chosen by the attacker. That's
+          a deployment posture, not an in-process check.
 
     Args:
         path: File to read.
@@ -266,14 +466,23 @@ def read_credential_bytes(path: Path) -> bytes:
         The file contents as bytes.
 
     Raises:
-        CredentialPathError: ``path`` is a symlink, or the file mode
-            has group/world bits set.
-        FileNotFoundError: ``path`` does not exist (non-symlink case).
+        CredentialPathError: ``path`` (or any ancestor) is a symlink,
+            the file is not regular, the mode has group/world bits,
+            or the size exceeds :data:`MAX_CREDENTIAL_BYTES`.
+        FileNotFoundError: A component of ``path`` does not exist.
         OSError: Any other I/O failure (EACCES, EISDIR, ...).
     """
     fd = _open_credential_fd(path)
     try:
-        _enforce_owner_only_mode(fd, path)
+        _enforce_credential_file_invariants(fd, path)
+        # Clear O_NONBLOCK on the fd. POSIX ignores it on regular
+        # files, but clearing keeps the fd's flag set tidy and avoids
+        # surprises if a future refactor reads from a non-regular fd.
+        if hasattr(os, "O_NONBLOCK"):
+            import fcntl
+
+            current = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, current & ~os.O_NONBLOCK)
         chunks: list[bytes] = []
         while True:
             chunk = os.read(fd, 65536)

--- a/src/mixpanel_headless/_internal/me.py
+++ b/src/mixpanel_headless/_internal/me.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Any
 import pydantic
 from pydantic import BaseModel, ConfigDict
 
-from mixpanel_headless._internal.io_utils import atomic_write_bytes
+from mixpanel_headless._internal.io_utils import (
+    CredentialPathError,
+    atomic_write_bytes,
+    read_credential_text,
+)
 from mixpanel_headless.exceptions import AuthenticationError, ConfigError, QueryError
 
 if TYPE_CHECKING:
@@ -298,8 +302,16 @@ class MeCache:
             return None
 
         try:
-            raw = path.read_text(encoding="utf-8")
+            raw = read_credential_text(path)
             data: dict[str, Any] = json.loads(raw)
+        except CredentialPathError as e:
+            # Structural rejection (symlink at the cache path, or a
+            # mode wider than 0o600). Log at WARNING — louder than the
+            # generic "corrupted cache" path below — so an admin
+            # grepping logs can spot a same-UID attacker probing the
+            # /me cache, instead of seeing only the silent re-fetch.
+            logger.warning("Refusing to read /me cache at %s: %s", path, e)
+            return None
         except (json.JSONDecodeError, OSError) as e:
             logger.debug("Corrupted cache file %s: %s", path, e)
             return None

--- a/src/mixpanel_headless/_internal/me.py
+++ b/src/mixpanel_headless/_internal/me.py
@@ -24,6 +24,7 @@ from mixpanel_headless._internal.io_utils import (
     CredentialPathError,
     atomic_write_bytes,
     read_credential_text,
+    reject_if_symlink,
 )
 from mixpanel_headless.exceptions import AuthenticationError, ConfigError, QueryError
 
@@ -298,6 +299,17 @@ class MeCache:
             ```
         """
         path = self._cache_path()
+        # Probe for symlink before existence check. A dangling symlink
+        # would silently pass through ``exists()`` returning False, and
+        # the read helper would never see the symlink shape — losing
+        # the security signal we just added. ``reject_if_symlink``
+        # surfaces it as ``CredentialPathError``, caught and logged
+        # below.
+        try:
+            reject_if_symlink(path)
+        except CredentialPathError as e:
+            logger.warning("Refusing to read /me cache at %s: %s", path, e)
+            return None
         if not path.exists():
             return None
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1038,6 +1038,7 @@ class TestErrorRendering:
             'region = "us"\n',
             encoding="utf-8",
         )
+        config_path.chmod(0o600)
 
         result = runner.invoke(app, ["account", "list"])
 

--- a/tests/unit/test_042_edge_cases.py
+++ b/tests/unit/test_042_edge_cases.py
@@ -470,6 +470,7 @@ class TestConfigManagerEdgeCases:
         """
         p = tmp_path / "config.toml"
         p.write_text("config_version = 2\n", encoding="utf-8")
+        p.chmod(0o600)
         cm = ConfigManager(config_path=p)
         assert cm.list_accounts() == []
 

--- a/tests/unit/test_accounts_namespace.py
+++ b/tests/unit/test_accounts_namespace.py
@@ -661,7 +661,8 @@ class TestTestOAuthBrowser:
         account_dir = tmp_path / ".mp" / "accounts" / "personal"
         account_dir.mkdir(parents=True)
         past = datetime.now(timezone.utc) - timedelta(hours=1)
-        (account_dir / "tokens.json").write_text(
+        tokens_path = account_dir / "tokens.json"
+        tokens_path.write_text(
             _json.dumps(
                 {
                     "access_token": "expired-tok",
@@ -672,6 +673,7 @@ class TestTestOAuthBrowser:
             ),
             encoding="utf-8",
         )
+        tokens_path.chmod(0o600)
         result = accounts_ns.test("personal")
         assert result.ok is False
         assert result.error is not None
@@ -701,7 +703,8 @@ class TestTestOAuthBrowser:
         account_dir = tmp_path / ".mp" / "accounts" / "personal"
         account_dir.mkdir(parents=True)
         past = datetime.now(timezone.utc) - timedelta(hours=1)
-        (account_dir / "tokens.json").write_text(
+        tokens_path = account_dir / "tokens.json"
+        tokens_path.write_text(
             _json.dumps(
                 {
                     "access_token": "expired-tok",
@@ -713,6 +716,7 @@ class TestTestOAuthBrowser:
             ),
             encoding="utf-8",
         )
+        tokens_path.chmod(0o600)
         # Stub DCR client info so the refresh path can find a client.
         monkeypatch.setattr(
             storage_mod.OAuthStorage,

--- a/tests/unit/test_bridge_export.py
+++ b/tests/unit/test_bridge_export.py
@@ -292,3 +292,80 @@ class TestAccountsNamespaceWiring:
         target.write_text("{}", encoding="utf-8")
         assert accounts_ns.remove_bridge(at=target) is True
         assert not target.exists()
+
+
+class TestBridgeSymlinkRejection:
+    """``load_bridge`` and ``_read_browser_tokens`` refuse symlinked credential paths.
+
+    Regression for the same-UID symlink attack covered by
+    ``io_utils.read_credential_text``. Two code paths in ``bridge.py``
+    read credential material from disk:
+
+    1. ``load_bridge`` reads the bridge file itself (env-controllable
+       via ``MP_AUTH_FILE``).
+    2. ``_read_browser_tokens`` reads per-account ``tokens.json``
+       when exporting a fresh bridge for an oauth_browser account.
+
+    Both must refuse a symlink at the leaf component.
+    """
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("os"), "O_NOFOLLOW"),
+        reason="O_NOFOLLOW required; Windows is not in scope",
+    )
+    def test_load_bridge_symlink_raises_configerror(self, tmp_path: Path) -> None:
+        """A symlink at the bridge path raises ``ConfigError``."""
+        from mixpanel_headless.exceptions import ConfigError
+
+        attacker = tmp_path / "attacker_bridge.json"
+        attacker.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "account": {
+                        "name": "evil",
+                        "type": "service_account",
+                        "region": "us",
+                        "default_project": "999",
+                        "username": "attacker",
+                        "secret": "stolen",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        attacker.chmod(0o600)
+        link = tmp_path / "bridge.json"
+        link.symlink_to(attacker)
+        with pytest.raises(ConfigError, match="symlink"):
+            load_bridge(link)
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("os"), "O_NOFOLLOW"),
+        reason="O_NOFOLLOW required; Windows is not in scope",
+    )
+    def test_export_bridge_symlinked_tokens_raises_oautherror(
+        self, tmp_path: Path
+    ) -> None:
+        """A symlink at the per-account tokens.json raises ``OAuthError``."""
+        account = OAuthBrowserAccount(name="personal", region="us")
+        account_dir = tmp_path / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        attacker = tmp_path / "attacker_tokens.json"
+        attacker.write_text(
+            json.dumps(
+                {
+                    "access_token": "stolen",
+                    "expires_at": (
+                        datetime.now(timezone.utc) + timedelta(hours=1)
+                    ).isoformat(),
+                    "token_type": "Bearer",
+                }
+            ),
+            encoding="utf-8",
+        )
+        attacker.chmod(0o600)
+        (account_dir / "tokens.json").symlink_to(attacker)
+        out = tmp_path / "bridge.json"
+        with pytest.raises(OAuthError, match="symlink"):
+            export_bridge(account, to=out, token_resolver=OnDiskTokenResolver())

--- a/tests/unit/test_bridge_export.py
+++ b/tests/unit/test_bridge_export.py
@@ -12,6 +12,7 @@ Reference:
 from __future__ import annotations
 
 import json
+import os
 import stat
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -32,6 +33,11 @@ from mixpanel_headless._internal.auth.bridge import (
 )
 from mixpanel_headless._internal.auth.token_resolver import OnDiskTokenResolver
 from mixpanel_headless.exceptions import OAuthError
+
+_REQUIRES_O_NOFOLLOW = pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW required; Windows is not in scope",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -309,10 +315,7 @@ class TestBridgeSymlinkRejection:
     Both must refuse a symlink at the leaf component.
     """
 
-    @pytest.mark.skipif(
-        not hasattr(__import__("os"), "O_NOFOLLOW"),
-        reason="O_NOFOLLOW required; Windows is not in scope",
-    )
+    @_REQUIRES_O_NOFOLLOW
     def test_load_bridge_symlink_raises_configerror(self, tmp_path: Path) -> None:
         """A symlink at the bridge path raises ``ConfigError``."""
         from mixpanel_headless.exceptions import ConfigError
@@ -340,10 +343,7 @@ class TestBridgeSymlinkRejection:
         with pytest.raises(ConfigError, match="symlink"):
             load_bridge(link)
 
-    @pytest.mark.skipif(
-        not hasattr(__import__("os"), "O_NOFOLLOW"),
-        reason="O_NOFOLLOW required; Windows is not in scope",
-    )
+    @_REQUIRES_O_NOFOLLOW
     def test_export_bridge_symlinked_tokens_raises_oautherror(
         self, tmp_path: Path
     ) -> None:
@@ -366,6 +366,30 @@ class TestBridgeSymlinkRejection:
         )
         attacker.chmod(0o600)
         (account_dir / "tokens.json").symlink_to(attacker)
+        out = tmp_path / "bridge.json"
+        with pytest.raises(OAuthError, match="symlink"):
+            export_bridge(account, to=out, token_resolver=OnDiskTokenResolver())
+
+    @_REQUIRES_O_NOFOLLOW
+    def test_dangling_bridge_symlink_rejected(self, tmp_path: Path) -> None:
+        """A dangling symlink at the bridge path raises ``ConfigError``.
+
+        Regression for the ``Path.exists()`` follows-symlink trap.
+        """
+        from mixpanel_headless.exceptions import ConfigError
+
+        link = tmp_path / "bridge.json"
+        link.symlink_to(tmp_path / "missing.json")
+        with pytest.raises(ConfigError, match="symlink"):
+            load_bridge(link)
+
+    @_REQUIRES_O_NOFOLLOW
+    def test_dangling_browser_tokens_symlink_rejected(self, tmp_path: Path) -> None:
+        """A dangling symlink at per-account tokens.json raises ``OAuthError``."""
+        account = OAuthBrowserAccount(name="personal", region="us")
+        account_dir = tmp_path / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        (account_dir / "tokens.json").symlink_to(tmp_path / "missing.json")
         out = tmp_path / "bridge.json"
         with pytest.raises(OAuthError, match="symlink"):
             export_bridge(account, to=out, token_resolver=OnDiskTokenResolver())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -765,3 +765,30 @@ class TestMutateTransaction:
 
         # File untouched — no partial mutation reached disk.
         assert p.read_bytes() == original
+
+
+class TestSymlinkRejection:
+    """``ConfigManager`` refuses to read a ``config.toml`` that is a symlink.
+
+    Regression for the same-UID symlink attack covered by the read-side
+    hardening in ``io_utils.read_credential_text``. An attacker who can
+    write to the user's ``$HOME`` (CI shared $HOME, container shared
+    mounts) could otherwise plant ``config.toml`` as a symlink to an
+    attacker-controlled TOML and steer the user's session at another
+    project / account.
+    """
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("os"), "O_NOFOLLOW"),
+        reason="O_NOFOLLOW required; Windows is not in scope",
+    )
+    def test_symlink_config_raises_configerror(self, tmp_path: Path) -> None:
+        """A symlink at ``config.toml`` raises ``ConfigError`` rather than reading."""
+        attacker = tmp_path / "attacker.toml"
+        attacker.write_text('[active]\naccount = "evil"\n', encoding="utf-8")
+        attacker.chmod(0o600)
+        link = tmp_path / "config.toml"
+        link.symlink_to(attacker)
+        cm = ConfigManager(config_path=link)
+        with pytest.raises(ConfigError, match="symlink"):
+            cm.list_accounts()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ Reference: specs/042-auth-architecture-redesign/contracts/config-schema.md §1.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,11 @@ from mixpanel_headless._internal.auth.session import ActiveSession
 from mixpanel_headless._internal.config import ConfigManager
 from mixpanel_headless.exceptions import ConfigError
 from mixpanel_headless.types import AccountSummary, Target
+
+_REQUIRES_O_NOFOLLOW = pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW required; Windows is not in scope",
+)
 
 # Path to the fixture corpus (constructed from project root).
 _FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "configs"
@@ -56,6 +62,7 @@ class TestLoadEmptyOrMissing:
         """An empty TOML file is also valid (no sections) — no errors."""
         p = tmp_path / "config.toml"
         p.write_text("", encoding="utf-8")
+        p.chmod(0o600)
         cm = ConfigManager(config_path=p)
         assert cm.list_accounts() == []
         assert cm.list_targets() == []
@@ -623,6 +630,7 @@ class TestFixtureLoad:
         src = _FIXTURE_DIR / "simple.toml"
         dst = tmp_path / "config.toml"
         dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        dst.chmod(0o600)
         cm = ConfigManager(config_path=dst)
         accounts = cm.list_accounts()
         assert len(accounts) == 1
@@ -638,6 +646,7 @@ class TestFixtureLoad:
         src = _FIXTURE_DIR / "multi.toml"
         dst = tmp_path / "config.toml"
         dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        dst.chmod(0o600)
         cm = ConfigManager(config_path=dst)
         accounts = {a.name: a for a in cm.list_accounts()}
         assert accounts["team"].type == "service_account"
@@ -757,6 +766,7 @@ class TestMutateTransaction:
             'region = "us"\n',
             encoding="utf-8",
         )
+        p.chmod(0o600)
         original = p.read_bytes()
         cm = ConfigManager(config_path=p)
 
@@ -778,10 +788,7 @@ class TestSymlinkRejection:
     project / account.
     """
 
-    @pytest.mark.skipif(
-        not hasattr(__import__("os"), "O_NOFOLLOW"),
-        reason="O_NOFOLLOW required; Windows is not in scope",
-    )
+    @_REQUIRES_O_NOFOLLOW
     def test_symlink_config_raises_configerror(self, tmp_path: Path) -> None:
         """A symlink at ``config.toml`` raises ``ConfigError`` rather than reading."""
         attacker = tmp_path / "attacker.toml"
@@ -790,5 +797,25 @@ class TestSymlinkRejection:
         link = tmp_path / "config.toml"
         link.symlink_to(attacker)
         cm = ConfigManager(config_path=link)
+        with pytest.raises(ConfigError, match="symlink"):
+            cm.list_accounts()
+
+    @_REQUIRES_O_NOFOLLOW
+    def test_dangling_symlink_config_still_rejected(self, tmp_path: Path) -> None:
+        """A dangling symlink at the config path is also rejected.
+
+        Regression for the ``Path.exists()`` follows-symlink trap: before
+        ``reject_if_symlink`` was added at the call site, a dangling
+        symlink would short-circuit through ``not path.exists()`` and
+        silently return an empty config — hiding the attack signal.
+        """
+        link = tmp_path / "config.toml"
+        link.symlink_to(tmp_path / "does-not-exist.toml")
+        cm = ConfigManager(config_path=link)
+        # ConfigManager._read_raw guards with ``if not self._path.exists()``;
+        # without the new ``reject_if_symlink``, this dangling symlink would
+        # silently return an empty dict and ``list_accounts()`` would return
+        # []. The new check raises a CredentialPathError that surfaces as
+        # ConfigError below.
         with pytest.raises(ConfigError, match="symlink"):
             cm.list_accounts()

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -1,12 +1,20 @@
-"""Unit tests for the atomic-write helper and the stdin secret reader.
+"""Unit tests for the atomic-write helper, credential-read helpers, and stdin reader.
 
-Tests :func:`mixpanel_headless._internal.io_utils.atomic_write_bytes`, the
-foundation under all token / config writes that must survive a mid-write
-crash without leaving the on-disk file in a partial state, and
-:func:`read_capped_secret_from_stdin`, the bounded reader shared by
-``mp account add --secret-stdin`` and the ``mp login`` orchestrator.
+Tests three pieces of :mod:`mixpanel_headless._internal.io_utils`:
 
-Verifies:
+* :func:`atomic_write_bytes` — the foundation under all token / config
+  writes that must survive a mid-write crash without leaving the on-disk
+  file in a partial state.
+* :func:`read_credential_bytes` / :func:`read_credential_text` — the
+  read-side mirror that refuses to traverse a symlink in the final
+  path component (``O_NOFOLLOW`` on POSIX) and refuses to read files
+  with group/world bits set. Surfaces structural failures as
+  :class:`CredentialPathError` so silent-degradation call sites can
+  log security-relevant rejections distinctly from generic I/O errors.
+* :func:`read_capped_secret_from_stdin` — the bounded reader shared
+  by ``mp account add --secret-stdin`` and the ``mp login`` orchestrator.
+
+Verifies (writes):
 - Writes bytes to a fresh path with default 0o600 mode
 - Accepts owner-only restrictive modes (0o400, 0o600)
 - Rejects modes that grant group/world access (0o644, 0o660, 0o604)
@@ -18,6 +26,22 @@ Verifies:
 - O_EXCL prevents collision with a stale tmp from same pid+tid
 - Empty payload still produces a file (not a missing one)
 - Missing parent directory propagates a FileNotFoundError to the caller
+
+Verifies (reads):
+- ``CredentialPathError`` is an ``OSError`` subclass (existing handlers keep working)
+- Returns bytes from a plain 0o600 file
+- Rejects a symlink whose target is attacker-controlled
+- Rejects a symlink whose target is a legitimate owned 0o600 file
+  (rejection is structural, not based on target metadata)
+- Rejects a dangling symlink as the same error class (proves we fail at
+  the symlink check, not at "file not found")
+- Rejects files with any of the 0o077 mode bits set
+- Accepts 0o400 and 0o600 modes
+- ``FileNotFoundError`` for a missing non-symlink path propagates verbatim
+- No fd leak across many rejections (symlink branch and mode branch)
+- Text variant round-trips UTF-8 and raises UnicodeDecodeError on bad bytes
+
+Verifies (stdin):
 - Stdin reader returns whitespace-stripped value at the cap boundary
 - Stdin reader rejects payloads exceeding the cap with ConfigError
 - Stdin reader rejects empty / whitespace-only stdin with ConfigError
@@ -33,12 +57,16 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
+import psutil
 import pytest
 
 from mixpanel_headless._internal.io_utils import (
     SECRET_STDIN_MAX_BYTES,
+    CredentialPathError,
     atomic_write_bytes,
     read_capped_secret_from_stdin,
+    read_credential_bytes,
+    read_credential_text,
 )
 from mixpanel_headless.exceptions import ConfigError
 
@@ -267,6 +295,207 @@ class TestAtomicWriteResilience:
         final = target.read_bytes()
         assert final == b"A" * 1024 or final == b"B" * 1024
         assert _tmp_glob(target) == []
+
+
+_POSIX_ONLY = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="POSIX file permissions / O_NOFOLLOW semantics not available on Windows",
+)
+
+
+def _write_owner_only(path: Path, data: bytes) -> Path:
+    """Write ``data`` to ``path`` and chmod it to 0o600.
+
+    The cred-read helper rejects anything wider than 0o600. Many tests
+    create fixture files via ``Path.write_bytes`` which honors the
+    process umask (typically 0o644), so they'd fail the mode check
+    before exercising the property under test. This helper makes the
+    intent explicit: "a normal credential file at rest".
+    """
+    path.write_bytes(data)
+    if platform.system() != "Windows":
+        path.chmod(0o600)
+    return path
+
+
+class TestCredentialPathError:
+    """Locks the contract that ``CredentialPathError`` is an ``OSError`` subclass."""
+
+    def test_is_oserror_subclass(self) -> None:
+        """Existing ``except OSError`` handlers MUST catch ``CredentialPathError``.
+
+        The call sites in ``config.py``, ``bridge.py``, ``token_resolver.py``,
+        ``storage.py``, and ``me.py`` already catch ``OSError`` and translate
+        to domain exceptions. If ``CredentialPathError`` ever drifts out of
+        that hierarchy, those handlers silently miss every symlink-attack
+        rejection — exactly the failure mode we're trying to prevent.
+        """
+        assert issubclass(CredentialPathError, OSError)
+
+    def test_carries_errno_and_path(self) -> None:
+        """The exception preserves ``errno`` (for log triage) and the path."""
+        exc = CredentialPathError(40, "symlink rejected", "/tmp/foo")
+        assert exc.errno == 40
+        assert exc.filename == "/tmp/foo"
+        assert "symlink rejected" in str(exc)
+
+
+class TestReadCredentialBytes:
+    """Tests for :func:`read_credential_bytes`."""
+
+    def test_reads_plain_owner_only_file(self, temp_dir: Path) -> None:
+        """Happy path: a normal 0o600 file returns its bytes verbatim."""
+        target = _write_owner_only(temp_dir / "creds.json", b'{"k":"v"}')
+        assert read_credential_bytes(target) == b'{"k":"v"}'
+
+    def test_reads_empty_file(self, temp_dir: Path) -> None:
+        """An empty 0o600 file returns ``b''`` rather than raising."""
+        target = _write_owner_only(temp_dir / "empty", b"")
+        assert read_credential_bytes(target) == b""
+
+    @_POSIX_ONLY
+    def test_rejects_symlink_to_attacker_file(self, temp_dir: Path) -> None:
+        """A symlink whose target is an attacker-controlled file is refused.
+
+        This is the threat the security review flagged: an attacker with
+        same-UID write access to ``/tmp`` plants ``/tmp/evil.json`` and
+        symlinks the credential path to it. The kernel surfaces ``ELOOP``
+        via ``O_NOFOLLOW``; we re-raise as ``CredentialPathError`` with
+        the symlink path named in the message.
+        """
+        attacker = temp_dir / "attacker.json"
+        _write_owner_only(attacker, b'{"stolen":"data"}')
+        link = temp_dir / "creds.json"
+        link.symlink_to(attacker)
+        with pytest.raises(CredentialPathError, match="symlink"):
+            read_credential_bytes(link)
+
+    @_POSIX_ONLY
+    def test_rejects_symlink_to_legitimate_owned_file(self, temp_dir: Path) -> None:
+        """Rejection is structural — even a 0o600 owned target is refused.
+
+        Proves the check fires on path shape, not on a heuristic about
+        the target's metadata. A reader that "looks safe because the
+        target file is owner-only" would still be exploitable: the
+        attacker chooses the target file from whatever they can write,
+        not from what passes a permission check.
+        """
+        legit = _write_owner_only(temp_dir / "legit.json", b'{"k":"v"}')
+        assert stat.S_IMODE(legit.stat().st_mode) == 0o600
+        link = temp_dir / "creds.json"
+        link.symlink_to(legit)
+        with pytest.raises(CredentialPathError, match="symlink"):
+            read_credential_bytes(link)
+
+    @_POSIX_ONLY
+    def test_rejects_dangling_symlink(self, temp_dir: Path) -> None:
+        """A symlink to a nonexistent target raises ``CredentialPathError``,
+        not ``FileNotFoundError`` — proves we fail at the symlink check
+        before any "does the target exist" lookup.
+        """
+        link = temp_dir / "creds.json"
+        link.symlink_to(temp_dir / "nonexistent.json")
+        with pytest.raises(CredentialPathError, match="symlink"):
+            read_credential_bytes(link)
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("bad_mode", [0o640, 0o660, 0o604, 0o644, 0o666, 0o777])
+    def test_rejects_lax_mode(self, temp_dir: Path, bad_mode: int) -> None:
+        """Any file with group or world bits set is refused.
+
+        Defense-in-depth against an attacker who can write to the
+        credential file directly (so ``O_NOFOLLOW`` is a no-op) but only
+        with a lax mode — typically the case when umask was wrong during
+        a manual edit. ``atomic_write_bytes`` already enforces 0o600 on
+        the write side, so any lax-mode credential file in the wild
+        is either tampering or a hand-edit.
+        """
+        target = temp_dir / "creds.json"
+        target.write_bytes(b"x")
+        target.chmod(bad_mode)
+        with pytest.raises(CredentialPathError, match="mode"):
+            read_credential_bytes(target)
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("good_mode", [0o400, 0o600])
+    def test_accepts_owner_only_modes(self, temp_dir: Path, good_mode: int) -> None:
+        """0o400 (read-only) and 0o600 (read/write) both pass the mode check."""
+        target = temp_dir / "creds.json"
+        target.write_bytes(b"ok")
+        target.chmod(good_mode)
+        assert read_credential_bytes(target) == b"ok"
+
+    def test_propagates_filenotfound(self, temp_dir: Path) -> None:
+        """A missing non-symlink path raises ``FileNotFoundError``, NOT
+        ``CredentialPathError`` — preserves the existing ``except OSError``
+        control flow at call sites that check ``path.exists()`` first.
+        """
+        missing = temp_dir / "does-not-exist.json"
+        with pytest.raises(FileNotFoundError):
+            read_credential_bytes(missing)
+
+    @_POSIX_ONLY
+    def test_no_fd_leak_on_symlink_rejection(self, temp_dir: Path) -> None:
+        """Many symlink rejections do not accumulate open file descriptors.
+
+        The ``O_NOFOLLOW`` open fails before any fd is returned to us;
+        the kernel cleans up. We verify by sampling ``Process.num_fds``
+        before and after — any growth indicates a fd leak in the
+        rejection path (e.g., if a future refactor opens a probe fd
+        before the symlink check and forgets to close it).
+        """
+        link = temp_dir / "creds.json"
+        link.symlink_to(temp_dir / "nonexistent.json")
+        proc = psutil.Process()
+        before = proc.num_fds()
+        for _ in range(200):
+            with pytest.raises(CredentialPathError):
+                read_credential_bytes(link)
+        after = proc.num_fds()
+        # Allow a small slack for unrelated test infra (logging file
+        # handlers, etc.) — a leak in our helper would show hundreds.
+        assert after - before < 5, f"fd leak: {before} -> {after}"
+
+    @_POSIX_ONLY
+    def test_no_fd_leak_on_mode_rejection(self, temp_dir: Path) -> None:
+        """The mode-check rejection path closes the fd before raising."""
+        target = temp_dir / "creds.json"
+        target.write_bytes(b"x")
+        target.chmod(0o644)
+        proc = psutil.Process()
+        before = proc.num_fds()
+        for _ in range(200):
+            with pytest.raises(CredentialPathError):
+                read_credential_bytes(target)
+        after = proc.num_fds()
+        assert after - before < 5, f"fd leak: {before} -> {after}"
+
+
+class TestReadCredentialText:
+    """Tests for :func:`read_credential_text` — UTF-8 wrapper over the bytes helper."""
+
+    def test_reads_utf8(self, temp_dir: Path) -> None:
+        """Happy path: UTF-8 round-trips."""
+        target = _write_owner_only(temp_dir / "creds.toml", "café".encode())
+        assert read_credential_text(target) == "café"
+
+    def test_rejects_invalid_utf8(self, temp_dir: Path) -> None:
+        """Invalid UTF-8 raises ``UnicodeDecodeError`` — preserves the
+        existing call-site behavior in ``storage.py`` where the bare
+        ``except (UnicodeDecodeError, ...)`` handler logs and returns None.
+        """
+        target = _write_owner_only(temp_dir / "creds.toml", b"\xff\xfe\xfd")
+        with pytest.raises(UnicodeDecodeError):
+            read_credential_text(target)
+
+    @_POSIX_ONLY
+    def test_rejects_symlink_same_as_bytes_variant(self, temp_dir: Path) -> None:
+        """Delegation contract: the text wrapper inherits all structural checks."""
+        target = _write_owner_only(temp_dir / "real.toml", b"x = 1")
+        link = temp_dir / "creds.toml"
+        link.symlink_to(target)
+        with pytest.raises(CredentialPathError, match="symlink"):
+            read_credential_text(link)
 
 
 def _stub_stdin(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -49,6 +49,7 @@ Verifies (stdin):
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import platform
@@ -61,12 +62,14 @@ import psutil
 import pytest
 
 from mixpanel_headless._internal.io_utils import (
+    MAX_CREDENTIAL_BYTES,
     SECRET_STDIN_MAX_BYTES,
     CredentialPathError,
     atomic_write_bytes,
     read_capped_secret_from_stdin,
     read_credential_bytes,
     read_credential_text,
+    reject_if_symlink,
 )
 from mixpanel_headless.exceptions import ConfigError
 
@@ -496,6 +499,259 @@ class TestReadCredentialText:
         link.symlink_to(target)
         with pytest.raises(CredentialPathError, match="symlink"):
             read_credential_text(link)
+
+
+class TestRejectIfSymlink:
+    """Tests for :func:`reject_if_symlink` — pre-read symlink probe."""
+
+    @_POSIX_ONLY
+    def test_live_symlink_raises(self, temp_dir: Path) -> None:
+        """A symlink at the path (whose target exists) raises ``CredentialPathError``."""
+        target = _write_owner_only(temp_dir / "real.json", b"x")
+        link = temp_dir / "creds.json"
+        link.symlink_to(target)
+        with pytest.raises(CredentialPathError, match="symlink"):
+            reject_if_symlink(link)
+
+    @_POSIX_ONLY
+    def test_dangling_symlink_raises(self, temp_dir: Path) -> None:
+        """A symlink whose target doesn't exist still raises.
+
+        This is the whole point of the helper: ``Path.exists()`` follows
+        symlinks and returns False for dangling links, hiding the attack
+        signal at every call site that short-circuits on ``not exists()``.
+        ``reject_if_symlink`` uses ``lstat`` so the symlink shape is
+        detected even when the target is gone.
+        """
+        link = temp_dir / "creds.json"
+        link.symlink_to(temp_dir / "missing.json")
+        with pytest.raises(CredentialPathError, match="symlink"):
+            reject_if_symlink(link)
+
+    def test_regular_file_is_noop(self, temp_dir: Path) -> None:
+        """A normal file path returns silently — no exception."""
+        target = _write_owner_only(temp_dir / "creds.json", b"x")
+        reject_if_symlink(target)  # no raise
+
+    def test_missing_path_is_noop(self, temp_dir: Path) -> None:
+        """A path that doesn't exist at all returns silently.
+
+        The helper's job is "reject symlinks", not "assert existence".
+        Existence is the caller's concern (each call site already has its
+        own ``not path.exists()`` check that handles the missing case).
+        """
+        reject_if_symlink(temp_dir / "nothing-here.json")  # no raise
+
+
+class TestOpenCredentialFdFlags:
+    """Lock the flag set on the fd returned by ``read_credential_bytes``.
+
+    These tests verify the defensive flag invariants without exposing
+    the private ``_open_credential_fd`` helper directly — they hook into
+    ``os.close`` to inspect the fd before the helper releases it.
+    """
+
+    @_POSIX_ONLY
+    def test_returned_fd_has_cloexec(self, temp_dir: Path) -> None:
+        """The credential fd has the FD_CLOEXEC bit set.
+
+        Without ``O_CLOEXEC``, any subprocess spawned while the fd is
+        open (logging handlers, signal-driven forks) inherits a live
+        handle to the credential file. The window is small but real.
+        """
+        import fcntl
+
+        target = _write_owner_only(temp_dir / "creds", b"x")
+        captured_flags: list[int] = []
+        real_close = os.close
+
+        def spy_close(fd: int) -> None:
+            # Inspect the descriptor BEFORE close — fcntl(F_GETFD) returns
+            # the cloexec flag set on the fd.
+            with contextlib.suppress(OSError):
+                captured_flags.append(fcntl.fcntl(fd, fcntl.F_GETFD))
+            real_close(fd)
+
+        with patch("mixpanel_headless._internal.io_utils.os.close", spy_close):
+            read_credential_bytes(target)
+        # The last close we see corresponds to the credential fd. Any
+        # intermediate dirfd opens (#3) also get FD_CLOEXEC, so every
+        # captured flag must include the bit.
+        assert captured_flags, "expected at least one close call"
+        for flags in captured_flags:
+            assert flags & fcntl.FD_CLOEXEC, (
+                f"credential fd lacks FD_CLOEXEC: flags={flags}"
+            )
+
+
+class TestNonRegularFileRejection:
+    """Reject FIFOs, devices, and other non-regular files at the credential path.
+
+    Same-UID attacker can ``mkfifo`` the credential path. Without
+    ``O_NONBLOCK`` the open blocks indefinitely; without an ``S_ISREG``
+    check the open eventually succeeds (with a writer attached) and we
+    read attacker-streamed bytes.
+    """
+
+    @_POSIX_ONLY
+    def test_rejects_fifo(self, temp_dir: Path) -> None:
+        """A FIFO at the credential path raises ``CredentialPathError``
+        without hanging the test process.
+        """
+        fifo = temp_dir / "creds.json"
+        os.mkfifo(fifo, 0o600)
+        # ``pytest-timeout`` isn't a dep — rely on the implementation's
+        # ``O_NONBLOCK`` to keep the call from blocking. If it blocks
+        # forever this test hangs the suite, which is itself a signal.
+        with pytest.raises(CredentialPathError, match="regular file|FIFO|pipe"):
+            read_credential_bytes(fifo)
+
+    @_POSIX_ONLY
+    def test_rejects_chardev_via_mock(self, temp_dir: Path) -> None:
+        """A character device at the credential path is rejected.
+
+        Constructing a real chardev needs root (``mknod``), so we patch
+        ``os.fstat`` to return a chardev mode while reading a real
+        regular file under the hood. The mode-check branch is what we're
+        exercising.
+        """
+        target = _write_owner_only(temp_dir / "creds", b"x")
+        real_fstat = os.fstat
+
+        def fake_fstat(fd: int) -> os.stat_result:
+            real = real_fstat(fd)
+            # Replace the file-type bits with S_IFCHR while keeping mode + size.
+            new_mode = (real.st_mode & ~0o170000) | stat.S_IFCHR
+            return os.stat_result(
+                (
+                    new_mode,
+                    real.st_ino,
+                    real.st_dev,
+                    real.st_nlink,
+                    real.st_uid,
+                    real.st_gid,
+                    real.st_size,
+                    real.st_atime,
+                    real.st_mtime,
+                    real.st_ctime,
+                )
+            )
+
+        with (
+            patch("mixpanel_headless._internal.io_utils.os.fstat", fake_fstat),
+            pytest.raises(CredentialPathError, match="regular file"),
+        ):
+            read_credential_bytes(target)
+
+
+class TestSizeCap:
+    """Reject credential files larger than ``MAX_CREDENTIAL_BYTES`` (1 MiB)."""
+
+    @_POSIX_ONLY
+    def test_accepts_at_cap(self, temp_dir: Path) -> None:
+        """A file exactly at the cap reads cleanly."""
+        target = _write_owner_only(temp_dir / "creds", b"A" * MAX_CREDENTIAL_BYTES)
+        assert len(read_credential_bytes(target)) == MAX_CREDENTIAL_BYTES
+
+    @_POSIX_ONLY
+    def test_rejects_over_cap(self, temp_dir: Path) -> None:
+        """One byte over the cap raises ``CredentialPathError(EFBIG, ...)``."""
+        target = _write_owner_only(
+            temp_dir / "creds", b"A" * (MAX_CREDENTIAL_BYTES + 1)
+        )
+        with pytest.raises(CredentialPathError, match="size|too large|EFBIG|cap"):
+            read_credential_bytes(target)
+
+    def test_cap_is_sane_value(self) -> None:
+        """1 MiB is documented as 100× the largest realistic credential file.
+
+        Locks the constant against accidental changes that would break
+        the size-rejection contract.
+        """
+        assert MAX_CREDENTIAL_BYTES == 1 << 20
+
+
+class TestDirfdWalk:
+    """Intermediate-component symlink rejection (the dirfd-walked open).
+
+    The original PR only checked the FINAL path component for symlinks.
+    A same-UID attacker who can ``rm -rf ~/.mp && ln -s /tmp/attack ~/.mp``
+    bypasses leaf-only ``O_NOFOLLOW`` entirely. The dirfd walk closes
+    the gap for paths under :func:`Path.home` (where attackers can
+    actually plant symlinks). Tests monkeypatch ``HOME`` to a tmp dir
+    so the walk fires on the test path.
+    """
+
+    @_POSIX_ONLY
+    def test_rejects_symlinked_ancestor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink in any intermediate path component raises ``CredentialPathError``.
+
+        Layout::
+
+            $HOME/real_dir/creds.json  (real file, 0o600)
+            $HOME/link_dir -> real_dir (symlink at the intermediate component)
+
+        Read via ``$HOME/link_dir/creds.json``. The leaf is a real
+        file, but ``link_dir`` is a symlink. Must reject.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir(mode=0o700)
+        _write_owner_only(real_dir / "creds.json", b"x")
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+        with pytest.raises(CredentialPathError, match="symlink"):
+            read_credential_bytes(link_dir / "creds.json")
+
+    @_POSIX_ONLY
+    def test_accepts_real_ancestors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path with no symlinks anywhere under HOME reads fine."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True, mode=0o700)
+        target = _write_owner_only(nested / "creds", b"deep")
+        assert read_credential_bytes(target) == b"deep"
+
+    @_POSIX_ONLY
+    def test_no_fd_leak_on_ancestor_rejection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repeated dirfd-walk rejections don't accumulate fds."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir(mode=0o700)
+        _write_owner_only(real_dir / "creds.json", b"x")
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+        proc = psutil.Process()
+        before = proc.num_fds()
+        for _ in range(200):
+            with pytest.raises(CredentialPathError):
+                read_credential_bytes(link_dir / "creds.json")
+        after = proc.num_fds()
+        assert after - before < 5, f"fd leak in dirfd walk: {before} -> {after}"
+
+    @_POSIX_ONLY
+    def test_outside_home_uses_leaf_only(self, tmp_path: Path) -> None:
+        """Paths outside HOME get leaf-only protection (no dirfd walk).
+
+        An intermediate symlink outside HOME is NOT rejected (the user
+        configured the path explicitly via env var / direct path).
+        This locks the documented carve-out so future changes don't
+        accidentally tighten or loosen the contract.
+        """
+        # tmp_path is in /var/folders on macOS, definitely not under HOME.
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir(mode=0o700)
+        _write_owner_only(real_dir / "creds.json", b"x")
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+        # Leaf is a real file → succeeds (no intermediate-symlink check).
+        assert read_credential_bytes(link_dir / "creds.json") == b"x"
 
 
 def _stub_stdin(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:

--- a/tests/unit/test_loc_budget.py
+++ b/tests/unit/test_loc_budget.py
@@ -66,10 +66,10 @@ class TestLocBudget:
     FILE_COUNT_CAP = 20
     """Maximum number of auth-subsystem files. A 21st file fails this test."""
 
-    LOC_CAP = 8800
+    LOC_CAP = 8900
     """Maximum total LoC across the auth subsystem (~7% headroom over current).
 
-    Bumped 6500 → 6700 → 8800 by 043 (frictionless-auth):
+    Bumped 6500 → 6700 → 8800 → 8900 by SEC-331 follow-up:
     - 6500 → 6700 covered the two new files
       (``_internal/auth/region_probe.py``, ``_internal/auth/naming.py``)
       plus the relaxations in ``cli/commands/account.py`` /
@@ -77,8 +77,12 @@ class TestLocBudget:
     - 6700 → 8800 added ``accounts.py`` (1500+ lines after the
       ``login_unified`` orchestrator landed) to the scope so the
       orchestrator's growth is also guarded going forward.
-    See ``specs/043-frictionless-auth/plan.md`` §"Scale/Scope" and the
-    rescue plan at ``~/.claude/plans/thoroughly-and-rigorously-and-gentle-lemur.md``.
+    - 8800 → 8900 covers the SEC-331 follow-up additions: dirfd-walk
+      ``_open_credential_fd``, ``reject_if_symlink`` helper, S_ISREG +
+      size cap checks in ``_enforce_credential_file_invariants``,
+      ``_fchmod_no_follow`` in ``storage.py``, and the
+      ``reject_if_symlink`` wires at the five call sites.
+    See ``specs/043-frictionless-auth/plan.md`` §"Scale/Scope".
     """
 
     def test_file_count_cap(self) -> None:

--- a/tests/unit/test_me.py
+++ b/tests/unit/test_me.py
@@ -674,3 +674,46 @@ class TestMeService:
         )
         ws = service.find_default_workspace("555")
         assert ws is None
+
+
+class TestMeCacheSymlinkRejection:
+    """``MeCache.get`` refuses a symlinked ``me.json``.
+
+    Regression for the same-UID symlink attack covered by
+    ``io_utils.read_credential_text``. The contract here is the same
+    as for ``OAuthStorage._read_file``: rejection turns into ``None``
+    (so the next call re-fetches from ``/me``) but the rejection is
+    logged at WARNING — escalated from the existing ``.debug`` path so
+    a symlink-attack signal doesn't disappear into a quiet "corrupted
+    cache, ignoring" log line.
+    """
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("os"), "O_NOFOLLOW"),
+        reason="O_NOFOLLOW required; Windows is not in scope",
+    )
+    def test_symlinked_cache_returns_none_and_warns(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A symlinked me.json is refused; ``get()`` returns None + WARNING."""
+        import json
+        import logging
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        account_dir = tmp_path / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        attacker = tmp_path / "attacker_me.json"
+        attacker.write_text(json.dumps({"cached_at": 0}), encoding="utf-8")
+        attacker.chmod(0o600)
+        (account_dir / "me.json").symlink_to(attacker)
+
+        cache = MeCache(account_name="personal")
+        caplog.set_level(logging.WARNING)
+        assert cache.get() is None
+        assert any(
+            "symlink" in rec.message.lower() or "refusing" in rec.message.lower()
+            for rec in caplog.records
+        ), f"expected WARNING log mentioning symlink/refusing, got: {caplog.text}"

--- a/tests/unit/test_me.py
+++ b/tests/unit/test_me.py
@@ -10,6 +10,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import os
 import stat
 import time
 from pathlib import Path
@@ -27,6 +28,11 @@ from mixpanel_headless._internal.me import (
     MeWorkspaceInfo,
 )
 from mixpanel_headless.exceptions import AuthenticationError, ConfigError, QueryError
+
+_REQUIRES_O_NOFOLLOW = pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW required; Windows is not in scope",
+)
 
 
 class TestMeOrgInfo:
@@ -688,10 +694,7 @@ class TestMeCacheSymlinkRejection:
     cache, ignoring" log line.
     """
 
-    @pytest.mark.skipif(
-        not hasattr(__import__("os"), "O_NOFOLLOW"),
-        reason="O_NOFOLLOW required; Windows is not in scope",
-    )
+    @_REQUIRES_O_NOFOLLOW
     def test_symlinked_cache_returns_none_and_warns(
         self,
         tmp_path: Path,
@@ -709,6 +712,32 @@ class TestMeCacheSymlinkRejection:
         attacker.write_text(json.dumps({"cached_at": 0}), encoding="utf-8")
         attacker.chmod(0o600)
         (account_dir / "me.json").symlink_to(attacker)
+
+        cache = MeCache(account_name="personal")
+        caplog.set_level(logging.WARNING)
+        assert cache.get() is None
+        assert any(
+            "symlink" in rec.message.lower() or "refusing" in rec.message.lower()
+            for rec in caplog.records
+        ), f"expected WARNING log mentioning symlink/refusing, got: {caplog.text}"
+
+    @_REQUIRES_O_NOFOLLOW
+    def test_dangling_symlink_cache_returns_none_and_warns(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A dangling symlink at me.json is refused with WARNING log.
+
+        Regression for the ``Path.exists()`` follows-symlink trap.
+        """
+        import logging
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        account_dir = tmp_path / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        (account_dir / "me.json").symlink_to(tmp_path / "missing.json")
 
         cache = MeCache(account_name="personal")
         caplog.set_level(logging.WARNING)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+import os
 import platform
 import stat
 from pathlib import Path
@@ -298,3 +299,29 @@ class TestOAuthStorageSymlinkRejection:
             storage._check_and_fix_permissions(target)
         # Verify the file was actually chmodded via the fchmod path.
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_windows_skip_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On platforms without ``os.O_NOFOLLOW`` or ``os.fchmod``,
+        ``_check_and_fix_permissions`` is a no-op rather than an
+        ``AttributeError`` crash.
+
+        Regression: an earlier revision of the SEC-331 follow-up
+        used ``os.O_NOFOLLOW | os.O_DIRECTORY`` at the call site,
+        which evaluated at construction time. On Windows that raises
+        ``AttributeError`` before the function body runs. We simulate
+        the platform via ``monkeypatch.delattr`` so the test exercises
+        the same code path that would run on a real Windows interpreter.
+        """
+        from mixpanel_headless._internal.auth.storage import OAuthStorage
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
+        storage = OAuthStorage()
+        storage._ensure_dir()
+        target = storage._tokens_path("us")
+        target.write_text("{}", encoding="utf-8")
+        # Pretend O_NOFOLLOW doesn't exist (Windows posture).
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        # Must not raise.
+        storage._check_and_fix_permissions(target)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -152,3 +152,88 @@ class TestEnsureAccountDir:
         monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
         with pytest.raises(ValueError):
             ensure_account_dir("../etc")
+
+
+class TestOAuthStorageSymlinkRejection:
+    """``OAuthStorage._read_file`` refuses symlinks; ``_check_and_fix_permissions``
+    refuses to chmod through them.
+
+    Regression for the same-UID symlink attack. The read path uses
+    :func:`read_credential_text`, which raises
+    :class:`CredentialPathError`; the silent-degradation contract
+    (``_read_file`` returns ``None`` and logs WARNING) is preserved so
+    a re-fetch still happens — but the rejection is now visible in logs.
+
+    The chmod path is independently dangerous: today
+    ``_check_and_fix_permissions`` does ``path.stat()`` (follows symlink)
+    + ``path.chmod()`` (chmods the target), so an attacker who plants
+    a 0o644 file gets it tightened to 0o600 just before the read. The
+    fix uses ``lstat()`` and bails on symlinks — we assert the target
+    file's mode is left untouched.
+    """
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX symlink + mode semantics required",
+    )
+    def test_read_symlinked_tokens_returns_none_and_warns(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A symlinked tokens file is refused; ``_read_file`` returns None + WARNING."""
+        import logging
+
+        from mixpanel_headless._internal.auth.storage import OAuthStorage
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
+        attacker = tmp_path / "attacker.json"
+        attacker.write_text('{"access_token":"stolen"}', encoding="utf-8")
+        attacker.chmod(0o600)
+        storage = OAuthStorage()
+        storage._ensure_dir()
+        target = storage._tokens_path("us")
+        target.symlink_to(attacker)
+
+        caplog.set_level(logging.WARNING)
+        result = storage.load_tokens("us")
+        assert result is None
+        assert any(
+            "symlink" in rec.message.lower() or "refusing" in rec.message.lower()
+            for rec in caplog.records
+        ), f"expected WARNING log mentioning symlink/refusing, got: {caplog.text}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX symlink + mode semantics required",
+    )
+    def test_check_and_fix_permissions_does_not_chmod_through_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The buggy chmod-through-symlink primitive is killed.
+
+        Before the fix: ``_check_and_fix_permissions`` followed the
+        symlink and chmodded the target to 0o600, silently tightening
+        the attacker's file right before the (then-unsafe) read.
+
+        After: ``lstat`` detects the symlink, logs a warning, and
+        leaves the target file's mode untouched.
+        """
+        from mixpanel_headless._internal.auth.storage import OAuthStorage
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
+        attacker = tmp_path / "attacker.json"
+        attacker.write_text("x", encoding="utf-8")
+        attacker.chmod(0o644)
+        original_mode = stat.S_IMODE(attacker.stat().st_mode)
+        assert original_mode == 0o644
+
+        storage = OAuthStorage()
+        storage._ensure_dir()
+        target = storage._tokens_path("us")
+        target.symlink_to(attacker)
+
+        storage._check_and_fix_permissions(target)
+        # Target file mode unchanged — no chmod side effect via the symlink.
+        assert stat.S_IMODE(attacker.stat().st_mode) == original_mode

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -237,3 +237,64 @@ class TestOAuthStorageSymlinkRejection:
         storage._check_and_fix_permissions(target)
         # Target file mode unchanged — no chmod side effect via the symlink.
         assert stat.S_IMODE(attacker.stat().st_mode) == original_mode
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX symlink + mode semantics required",
+    )
+    def test_dangling_symlink_returns_none_and_warns(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dangling symlink at the credential path is refused with WARNING."""
+        import logging
+
+        from mixpanel_headless._internal.auth.storage import OAuthStorage
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
+        storage = OAuthStorage()
+        storage._ensure_dir()
+        target = storage._tokens_path("us")
+        target.symlink_to(tmp_path / "missing.json")
+
+        caplog.set_level(logging.WARNING)
+        result = storage.load_tokens("us")
+        assert result is None
+        assert any(
+            "symlink" in rec.message.lower() or "refusing" in rec.message.lower()
+            for rec in caplog.records
+        ), f"expected WARNING log mentioning symlink/refusing, got: {caplog.text}"
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="POSIX symlink + mode semantics required",
+    )
+    def test_check_and_fix_permissions_uses_fchmod_not_chmod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The chmod-through-symlink TOCTOU is closed via open+fchmod.
+
+        Confirm by patching ``Path.chmod`` to fail loudly — if the code
+        still reaches it, the test fails. The fchmod-on-fd path doesn't
+        go through ``Path.chmod``.
+        """
+        from unittest.mock import patch
+
+        from mixpanel_headless._internal.auth.storage import OAuthStorage
+
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
+        storage = OAuthStorage()
+        storage._ensure_dir()
+        target = storage._tokens_path("us")
+        target.write_text("{}", encoding="utf-8")
+        target.chmod(0o644)  # set up lax mode to trigger the repair path
+
+        with patch.object(
+            Path, "chmod", side_effect=AssertionError("Path.chmod called!")
+        ):
+            # _check_and_fix_permissions must NOT call Path.chmod anywhere.
+            storage._check_and_fix_permissions(target)
+        # Verify the file was actually chmodded via the fchmod path.
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600

--- a/tests/unit/test_token_resolver.py
+++ b/tests/unit/test_token_resolver.py
@@ -499,3 +499,41 @@ class TestConcurrentRefresh:
         # Both threads triggered an IdP call (the resolver does NOT have a
         # single-flight guard; this assertion documents the current behaviour).
         assert call_count == 2
+
+
+class TestSymlinkRejection:
+    """``get_browser_token`` refuses a symlinked ``tokens.json``.
+
+    Regression for the same-UID symlink attack covered by
+    ``io_utils.read_credential_bytes``. The error is surfaced through
+    the existing ``OAuthError`` translation in
+    ``OnDiskTokenResolver.get_browser_token`` so the CLI output stays
+    domain-specific.
+    """
+
+    @pytest.mark.skipif(
+        not hasattr(os, "O_NOFOLLOW"),
+        reason="O_NOFOLLOW required; Windows is not in scope",
+    )
+    def test_symlinked_tokens_raises_oautherror(self, isolated_home: Path) -> None:
+        """Symlinked tokens.json yields OAuthError with the symlink path named."""
+        account_dir = isolated_home / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        attacker = isolated_home / "attacker_tokens.json"
+        attacker.write_text(
+            json.dumps(
+                {
+                    "access_token": "stolen-acc",
+                    "expires_at": future.isoformat(),
+                    "token_type": "Bearer",
+                    "scope": "read:project",
+                }
+            ),
+            encoding="utf-8",
+        )
+        attacker.chmod(0o600)
+        (account_dir / "tokens.json").symlink_to(attacker)
+        resolver = OnDiskTokenResolver()
+        with pytest.raises(OAuthError, match="symlink"):
+            resolver.get_browser_token("personal", "us")

--- a/tests/unit/test_token_resolver.py
+++ b/tests/unit/test_token_resolver.py
@@ -27,6 +27,11 @@ from mixpanel_headless._internal.auth.account import (
 from mixpanel_headless._internal.auth.token_resolver import OnDiskTokenResolver
 from mixpanel_headless.exceptions import OAuthError
 
+_REQUIRES_O_NOFOLLOW = pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW required; Windows is not in scope",
+)
+
 
 @pytest.fixture
 def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -511,10 +516,7 @@ class TestSymlinkRejection:
     domain-specific.
     """
 
-    @pytest.mark.skipif(
-        not hasattr(os, "O_NOFOLLOW"),
-        reason="O_NOFOLLOW required; Windows is not in scope",
-    )
+    @_REQUIRES_O_NOFOLLOW
     def test_symlinked_tokens_raises_oautherror(self, isolated_home: Path) -> None:
         """Symlinked tokens.json yields OAuthError with the symlink path named."""
         account_dir = isolated_home / ".mp" / "accounts" / "personal"
@@ -534,6 +536,25 @@ class TestSymlinkRejection:
         )
         attacker.chmod(0o600)
         (account_dir / "tokens.json").symlink_to(attacker)
+        resolver = OnDiskTokenResolver()
+        with pytest.raises(OAuthError, match="symlink"):
+            resolver.get_browser_token("personal", "us")
+
+    @_REQUIRES_O_NOFOLLOW
+    def test_dangling_symlink_tokens_raises_oautherror(
+        self, isolated_home: Path
+    ) -> None:
+        """A dangling symlink at tokens.json raises ``OAuthError``.
+
+        Regression for the ``Path.exists()`` follows-symlink trap:
+        without the new ``reject_if_symlink`` probe, a dangling symlink
+        would surface as ``OAuthError("No OAuth tokens found... Run `mp
+        account login`")`` instead of the symlink-specific message, and
+        ``mp login`` would then try to write through the symlink.
+        """
+        account_dir = isolated_home / ".mp" / "accounts" / "personal"
+        account_dir.mkdir(parents=True, mode=0o700)
+        (account_dir / "tokens.json").symlink_to(isolated_home / "missing.json")
         resolver = OnDiskTokenResolver()
         with pytest.raises(OAuthError, match="symlink"):
             resolver.get_browser_token("personal", "us")

--- a/tests/unit/test_workspace_init.py
+++ b/tests/unit/test_workspace_init.py
@@ -202,6 +202,7 @@ class TestBridgeTokenMaterialization:
             ),
             encoding="utf-8",
         )
+        stale_path.chmod(0o600)
 
         fresh_expires = datetime.now(timezone.utc) + timedelta(hours=1)
         bridge_payload = {
@@ -222,6 +223,7 @@ class TestBridgeTokenMaterialization:
         }
         bridge_path = tmp_path / "bridge.json"
         bridge_path.write_text(json.dumps(bridge_payload), encoding="utf-8")
+        bridge_path.chmod(0o600)
         monkeypatch.setenv("MP_AUTH_FILE", str(bridge_path))
 
         Workspace()

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-07T23:44:29.929192Z"
+exclude-newer = "2026-05-13T11:16:19.253093Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1322,9 +1322,11 @@ dev = [
     { name = "mypy" },
     { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas-stubs", version = "3.0.0.260204", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-psutil" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1366,6 +1368,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.0" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "psutil", marker = "extra == 'dev'", specifier = ">=7.2.0" },
     { name = "pyarrow", marker = "python_full_version >= '3.11'", specifier = ">=17.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
@@ -1375,6 +1378,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=7.2.0.20251228" },
 ]
 provides-extras = ["dev", "docs", "notebook"]
 


### PR DESCRIPTION
## Summary
- Closes [SEC-331](https://linear.app/mixpanel/issue/SEC-331/appsec-review-mixpanel-headless-implementation). Six credential read sites (`config.toml`, `MP_AUTH_FILE` bridge, per-account `tokens.json`, `oauth/tokens_*.json`, `oauth/client_*.json`, `me.json`) used `Path.read_text()` / `read_bytes()`, which follow symlinks unconditionally. A same-UID attacker could plant a symlink and have us read attacker-controlled credential material.
- New `read_credential_bytes` / `read_credential_text` in `_internal/io_utils.py`. POSIX uses `O_NOFOLLOW` + post-open `fstat` mode check (no TOCTOU window — the fd pins the inode); Windows falls back to `is_symlink()` (not in threat model). Failures raise `CredentialPathError(OSError)` so existing `except OSError` handlers keep working while silent-degradation sites in `storage._read_file` and `me.MeCache.get` distinguish attack-shaped rejections from generic corruption and log at WARNING.
- Also fixes `OAuthStorage._check_and_fix_permissions` chmod-through-symlink bug — it used to silently tighten an attacker's planted file to 0o600 right before the (then-unsafe) read.

## Test plan
- [x] `just check` — lint + format + mypy --strict + 6412 tests + 92.16% coverage + build
- [x] 15 new helper tests in `test_io_utils.py` (symlink targets: attacker / legitimate-owned / dangling; mode rejection across 0o640–0o777; fd-leak under both rejection branches; `OSError` subclass contract)
- [x] 7 call-site regression tests covering each of the 6 sites + the chmod-through-symlink mode-preservation assertion
- [x] Manual repro — symlinked `~/.mp/config.toml` produces `Configuration error: Could not parse config at ...: [Errno 62] Refusing to read credential at symlink: ...` and non-zero exit
- [x] Manual repro — symlinked `$MP_AUTH_FILE` produces the equivalent error at the bridge call site

## Out of scope
- Hard-link defense (`O_NOFOLLOW` doesn't catch them; requires strictly stronger attacker capability than the threat model)
- Intermediate-path symlinks (ancestor dirs are `0o700` via `ensure_account_dir` / `_ensure_dir`)
- Replacing `_check_and_fix_permissions`' silent chmod-to-fix behavior on non-symlink lax-mode files (the credential is already exposed if it was 0o644 — separate review)
- Attacker-controlled `\$HOME` (deployment posture, not in-process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)