### PR TITLE
Release v0.1.1

### DIFF
--- a/src/mixpanel_headless/__init__.py
+++ b/src/mixpanel_headless/__init__.py
@@ -285,7 +285,7 @@ from mixpanel_headless.types import (
 )
 from mixpanel_headless.workspace import Workspace
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Core

--- a/src/mixpanel_headless/_internal/client_metadata.py
+++ b/src/mixpanel_headless/_internal/client_metadata.py
@@ -61,7 +61,7 @@ def get_user_agent() -> str:
     Example:
         ```python
         get_user_agent()
-        # "mixpanel-headless/0.1.0 (entry=lib; python/3.11)"
+        # "mixpanel-headless/0.1.1 (entry=lib; python/3.11)"
         ```
     """
     # Lazy import: mixpanel_headless/__init__.py defines __version__ after


### PR DESCRIPTION
## Summary
Patch release bundling everything merged since v0.1.0 (5ebba08).

## Version
`0.1.0` → `0.1.1` in `src/mixpanel_headless/__init__.py`. Updated the matching docstring example in `_internal/client_metadata.py` so the User-Agent example tracks the real version.

## Included since v0.1.0
**Features / API**
- Widen `events()` listing defaults + 403 retry on date-range narrowing (#170)

**Security**
- Reject symlinks on credential file reads, SEC-331 (#177)
- Remove sensitive file paths from credential handler log messages (#179)
- Stricter `atomic_write_bytes` mode + codex-review gate, closes CodeQL findings (#166)
- Revise SECURITY.md reporting guidelines (#167)

**Observability**
- Stamp `User-Agent` + `query_origin` on outbound API requests (#169)

**Infra / deps**
- Bump `urllib3` 2.6.3 → 2.7.0 (GHSA-qccp-gfcp-xxvc, #165)
- Hypothesis CLI floor bumped to 6.151.13 (#164)
- Dependabot bumps for `actions/github-script`, `actions/checkout`, `actions/create-github-app-token`, `actions/upload-artifact`, `codecov/codecov-action`

## Release process
After merge, cut a `v0.1.1` GitHub Release. The `release.yml` workflow verifies the built wheel version against the tag and publishes to PyPI via Trusted Publishers.

## Test plan
- [x] `just lint` / `just fmt-check` / `just typecheck` clean locally
- [ ] CI green on the PR
- [ ] After merge: tag `v0.1.1`, watch `release.yml` build + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)