### PR TITLE
write display_name and example_value across lexicon definitions

### DIFF
--- a/src/mixpanel_headless/cli/commands/lexicon.py
+++ b/src/mixpanel_headless/cli/commands/lexicon.py
@@ -154,6 +154,10 @@ def events_update(
             "--verified/--no-verified", help="Mark event as verified or unverified."
         ),
     ] = None,
+    display_name: Annotated[
+        str | None,
+        typer.Option("--display-name", help="New human-readable display name."),
+    ] = None,
     description: Annotated[
         str | None,
         typer.Option("--description", help="New event description."),
@@ -176,6 +180,7 @@ def events_update(
         hidden: Whether to hide the event.
         dropped: Whether to drop event data at ingestion.
         verified: Whether to mark the event as verified.
+        display_name: New human-readable display name.
         description: New description text.
         tags: Comma-separated tag names to assign.
         format: Output format.
@@ -190,6 +195,8 @@ def events_update(
         kwargs["dropped"] = dropped
     if verified is not None:
         kwargs["verified"] = verified
+    if display_name is not None:
+        kwargs["display_name"] = display_name
     if description is not None:
         kwargs["description"] = description
     if tags is not None:
@@ -345,9 +352,27 @@ def properties_update(
             "--sensitive/--no-sensitive", help="Mark property as PII sensitive."
         ),
     ] = None,
+    display_name: Annotated[
+        str | None,
+        typer.Option("--display-name", help="New human-readable display name."),
+    ] = None,
     description: Annotated[
         str | None,
         typer.Option("--description", help="New property description."),
+    ] = None,
+    example_value: Annotated[
+        str | None,
+        typer.Option("--example-value", help="Example value shown in the Lexicon."),
+    ] = None,
+    resource_type: Annotated[
+        str | None,
+        typer.Option(
+            "--resource-type",
+            help="Resource type (Event or User). Pass this to disambiguate a "
+            "user property from an event property of the same name. Sent "
+            "verbatim, so match the API's casing (the value reads back as "
+            "'Event' / 'User').",
+        ),
     ] = None,
     format: FormatOption = "json",
     jq_filter: JqOption = None,
@@ -355,7 +380,10 @@ def properties_update(
     """Update a property definition (PATCH semantics).
 
     Only fields provided will be updated. Use boolean flags like
-    ``--hidden/--no-hidden`` to toggle visibility.
+    ``--hidden/--no-hidden`` to toggle visibility. ``--resource-type`` is sent
+    only when given; pass it to target a user property that shares a name with
+    an event property. The value is forwarded verbatim, so match the API's
+    casing (``Event`` / ``User``).
 
     Args:
         ctx: Typer context with global options.
@@ -363,21 +391,31 @@ def properties_update(
         hidden: Whether to hide the property.
         dropped: Whether to drop property data.
         sensitive: Whether to mark the property as PII sensitive.
+        display_name: New human-readable display name.
         description: New description text.
+        example_value: New example value shown in the Lexicon.
+        resource_type: Resource type (``Event`` / ``User``); sent only when
+            provided.
         format: Output format.
         jq_filter: Optional jq filter expression.
     """
     from mixpanel_headless.types import UpdatePropertyDefinitionParams
 
     kwargs: dict[str, Any] = {}
+    if resource_type is not None:
+        kwargs["resource_type"] = resource_type
     if hidden is not None:
         kwargs["hidden"] = hidden
     if dropped is not None:
         kwargs["dropped"] = dropped
     if sensitive is not None:
         kwargs["sensitive"] = sensitive
+    if display_name is not None:
+        kwargs["display_name"] = display_name
     if description is not None:
         kwargs["description"] = description
+    if example_value is not None:
+        kwargs["example_value"] = example_value
 
     params = UpdatePropertyDefinitionParams(**kwargs)
     workspace = get_workspace(ctx)

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -4700,8 +4700,12 @@ class PropertyDefinition(BaseModel):
     Attributes:
         id: Server-assigned property ID.
         name: Property name.
-        resource_type: Property resource type (event, user, groupprofile).
+        resource_type: Property resource type as the API returns it, e.g.
+            ``Event`` / ``User`` (capitalized, matching the write contract on
+            :class:`UpdatePropertyDefinitionParams`).
+        display_name: Human-readable name.
         description: Property description.
+        example_value: Example value shown in the Lexicon.
         hidden: Whether hidden from UI.
         dropped: Whether data is dropped.
         merged: Whether merged into another property.
@@ -4725,10 +4729,17 @@ class PropertyDefinition(BaseModel):
     """Property name."""
 
     resource_type: str | None = None
-    """Property resource type (event, user, groupprofile)."""
+    """Property resource type as the API returns it, e.g. ``Event`` / ``User``
+    (capitalized, matching the write contract)."""
+
+    display_name: str | None = None
+    """Human-readable name (Lexicon ``displayName``)."""
 
     description: str | None = None
     """Property description."""
+
+    example_value: str | None = None
+    """Example value shown in the Lexicon (``exampleValue``)."""
 
     hidden: bool | None = None
     """Whether hidden from UI."""
@@ -4757,15 +4768,20 @@ class UpdateEventDefinitionParams(BaseModel):
         merged: Whether merged.
         verified: Whether verified.
         tags: Tag names to assign.
+        display_name: Human-readable name (sent as ``displayName``).
         description: Event description.
 
     Example:
         ```python
         params = UpdateEventDefinitionParams(
-            description="User completed a purchase", verified=True
+            display_name="Purchase",
+            description="User completed a purchase",
+            verified=True,
         )
         ```
     """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     hidden: bool | None = None
     """Whether hidden from UI."""
@@ -4781,6 +4797,9 @@ class UpdateEventDefinitionParams(BaseModel):
 
     tags: list[str] | None = None
     """Tag names to assign."""
+
+    display_name: str | None = None
+    """Human-readable name (sent as ``displayName``)."""
 
     description: str | None = None
     """Event description."""
@@ -4921,13 +4940,25 @@ class UpdatePropertyDefinitionParams(BaseModel):
         dropped: Whether data is dropped.
         merged: Whether merged.
         sensitive: PII flag.
+        display_name: Human-readable name (sent as ``displayName``).
         description: Property description.
+        example_value: Example value (sent as ``exampleValue``).
+        resource_type: Resource type (``Event`` / ``User``); sent verbatim as
+            ``resourceType`` to disambiguate a user property from an event
+            property of the same name. The value mirrors what the API returns
+            on reads, so use the capitalized form.
 
     Example:
         ```python
-        params = UpdatePropertyDefinitionParams(sensitive=True)
+        params = UpdatePropertyDefinitionParams(
+            display_name="Plan Type",
+            example_value="free, pro, enterprise",
+            resource_type="User",
+        )
         ```
     """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     hidden: bool | None = None
     """Whether hidden from UI."""
@@ -4941,8 +4972,18 @@ class UpdatePropertyDefinitionParams(BaseModel):
     sensitive: bool | None = None
     """PII flag."""
 
+    display_name: str | None = None
+    """Human-readable name (sent as ``displayName``)."""
+
     description: str | None = None
     """Property description."""
+
+    example_value: str | None = None
+    """Example value (sent as ``exampleValue``)."""
+
+    resource_type: str | None = None
+    """Resource type (``Event`` / ``User``); sent verbatim as ``resourceType``
+    to disambiguate a user property from an event property of the same name."""
 
 
 class BulkEventUpdate(BaseModel):
@@ -4956,12 +4997,13 @@ class BulkEventUpdate(BaseModel):
         merged: Whether merged.
         verified: Whether verified.
         tags: Tag names.
+        display_name: Human-readable name (sent as ``displayName``).
         contacts: Contact emails.
         team_contacts: Team contact emails.
 
     Example:
         ```python
-        entry = BulkEventUpdate(name="OldEvent", hidden=True)
+        entry = BulkEventUpdate(name="OldEvent", display_name="Old Event")
         ```
     """
 
@@ -4985,6 +5027,11 @@ class BulkEventUpdate(BaseModel):
 
     tags: list[str] | None = None
     """Tag names."""
+
+    display_name: str | None = Field(default=None, serialization_alias="displayName")
+    """Human-readable name. Serialized as ``displayName`` via an explicit alias
+    (rather than a model-wide ``alias_generator``) so the established
+    ``team_contacts`` wire shape stays snake_case."""
 
     contacts: list[str] | None = None
     """Contact emails."""
@@ -5023,11 +5070,15 @@ class BulkPropertyUpdate(BaseModel):
         hidden: Whether hidden from UI.
         dropped: Whether data is dropped.
         sensitive: PII flag.
+        display_name: Human-readable name (sent as ``displayName``).
+        example_value: Example value (sent as ``exampleValue``).
         data_group_id: Data group identifier.
 
     Example:
         ```python
-        entry = BulkPropertyUpdate(name="$browser", resource_type="event")
+        entry = BulkPropertyUpdate(
+            name="$browser", resource_type="event", display_name="Browser"
+        )
         ```
     """
 
@@ -5050,6 +5101,12 @@ class BulkPropertyUpdate(BaseModel):
 
     sensitive: bool | None = None
     """PII flag."""
+
+    display_name: str | None = None
+    """Human-readable name (sent as ``displayName``)."""
+
+    example_value: str | None = None
+    """Example value (sent as ``exampleValue``)."""
 
     data_group_id: str | None = None
     """Data group identifier."""

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     import networkx as nx
 import pandas as pd
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -4757,6 +4758,14 @@ class PropertyDefinition(BaseModel):
     """Data group identifier."""
 
 
+# Lexicon write-param alias convention:
+#   ``UpdateEventDefinitionParams``, ``UpdatePropertyDefinitionParams`` and
+#   ``BulkPropertyUpdate`` camelCase their wire keys via a model-wide
+#   ``alias_generator=to_camel``. ``BulkEventUpdate`` deliberately does NOT —
+#   it uses a per-field alias on ``display_name`` because a model-wide generator
+#   would re-case its ``team_contacts`` field to ``teamContacts`` and break that
+#   established snake_case wire shape. When adding a two-word field, follow the
+#   strategy already on the model you are editing.
 class UpdateEventDefinitionParams(BaseModel):
     """Parameters for updating an event definition (PATCH semantics).
 
@@ -4981,9 +4990,10 @@ class UpdatePropertyDefinitionParams(BaseModel):
     example_value: str | None = None
     """Example value (sent as ``exampleValue``)."""
 
-    resource_type: str | None = None
-    """Resource type (``Event`` / ``User``); sent verbatim as ``resourceType``
-    to disambiguate a user property from an event property of the same name."""
+    resource_type: Literal["Event", "User"] | None = None
+    """Resource type, constrained to the capitalized forms the data-definitions
+    API accepts. Sent verbatim as ``resourceType`` to disambiguate a user
+    property from an event property of the same name."""
 
 
 class BulkEventUpdate(BaseModel):
@@ -5028,10 +5038,18 @@ class BulkEventUpdate(BaseModel):
     tags: list[str] | None = None
     """Tag names."""
 
-    display_name: str | None = Field(default=None, serialization_alias="displayName")
-    """Human-readable name. Serialized as ``displayName`` via an explicit alias
-    (rather than a model-wide ``alias_generator``) so the established
-    ``team_contacts`` wire shape stays snake_case."""
+    display_name: str | None = Field(
+        default=None,
+        serialization_alias="displayName",
+        validation_alias=AliasChoices("display_name", "displayName"),
+    )
+    """Human-readable name. Always emitted as ``displayName`` via an explicit
+    serialization alias (rather than a model-wide ``alias_generator``) so the
+    established ``team_contacts`` wire shape stays snake_case. Accepts either
+    ``display_name`` or ``displayName`` on input, so a camelCase payload echoed
+    by ``lexicon events get`` round-trips instead of silently dropping the
+    field. (``contacts`` / ``team_contacts`` remain snake_case on input and the
+    wire by design.)"""
 
     contacts: list[str] | None = None
     """Contact emails."""
@@ -5077,7 +5095,7 @@ class BulkPropertyUpdate(BaseModel):
     Example:
         ```python
         entry = BulkPropertyUpdate(
-            name="$browser", resource_type="event", display_name="Browser"
+            name="$browser", resource_type="Event", display_name="Browser"
         )
         ```
     """
@@ -5087,8 +5105,10 @@ class BulkPropertyUpdate(BaseModel):
     name: str
     """Property name."""
 
-    resource_type: str
-    """Resource type (event, user, groupprofile)."""
+    resource_type: Literal["Event", "User"]
+    """Resource type (``Event`` / ``User``); sent verbatim as ``resourceType``
+    to disambiguate a user property from an event property of the same name.
+    Constrained to the capitalized forms the data-definitions API accepts."""
 
     id: int | None = None
     """Property ID."""
@@ -5121,7 +5141,7 @@ class BulkUpdatePropertiesParams(BaseModel):
     Example:
         ```python
         params = BulkUpdatePropertiesParams(
-            properties=[BulkPropertyUpdate(name="$browser", resource_type="event")]
+            properties=[BulkPropertyUpdate(name="$browser", resource_type="Event")]
         )
         ```
     """

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -7104,8 +7104,16 @@ class Workspace:
             ws = Workspace()
             defs = ws.bulk_update_property_definitions(
                 BulkUpdatePropertiesParams(properties=[
-                    {"name": "plan_type", "description": "User plan tier"},
-                    {"name": "country", "hidden": True},
+                    BulkPropertyUpdate(
+                        name="plan_type",
+                        resource_type="User",
+                        display_name="Plan Type",
+                    ),
+                    BulkPropertyUpdate(
+                        name="$city",
+                        resource_type="Event",
+                        example_value="San Francisco",
+                    ),
                 ])
             )
             ```

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -6928,7 +6928,7 @@ class Workspace:
         Args:
             event_name: Name of the event to update.
             params: Fields to update (hidden, dropped, merged,
-                verified, tags, description).
+                verified, tags, display_name, description).
 
         Returns:
             The updated ``EventDefinition``.
@@ -6949,7 +6949,7 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        body = params.model_dump(exclude_none=True)
+        body = params.model_dump(exclude_none=True, by_alias=True)
         raw = client.update_event_definition(event_name, body)
         return EventDefinition.model_validate(raw)
 
@@ -7004,7 +7004,7 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        body = params.model_dump(exclude_none=True)
+        body = params.model_dump(exclude_none=True, by_alias=True)
         raw_list = client.bulk_update_event_definitions(body)
         return [EventDefinition.model_validate(x) for x in raw_list]
 
@@ -7055,8 +7055,8 @@ class Workspace:
 
         Args:
             property_name: Name of the property to update.
-            params: Fields to update (hidden, dropped, merged,
-                sensitive, description).
+            params: Fields to update (hidden, dropped, merged, sensitive,
+                display_name, description, example_value, resource_type).
 
         Returns:
             The updated ``PropertyDefinition``.
@@ -7077,7 +7077,7 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        body = params.model_dump(exclude_none=True)
+        body = params.model_dump(exclude_none=True, by_alias=True)
         raw = client.update_property_definition(property_name, body)
         return PropertyDefinition.model_validate(raw)
 
@@ -8077,7 +8077,7 @@ class Workspace:
             ```
         """
         client = self._require_api_client()
-        body = params.model_dump(exclude_none=True)
+        body = params.model_dump(exclude_none=True, by_alias=True)
         raw = client.update_custom_event(custom_event_id, body)
         return EventDefinition.model_validate(raw)
 

--- a/tests/pbt/test_lexicon_write_pbt.py
+++ b/tests/pbt/test_lexicon_write_pbt.py
@@ -1,0 +1,63 @@
+"""Property-based tests for Lexicon metadata write serialization (PR2).
+
+Invariants:
+- ``model_dump(by_alias=True)`` never emits the snake_case forms of the
+  metadata fields (the API only understands camelCase).
+- ``exclude_none=True`` omits unset fields entirely.
+- snake_case construction round-trips through the camelCase dump.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from mixpanel_headless.types import (
+    UpdateEventDefinitionParams,
+    UpdatePropertyDefinitionParams,
+)
+
+_text = st.text(min_size=1, max_size=20)
+
+
+@given(display_name=st.none() | _text, description=st.none() | _text)
+def test_event_update_never_emits_snake(
+    display_name: str | None, description: str | None
+) -> None:
+    """Event update dumps never contain ``display_name`` (snake)."""
+    params = UpdateEventDefinitionParams(
+        display_name=display_name, description=description
+    )
+    body = params.model_dump(exclude_none=True, by_alias=True)
+    assert "display_name" not in body
+    if display_name is not None:
+        assert body["displayName"] == display_name
+    else:
+        assert "displayName" not in body
+
+
+@given(
+    display_name=st.none() | _text,
+    example_value=st.none() | _text,
+    resource_type=st.none() | st.sampled_from(["Event", "User"]),
+)
+def test_property_update_emits_only_camel(
+    display_name: str | None,
+    example_value: str | None,
+    resource_type: str | None,
+) -> None:
+    """Property update dumps emit camelCase metadata keys and no snake forms."""
+    params = UpdatePropertyDefinitionParams(
+        display_name=display_name,
+        example_value=example_value,
+        resource_type=resource_type,
+    )
+    body = params.model_dump(exclude_none=True, by_alias=True)
+    for snake in ("display_name", "example_value", "resource_type"):
+        assert snake not in body
+    if display_name is not None:
+        assert body["displayName"] == display_name
+    if example_value is not None:
+        assert body["exampleValue"] == example_value
+    if resource_type is not None:
+        assert body["resourceType"] == resource_type

--- a/tests/pbt/test_lexicon_write_pbt.py
+++ b/tests/pbt/test_lexicon_write_pbt.py
@@ -9,15 +9,21 @@ Invariants:
 
 from __future__ import annotations
 
+from typing import Literal
+
 from hypothesis import given
 from hypothesis import strategies as st
 
 from mixpanel_headless.types import (
+    BulkEventUpdate,
+    BulkPropertyUpdate,
     UpdateEventDefinitionParams,
     UpdatePropertyDefinitionParams,
 )
 
 _text = st.text(min_size=1, max_size=20)
+# Typed so the pydantic mypy plugin sees the Literal the write models require.
+_RESOURCE_TYPES: list[Literal["Event", "User"]] = ["Event", "User"]
 
 
 @given(display_name=st.none() | _text, description=st.none() | _text)
@@ -39,12 +45,12 @@ def test_event_update_never_emits_snake(
 @given(
     display_name=st.none() | _text,
     example_value=st.none() | _text,
-    resource_type=st.none() | st.sampled_from(["Event", "User"]),
+    resource_type=st.none() | st.sampled_from(_RESOURCE_TYPES),
 )
 def test_property_update_emits_only_camel(
     display_name: str | None,
     example_value: str | None,
-    resource_type: str | None,
+    resource_type: Literal["Event", "User"] | None,
 ) -> None:
     """Property update dumps emit camelCase metadata keys and no snake forms."""
     params = UpdatePropertyDefinitionParams(
@@ -61,3 +67,64 @@ def test_property_update_emits_only_camel(
         assert body["exampleValue"] == example_value
     if resource_type is not None:
         assert body["resourceType"] == resource_type
+
+
+@given(
+    resource_type=st.sampled_from(_RESOURCE_TYPES),
+    display_name=st.none() | _text,
+    example_value=st.none() | _text,
+)
+def test_bulk_property_update_emits_only_camel(
+    resource_type: Literal["Event", "User"],
+    display_name: str | None,
+    example_value: str | None,
+) -> None:
+    """Bulk property entries dump camelCase keys and never the snake forms."""
+    entry = BulkPropertyUpdate(
+        name="p",
+        resource_type=resource_type,
+        display_name=display_name,
+        example_value=example_value,
+    )
+    body = entry.model_dump(exclude_none=True, by_alias=True)
+    for snake in ("display_name", "example_value", "resource_type"):
+        assert snake not in body
+    assert body["resourceType"] == resource_type
+    if display_name is not None:
+        assert body["displayName"] == display_name
+    if example_value is not None:
+        assert body["exampleValue"] == example_value
+
+
+@given(
+    display_name=st.none() | _text,
+    team_contacts=st.none() | st.lists(_text, max_size=3),
+    contacts=st.none() | st.lists(_text, max_size=3),
+)
+def test_bulk_event_update_keeps_contacts_snake(
+    display_name: str | None,
+    team_contacts: list[str] | None,
+    contacts: list[str] | None,
+) -> None:
+    """Bulk event entries camelCase only ``display_name``; contact lists stay snake.
+
+    This is the exact invariant the per-field-alias strategy on
+    ``BulkEventUpdate`` exists to protect: ``display_name`` must reach the wire
+    as ``displayName`` while ``team_contacts`` / ``contacts`` keep their
+    established snake_case shape in the same payload.
+    """
+    entry = BulkEventUpdate(
+        name="e",
+        display_name=display_name,
+        team_contacts=team_contacts,
+        contacts=contacts,
+    )
+    body = entry.model_dump(exclude_none=True, by_alias=True)
+    assert "display_name" not in body
+    if display_name is not None:
+        assert body["displayName"] == display_name
+    if team_contacts is not None:
+        assert body["team_contacts"] == team_contacts
+        assert "teamContacts" not in body
+    if contacts is not None:
+        assert body["contacts"] == contacts

--- a/tests/unit/cli/test_lexicon.py
+++ b/tests/unit/cli/test_lexicon.py
@@ -264,7 +264,7 @@ class TestLexiconPropertiesBulkUpdate:
         payload = json.dumps(
             {
                 "properties": [
-                    {"name": "email", "resource_type": "event", "hidden": False}
+                    {"name": "email", "resource_type": "Event", "hidden": False}
                 ]
             }
         )

--- a/tests/unit/test_lexicon_write_metadata.py
+++ b/tests/unit/test_lexicon_write_metadata.py
@@ -17,7 +17,7 @@ end to end:
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -85,13 +85,14 @@ class TestParamSerialization:
         }
 
     def test_resource_type_passes_through_verbatim(self) -> None:
-        """``resource_type`` reaches the body as ``resourceType`` unchanged.
+        """Each accepted ``resource_type`` reaches the body as ``resourceType``.
 
-        We do not enforce an enum: the data-definitions API mirrors the value it
-        returns on reads (``"Event"`` / ``"User"``), which is also what
-        mixpanel-power-tools sends. Pass-through fidelity is the contract.
+        The field is constrained to the capitalized ``"Event"`` / ``"User"`` the
+        data-definitions API accepts (also what mixpanel-power-tools sends); the
+        chosen value is forwarded to the wire key unchanged.
         """
-        for value in ("Event", "User"):
+        values: tuple[Literal["Event", "User"], ...] = ("Event", "User")
+        for value in values:
             body = UpdatePropertyDefinitionParams(resource_type=value).model_dump(
                 exclude_none=True, by_alias=True
             )
@@ -127,6 +128,33 @@ class TestParamSerialization:
         assert UpdatePropertyDefinitionParams(display_name="x").display_name == "x"
         assert UpdateEventDefinitionParams(display_name="y").display_name == "y"
 
+    def test_camel_input_validates(self) -> None:
+        """camelCase input also validates for the single-update models.
+
+        Guards the ``alias_generator``: a camelCase payload (the shape the API
+        and reads use) populates the snake_case attribute.
+        """
+        prop = UpdatePropertyDefinitionParams.model_validate({"displayName": "x"})
+        assert prop.display_name == "x"
+        event = UpdateEventDefinitionParams.model_validate({"displayName": "y"})
+        assert event.display_name == "y"
+
+    def test_bulk_event_update_accepts_camel_input(self) -> None:
+        """camelCase ``displayName`` input round-trips (the events bulk-update path).
+
+        ``mp lexicon events bulk-update --data`` feeds camelCase JSON (the shape
+        the API and ``events get`` return). Before the validation alias was added
+        this was silently dropped, sending an empty update.
+        """
+        parsed: dict[str, Any] = json.loads(
+            '{"events": [{"name": "purchase", "displayName": "Purchase"}]}'
+        )
+        params = BulkUpdateEventsParams(**parsed)
+        assert params.events[0].display_name == "Purchase"
+        # dump (camelCase) -> revalidate preserves the field
+        redumped: dict[str, Any] = params.model_dump(exclude_none=True, by_alias=True)
+        assert BulkUpdateEventsParams(**redumped).events[0].display_name == "Purchase"
+
 
 class TestReadModelParsing:
     """The read model parses the camelCase metadata fields."""
@@ -143,6 +171,14 @@ class TestReadModelParsing:
         )
         assert prop.display_name == "City"
         assert prop.example_value == "San Francisco"
+        assert prop.resource_type == "Event"
+
+    def test_event_definition_parses_camel_display_name(self) -> None:
+        """``EventDefinition`` reads back camelCase ``displayName`` from the API."""
+        ev = EventDefinition.model_validate(
+            {"id": 1, "name": "purchase", "displayName": "Purchase"}
+        )
+        assert ev.display_name == "Purchase"
 
 
 def _capture_workspace(captured: dict[str, Any], response: Any) -> Workspace:
@@ -174,12 +210,12 @@ class TestFacadeSendsCamelCase:
         assert captured["body"]["name"] == "purchase"
 
     def test_update_property_definition_body(self) -> None:
-        """Property update sends displayName/exampleValue/resourceType."""
+        """Property update sends displayName/exampleValue/resourceType and reads it back."""
         captured: dict[str, Any] = {}
         ws = _capture_workspace(
-            captured, {"results": {"id": 1, "name": "plan", "resourceType": "user"}}
+            captured, {"results": {"id": 1, "name": "plan", "resourceType": "User"}}
         )
-        ws.update_property_definition(
+        result = ws.update_property_definition(
             "plan",
             UpdatePropertyDefinitionParams(
                 display_name="Plan", example_value="free, pro", resource_type="User"
@@ -190,6 +226,8 @@ class TestFacadeSendsCamelCase:
         assert body["exampleValue"] == "free, pro"
         assert body["resourceType"] == "User"
         assert body["name"] == "plan"
+        # read-back: the API echoes the capitalized form into the parsed model
+        assert result.resource_type == "User"
 
     def test_update_property_definition_user_scoped_body(self) -> None:
         """A user-property update sends resourceType=User to disambiguate.

--- a/tests/unit/test_lexicon_write_metadata.py
+++ b/tests/unit/test_lexicon_write_metadata.py
@@ -1,0 +1,366 @@
+"""Tests for writing Lexicon metadata: display_name, example_value, resource_type.
+
+The Mixpanel data-definitions API reads and writes these fields in camelCase
+(``displayName``, ``exampleValue``, ``resourceType``). Before this change the
+update parameter models lacked the fields and the facade dumped snake_case, so
+``display_name`` writes were silently dropped. These tests lock the wire format
+end to end:
+
+- the parameter models emit camelCase under ``model_dump(by_alias=True)`` while
+  leaving existing single-word fields untouched;
+- the read model parses the camelCase fields back;
+- the Workspace facade sends camelCase bodies for events and for event / user
+  properties, single and bulk (group properties are a follow-up, see the PR);
+- the CLI exposes ``--display-name`` / ``--example-value`` / ``--resource-type``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import typer.testing
+from pydantic import SecretStr
+
+from mixpanel_headless._internal.api_client import MixpanelAPIClient
+from mixpanel_headless._internal.auth.account import ServiceAccount
+from mixpanel_headless._internal.auth.session import Project, Session
+from mixpanel_headless.cli.main import app
+from mixpanel_headless.types import (
+    BulkEventUpdate,
+    BulkPropertyUpdate,
+    BulkUpdateEventsParams,
+    BulkUpdatePropertiesParams,
+    EventDefinition,
+    PropertyDefinition,
+    UpdateEventDefinitionParams,
+    UpdatePropertyDefinitionParams,
+)
+from mixpanel_headless.workspace import Workspace
+
+runner = typer.testing.CliRunner()
+
+_SESSION = Session(
+    account=ServiceAccount(
+        name="t",
+        region="us",
+        username="u",
+        secret=SecretStr("s"),
+        default_project="12345",
+    ),
+    project=Project(id="12345"),
+)
+
+
+class TestParamSerialization:
+    """``model_dump(by_alias=True)`` emits the camelCase the API expects."""
+
+    def test_event_update_emits_camel_display_name(self) -> None:
+        """``display_name`` serializes to ``displayName``."""
+        params = UpdateEventDefinitionParams(
+            display_name="App Open", description="user opened the app"
+        )
+        body = params.model_dump(exclude_none=True, by_alias=True)
+        assert body == {"displayName": "App Open", "description": "user opened the app"}
+
+    def test_event_update_single_word_fields_unchanged(self) -> None:
+        """Single-word fields are unchanged by aliasing."""
+        body = UpdateEventDefinitionParams(hidden=True, verified=True).model_dump(
+            exclude_none=True, by_alias=True
+        )
+        assert body == {"hidden": True, "verified": True}
+
+    def test_property_update_emits_camel(self) -> None:
+        """Property updates emit ``displayName``/``exampleValue``/``resourceType``."""
+        params = UpdatePropertyDefinitionParams(
+            display_name="Plan Type", example_value="free, pro", resource_type="User"
+        )
+        body = params.model_dump(exclude_none=True, by_alias=True)
+        assert body == {
+            "displayName": "Plan Type",
+            "exampleValue": "free, pro",
+            "resourceType": "User",
+        }
+
+    def test_resource_type_passes_through_verbatim(self) -> None:
+        """``resource_type`` reaches the body as ``resourceType`` unchanged.
+
+        We do not enforce an enum: the data-definitions API mirrors the value it
+        returns on reads (``"Event"`` / ``"User"``), which is also what
+        mixpanel-power-tools sends. Pass-through fidelity is the contract.
+        """
+        for value in ("Event", "User"):
+            body = UpdatePropertyDefinitionParams(resource_type=value).model_dump(
+                exclude_none=True, by_alias=True
+            )
+            assert body == {"resourceType": value}
+
+    def test_bulk_event_update_aliases_display_name_only(self) -> None:
+        """Bulk event display_name aliases without re-casing existing fields."""
+        entry = BulkEventUpdate(
+            name="purchase", display_name="Purchase", team_contacts=["t@x.io"]
+        )
+        body = entry.model_dump(exclude_none=True, by_alias=True)
+        assert body["displayName"] == "Purchase"
+        assert body["name"] == "purchase"
+        # Existing fields keep their established wire shape (not silently re-cased).
+        assert body["team_contacts"] == ["t@x.io"]
+        assert "displayName" in body and "display_name" not in body
+
+    def test_bulk_property_update_emits_camel(self) -> None:
+        """Bulk property updates emit camelCase for the new fields."""
+        entry = BulkPropertyUpdate(
+            name="plan",
+            resource_type="Event",
+            display_name="Plan",
+            example_value="free, pro",
+        )
+        body = entry.model_dump(exclude_none=True, by_alias=True)
+        assert body["displayName"] == "Plan"
+        assert body["exampleValue"] == "free, pro"
+        assert body["resourceType"] == "Event"
+
+    def test_snake_kwargs_still_construct(self) -> None:
+        """Construction by snake_case field name still works."""
+        assert UpdatePropertyDefinitionParams(display_name="x").display_name == "x"
+        assert UpdateEventDefinitionParams(display_name="y").display_name == "y"
+
+
+class TestReadModelParsing:
+    """The read model parses the camelCase metadata fields."""
+
+    def test_property_definition_parses_display_and_example(self) -> None:
+        """``displayName``/``exampleValue`` populate the snake_case attributes."""
+        prop = PropertyDefinition.model_validate(
+            {
+                "name": "$city",
+                "displayName": "City",
+                "exampleValue": "San Francisco",
+                "resourceType": "Event",
+            }
+        )
+        assert prop.display_name == "City"
+        assert prop.example_value == "San Francisco"
+
+
+def _capture_workspace(captured: dict[str, Any], response: Any) -> Workspace:
+    """Build a Workspace whose transport records the last request body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.content:
+            captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json=response)
+
+    client = MixpanelAPIClient(
+        session=_SESSION, _transport=httpx.MockTransport(handler)
+    )
+    return Workspace(session=_SESSION, _api_client=client)
+
+
+class TestFacadeSendsCamelCase:
+    """The Workspace facade sends camelCase bodies to the API."""
+
+    def test_update_event_definition_body(self) -> None:
+        """Event update sends ``displayName`` in the PATCH body."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(captured, {"results": {"id": 1, "name": "purchase"}})
+        result = ws.update_event_definition(
+            "purchase", UpdateEventDefinitionParams(display_name="Purchase")
+        )
+        assert isinstance(result, EventDefinition)
+        assert captured["body"]["displayName"] == "Purchase"
+        assert captured["body"]["name"] == "purchase"
+
+    def test_update_property_definition_body(self) -> None:
+        """Property update sends displayName/exampleValue/resourceType."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(
+            captured, {"results": {"id": 1, "name": "plan", "resourceType": "user"}}
+        )
+        ws.update_property_definition(
+            "plan",
+            UpdatePropertyDefinitionParams(
+                display_name="Plan", example_value="free, pro", resource_type="User"
+            ),
+        )
+        body = captured["body"]
+        assert body["displayName"] == "Plan"
+        assert body["exampleValue"] == "free, pro"
+        assert body["resourceType"] == "User"
+        assert body["name"] == "plan"
+
+    def test_update_property_definition_user_scoped_body(self) -> None:
+        """A user-property update sends resourceType=User to disambiguate.
+
+        ``resourceType`` lets the PATCH target a user property that shares a name
+        with an event property (the common Lexicon collision).
+        """
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(captured, {"results": {"id": 1, "name": "tier"}})
+        ws.update_property_definition(
+            "tier",
+            UpdatePropertyDefinitionParams(display_name="Tier", resource_type="User"),
+        )
+        assert captured["body"]["resourceType"] == "User"
+        assert captured["body"]["displayName"] == "Tier"
+
+    def test_update_custom_event_sends_camel(self) -> None:
+        """Custom-event update (shares the event param model) sends displayName."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(
+            captured, {"results": {"id": 1, "name": "ce", "customEventId": 7}}
+        )
+        ws.update_custom_event(
+            7, UpdateEventDefinitionParams(display_name="Metric Tree Opened")
+        )
+        assert captured["body"]["displayName"] == "Metric Tree Opened"
+
+    def test_bulk_update_event_definitions_body(self) -> None:
+        """Bulk event update sends ``displayName`` per entry."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(captured, {"results": [{"id": 1, "name": "e"}]})
+        ws.bulk_update_event_definitions(
+            BulkUpdateEventsParams(events=[BulkEventUpdate(name="e", display_name="E")])
+        )
+        assert captured["body"]["events"][0]["displayName"] == "E"
+
+    def test_bulk_update_property_definitions_body(self) -> None:
+        """Bulk property update sends displayName/exampleValue per entry."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(captured, {"results": [{"id": 1, "name": "p"}]})
+        ws.bulk_update_property_definitions(
+            BulkUpdatePropertiesParams(
+                properties=[
+                    BulkPropertyUpdate(
+                        name="p",
+                        resource_type="Event",
+                        display_name="P",
+                        example_value="x",
+                    )
+                ]
+            )
+        )
+        entry = captured["body"]["properties"][0]
+        assert entry["displayName"] == "P"
+        assert entry["exampleValue"] == "x"
+
+    def test_bulk_update_property_definitions_user_scoped(self) -> None:
+        """Bulk property update carries resourceType=User for user properties."""
+        captured: dict[str, Any] = {}
+        ws = _capture_workspace(captured, {"results": [{"id": 1, "name": "plan"}]})
+        ws.bulk_update_property_definitions(
+            BulkUpdatePropertiesParams(
+                properties=[
+                    BulkPropertyUpdate(
+                        name="plan", resource_type="User", display_name="Plan"
+                    )
+                ]
+            )
+        )
+        entry = captured["body"]["properties"][0]
+        assert entry["resourceType"] == "User"
+        assert entry["displayName"] == "Plan"
+
+
+class TestCli:
+    """The CLI exposes the new metadata flags."""
+
+    @patch("mixpanel_headless.cli.commands.lexicon.get_workspace")
+    def test_events_update_display_name_flag(self, mock_get_ws: MagicMock) -> None:
+        """``--display-name`` reaches the update params."""
+        mock_ws = MagicMock()
+        mock_ws.update_event_definition.return_value = MagicMock(
+            model_dump=MagicMock(
+                return_value={"name": "purchase", "displayName": "Purchase"}
+            )
+        )
+        mock_get_ws.return_value = mock_ws
+
+        result = runner.invoke(
+            app,
+            [
+                "lexicon",
+                "events",
+                "update",
+                "--name",
+                "purchase",
+                "--display-name",
+                "Purchase",
+            ],
+        )
+        assert result.exit_code == 0
+        params = mock_ws.update_event_definition.call_args[0][1]
+        assert params.display_name == "Purchase"
+
+    @patch("mixpanel_headless.cli.commands.lexicon.get_workspace")
+    def test_properties_update_metadata_flags(self, mock_get_ws: MagicMock) -> None:
+        """``--display-name``/``--example-value``/``--resource-type`` reach params."""
+        mock_ws = MagicMock()
+        mock_ws.update_property_definition.return_value = MagicMock(
+            model_dump=MagicMock(return_value={"name": "plan"})
+        )
+        mock_get_ws.return_value = mock_ws
+
+        result = runner.invoke(
+            app,
+            [
+                "lexicon",
+                "properties",
+                "update",
+                "--name",
+                "plan",
+                "--display-name",
+                "Plan Type",
+                "--example-value",
+                "free, pro",
+                "--resource-type",
+                "User",
+            ],
+        )
+        assert result.exit_code == 0
+        params = mock_ws.update_property_definition.call_args[0][1]
+        assert params.display_name == "Plan Type"
+        assert params.example_value == "free, pro"
+        assert params.resource_type == "User"
+
+    @patch("mixpanel_headless.cli.commands.lexicon.get_workspace")
+    def test_properties_update_omits_resource_type_by_default(
+        self, mock_get_ws: MagicMock
+    ) -> None:
+        """Without --resource-type the param stays None (no always-send)."""
+        mock_ws = MagicMock()
+        mock_ws.update_property_definition.return_value = MagicMock(
+            model_dump=MagicMock(return_value={"name": "plan"})
+        )
+        mock_get_ws.return_value = mock_ws
+
+        result = runner.invoke(
+            app,
+            ["lexicon", "properties", "update", "--name", "plan", "--description", "x"],
+        )
+        assert result.exit_code == 0
+        params = mock_ws.update_property_definition.call_args[0][1]
+        assert params.resource_type is None
+        # exclude_none keeps resourceType out of the wire body entirely
+        assert "resourceType" not in params.model_dump(exclude_none=True, by_alias=True)
+
+    @patch("mixpanel_headless.cli.commands.lexicon.get_workspace")
+    def test_events_bulk_update_carries_display_name(
+        self, mock_get_ws: MagicMock
+    ) -> None:
+        """`events bulk-update` JSON entries carry display_name through to params."""
+        mock_ws = MagicMock()
+        mock_ws.bulk_update_event_definitions.return_value = []
+        mock_get_ws.return_value = mock_ws
+
+        payload = json.dumps(
+            {"events": [{"name": "purchase", "display_name": "Purchase"}]}
+        )
+        result = runner.invoke(
+            app, ["lexicon", "events", "bulk-update", "--data", payload]
+        )
+        assert result.exit_code == 0
+        params = mock_ws.bulk_update_event_definitions.call_args[0][0]
+        assert params.events[0].display_name == "Purchase"

--- a/tests/unit/test_types_data_governance.py
+++ b/tests/unit/test_types_data_governance.py
@@ -617,9 +617,9 @@ class TestBulkPropertyUpdateModel:
 
     def test_required_fields(self) -> None:
         """BulkPropertyUpdate requires name and resource_type."""
-        update = BulkPropertyUpdate(name="$browser", resource_type="event")
+        update = BulkPropertyUpdate(name="$browser", resource_type="Event")
         assert update.name == "$browser"
-        assert update.resource_type == "event"
+        assert update.resource_type == "Event"
         assert update.id is None
         assert update.hidden is None
         assert update.dropped is None
@@ -630,7 +630,7 @@ class TestBulkPropertyUpdateModel:
         """BulkPropertyUpdate with all fields stores correctly."""
         update = BulkPropertyUpdate(
             name="$browser",
-            resource_type="event",
+            resource_type="Event",
             id=99,
             hidden=False,
             dropped=False,
@@ -659,7 +659,7 @@ class TestBulkUpdatePropertiesParams:
         """BulkUpdatePropertiesParams requires properties list."""
         params = BulkUpdatePropertiesParams(
             properties=[
-                BulkPropertyUpdate(name="$browser", resource_type="event", hidden=True)
+                BulkPropertyUpdate(name="$browser", resource_type="Event", hidden=True)
             ]
         )
         assert len(params.properties) == 1
@@ -1465,7 +1465,7 @@ class TestByAliasSerialization:
         """Verify BulkPropertyUpdate serializes to camelCase with by_alias=True."""
         update = BulkPropertyUpdate(
             name="test_prop",
-            resource_type="event",
+            resource_type="Event",
             data_group_id="group-1",
             description="test",
         )
@@ -1474,7 +1474,7 @@ class TestByAliasSerialization:
         assert "dataGroupId" in dumped
         assert "resource_type" not in dumped
         assert "data_group_id" not in dumped
-        assert dumped["resourceType"] == "event"
+        assert dumped["resourceType"] == "Event"
         assert dumped["dataGroupId"] == "group-1"
         assert dumped["name"] == "test_prop"
 
@@ -1482,7 +1482,7 @@ class TestByAliasSerialization:
         """Verify BulkPropertyUpdate uses snake_case keys without by_alias."""
         update = BulkPropertyUpdate(
             name="test_prop",
-            resource_type="event",
+            resource_type="Event",
         )
         dumped = update.model_dump(exclude_none=True)
         assert "resource_type" in dumped

--- a/tests/unit/test_workspace_data_governance.py
+++ b/tests/unit/test_workspace_data_governance.py
@@ -493,8 +493,8 @@ class TestBulkUpdatePropertyDefinitions:
         ws = _make_workspace(temp_dir, handler)
         params = BulkUpdatePropertiesParams(
             properties=[
-                BulkPropertyUpdate(name="$browser", resource_type="event", hidden=True),
-                BulkPropertyUpdate(name="$city", resource_type="event", sensitive=True),
+                BulkPropertyUpdate(name="$browser", resource_type="Event", hidden=True),
+                BulkPropertyUpdate(name="$city", resource_type="Event", sensitive=True),
             ]
         )
         result = ws.bulk_update_property_definitions(params)


### PR DESCRIPTION
## what this does

lets you write `display_name`, `description`, and `example_value` on lexicon definitions, for events, event properties, and user properties, single and bulk, from both the library and the cli.

## the bug

you could read `displayName` / `exampleValue` off a lexicon definition but not write them back. the update param models did not have the fields, and the facade dumped snake_case while the data-definitions api only understands camelCase, so a `display_name` write was silently dropped. this came up setting lexicon metadata in the field (popsa, zola).

## changes

- add `display_name` to `UpdateEventDefinitionParams` and `BulkEventUpdate`
- add `display_name`, `example_value`, `resource_type` to `UpdatePropertyDefinitionParams`; add `display_name`, `example_value` to `BulkPropertyUpdate`
- add `display_name`, `example_value` to the `PropertyDefinition` read model
- alias the new fields to camelCase (`displayName` / `exampleValue` / `resourceType`) and dump the single and bulk update bodies with `by_alias=True`. existing single-word fields are unaffected (`to_camel` is identity for them). the bulk event `contacts` / `team_contacts` wire shape is left alone by putting an explicit serialization alias on `display_name` instead of a model-wide generator
- cli: `--display-name` on `mp lexicon events update`, and `--display-name` / `--example-value` / `--resource-type` on `mp lexicon properties update`

## verified live

on project `4025120` the read side comes back populated, e.g.:

```
"name": "$city", "resource_type": "Event",
"display_name": "City", "example_value": "San Francisco, Los Angeles"
```

and an event `displayName` write round-trips through `events update` -> `events get`.

`resource_type` is forwarded verbatim as `resourceType` to disambiguate a user property from an event property of the same name. it matches the value the api returns on reads (`Event` / `User`), and it is only sent when provided, so existing event-property writes are unchanged.

## scope / follow-ups

- group-property writes are a follow-up. power-tools sends them as `resourceType: "User"` plus a `dataGroupId` ([index.js#L4560](https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L4560)), which needs a data-group lookup headless does not expose yet.

## power-tools reference

- renameEntities https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L4661
- updateExampleValues https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L4601
- updateDescriptions https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L4351

## tests

unit tests lock the camelCase emission, the single-word fields staying put, the facade patch bodies for events / user props / single + bulk, the read-model parse, and the cli flags (including `resource_type` staying out of the body when not passed). pbt asserts the dumped keys are always camel aliases and never the snake forms.

`just check` is green (lint, format, mypy --strict, docstrings, coverage, build).
