### PR TITLE
Migrate engage endpoint to /api/query/engage path

### DIFF
--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -107,19 +107,19 @@ ENDPOINTS: dict[str, dict[str, str]] = {
     "us": {
         "query": "https://mixpanel.com/api/query",
         "export": "https://data.mixpanel.com/api/2.0",
-        "engage": "https://mixpanel.com/api/2.0/engage",
+        "engage": "https://mixpanel.com/api/query/engage",
         "app": "https://mixpanel.com/api/app",
     },
     "eu": {
         "query": "https://eu.mixpanel.com/api/query",
         "export": "https://data-eu.mixpanel.com/api/2.0",
-        "engage": "https://eu.mixpanel.com/api/2.0/engage",
+        "engage": "https://eu.mixpanel.com/api/query/engage",
         "app": "https://eu.mixpanel.com/api/app",
     },
     "in": {
         "query": "https://in.mixpanel.com/api/query",
         "export": "https://data-in.mixpanel.com/api/2.0",
-        "engage": "https://in.mixpanel.com/api/2.0/engage",
+        "engage": "https://in.mixpanel.com/api/query/engage",
         "app": "https://in.mixpanel.com/api/app",
     },
 }
@@ -1801,7 +1801,7 @@ class MixpanelAPIClient:
     ) -> dict[str, Any]:
         """Fetch aggregate statistics from the Engage API.
 
-        POSTs to ``/api/2.0/engage/stats`` to retrieve aggregate metrics
+        POSTs to ``/api/query/engage/stats`` to retrieve aggregate metrics
         over the user/group population.
 
         Args:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -99,6 +99,18 @@ class TestEndpoints:
         assert "query" in ENDPOINTS["in"]
         assert "export" in ENDPOINTS["in"]
 
+    def test_engage_uses_query_api_path(self) -> None:
+        """Engage endpoint should use the documented /api/query/engage path.
+
+        The Mixpanel Query API spec documents Engage profile queries under
+        ``https://{regionAndDomain}.com/api/query/engage``. The analytics
+        request handler accepts both ``/api/query/`` and ``/api/2.0/`` as
+        equivalent prefixes, but we follow the documented contract.
+        """
+        assert ENDPOINTS["us"]["engage"] == "https://mixpanel.com/api/query/engage"
+        assert ENDPOINTS["eu"]["engage"] == "https://eu.mixpanel.com/api/query/engage"
+        assert ENDPOINTS["in"]["engage"] == "https://in.mixpanel.com/api/query/engage"
+
 
 class TestClientInit:
     """Test client initialization."""


### PR DESCRIPTION
## Summary
- Migrate engage profile/stats endpoint from `/api/2.0/engage` to the documented `/api/query/engage` path
- Add `ENDPOINTS` test pinning the new path per region (us/eu/in)
- Update `engage_stats()` docstring to reference the new URL

## Why
Mixpanel's Query API OpenAPI spec documents the engage operation under `/api/query/engage`. The analytics request handler aliases `/api/2.0/...` and `/api/query/...` at the routing layer (`analytics/api/version_2_0/request_handler.py:510`), so this is a contract alignment with no server-side behavior difference. Mixpanel's own internal tools already hit sub-endpoints under `/api/query/engage/` (e.g. `tools/security/raw-export-p3.py:19` calls `/api/query/engage/aliases`).

A single `ENDPOINTS` config change covers all three callers in `api_client.py`:
- `export_profiles()` (line 1599)
- `export_profiles_page()` (line 1732)
- `engage_stats()` (line 1849)

## Test plan
- [x] `just check` — 6443 passed, 92.08% coverage, build green
- [x] New unit test pins `ENDPOINTS["{us,eu,in}"]["engage"]` to the new path
- [x] Live smoke against project 3409416 (account `mixpanel-4`, US):
  - `export_profiles_page(page=0, limit=3)` → 3 profiles, valid `session_id`, `has_more=True`
  - `engage_stats(action="count()")` → `results: 250000`
  - `events()` control → 21 known events

🤖 Generated with [Claude Code](https://claude.com/claude-code)