### PR TITLE
Security: Upgrade pymdown-extensions to 10.21.3 (CVE-2026-46338)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-13T11:16:19.253093Z"
+exclude-newer = "2026-05-14T17:03:16.245207371Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -2385,15 +2385,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Upgrades pymdown-extensions from 10.21.2 to 10.21.3 to address CVE-2026-46338, a medium-severity path traversal vulnerability in the snippets preprocessor.

**Origin:** This security issue was surfaced by [Dependabot alert #13](https://github.com/mixpanel/mixpanel-headless/security/dependabot/13).

## Risk Assessment
**Actual exposure: MINIMAL**
- The vulnerable `pymdownx.snippets` feature is enabled but not used (zero instances in docs)
- Default configuration (`restrict_base_path: true`) provides protection
- No secrets or sensitive files in repository root
- Code review process would catch malicious snippet syntax

## Vulnerability Details
**CVE:** CVE-2026-46338 / GHSA-62q4-447f-wv8h  
**Affected:** pymdown-extensions 10.0.1 - 10.21.2  
**Fixed in:** 10.21.3 (released 2026-05-13)  
**Dependabot alert:** [#13](https://github.com/mixpanel/mixpanel-headless/security/dependabot/13)

**Technical issue:** Path traversal in `pymdownx.snippets` preprocessor allows reading files outside `base_path` using sibling prefix bypass. The vulnerable code uses `filename.startswith(base)` for path containment checks, which doesn't enforce directory boundaries. This allows snippet directives like `--8<-- "../docs_secret/file.txt"` to bypass `restrict_base_path` settings and read files from sibling directories that share the same prefix (e.g., `docs` vs `docs_secret`).

**Attack scenario:**
1. Attacker contributes a PR with malicious markdown containing: `--8<-- "../sensitive_dir/secrets.txt"`
2. During docs build, the snippet preprocessor reads the file
3. Sensitive content gets embedded in generated HTML
4. HTML is published to GitHub Pages, exposing secrets

**Impact:** Arbitrary file read within the host filesystem, bounded by prefix matching. In CI/CD contexts, could expose secrets or sensitive files in documentation builds.

## Testing
- ✅ Clean rebase from latest main (eec1379)
- ✅ Documentation builds successfully (`mkdocs build --strict`)
- ✅ Only uv.lock changed (no merge conflicts)
- ✅ Sanity tests pass locally
- ✅ Pre-commit hooks pass (ruff format, ruff lint, interrogate)
- ✅ CI will run full test suite (6,772+ tests with ≥90% coverage)

## Changes
- `uv.lock`: pymdown-extensions 10.21.2 → 10.21.3
- Single patch version bump, no breaking changes expected
- Transitive dependency via mkdocs-material (no pyproject.toml changes needed)

## Post-Merge Actions
- [ ] Dependabot alert #13 will auto-close
- [ ] Consider optional hardening: remove unused `pymdownx.snippets` extension from `mkdocs.yml` for defense-in-depth

## References
- **Dependabot alert:** [#13](https://github.com/mixpanel/mixpanel-headless/security/dependabot/13)
- **CVE:** [CVE-2026-46338](https://nvd.nist.gov/vuln/detail/CVE-2026-46338)
- **GHSA:** [GHSA-62q4-447f-wv8h](https://github.com/advisories/GHSA-62q4-447f-wv8h)
- **Package:** [pymdown-extensions 10.21.3](https://pypi.org/project/pymdown-extensions/10.21.3/)
- **Supersedes:** #181 (closed due to merge conflicts)