### PR TITLE
schema_graph(): full lexicon + event<->property relationships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Infrastructure           → ConfigManager, MixpanelAPIClient
 ```
 
 **Three capability areas:**
-- **Discovery**: Explore schema (events, properties, funnels, cohorts, bookmarks)
+- **Discovery**: Explore schema (events, properties, funnels, cohorts, bookmarks, schema graph)
 - **Live queries & streaming**: Call Mixpanel API directly (segmentation, funnels, retention, user profiles), stream events and profiles
 - **Entity CRUD & Data Governance**: Create, read, update, delete dashboards, reports (bookmarks), cohorts, feature flags, experiments, alerts, annotations, webhooks, Lexicon definitions, drop filters, custom properties, custom events, and lookup tables via App API
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ for event in ws.stream_events(from_date="2025-01-01", to_date="2025-01-31"):
 
 **`mp query`** — Run analytics: `segmentation`, `funnel`, `retention`, `saved-report`, `flows`, `event-counts`, `property-counts`, `activity-feed`, `frequency`, `segmentation-numeric`, `segmentation-sum`, `segmentation-average`
 
-**`mp inspect`** — Schema discovery: `events`, `properties`, `values`, `funnels`, `cohorts`, `top-events`, `bookmarks`, `lexicon-schemas`, `lexicon-schema`
+**`mp inspect`** — Schema discovery: `events`, `properties`, `values`, `funnels`, `cohorts`, `top-events`, `bookmarks`, `lexicon-schemas`, `lexicon-schema`, `schema-graph`
 
 **`mp dashboards`** — Dashboard management: `list`, `create`, `get`, `update`, `delete`, `bulk-delete`, `favorite`, `unfavorite`, `pin`, `unpin`, `add-report`, `remove-report`, `update-report-link`, `update-text-card`, `blueprints`, `blueprint-create`, `rca`, `erf`
 
@@ -367,7 +367,7 @@ Key design features:
 
 - **Typed Query Engines**: `query()`, `query_funnel()`, `query_retention()`, `query_flow()`, and `query_user()` provide five composable engines — Insights analytics, funnel conversion, retention cohorts, flow path analysis, and user profile queries — with period-over-period comparison (`TimeComparison`), frequency analysis (`FrequencyBreakdown`/`FrequencyFilter`), 21 math types, and 27+ filter methods, all sharing the same `Filter` vocabulary, `CohortDefinition` builders, and DataFrame output
 - **Entity CRUD & Data Governance**: Full lifecycle management of dashboards, reports, cohorts, feature flags, experiments, alerts, annotations, webhooks, plus Lexicon definitions, drop filters, custom properties, custom events, and lookup tables via Mixpanel App API
-- **Discoverable schema**: `events()`, `properties()`, `funnels()`, `cohorts()`, `bookmarks()` reveal what's in your project before you query
+- **Discoverable schema**: `events()`, `properties()`, `funnels()`, `cohorts()`, `bookmarks()`, `schema_graph()` reveal what's in your project before you query
 - **Consistent interfaces**: Same operations available as Python methods and CLI commands
 - **Structured output**: All CLI commands support `--format json` for machine-readable responses, plus `--jq` for inline filtering
 - **Streaming data extraction**: Memory-efficient iterators for events and profiles

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -43,6 +43,9 @@ from mixpanel_headless import FlowStep, FlowTreeNode, FlowQueryResult
 # User Profile Query types
 from mixpanel_headless import UserQueryResult
 
+# Schema graph (discovery)
+from mixpanel_headless import SchemaGraphResult
+
 # Auth surface — recommended top-level imports
 from mixpanel_headless import (
     Account, ServiceAccount, OAuthBrowserAccount, OAuthTokenAccount,
@@ -150,6 +153,7 @@ Typed results for all operations:
 - **RetentionQueryResult**, **RetentionEvent**, **RetentionAlignment**, **RetentionMode**, **RetentionMathType** — Typed retention results
 - **FlowQueryResult**, **FlowStep**, **FlowTreeNode** — Typed flow analysis results
 - **UserQueryResult** — Typed user profile query results
+- **SchemaGraphResult** — Full Lexicon schema + event↔property relationship graph (from `schema_graph()`)
 - **SegmentationResult** — Time-series data (legacy)
 - **FunnelResult** — Funnel conversion data (legacy)
 - **RetentionResult** — Retention cohort data (legacy)

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -246,6 +246,11 @@ Types for `Workspace.query_flow()` — typed flow path analysis with step defini
       show_root_heading: true
       show_root_toc_entry: true
 
+::: mixpanel_headless.SchemaGraphResult
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true
+
 ## Subproperty Discovery Types
 
 Types for `Workspace.subproperties()` — schema discovery for list-of-object event properties. See [Subproperties](../guide/discovery.md#subproperties) for usage.

--- a/docs/api/workspace.md
+++ b/docs/api/workspace.md
@@ -195,6 +195,7 @@ See [Auth → Workspace.use()](auth.md#workspaceuse-in-session-switching) for th
         - top_events
         - lexicon_schemas
         - lexicon_schema
+        - schema_graph
         - clear_discovery_cache
         - stream_events
         - stream_profiles

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -147,6 +147,7 @@ Explore your Mixpanel project schema.
 | `mp inspect top-events` | List today's top events |
 | `mp inspect lexicon-schemas` | List Lexicon schemas from data dictionary |
 | `mp inspect lexicon-schema` | Get a single Lexicon schema |
+| `mp inspect schema-graph` | Full Lexicon + event↔property relationship graph |
 
 ### dashboards — Dashboard Management
 

--- a/docs/guide/discovery.md
+++ b/docs/guide/discovery.md
@@ -251,6 +251,55 @@ meta.team_contacts      # ["Analytics Team"]
 !!! tip "Write Operations"
     The Lexicon schemas shown here are **read-only discovery** methods. For full CRUD operations on Lexicon definitions (update, delete events/properties, manage tags, bulk updates), see the [Data Governance guide](data-governance.md).
 
+## Schema Graph
+
+`schema_graph()` gathers the whole project's Lexicon in one pass — event definitions, event properties, and user properties — plus the event↔property relationship graph (which properties appear on which events). It returns a typed `SchemaGraphResult` with DataFrame views and a networkx export, so you can map the schema without a per-entity lookup.
+
+=== "Python"
+
+    ```python
+    schema = ws.schema_graph()
+
+    schema.events_df          # event definitions (name, display_name, count, ...)
+    schema.properties_df      # event + user properties, with a resource_type column
+    schema.relationships_df   # one row per (event, property) edge — the headline view
+
+    schema.properties_for_event("Purchase")   # ['amount', 'currency', ...]
+    schema.events_for_property("utm_source")   # events carrying the property
+    schema.orphan_properties()                 # event properties that appear on no events
+
+    graph = schema.to_graph()  # networkx.DiGraph, events -> properties
+    ```
+
+=== "CLI"
+
+    ```bash
+    mp inspect schema-graph                    # full structure (JSON)
+    mp inspect schema-graph --format table     # the relationship edge list
+    mp inspect schema-graph --no-user-properties --jq '.event_to_properties'
+
+    # Per-property density (densityLocal), repeated onto each edge
+    mp inspect schema-graph --density --format table
+    ```
+
+The relationships come from one bulk `data-definitions/properties?includeEvents=true` request — a single call for the whole project rather than a schema lookup per entity. Group properties are not gathered (Headless has no data-groups listing to enumerate them).
+
+### SchemaGraphResult
+
+```python
+schema.events                # list[dict] — raw event definitions
+schema.properties            # list[dict] — event properties (each carries an `events` list)
+schema.user_properties       # list[dict] — user properties
+schema.event_to_properties   # {event_name: [property_name, ...]}
+schema.property_to_events    # {property_name: [event_name, ...]}
+schema.relationships_df      # DataFrame: event | property | density_local
+schema.to_graph()            # networkx.DiGraph (events -> properties; bipartite when names are disjoint)
+schema.to_dict()             # JSON-serializable
+```
+
+!!! note "Caching"
+    Like other discovery methods, `schema_graph()` is cached for the lifetime of the Workspace. Pass `force_refresh=True` to re-fetch, or call `clear_discovery_cache()`.
+
 ## Top Events
 
 Get today's most active events:

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-headless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_headless auth surface (Account → Project → Workspace hierarchy), API (5 query engines, discovery, entity CRUD), and Business Context read/write (the markdown documentation that grounds AI assistants, at org and project scopes), with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -41,6 +41,13 @@ import mixpanel_headless as mp
 from mixpanel_headless import Filter, GroupBy, Metric
 ws = mp.Workspace()
 
+# 0. (Best first move) Map the WHOLE schema in one call — which properties are on
+#    which events, plus per-property coverage. Ground yourself here so you never
+#    filter or group by a property an event doesn't actually have.
+schema = ws.schema_graph(include_density=True)
+print(schema.properties_for_event("Login"))   # exact property names on this event
+print(schema.relationships_df.head())           # event | property | density_local
+
 # 1. Find real event names
 events = ws.events()
 top = ws.top_events(limit=10)
@@ -131,22 +138,39 @@ When exploring an unfamiliar dataset or asked to "find insights," follow this sy
 
 ### Step 1: Orient — Map the Event Schema
 
+Start with `schema_graph()`. One call returns the whole event↔property map plus
+per-property coverage (`density_local`), so you learn which properties actually
+travel with which events — and how well-populated each is — before querying. This
+is the single most useful grounding step: it stops you filtering or grouping by a
+property an event doesn't carry.
+
 ```python
 import mixpanel_headless as mp
 ws = mp.Workspace()
 
-events = ws.events()
-top = ws.top_events(limit=15)
-print("Events:", events)
-print("Top events:", [(e.event, e.count) for e in top])
+schema = ws.schema_graph(include_density=True)
+print("events:", schema.meta["event_count"],
+      "| event properties:", schema.meta["event_property_count"])
 
-# Profile the top 3-5 events by volume
-for event in [e.event for e in top[:5]]:
-    props = ws.properties(event)
-    print(f"\n{event} ({len(props)} properties):")
-    for p in props[:15]:
-        vals = ws.property_values(p, event=event, limit=10)
-        print(f"  {p}: {vals}")
+# Headline view: one row per (event, property), with coverage.
+print(schema.relationships_df.head(20))   # event | property | density_local
+
+# Exact properties on each top event — use these names verbatim in queries.
+for event_name in list(schema.event_to_properties)[:5]:
+    print(f"\n{event_name}: {schema.properties_for_event(event_name)}")
+
+# Properties attached to no events — usually noise; skip them.
+print("\nOrphans:", schema.orphan_properties()[:20])
+
+top = ws.top_events(limit=15)
+print("\nTop by volume:", [(e.event, e.count) for e in top])
+```
+
+Then sample values for the properties you'll actually group or filter by:
+
+```python
+for p in schema.properties_for_event("Purchase")[:15]:
+    print(p, ws.property_values(p, event="Purchase", limit=10))
 ```
 
 ### Step 2: Classify Properties

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -115,6 +115,11 @@ def list_bookmarks(self, bookmark_type: BookmarkType | None = None) -> list[Book
 def lexicon_schemas(self, *, entity_type: EntityType | None = None) -> list[LexiconSchema]: ...
     # List Lexicon schemas (event/property definitions).
 
+def schema_graph(self, *, include_density: bool = False, include_user_properties: bool = True, force_refresh: bool = False) -> SchemaGraphResult: ...
+    # Whole-project Lexicon + event<->property graph in one call. SchemaGraphResult has
+    # .relationships_df (event|property|density_local), .properties_for_event(e),
+    # .events_for_property(p), .orphan_properties(), .to_graph() (networkx DiGraph).
+
 def clear_discovery_cache(self) -> None: ...
     # Clear cached discovery results.
 # User Guide: WebFetch(url="https://mixpanel.github.io/mixpanel-headless/guide/discovery/index.md")

--- a/mixpanel-plugin/skills/mixpanelyst/scripts/help.py
+++ b/mixpanel-plugin/skills/mixpanelyst/scripts/help.py
@@ -653,6 +653,32 @@ _REFERENCE_HINTS: list[tuple[frozenset[str], str, str]] = [
         "guide/entity-management/index.md",
         "bookmark params, entity management",
     ),
+    (
+        frozenset(
+            {
+                "schema_graph",
+                "SchemaGraphResult",
+                "events",
+                "properties",
+                "property_values",
+                "subproperties",
+                "SubPropertyInfo",
+                "lexicon_schemas",
+                "lexicon_schema",
+                "LexiconSchema",
+                "top_events",
+                "TopEvent",
+                "funnels",
+                "FunnelInfo",
+                "cohorts",
+                "SavedCohort",
+                "clear_discovery_cache",
+            }
+        ),
+        "guide/discovery/index.md",
+        "schema_graph (event<->property map + coverage), events, properties, "
+        "values, lexicon schemas",
+    ),
 ]
 
 # Dashboard hints point to the dashboard-expert skill (sibling skill directory),

--- a/src/mixpanel_headless/CLAUDE.md
+++ b/src/mixpanel_headless/CLAUDE.md
@@ -99,7 +99,7 @@ with mp.Workspace() as ws:
 
 ## Workspace Methods
 
-**Discovery** (self-documenting API): `events()`, `properties()`, `property_values()`, `funnels()`, `cohorts()`, `list_bookmarks()`, `top_events()`, `lexicon_schemas()`, `lexicon_schema()`, `clear_discovery_cache()`
+**Discovery** (self-documenting API): `events()`, `properties()`, `property_values()`, `funnels()`, `cohorts()`, `list_bookmarks()`, `top_events()`, `lexicon_schemas()`, `lexicon_schema()`, `schema_graph()`, `clear_discovery_cache()`
 
 **Streaming**: `stream_events()`, `stream_profiles()`
 
@@ -166,7 +166,7 @@ All frozen dataclasses with:
 - `.df` property: Lazy DataFrame conversion (cached)
 - `.to_dict()`: JSON-serializable output
 
-Key types: `SegmentationResult`, `FunnelResult`, `RetentionResult`, `SavedReportResult`, `FlowsResult`, `UserQueryResult`, `BookmarkInfo`, `Dashboard`, `CreateDashboardParams`, `UpdateDashboardParams`, `Bookmark`, `CreateBookmarkParams`, `UpdateBookmarkParams`, `Cohort`, `CreateCohortParams`, `UpdateCohortParams`, `BlueprintTemplate`, `BlueprintConfig`, `BookmarkHistoryResponse`
+Key types: `SegmentationResult`, `FunnelResult`, `RetentionResult`, `SavedReportResult`, `FlowsResult`, `UserQueryResult`, `SchemaGraphResult`, `BookmarkInfo`, `Dashboard`, `CreateDashboardParams`, `UpdateDashboardParams`, `Bookmark`, `CreateBookmarkParams`, `UpdateBookmarkParams`, `Cohort`, `CreateCohortParams`, `UpdateCohortParams`, `BlueprintTemplate`, `BlueprintConfig`, `BookmarkHistoryResponse`
 
 ## Type Aliases
 

--- a/src/mixpanel_headless/__init__.py
+++ b/src/mixpanel_headless/__init__.py
@@ -237,6 +237,7 @@ from mixpanel_headless.types import (
     SavedReportType,
     SchemaEnforcementConfig,
     SchemaEntry,
+    SchemaGraphResult,
     SegmentationResult,
     ServingMethod,
     SetTestUsersParams,
@@ -388,6 +389,7 @@ __all__ = [
     "BookmarkType",
     "SavedReportResult",
     "SavedReportType",
+    "SchemaGraphResult",
     "FlowsResult",
     # Phase 008: Query Service Enhancement types
     "UserEvent",

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -6115,6 +6115,37 @@ class MixpanelAPIClient:
             )
         return result
 
+    def list_event_definitions(self) -> list[dict[str, Any]]:
+        """List all event definitions in the Lexicon.
+
+        Calls ``GET .../data-definitions/events`` without a name filter, so the
+        whole project's event definitions come back in one request. Used by the
+        schema-graph gather to enumerate events.
+
+        Returns:
+            List of event definition dictionaries.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400/404).
+            ServerError: Server-side errors (5xx).
+            MixpanelHeadlessError: Network/connection errors.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(session) as client:
+                events = client.list_event_definitions()
+            ```
+        """
+        path = self.maybe_scoped_path("data-definitions/events/")
+        result = self.app_request("GET", path)
+        if not isinstance(result, list):
+            raise MixpanelHeadlessError(
+                f"Unexpected response from list_event_definitions: "
+                f"expected list, got {type(result).__name__}",
+            )
+        return result
+
     def update_event_definition(
         self, name: str, body: dict[str, Any]
     ) -> dict[str, Any]:
@@ -6257,6 +6288,67 @@ class MixpanelAPIClient:
         if not isinstance(result, list):
             raise MixpanelHeadlessError(
                 f"Unexpected response from get_property_definitions: "
+                f"expected list, got {type(result).__name__}",
+            )
+        return result
+
+    def list_property_definitions(
+        self,
+        *,
+        resource_type: str = "Event",
+        include_events: bool = False,
+        include_density: bool = False,
+        include_custom: bool = True,
+        include_zero_counts: bool = True,
+    ) -> list[dict[str, Any]]:
+        """List all property definitions for a resource type.
+
+        Calls ``GET .../data-definitions/properties`` without a name filter, so
+        the whole project's properties come back in one request. With
+        ``include_events`` each returned event property carries an ``events``
+        list of ``{"name": ...}`` entries — the bulk call that powers the
+        event<->property relationship graph (one request for the project, rather
+        than a schema lookup per entity).
+
+        Args:
+            resource_type: Property family — ``"Event"`` or ``"User"``.
+            include_events: Attach the events each property appears on.
+            include_density: Request the property-level density (``densityLocal``)
+                each row carries. Only populated when the API has computed it.
+            include_custom: Include custom (computed) properties.
+            include_zero_counts: Include properties with no recorded data points.
+
+        Returns:
+            List of property definition dictionaries. When ``include_events`` is
+            set, event properties carry an ``events`` list.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400/404).
+            ServerError: Server-side errors (5xx).
+            MixpanelHeadlessError: Network/connection errors.
+
+        Example:
+            ```python
+            with MixpanelAPIClient(session) as client:
+                rows = client.list_property_definitions(include_events=True)
+                rows[0]["events"]  # [{"name": "Purchase"}, ...]
+            ```
+        """
+        path = self.maybe_scoped_path("data-definitions/properties/")
+        params: dict[str, str] = {
+            "resourceType": resource_type,
+            "includeCustom": "true" if include_custom else "false",
+            "includeZeroCounts": "true" if include_zero_counts else "false",
+        }
+        if include_events:
+            params["includeEvents"] = "true"
+        if include_density:
+            params["includeDensity"] = "true"
+        result = self.app_request("GET", path, params=params)
+        if not isinstance(result, list):
+            raise MixpanelHeadlessError(
+                f"Unexpected response from list_property_definitions: "
                 f"expected list, got {type(result).__name__}",
             )
         return result

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -201,6 +201,41 @@ def _build_activity_feed_date_range(
     return {"type": "relative_after", "window": {"unit": "day", "value": 30}}
 
 
+# Map the resource-type spellings callers pass (lowercase / plural / snake-era) to the
+# App API's canonical Lexicon values. The data-definitions endpoints accept only the
+# camelCase ``resourceType`` query param with a capitalized value ("Event"/"User"); a
+# lowercase value 400s ("Invalid resource type") and the snake_case ``resource_type``
+# param is silently ignored (both verified live). Unknown spellings pass through.
+_RESOURCE_TYPE_CANONICAL = {
+    "event": "Event",
+    "events": "Event",
+    "user": "User",
+    "users": "User",
+    "people": "User",
+}
+
+
+def _canonical_resource_type(resource_type: str) -> str:
+    """Normalize a caller's resource-type spelling to the App API's canonical value.
+
+    Args:
+        resource_type: A resource-type filter as a caller might supply it
+            (e.g. ``"event"``, ``"User"``, ``"people"``).
+
+    Returns:
+        The canonical value the ``data-definitions`` endpoints accept
+        (``"Event"`` / ``"User"``). Unrecognized spellings are returned unchanged
+        so callers can pass values this map does not know about.
+
+    Example:
+        ```python
+        _canonical_resource_type("event")  # "Event"
+        _canonical_resource_type("User")   # "User"
+        ```
+    """
+    return _RESOURCE_TYPE_CANONICAL.get(resource_type.lower(), resource_type)
+
+
 class MixpanelAPIClient:
     """Low-level HTTP client for Mixpanel APIs.
 
@@ -6081,6 +6116,41 @@ class MixpanelAPIClient:
     # Data Governance — Data Definitions / Lexicon (Phase 027)
     # =========================================================================
 
+    def _event_definitions(
+        self, *, names: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        """Fetch event definitions from the Lexicon (shared core).
+
+        Single implementation behind ``get_event_definitions`` (by-name lookup)
+        and ``list_event_definitions`` (bulk enumerate): it owns the endpoint
+        path and the bare-list shape validation so the two public methods cannot
+        drift apart.
+
+        Args:
+            names: Event names to look up; when ``None`` the whole project's
+                event definitions are returned (no ``name[]`` filter).
+
+        Returns:
+            List of event definition dictionaries.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400/404).
+            ServerError: Server-side errors (5xx).
+            MixpanelHeadlessError: Network/connection errors, or a non-list response.
+        """
+        path = self.maybe_scoped_path("data-definitions/events/")
+        params: dict[str, str | list[str]] = {}
+        if names is not None:
+            params["name[]"] = names
+        result = self.app_request("GET", path, params=params)  # type: ignore[arg-type]
+        if not isinstance(result, list):
+            raise MixpanelHeadlessError(
+                f"Unexpected response from event definitions: "
+                f"expected list, got {type(result).__name__}",
+            )
+        return result
+
     def get_event_definitions(self, names: list[str]) -> list[dict[str, Any]]:
         """Get event definitions by name from the Lexicon.
 
@@ -6105,15 +6175,7 @@ class MixpanelAPIClient:
                 defs = client.get_event_definitions(["Signup", "Login"])
             ```
         """
-        path = self.maybe_scoped_path("data-definitions/events/")
-        params: dict[str, str | list[str]] = {"name[]": names}
-        result = self.app_request("GET", path, params=params)  # type: ignore[arg-type]
-        if not isinstance(result, list):
-            raise MixpanelHeadlessError(
-                f"Unexpected response from get_event_definitions: "
-                f"expected list, got {type(result).__name__}",
-            )
-        return result
+        return self._event_definitions(names=names)
 
     def list_event_definitions(self) -> list[dict[str, Any]]:
         """List all event definitions in the Lexicon.
@@ -6137,14 +6199,7 @@ class MixpanelAPIClient:
                 events = client.list_event_definitions()
             ```
         """
-        path = self.maybe_scoped_path("data-definitions/events/")
-        result = self.app_request("GET", path)
-        if not isinstance(result, list):
-            raise MixpanelHeadlessError(
-                f"Unexpected response from list_event_definitions: "
-                f"expected list, got {type(result).__name__}",
-            )
-        return result
+        return self._event_definitions()
 
     def update_event_definition(
         self, name: str, body: dict[str, Any]
@@ -6250,6 +6305,75 @@ class MixpanelAPIClient:
             )
         return result
 
+    def _property_definitions(
+        self,
+        *,
+        names: list[str] | None = None,
+        resource_type: str | None = None,
+        include_events: bool = False,
+        include_density: bool = False,
+        include_custom: bool | None = None,
+        include_zero_counts: bool | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch property definitions from the Lexicon (shared core).
+
+        Single implementation behind ``get_property_definitions`` (by-name
+        lookup) and ``list_property_definitions`` (bulk enumerate). It owns the
+        endpoint path, the ``resourceType`` contract, and the bare-list shape
+        validation, so the two public methods encode the wire format in exactly
+        one place.
+
+        The App API accepts only the camelCase ``resourceType`` query param with
+        a capitalized value (``"Event"`` / ``"User"``); a lowercase value is
+        rejected and the snake_case ``resource_type`` param is silently ignored
+        (both verified live), so caller-supplied spellings are normalized via
+        :func:`_canonical_resource_type`. The boolean ``include_*`` toggles are
+        sent only when not ``None``, preserving each public method's wire format.
+
+        Args:
+            names: Property names to look up; ``None`` omits the ``name[]`` filter
+                (whole-project enumerate).
+            resource_type: Resource family filter, normalized to the canonical
+                value. ``None`` omits the param (the API then defaults to events).
+            include_events: Attach the events each property appears on
+                (``includeEvents``).
+            include_density: Request the property-level density (``includeDensity``).
+            include_custom: Include custom (computed) properties (``includeCustom``);
+                omitted when ``None``.
+            include_zero_counts: Include properties with no recorded data points
+                (``includeZeroCounts``); omitted when ``None``.
+
+        Returns:
+            List of property definition dictionaries.
+
+        Raises:
+            AuthenticationError: Invalid credentials (401).
+            QueryError: API error (400/404), including an invalid resource type.
+            ServerError: Server-side errors (5xx).
+            MixpanelHeadlessError: Network/connection errors, or a non-list response.
+        """
+        path = self.maybe_scoped_path("data-definitions/properties/")
+        params: dict[str, str | list[str]] = {}
+        if names is not None:
+            params["name[]"] = names
+        if resource_type is not None:
+            params["resourceType"] = _canonical_resource_type(resource_type)
+        if include_events:
+            params["includeEvents"] = "true"
+        if include_density:
+            params["includeDensity"] = "true"
+        if include_custom is not None:
+            params["includeCustom"] = "true" if include_custom else "false"
+        if include_zero_counts is not None:
+            params["includeZeroCounts"] = "true" if include_zero_counts else "false"
+        result = self.app_request("GET", path, params=params)  # type: ignore[arg-type]
+        if not isinstance(result, list):
+            raise MixpanelHeadlessError(
+                f"Unexpected response from property definitions: "
+                f"expected list, got {type(result).__name__}",
+            )
+        return result
+
     def get_property_definitions(
         self,
         names: list[str],
@@ -6262,8 +6386,8 @@ class MixpanelAPIClient:
 
         Args:
             names: List of property names to look up.
-            resource_type: Optional resource type filter
-                (e.g., ``"event"``, ``"user"``, ``"groupprofile"``).
+            resource_type: Optional resource type filter (e.g. ``"event"`` /
+                ``"user"``); normalized to the App API's canonical value.
 
         Returns:
             List of property definition dictionaries.
@@ -6280,17 +6404,7 @@ class MixpanelAPIClient:
                 props = client.get_property_definitions(["plan", "country"])
             ```
         """
-        path = self.maybe_scoped_path("data-definitions/properties/")
-        params: dict[str, str | list[str]] = {"name[]": names}
-        if resource_type is not None:
-            params["resource_type"] = resource_type
-        result = self.app_request("GET", path, params=params)  # type: ignore[arg-type]
-        if not isinstance(result, list):
-            raise MixpanelHeadlessError(
-                f"Unexpected response from get_property_definitions: "
-                f"expected list, got {type(result).__name__}",
-            )
-        return result
+        return self._property_definitions(names=names, resource_type=resource_type)
 
     def list_property_definitions(
         self,
@@ -6335,23 +6449,13 @@ class MixpanelAPIClient:
                 rows[0]["events"]  # [{"name": "Purchase"}, ...]
             ```
         """
-        path = self.maybe_scoped_path("data-definitions/properties/")
-        params: dict[str, str] = {
-            "resourceType": resource_type,
-            "includeCustom": "true" if include_custom else "false",
-            "includeZeroCounts": "true" if include_zero_counts else "false",
-        }
-        if include_events:
-            params["includeEvents"] = "true"
-        if include_density:
-            params["includeDensity"] = "true"
-        result = self.app_request("GET", path, params=params)
-        if not isinstance(result, list):
-            raise MixpanelHeadlessError(
-                f"Unexpected response from list_property_definitions: "
-                f"expected list, got {type(result).__name__}",
-            )
-        return result
+        return self._property_definitions(
+            resource_type=resource_type,
+            include_events=include_events,
+            include_density=include_density,
+            include_custom=include_custom,
+            include_zero_counts=include_zero_counts,
+        )
 
     def update_property_definition(
         self, name: str, body: dict[str, Any]

--- a/src/mixpanel_headless/_internal/services/discovery.py
+++ b/src/mixpanel_headless/_internal/services/discovery.py
@@ -839,11 +839,11 @@ class DiscoveryService:
     ) -> SchemaGraphResult:
         """Gather the full Lexicon schema and the event<->property graph.
 
-        Issues three bulk Lexicon calls (event definitions, event properties
-        with their attached events, and optionally user properties) and folds
-        them into a :class:`SchemaGraphResult`. The event<->property adjacency
-        maps are built from the ``events`` lists the API returns on each event
-        property.
+        Issues two or three bulk Lexicon calls — event definitions and event
+        properties (with their attached events) always, plus user properties when
+        ``include_user_properties`` is set (the default) — and folds them into a
+        :class:`SchemaGraphResult`, which derives the event<->property adjacency
+        maps from the ``events`` lists the API returns on each event property.
 
         Args:
             include_density: Request the property-level density (``densityLocal``)
@@ -860,6 +860,8 @@ class DiscoveryService:
         Raises:
             AuthenticationError: Invalid credentials.
             QueryError: API error.
+            ServerError: Server-side errors (5xx).
+            MixpanelHeadlessError: Network/connection errors.
 
         Note:
             Results are cached for the lifetime of this service instance, keyed
@@ -881,40 +883,38 @@ class DiscoveryService:
                 resource_type="User",
             )
 
-        event_to_properties: dict[str, list[str]] = {
-            str(e["name"]): [] for e in events if e.get("name")
-        }
-        property_to_events: dict[str, list[str]] = {}
-        for prop in properties:
-            prop_name = prop.get("name")
-            if not prop_name:
-                continue
-            attached = [
-                str(entry["name"])
-                for entry in prop.get("events") or []
-                if isinstance(entry, dict) and entry.get("name")
-            ]
-            property_to_events[str(prop_name)] = attached
-            for event_name in attached:
-                event_to_properties.setdefault(event_name, []).append(str(prop_name))
-
+        # SchemaGraphResult derives the adjacency maps + meta (incl. drop counts)
+        # from ``properties`` in __post_init__ — ``properties`` is the single source.
         result = SchemaGraphResult(
             computed_at=datetime.now(timezone.utc).isoformat(),
             events=events,
             properties=properties,
             user_properties=user_properties,
-            event_to_properties=event_to_properties,
-            property_to_events=property_to_events,
             include_density=include_density,
-            meta={
-                "event_count": len(events),
-                "event_property_count": len(properties),
-                "user_property_count": len(user_properties),
-            },
             params={
                 "include_density": include_density,
                 "include_user_properties": include_user_properties,
             },
         )
+        # A nonzero drop count means rows were skipped for a missing name or a
+        # malformed events entry — surface it at debug level (matching the
+        # _iter_dict_rows convention) so an empty/odd graph can be diagnosed.
+        if any(
+            result.meta[key]
+            for key in (
+                "events_without_name",
+                "properties_without_name",
+                "property_event_entries_dropped",
+            )
+        ):
+            _logger.debug(
+                "schema_graph dropped %d nameless event(s), %d nameless "
+                "propert(y/ies), %d malformed property->event entr(y/ies); "
+                "%d relationship edge(s) survived (possible Lexicon contract change)",
+                result.meta["events_without_name"],
+                result.meta["properties_without_name"],
+                result.meta["property_event_entries_dropped"],
+                result.meta["relationship_edges"],
+            )
         self._schema_graph_cache[cache_key] = result
         return result

--- a/src/mixpanel_headless/_internal/services/discovery.py
+++ b/src/mixpanel_headless/_internal/services/discovery.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from mixpanel_headless._literal_types import CustomPropertyType
@@ -24,6 +24,7 @@ from mixpanel_headless.types import (
     LexiconProperty,
     LexiconSchema,
     SavedCohort,
+    SchemaGraphResult,
     SubPropertyInfo,
     TopEvent,
 )
@@ -398,6 +399,8 @@ class DiscoveryService:
         self._api_client = api_client
         # Internal cache: tuple keys map to cached results
         self._cache: dict[tuple[str | int | None, ...], list[Any]] = {}
+        # Separate cache for schema-graph results (not list-shaped).
+        self._schema_graph_cache: dict[tuple[Any, ...], SchemaGraphResult] = {}
 
     def list_events(
         self,
@@ -749,9 +752,11 @@ class DiscoveryService:
         """Clear all cached discovery results.
 
         After calling this method, the next discovery request will
-        fetch fresh data from the Mixpanel API.
+        fetch fresh data from the Mixpanel API. Clears both the list-shaped
+        discovery cache and the schema-graph cache.
         """
         self._cache = {}
+        self._schema_graph_cache = {}
 
     # =========================================================================
     # Lexicon Schemas API
@@ -824,3 +829,92 @@ class DiscoveryService:
         schema = _parse_lexicon_schema(raw)
         self._cache[cache_key] = [schema]
         return schema
+
+    def get_schema_graph(
+        self,
+        *,
+        include_density: bool = False,
+        include_user_properties: bool = True,
+        force_refresh: bool = False,
+    ) -> SchemaGraphResult:
+        """Gather the full Lexicon schema and the event<->property graph.
+
+        Issues three bulk Lexicon calls (event definitions, event properties
+        with their attached events, and optionally user properties) and folds
+        them into a :class:`SchemaGraphResult`. The event<->property adjacency
+        maps are built from the ``events`` lists the API returns on each event
+        property.
+
+        Args:
+            include_density: Request the property-level density (``densityLocal``)
+                the bulk call returns, repeated onto each of a property's
+                relationship edges. Only populated when the API has computed it.
+            include_user_properties: Also gather user properties (they carry no
+                event relationships).
+            force_refresh: Bypass the per-instance cache and re-fetch.
+
+        Returns:
+            A :class:`SchemaGraphResult` with events, properties, optional user
+            properties, and the event<->property adjacency maps.
+
+        Raises:
+            AuthenticationError: Invalid credentials.
+            QueryError: API error.
+
+        Note:
+            Results are cached for the lifetime of this service instance, keyed
+            by ``(include_density, include_user_properties)``.
+        """
+        cache_key = ("schema_graph", include_density, include_user_properties)
+        if not force_refresh and cache_key in self._schema_graph_cache:
+            return self._schema_graph_cache[cache_key]
+
+        events = self._api_client.list_event_definitions()
+        properties = self._api_client.list_property_definitions(
+            resource_type="Event",
+            include_events=True,
+            include_density=include_density,
+        )
+        user_properties: list[dict[str, Any]] = []
+        if include_user_properties:
+            user_properties = self._api_client.list_property_definitions(
+                resource_type="User",
+            )
+
+        event_to_properties: dict[str, list[str]] = {
+            str(e["name"]): [] for e in events if e.get("name")
+        }
+        property_to_events: dict[str, list[str]] = {}
+        for prop in properties:
+            prop_name = prop.get("name")
+            if not prop_name:
+                continue
+            attached = [
+                str(entry["name"])
+                for entry in prop.get("events") or []
+                if isinstance(entry, dict) and entry.get("name")
+            ]
+            property_to_events[str(prop_name)] = attached
+            for event_name in attached:
+                event_to_properties.setdefault(event_name, []).append(str(prop_name))
+
+        result = SchemaGraphResult(
+            computed_at=datetime.now(timezone.utc).isoformat(),
+            events=events,
+            properties=properties,
+            user_properties=user_properties,
+            event_to_properties=event_to_properties,
+            property_to_events=property_to_events,
+            include_density=include_density,
+            meta={
+                "event_count": len(events),
+                "event_property_count": len(properties),
+                "user_property_count": len(user_properties),
+            },
+            params={
+                "include_density": include_density,
+                "include_user_properties": include_user_properties,
+            },
+        )
+        self._schema_graph_cache[cache_key] = result
+        return result

--- a/src/mixpanel_headless/cli/commands/inspect.py
+++ b/src/mixpanel_headless/cli/commands/inspect.py
@@ -26,6 +26,7 @@ from mixpanel_headless.cli.utils import (
     get_workspace,
     handle_errors,
     output_result,
+    present_result,
     status_spinner,
 )
 from mixpanel_headless.cli.validators import (
@@ -38,7 +39,7 @@ inspect_app = typer.Typer(
     help="Inspect Mixpanel project schema.",
     epilog="""Live (calls Mixpanel API):
   events, properties, values, subproperties, funnels, cohorts, top-events,
-  bookmarks, lexicon-schemas, lexicon-schema""",
+  bookmarks, lexicon-schemas, lexicon-schema, schema-graph""",
     no_args_is_help=True,
     rich_markup_mode="markdown",
 )
@@ -570,3 +571,51 @@ def inspect_lexicon_schema(
     with status_spinner(ctx, "Fetching schema..."):
         schema = workspace.lexicon_schema(validated_type, name)
     output_result(ctx, schema.to_dict(), format=format, jq_filter=jq_filter)
+
+
+@inspect_app.command("schema-graph")
+@handle_errors
+def inspect_schema_graph(
+    ctx: typer.Context,
+    density: Annotated[
+        bool,
+        typer.Option(
+            "--density/--no-density",
+            help="Request property density (densityLocal) on relationship edges.",
+        ),
+    ] = False,
+    user_properties: Annotated[
+        bool,
+        typer.Option(
+            "--user-properties/--no-user-properties",
+            help="Include user properties in the gather.",
+        ),
+    ] = True,
+    format: FormatOption = "json",
+    jq_filter: JqOption = None,
+) -> None:
+    """Gather the full Lexicon schema and event<->property relationships.
+
+    One call returns event definitions, event properties, and user properties
+    plus which properties appear on which events. ``--format table`` shows the
+    relationship edge list; other formats return the full structure.
+
+    Output Structure (table):
+
+        EVENT      PROPERTY        DENSITY_LOCAL
+        Purchase   amount
+        Purchase   currency
+
+    Examples:
+
+        mp inspect schema-graph
+        mp inspect schema-graph --format table
+        mp inspect schema-graph --no-user-properties --jq '.event_to_properties'
+    """
+    workspace = get_workspace(ctx)
+    with status_spinner(ctx, "Gathering schema graph..."):
+        schema = workspace.schema_graph(
+            include_density=density,
+            include_user_properties=user_properties,
+        )
+    present_result(ctx, schema, format, jq_filter=jq_filter)

--- a/src/mixpanel_headless/cli/commands/inspect.py
+++ b/src/mixpanel_headless/cli/commands/inspect.py
@@ -602,7 +602,7 @@ def inspect_schema_graph(
 
     Output Structure (table):
 
-        EVENT      PROPERTY        DENSITY_LOCAL
+        EVENT      PROPERTY        DENSITY LOCAL
         Purchase   amount
         Purchase   currency
 

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -11203,6 +11203,318 @@ class FlowQueryResult(ResultWithDataFrame):
 
 
 # =============================================================================
+# Schema Graph (full lexicon + event<->property relationships)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SchemaGraphResult(ResultWithDataFrame):
+    """Full Lexicon schema plus the event<->property relationship graph.
+
+    Adapts the power-tools ``getSchema`` view to headless: it gathers event
+    definitions, event properties, and user properties from the Lexicon, and
+    records which properties appear on which events (and the inverse) from a
+    single bulk ``data-definitions/properties?includeEvents=true`` call, so for
+    any event you can list the properties that travel with it.
+
+    Group properties are out of scope for now (headless has no data-groups
+    listing to enumerate them); only event and user properties are gathered.
+
+    Attributes:
+        computed_at: ISO-8601 timestamp when the schema was gathered.
+        events: Event definition dicts (Lexicon shape, camelCase keys).
+        properties: Event property dicts; each carries an ``events`` list of
+            ``{"name": ...}`` entries describing the events it appears on, and a
+            top-level ``densityLocal`` when ``include_density`` was requested.
+        user_properties: User property dicts.
+        event_to_properties: Map of event name to the property names on it.
+        property_to_events: Map of property name to the events it appears on.
+        include_density: Whether per-property density was requested.
+        meta: Free-form metadata about the gather (counts, flags).
+        params: The parameters that produced this result.
+
+    Example:
+        ```python
+        schema = ws.schema_graph()
+        schema.properties_for_event("Purchase")
+        # ["amount", "currency", "item_id", ...]
+        schema.relationships_df.head()
+        g = schema.to_graph()  # networkx.DiGraph, events -> properties
+        ```
+    """
+
+    computed_at: str
+    events: list[dict[str, Any]] = field(default_factory=list)
+    properties: list[dict[str, Any]] = field(default_factory=list)
+    user_properties: list[dict[str, Any]] = field(default_factory=list)
+    event_to_properties: dict[str, list[str]] = field(default_factory=dict)
+    property_to_events: dict[str, list[str]] = field(default_factory=dict)
+    include_density: bool = False
+    meta: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+    _events_df_cache: pd.DataFrame | None = field(
+        default=None, repr=False, kw_only=True
+    )
+    _properties_df_cache: pd.DataFrame | None = field(
+        default=None, repr=False, kw_only=True
+    )
+    _relationships_df_cache: pd.DataFrame | None = field(
+        default=None, repr=False, kw_only=True
+    )
+    _graph_cache: nx.DiGraph[str] | None = field(default=None, repr=False, kw_only=True)
+    """Internal cache for the networkx graph (optional dependency)."""
+
+    @property
+    def events_df(self) -> pd.DataFrame:
+        """Flat DataFrame of event definitions.
+
+        Returns:
+            DataFrame with columns ``name``, ``display_name``, ``description``,
+            ``hidden``, ``dropped``, ``verified``, ``count``. Empty (with those
+            columns) when there are no events.
+        """
+        cols = [
+            "name",
+            "display_name",
+            "description",
+            "hidden",
+            "dropped",
+            "verified",
+            "count",
+        ]
+        if self._events_df_cache is not None:
+            return self._events_df_cache
+        rows = [
+            {
+                "name": e.get("name"),
+                "display_name": e.get("displayName"),
+                "description": e.get("description"),
+                "hidden": e.get("hidden"),
+                "dropped": e.get("dropped"),
+                "verified": e.get("verified"),
+                "count": e.get("count"),
+            }
+            for e in self.events
+        ]
+        result_df = pd.DataFrame(rows, columns=cols)
+        object.__setattr__(self, "_events_df_cache", result_df)
+        return result_df
+
+    @property
+    def properties_df(self) -> pd.DataFrame:
+        """Flat DataFrame of event and user properties.
+
+        Each row carries a ``resource_type`` discriminator (``event`` or
+        ``user``).
+
+        Returns:
+            DataFrame with columns ``name``, ``resource_type``,
+            ``display_name``, ``description``, ``example_value``, ``type``,
+            ``hidden``, ``count``. Empty (with those columns) when there are
+            no properties.
+        """
+        cols = [
+            "name",
+            "resource_type",
+            "display_name",
+            "description",
+            "example_value",
+            "type",
+            "hidden",
+            "count",
+        ]
+        if self._properties_df_cache is not None:
+            return self._properties_df_cache
+        rows: list[dict[str, Any]] = []
+        for prop in self.properties:
+            rows.append(self._property_row(prop, "event"))
+        for prop in self.user_properties:
+            rows.append(self._property_row(prop, "user"))
+        result_df = pd.DataFrame(rows, columns=cols)
+        object.__setattr__(self, "_properties_df_cache", result_df)
+        return result_df
+
+    @staticmethod
+    def _property_row(prop: dict[str, Any], default_resource: str) -> dict[str, Any]:
+        """Project a raw property dict into a flat row.
+
+        Args:
+            prop: Raw property definition dict (camelCase keys).
+            default_resource: Resource type to use when the row omits one.
+
+        Returns:
+            A flat dict keyed by the ``properties_df`` columns.
+        """
+        resource = prop.get("resourceType")
+        resource_type = str(resource).lower() if resource else default_resource
+        return {
+            "name": prop.get("name"),
+            "resource_type": resource_type,
+            "display_name": prop.get("displayName"),
+            "description": prop.get("description"),
+            "example_value": prop.get("exampleValue"),
+            "type": prop.get("type"),
+            "hidden": prop.get("hidden"),
+            "count": prop.get("count"),
+        }
+
+    @property
+    def relationships_df(self) -> pd.DataFrame:
+        """Edge-list DataFrame of event<->property relationships.
+
+        One row per (event, property) pair. ``density_local`` is the property's
+        ``densityLocal`` (the share of the property's records, returned at the
+        property level by the bulk call) repeated on each of its edges; it is
+        ``None`` unless ``include_density`` was requested.
+
+        Returns:
+            DataFrame with columns ``event``, ``property``, ``density_local``.
+            Empty (with those columns) when no relationships exist.
+        """
+        cols = ["event", "property", "density_local"]
+        if self._relationships_df_cache is not None:
+            return self._relationships_df_cache
+        rows: list[dict[str, Any]] = []
+        for prop in self.properties:
+            name = prop.get("name")
+            if not name:
+                continue
+            density = prop.get("densityLocal")
+            for entry in prop.get("events") or []:
+                event_name = entry.get("name") if isinstance(entry, dict) else None
+                if not event_name:
+                    continue
+                # str()-cast names so the edge list, the adjacency maps, and the
+                # graph all key relationships the same way.
+                rows.append(
+                    {
+                        "event": str(event_name),
+                        "property": str(name),
+                        "density_local": density,
+                    }
+                )
+        result_df = pd.DataFrame(rows, columns=cols)
+        object.__setattr__(self, "_relationships_df_cache", result_df)
+        return result_df
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Headline DataFrame — the event<->property relationship edge list.
+
+        Returns:
+            The :attr:`relationships_df` edge list.
+        """
+        return self.relationships_df
+
+    def properties_for_event(self, event: str) -> list[str]:
+        """Return the property names that appear on an event.
+
+        Args:
+            event: Event name.
+
+        Returns:
+            Property names on the event (empty when unknown or none).
+        """
+        return list(self.event_to_properties.get(event, []))
+
+    def events_for_property(self, prop: str) -> list[str]:
+        """Return the events a property appears on.
+
+        Args:
+            prop: Property name.
+
+        Returns:
+            Event names carrying the property (empty when unknown or none).
+        """
+        return list(self.property_to_events.get(prop, []))
+
+    def orphan_properties(self) -> list[str]:
+        """Return event properties that appear on no events.
+
+        Returns:
+            Property names with no event relationships. Properties without a
+            name are skipped (matching ``relationships_df`` / ``to_graph``).
+        """
+        return [
+            str(name)
+            for p in self.properties
+            if (name := p.get("name")) and not self.property_to_events.get(str(name))
+        ]
+
+    def to_graph(self) -> nx.DiGraph:
+        """Build a directed event->property relationship graph.
+
+        Event names become nodes with ``kind="event"`` and property names nodes
+        with ``kind="property"``; a directed edge runs from each event to every
+        property that appears on it, carrying the property's ``density_local``
+        (``None`` unless ``include_density`` was requested).
+        The graph is bipartite (no event->event or property->property edges)
+        provided event and property names are disjoint; nodes are keyed by bare
+        name, so an event and a property that share a name collapse to one node.
+        Built lazily and cached.
+
+        Returns:
+            A ``networkx.DiGraph``. Empty when there are no events or
+            properties.
+
+        Example:
+            ```python
+            g = ws.schema_graph().to_graph()
+            g.nodes["Purchase"]["kind"]  # "event"
+            list(g.successors("Purchase"))  # properties on Purchase
+            ```
+        """
+        import networkx as nx  # lazy — only paid when the graph is accessed
+
+        if self._graph_cache is not None:
+            return self._graph_cache
+        graph: nx.DiGraph = nx.DiGraph()
+        # str()-cast every node name so the graph keys nodes the same way the
+        # adjacency maps and the edge-list DataFrame do (one node per name).
+        for event_name in self.event_to_properties:
+            graph.add_node(str(event_name), kind="event")
+        for event in self.events:
+            name = event.get("name")
+            if name:
+                graph.add_node(str(name), kind="event")
+        for prop in self.properties:
+            prop_name = prop.get("name")
+            if not prop_name:
+                continue
+            graph.add_node(str(prop_name), kind="property")
+            density = prop.get("densityLocal")
+            for entry in prop.get("events") or []:
+                if not isinstance(entry, dict) or not entry.get("name"):
+                    continue
+                graph.add_node(str(entry["name"]), kind="event")
+                graph.add_edge(
+                    str(entry["name"]),
+                    str(prop_name),
+                    density_local=density,
+                )
+        object.__setattr__(self, "_graph_cache", graph)
+        return graph
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the schema graph for JSON output.
+
+        Returns:
+            Dictionary with all fields suitable for JSON serialization.
+        """
+        return {
+            "computed_at": self.computed_at,
+            "events": self.events,
+            "properties": self.properties,
+            "user_properties": self.user_properties,
+            "event_to_properties": self.event_to_properties,
+            "property_to_events": self.property_to_events,
+            "include_density": self.include_density,
+            "meta": self.meta,
+            "params": self.params,
+        }
+
+
+# =============================================================================
 # User / Engage Query Result (Phase 039)
 # =============================================================================
 

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -11227,10 +11227,14 @@ class SchemaGraphResult(ResultWithDataFrame):
             ``{"name": ...}`` entries describing the events it appears on, and a
             top-level ``densityLocal`` when ``include_density`` was requested.
         user_properties: User property dicts.
-        event_to_properties: Map of event name to the property names on it.
-        property_to_events: Map of property name to the events it appears on.
+        event_to_properties: Map of event name to the property names on it
+            (derived from ``properties`` in __post_init__).
+        property_to_events: Map of property name to the events it appears on
+            (derived from ``properties`` in __post_init__).
         include_density: Whether per-property density was requested.
-        meta: Free-form metadata about the gather (counts, flags).
+        meta: Derived gather metadata — entity counts plus per-row drop counts
+            (``events_without_name``, ``properties_without_name``,
+            ``property_event_entries_dropped``, ``relationship_edges``).
         params: The parameters that produced this result.
 
     Example:
@@ -11247,10 +11251,15 @@ class SchemaGraphResult(ResultWithDataFrame):
     events: list[dict[str, Any]] = field(default_factory=list)
     properties: list[dict[str, Any]] = field(default_factory=list)
     user_properties: list[dict[str, Any]] = field(default_factory=list)
-    event_to_properties: dict[str, list[str]] = field(default_factory=dict)
-    property_to_events: dict[str, list[str]] = field(default_factory=dict)
+    # event_to_properties / property_to_events / meta are DERIVED from ``properties``
+    # (+ ``events``) in __post_init__, so they are init=False and cannot be passed in —
+    # ``properties`` is the single source of truth. ``params`` stays an init field
+    # because it records the fetch flags (e.g. include_user_properties), which are not
+    # reconstructible from the result.
+    event_to_properties: dict[str, list[str]] = field(init=False, default_factory=dict)
+    property_to_events: dict[str, list[str]] = field(init=False, default_factory=dict)
     include_density: bool = False
-    meta: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(init=False, default_factory=dict)
     params: dict[str, Any] = field(default_factory=dict)
     _events_df_cache: pd.DataFrame | None = field(
         default=None, repr=False, kw_only=True
@@ -11263,6 +11272,58 @@ class SchemaGraphResult(ResultWithDataFrame):
     )
     _graph_cache: nx.DiGraph[str] | None = field(default=None, repr=False, kw_only=True)
     """Internal cache for the networkx graph (optional dependency)."""
+
+    def __post_init__(self) -> None:
+        """Derive the adjacency maps and ``meta`` from ``properties``.
+
+        ``properties`` (each entry carrying an inner ``events`` list) is the single
+        source of truth: ``event_to_properties`` / ``property_to_events`` are built
+        here — events seeded from ``events`` so an event with no properties still
+        appears — rather than being passed in, so the maps can never disagree with
+        ``properties``. The same pass records ``meta`` counts, including the rows
+        dropped for a missing/empty ``name`` or a malformed ``events`` entry; a
+        nonzero drop count signals the Lexicon response shape may have changed.
+        """
+        event_to_properties: dict[str, list[str]] = {
+            str(e["name"]): [] for e in self.events if e.get("name")
+        }
+        events_without_name = sum(1 for e in self.events if not e.get("name"))
+        property_to_events: dict[str, list[str]] = {}
+        properties_without_name = 0
+        property_event_entries_dropped = 0
+        relationship_edges = 0
+        for prop in self.properties:
+            prop_name = prop.get("name")
+            if not prop_name:
+                properties_without_name += 1
+                continue
+            raw_entries = prop.get("events") or []
+            attached = [
+                str(entry["name"])
+                for entry in raw_entries
+                if isinstance(entry, dict) and entry.get("name")
+            ]
+            property_event_entries_dropped += len(raw_entries) - len(attached)
+            property_to_events[str(prop_name)] = attached
+            relationship_edges += len(attached)
+            for event_name in attached:
+                event_to_properties.setdefault(event_name, []).append(str(prop_name))
+
+        object.__setattr__(self, "event_to_properties", event_to_properties)
+        object.__setattr__(self, "property_to_events", property_to_events)
+        object.__setattr__(
+            self,
+            "meta",
+            {
+                "event_count": len(self.events),
+                "event_property_count": len(self.properties),
+                "user_property_count": len(self.user_properties),
+                "events_without_name": events_without_name,
+                "properties_without_name": properties_without_name,
+                "property_event_entries_dropped": property_event_entries_dropped,
+                "relationship_edges": relationship_edges,
+            },
+        )
 
     @property
     def events_df(self) -> pd.DataFrame:
@@ -11363,9 +11424,9 @@ class SchemaGraphResult(ResultWithDataFrame):
         """Edge-list DataFrame of event<->property relationships.
 
         One row per (event, property) pair. ``density_local`` is the property's
-        ``densityLocal`` (the share of the property's records, returned at the
-        property level by the bulk call) repeated on each of its edges; it is
-        ``None`` unless ``include_density`` was requested.
+        top-level ``densityLocal`` (returned at the property level by the bulk
+        call) repeated on each of its edges; it is ``None`` unless
+        ``include_density`` was requested.
 
         Returns:
             DataFrame with columns ``event``, ``property``, ``density_local``.

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -242,6 +242,7 @@ from mixpanel_headless.types import (
     SavedReportResult,
     SchemaEnforcementConfig,
     SchemaEntry,
+    SchemaGraphResult,
     SegmentationResult,
     SetTestUsersParams,
     SubPropertyInfo,
@@ -1232,6 +1233,56 @@ class Workspace:
             only when fresh data is needed.
         """
         return self._discovery_service.get_schema(entity_type, name)
+
+    def schema_graph(
+        self,
+        *,
+        include_density: bool = False,
+        include_user_properties: bool = True,
+        force_refresh: bool = False,
+    ) -> SchemaGraphResult:
+        """Gather the full Lexicon schema and event<->property relationships.
+
+        Adapts the power-tools ``getSchema`` view: one call returns the project's
+        event definitions, event properties, and user properties, plus the
+        adjacency between events and the properties that appear on them. The
+        result is a typed :class:`SchemaGraphResult` with DataFrame views
+        (``events_df``, ``properties_df``, ``relationships_df``) and a
+        ``to_graph()`` networkx export.
+
+        Group properties are not gathered yet (headless has no data-groups
+        listing to enumerate them).
+
+        Results are cached for the lifetime of the Workspace.
+
+        Args:
+            include_density: Request the property-level density (``densityLocal``)
+                the bulk call returns; it repeats onto each of a property's
+                relationship edges and is ``None`` otherwise.
+            include_user_properties: Also gather user properties.
+            force_refresh: Bypass the cache and re-fetch.
+
+        Returns:
+            A :class:`SchemaGraphResult`.
+
+        Raises:
+            ConfigError: If API credentials are not available.
+            AuthenticationError: If credentials are invalid.
+
+        Example:
+            ```python
+            ws = Workspace()
+            schema = ws.schema_graph()
+            schema.properties_for_event("Purchase")
+            schema.relationships_df.head()
+            graph = schema.to_graph()
+            ```
+        """
+        return self._discovery_service.get_schema_graph(
+            include_density=include_density,
+            include_user_properties=include_user_properties,
+            force_refresh=force_refresh,
+        )
 
     # =========================================================================
     # STREAMING METHODS

--- a/tests/pbt/test_schema_graph_pbt.py
+++ b/tests/pbt/test_schema_graph_pbt.py
@@ -77,3 +77,41 @@ def test_graph_counts(events: list[str], props: list[str], data: st.DataObject) 
     # property nodes have no outgoing edges
     for p in props:
         assert g.out_degree(p) == 0
+
+
+@given(events=_events, props=_props, data=st.data())
+def test_orphan_properties_matches_empty_adjacency(
+    events: list[str], props: list[str], data: st.DataObject
+) -> None:
+    """orphan_properties() is exactly the properties whose events list is empty."""
+    edges = {
+        p: data.draw(st.lists(st.sampled_from(events), max_size=3, unique=True))
+        for p in props
+    }
+    result = _build(events, props, edges)
+    expected = {p for p in props if not edges[p]}
+    assert set(result.orphan_properties()) == expected
+
+
+@given(events=_events, props=_props, data=st.data())
+def test_graph_edges_when_relationships_exist(
+    events: list[str], props: list[str], data: st.DataObject
+) -> None:
+    """Forcing one property to carry an edge exercises the non-empty graph path.
+
+    The first property always gets >=1 event, so this never passes vacuously on
+    an all-empty draw; the graph edge count must match the adjacency total.
+    """
+    edges = {
+        props[0]: data.draw(
+            st.lists(st.sampled_from(events), min_size=1, max_size=3, unique=True)
+        )
+    }
+    for p in props[1:]:
+        edges[p] = data.draw(st.lists(st.sampled_from(events), max_size=3, unique=True))
+    result = _build(events, props, edges)
+    g = result.to_graph()
+    assert g.number_of_edges() >= 1
+    assert g.number_of_edges() == sum(
+        len(v) for v in result.property_to_events.values()
+    )

--- a/tests/pbt/test_schema_graph_pbt.py
+++ b/tests/pbt/test_schema_graph_pbt.py
@@ -1,0 +1,79 @@
+"""Property-based tests for the schema graph (PR3).
+
+Invariants over randomly generated lexicons:
+- ``property_to_events`` is the exact inverse of ``event_to_properties``.
+- the networkx graph has one node per distinct event/property and one edge per
+  adjacency entry, with no property->* edges.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from mixpanel_headless._internal.services.discovery import DiscoveryService
+
+# Event and property names are drawn from disjoint namespaces (the realistic
+# case); to_graph keys nodes by bare name, so a shared name would intentionally
+# collapse to a single node.
+_base = st.text(alphabet="abcdef", min_size=1, max_size=5)
+_events = st.lists(_base.map(lambda s: f"evt_{s}"), min_size=1, max_size=6, unique=True)
+_props = st.lists(_base.map(lambda s: f"prop_{s}"), min_size=1, max_size=6, unique=True)
+
+
+def _build(events: list[str], props: list[str], edges: dict[str, list[str]]) -> Any:
+    """Run get_schema_graph against a mocked api client built from edges."""
+    api = MagicMock()
+    api.list_event_definitions.return_value = [{"name": e} for e in events]
+
+    def list_props(*, resource_type: str = "Event", **_: Any) -> list[dict[str, Any]]:
+        if resource_type == "User":
+            return []
+        return [
+            {"name": p, "events": [{"name": e} for e in edges.get(p, [])]}
+            for p in props
+        ]
+
+    api.list_property_definitions.side_effect = list_props
+    return DiscoveryService(api).get_schema_graph(include_user_properties=False)
+
+
+@given(events=_events, props=_props, data=st.data())
+def test_inverse_maps(events: list[str], props: list[str], data: st.DataObject) -> None:
+    """property_to_events is the inverse of event_to_properties."""
+    edges = {
+        p: data.draw(st.lists(st.sampled_from(events), max_size=3, unique=True))
+        for p in props
+    }
+    result = _build(events, props, edges)
+
+    # Forward edges reconstructed from property_to_events match event_to_properties.
+    forward: set[tuple[str, str]] = set()
+    for prop, evs in result.property_to_events.items():
+        for ev in evs:
+            forward.add((ev, prop))
+    inverse: set[tuple[str, str]] = set()
+    for ev, ps in result.event_to_properties.items():
+        for prop in ps:
+            inverse.add((ev, prop))
+    assert forward == inverse
+
+
+@given(events=_events, props=_props, data=st.data())
+def test_graph_counts(events: list[str], props: list[str], data: st.DataObject) -> None:
+    """Graph has one edge per adjacency entry and no property->* edges."""
+    edges = {
+        p: data.draw(st.lists(st.sampled_from(events), max_size=3, unique=True))
+        for p in props
+    }
+    result = _build(events, props, edges)
+    g = result.to_graph()
+
+    expected_edges = sum(len(v) for v in result.property_to_events.values())
+    assert g.number_of_edges() == expected_edges
+    # property nodes have no outgoing edges
+    for p in props:
+        assert g.out_degree(p) == 0

--- a/tests/unit/test_api_client_data_governance.py
+++ b/tests/unit/test_api_client_data_governance.py
@@ -300,7 +300,12 @@ class TestGetPropertyDefinitions:
         assert "/data-definitions/properties/" in captured_urls[0]
 
     def test_resource_type_param(self, oauth_credentials: Session) -> None:
-        """get_property_definitions() passes resource_type query param."""
+        """get_property_definitions() normalizes resource_type to the camelCase param.
+
+        The App API honors only ``resourceType`` with a capitalized value; the
+        lowercase ``"event"`` a caller passes is normalized to ``"Event"`` (the
+        legacy snake_case ``resource_type`` param was silently ignored server-side).
+        """
         captured_urls: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -312,7 +317,8 @@ class TestGetPropertyDefinitions:
         with client:
             client.get_property_definitions(["plan_type"], resource_type="event")
 
-        assert "resource_type=event" in captured_urls[0]
+        assert "resourceType=Event" in captured_urls[0]
+        assert "resource_type=event" not in captured_urls[0]
 
 
 class TestUpdatePropertyDefinition:

--- a/tests/unit/test_schema_graph.py
+++ b/tests/unit/test_schema_graph.py
@@ -12,6 +12,7 @@ Five layers:
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -20,7 +21,10 @@ import pytest
 import typer.testing
 from pydantic import SecretStr
 
-from mixpanel_headless._internal.api_client import MixpanelAPIClient
+from mixpanel_headless._internal.api_client import (
+    MixpanelAPIClient,
+    _canonical_resource_type,
+)
 from mixpanel_headless._internal.auth.account import ServiceAccount
 from mixpanel_headless._internal.auth.session import Project, Session
 from mixpanel_headless._internal.services.discovery import DiscoveryService
@@ -56,8 +60,8 @@ def _sample_result() -> SchemaGraphResult:
         user_properties=[
             {"name": "plan", "resourceType": "User", "displayName": "Plan"}
         ],
-        event_to_properties={"Purchase": ["amount"]},
-        property_to_events={"amount": ["Purchase"], "orphan": []},
+        # event_to_properties / property_to_events are derived from ``properties``
+        # in __post_init__ (init=False), so they are no longer passed here.
         include_density=True,
     )
 
@@ -161,6 +165,106 @@ class TestSchemaGraphResult:
         assert result.properties_df is result.properties_df
         assert result.relationships_df is result.relationships_df
 
+    def test_density_local_none_when_density_not_requested(self) -> None:
+        """Without include_density, density_local is None on each edge + graph edge."""
+        result = SchemaGraphResult(
+            computed_at="t",
+            events=[{"name": "Purchase"}],
+            properties=[{"name": "amount", "events": [{"name": "Purchase"}]}],
+        )
+        assert result.include_density is False
+        assert result.relationships_df.iloc[0]["density_local"] is None
+        assert result.to_graph().edges["Purchase", "amount"]["density_local"] is None
+
+    def test_non_dict_event_entry_is_filtered(self) -> None:
+        """Non-dict / nameless entries in a property's events list are dropped."""
+        result = SchemaGraphResult(
+            computed_at="t",
+            properties=[
+                {
+                    "name": "amount",
+                    "events": ["NotADict", {"no": "name"}, {"name": "Purchase"}],
+                }
+            ],
+        )
+        # Only the well-formed {"name": "Purchase"} entry survives.
+        assert list(result.relationships_df["event"]) == ["Purchase"]
+        assert result.property_to_events["amount"] == ["Purchase"]
+        assert list(result.to_graph().successors("Purchase")) == ["amount"]
+
+    def test_relationships_df_skips_nameless_property(self) -> None:
+        """A property without a name is skipped by the relationships edge list."""
+        result = SchemaGraphResult(
+            computed_at="t",
+            properties=[
+                {"events": [{"name": "Purchase"}]},  # no name -> skipped
+                {"name": "amount", "events": [{"name": "Purchase"}]},
+            ],
+        )
+        assert list(result.relationships_df["property"]) == ["amount"]
+
+    def test_events_for_property_unknown_returns_empty(self) -> None:
+        """events_for_property on an unknown property name returns []."""
+        assert _sample_result().events_for_property("missing") == []
+
+    def test_property_without_events_key(self) -> None:
+        """A property dict lacking an ``events`` key contributes no edges."""
+        result = SchemaGraphResult(computed_at="t", properties=[{"name": "amount"}])
+        assert result.relationships_df.empty
+        assert result.property_to_events == {"amount": []}
+        assert result.orphan_properties() == ["amount"]
+
+    def test_maps_derived_from_properties(self) -> None:
+        """event_to_properties / property_to_events are derived, not passed in.
+
+        Events with no properties are still seeded (so the event is a known key
+        and a graph node); the inverse map is built from each property's events.
+        """
+        result = SchemaGraphResult(
+            computed_at="t",
+            events=[{"name": "Purchase"}, {"name": "Login"}],
+            properties=[{"name": "amount", "events": [{"name": "Purchase"}]}],
+        )
+        assert result.event_to_properties == {"Purchase": ["amount"], "Login": []}
+        assert result.property_to_events == {"amount": ["Purchase"]}
+        assert result.properties_for_event("Login") == []
+        assert result.to_graph().nodes["Login"]["kind"] == "event"
+
+    def test_meta_records_drop_counts(self) -> None:
+        """meta carries entity counts and per-row drop counts."""
+        result = SchemaGraphResult(
+            computed_at="t",
+            events=[{"name": "Purchase"}, {"count": 5}],  # one nameless event
+            properties=[
+                {"name": "amount", "events": [{"name": "Purchase"}, "bad"]},
+                {"events": []},  # nameless property
+            ],
+            user_properties=[{"name": "plan"}],
+        )
+        assert result.meta["event_count"] == 2
+        assert result.meta["event_property_count"] == 2
+        assert result.meta["user_property_count"] == 1
+        assert result.meta["events_without_name"] == 1
+        assert result.meta["properties_without_name"] == 1
+        assert result.meta["property_event_entries_dropped"] == 1
+        assert result.meta["relationship_edges"] == 1
+
+    def test_to_dict_contains_all_fields(self) -> None:
+        """to_dict exposes every public field."""
+        d = _sample_result().to_dict()
+        for key in (
+            "computed_at",
+            "events",
+            "properties",
+            "user_properties",
+            "event_to_properties",
+            "property_to_events",
+            "include_density",
+            "meta",
+            "params",
+        ):
+            assert key in d
+
 
 def _client(handler: Any) -> MixpanelAPIClient:
     """Build a client wired to a MockTransport handler."""
@@ -224,6 +328,71 @@ class TestApiClientBulkLexicon:
 
         with pytest.raises(MixpanelHeadlessError, match="expected list"):
             _client(handler).list_property_definitions()
+
+    def test_list_property_definitions_default_params(self) -> None:
+        """A default bulk call pins the canonical params and omits the toggles.
+
+        ``resourceType=Event`` + ``includeCustom`` / ``includeZeroCounts`` are
+        sent; ``includeEvents`` / ``includeDensity`` are absent unless requested.
+        """
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json=[])
+
+        _client(handler).list_property_definitions()
+        assert seen["params"]["resourceType"] == "Event"
+        assert seen["params"]["includeCustom"] == "true"
+        assert seen["params"]["includeZeroCounts"] == "true"
+        assert "includeEvents" not in seen["params"]
+        assert "includeDensity" not in seen["params"]
+
+    def test_get_property_definitions_normalizes_resource_type(self) -> None:
+        """get_* sends the name filter and the normalized camelCase resourceType."""
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json=[])
+
+        _client(handler).get_property_definitions(["amount"], resource_type="user")
+        assert seen["params"]["name[]"] == "amount"
+        assert seen["params"]["resourceType"] == "User"
+        # get_* must not send the bulk-only include toggles.
+        assert "includeCustom" not in seen["params"]
+        assert "includeZeroCounts" not in seen["params"]
+
+    def test_get_event_definitions_sends_name_filter(self) -> None:
+        """get_event_definitions sends a name[] filter (the bulk list does not)."""
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json=[])
+
+        _client(handler).get_event_definitions(["Purchase"])
+        assert seen["params"]["name[]"] == "Purchase"
+
+
+class TestCanonicalResourceType:
+    """The resource-type value normalizer."""
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [
+            ("event", "Event"),
+            ("events", "Event"),
+            ("Event", "Event"),
+            ("user", "User"),
+            ("people", "User"),
+            ("User", "User"),
+            ("groupprofile", "groupprofile"),  # unknown spelling passes through
+        ],
+    )
+    def test_normalizes(self, given: str, expected: str) -> None:
+        """Known spellings map to canonical values; unknowns pass through."""
+        assert _canonical_resource_type(given) == expected
 
 
 class TestDiscoveryGetSchemaGraph:
@@ -305,6 +474,31 @@ class TestDiscoveryGetSchemaGraph:
         assert result.include_density is True
         assert result.relationships_df.iloc[0]["density_local"] == 0.75
         assert result.to_graph().edges["Purchase", "amount"]["density_local"] == 0.75
+
+    def test_debug_log_on_dropped_rows(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Dropped (nameless / malformed) rows emit a debug summary."""
+        api = MagicMock()
+        api.list_event_definitions.return_value = [{"name": "Purchase"}, {"count": 1}]
+        api.list_property_definitions.return_value = [
+            {"name": "amount", "events": ["bad", {"name": "Purchase"}]},
+            {"events": []},
+        ]
+        logger_name = "mixpanel_headless._internal.services.discovery"
+        with caplog.at_level(logging.DEBUG, logger=logger_name):
+            DiscoveryService(api).get_schema_graph(include_user_properties=False)
+        assert any("schema_graph dropped" in r.message for r in caplog.records)
+
+    def test_no_debug_log_when_no_drops(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A clean gather emits no drop summary."""
+        api = MagicMock()
+        api.list_event_definitions.return_value = [{"name": "Purchase"}]
+        api.list_property_definitions.return_value = [
+            {"name": "amount", "events": [{"name": "Purchase"}]}
+        ]
+        logger_name = "mixpanel_headless._internal.services.discovery"
+        with caplog.at_level(logging.DEBUG, logger=logger_name):
+            DiscoveryService(api).get_schema_graph(include_user_properties=False)
+        assert not any("schema_graph dropped" in r.message for r in caplog.records)
 
 
 class TestFacadeAndCli:

--- a/tests/unit/test_schema_graph.py
+++ b/tests/unit/test_schema_graph.py
@@ -1,0 +1,345 @@
+"""Tests for the schema graph: full lexicon + event<->property relationships (PR3).
+
+Five layers:
+
+- ``SchemaGraphResult`` DataFrame views, networkx export, convenience accessors;
+- the ``MixpanelAPIClient`` bulk lexicon calls (URL/params, shape handling);
+- ``DiscoveryService.get_schema_graph`` adjacency building + caching;
+- the ``Workspace.schema_graph`` facade;
+- the ``mp inspect schema-graph`` CLI command.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import typer.testing
+from pydantic import SecretStr
+
+from mixpanel_headless._internal.api_client import MixpanelAPIClient
+from mixpanel_headless._internal.auth.account import ServiceAccount
+from mixpanel_headless._internal.auth.session import Project, Session
+from mixpanel_headless._internal.services.discovery import DiscoveryService
+from mixpanel_headless.cli.main import app
+from mixpanel_headless.exceptions import MixpanelHeadlessError
+from mixpanel_headless.types import SchemaGraphResult
+from mixpanel_headless.workspace import Workspace
+
+runner = typer.testing.CliRunner()
+
+_SESSION = Session(
+    account=ServiceAccount(
+        name="t",
+        region="us",
+        username="u",
+        secret=SecretStr("s"),
+        default_project="12345",
+    ),
+    project=Project(id="12345"),
+)
+
+
+def _sample_result() -> SchemaGraphResult:
+    """Build a small SchemaGraphResult covering an edge, an orphan, and a user prop."""
+    return SchemaGraphResult(
+        computed_at="2026-06-03T00:00:00+00:00",
+        events=[{"name": "Purchase", "displayName": "Purchase", "count": 10}],
+        properties=[
+            # densityLocal is a property-level field; it repeats onto each edge.
+            {"name": "amount", "densityLocal": 0.9, "events": [{"name": "Purchase"}]},
+            {"name": "orphan", "events": []},
+        ],
+        user_properties=[
+            {"name": "plan", "resourceType": "User", "displayName": "Plan"}
+        ],
+        event_to_properties={"Purchase": ["amount"]},
+        property_to_events={"amount": ["Purchase"], "orphan": []},
+        include_density=True,
+    )
+
+
+class TestSchemaGraphResult:
+    """DataFrame views, graph, and convenience accessors."""
+
+    def test_events_df_shape(self) -> None:
+        """events_df has the expected columns and row."""
+        df = _sample_result().events_df
+        assert list(df.columns) == [
+            "name",
+            "display_name",
+            "description",
+            "hidden",
+            "dropped",
+            "verified",
+            "count",
+        ]
+        assert df.iloc[0]["name"] == "Purchase"
+        assert df.iloc[0]["display_name"] == "Purchase"
+
+    def test_properties_df_covers_event_and_user(self) -> None:
+        """properties_df includes event and user properties with resource_type."""
+        df = _sample_result().properties_df
+        by_name = {r["name"]: r for r in df.to_dict("records")}
+        assert by_name["amount"]["resource_type"] == "event"
+        assert by_name["plan"]["resource_type"] == "user"
+        assert by_name["plan"]["display_name"] == "Plan"
+
+    def test_relationships_df_is_edge_list(self) -> None:
+        """relationships_df is one row per (event, property) with density."""
+        df = _sample_result().relationships_df
+        assert list(df.columns) == ["event", "property", "density_local"]
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["event"] == "Purchase"
+        assert row["property"] == "amount"
+        assert row["density_local"] == 0.9
+
+    def test_df_is_relationships(self) -> None:
+        """The headline ``df`` is the relationship edge list."""
+        result = _sample_result()
+        assert result.df.equals(result.relationships_df)
+
+    def test_convenience_accessors(self) -> None:
+        """properties_for_event / events_for_property / orphan_properties."""
+        result = _sample_result()
+        assert result.properties_for_event("Purchase") == ["amount"]
+        assert result.events_for_property("amount") == ["Purchase"]
+        assert result.orphan_properties() == ["orphan"]
+        assert result.properties_for_event("missing") == []
+
+    def test_orphan_properties_skips_nameless(self) -> None:
+        """A property dict without a name never leaks into orphan_properties."""
+        result = SchemaGraphResult(
+            computed_at="t",
+            properties=[{"events": []}, {"name": "real", "events": []}],
+        )
+        assert result.orphan_properties() == ["real"]
+
+    def test_to_graph_is_bipartite(self) -> None:
+        """to_graph yields a directed event->property graph with node kinds."""
+        g = _sample_result().to_graph()
+        assert g.nodes["Purchase"]["kind"] == "event"
+        assert g.nodes["amount"]["kind"] == "property"
+        assert g.nodes["orphan"]["kind"] == "property"
+        assert list(g.successors("Purchase")) == ["amount"]
+        assert g.edges["Purchase", "amount"]["density_local"] == 0.9
+        # no property->anything edges
+        assert list(g.successors("amount")) == []
+        assert list(g.successors("orphan")) == []
+
+    def test_to_graph_cached(self) -> None:
+        """to_graph caches the constructed graph."""
+        result = _sample_result()
+        assert result.to_graph() is result.to_graph()
+
+    def test_empty_result_has_typed_empty_frames(self) -> None:
+        """An empty result returns empty DataFrames with the right columns."""
+        result = SchemaGraphResult(computed_at="t")
+        assert result.events_df.empty
+        assert list(result.relationships_df.columns) == [
+            "event",
+            "property",
+            "density_local",
+        ]
+        assert result.to_graph().number_of_nodes() == 0
+
+    def test_to_dict_round_trips_fields(self) -> None:
+        """to_dict exposes all the structured fields."""
+        d = _sample_result().to_dict()
+        assert d["event_to_properties"] == {"Purchase": ["amount"]}
+        assert d["include_density"] is True
+        assert "user_properties" in d
+
+    def test_dataframes_are_cached(self) -> None:
+        """Each DataFrame view is built once and cached for reuse."""
+        result = _sample_result()
+        assert result.events_df is result.events_df
+        assert result.properties_df is result.properties_df
+        assert result.relationships_df is result.relationships_df
+
+
+def _client(handler: Any) -> MixpanelAPIClient:
+    """Build a client wired to a MockTransport handler."""
+    return MixpanelAPIClient(session=_SESSION, _transport=httpx.MockTransport(handler))
+
+
+class TestApiClientBulkLexicon:
+    """The bulk no-filter lexicon calls."""
+
+    def test_list_property_definitions_include_events_params(self) -> None:
+        """include_events adds includeEvents=true and resourceType to the query."""
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(
+                200, json=[{"name": "amount", "events": [{"name": "Purchase"}]}]
+            )
+
+        rows = _client(handler).list_property_definitions(
+            resource_type="Event", include_events=True
+        )
+        assert seen["params"]["resourceType"] == "Event"
+        assert seen["params"]["includeEvents"] == "true"
+        assert rows[0]["events"][0]["name"] == "Purchase"
+
+    def test_list_property_definitions_density_toggle(self) -> None:
+        """include_density adds includeDensity=true only when requested."""
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json=[])
+
+        _client(handler).list_property_definitions(include_density=True)
+        assert seen["params"]["includeDensity"] == "true"
+
+    def test_list_event_definitions_returns_bare_list(self) -> None:
+        """list_event_definitions returns the bare list the API sends."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"name": "Purchase"}])
+
+        rows = _client(handler).list_event_definitions()
+        assert rows == [{"name": "Purchase"}]
+
+    def test_list_event_definitions_raises_on_unexpected_shape(self) -> None:
+        """A non-list response (no results envelope to unwrap) is rejected."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"unexpected": "shape"})
+
+        with pytest.raises(MixpanelHeadlessError, match="expected list"):
+            _client(handler).list_event_definitions()
+
+    def test_list_property_definitions_raises_on_unexpected_shape(self) -> None:
+        """A non-list property response is rejected."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"unexpected": "shape"})
+
+        with pytest.raises(MixpanelHeadlessError, match="expected list"):
+            _client(handler).list_property_definitions()
+
+
+class TestDiscoveryGetSchemaGraph:
+    """DiscoveryService.get_schema_graph composition + caching."""
+
+    def _mock_api(self) -> MagicMock:
+        """Mock api client returning small lexicon lists."""
+        api = MagicMock()
+        api.list_event_definitions.return_value = [
+            {"name": "Purchase", "displayName": "Purchase"},
+            {"name": "Login"},
+        ]
+
+        def list_props(
+            *, resource_type: str = "Event", **_: Any
+        ) -> list[dict[str, Any]]:
+            if resource_type == "User":
+                return [{"name": "plan", "resourceType": "User"}]
+            return [
+                {"name": "amount", "events": [{"name": "Purchase"}]},
+                {"name": "ts", "events": [{"name": "Purchase"}, {"name": "Login"}]},
+            ]
+
+        api.list_property_definitions.side_effect = list_props
+        return api
+
+    def test_builds_adjacency_maps(self) -> None:
+        """Adjacency maps are built from the property event lists."""
+        svc = DiscoveryService(self._mock_api())
+        result = svc.get_schema_graph()
+        assert result.event_to_properties["Purchase"] == ["amount", "ts"]
+        assert result.event_to_properties["Login"] == ["ts"]
+        assert result.property_to_events["amount"] == ["Purchase"]
+        assert result.user_properties == [{"name": "plan", "resourceType": "User"}]
+        assert result.meta["event_count"] == 2
+
+    def test_caches_and_force_refresh(self) -> None:
+        """Results are cached; force_refresh re-fetches."""
+        api = self._mock_api()
+        svc = DiscoveryService(api)
+        svc.get_schema_graph()
+        svc.get_schema_graph()
+        assert api.list_event_definitions.call_count == 1
+        svc.get_schema_graph(force_refresh=True)
+        assert api.list_event_definitions.call_count == 2
+
+    def test_skip_user_properties(self) -> None:
+        """include_user_properties=False skips the user call."""
+        api = self._mock_api()
+        result = DiscoveryService(api).get_schema_graph(include_user_properties=False)
+        assert result.user_properties == []
+        # only the Event resource_type call was made
+        resource_types = [
+            c.kwargs.get("resource_type")
+            for c in api.list_property_definitions.call_args_list
+        ]
+        assert "User" not in resource_types
+
+    def test_clear_cache_resets_schema_graph(self) -> None:
+        """clear_cache drops the schema-graph cache so the next call re-fetches."""
+        api = self._mock_api()
+        svc = DiscoveryService(api)
+        svc.get_schema_graph()
+        assert api.list_event_definitions.call_count == 1
+        svc.clear_cache()
+        svc.get_schema_graph()
+        assert api.list_event_definitions.call_count == 2
+
+    def test_density_flows_from_property_to_edges(self) -> None:
+        """A property-level densityLocal lands on every edge and graph edge."""
+        api = MagicMock()
+        api.list_event_definitions.return_value = [{"name": "Purchase"}]
+        api.list_property_definitions.return_value = [
+            {"name": "amount", "densityLocal": 0.75, "events": [{"name": "Purchase"}]}
+        ]
+        result = DiscoveryService(api).get_schema_graph(
+            include_density=True, include_user_properties=False
+        )
+        assert result.include_density is True
+        assert result.relationships_df.iloc[0]["density_local"] == 0.75
+        assert result.to_graph().edges["Purchase", "amount"]["density_local"] == 0.75
+
+
+class TestFacadeAndCli:
+    """Workspace facade delegation and the CLI command."""
+
+    def test_facade_delegates(self) -> None:
+        """Workspace.schema_graph delegates to the discovery service."""
+        api = MagicMock()
+        api.list_event_definitions.return_value = [{"name": "Purchase"}]
+        api.list_property_definitions.return_value = []
+        ws = Workspace(session=_SESSION, _api_client=api)
+        result = ws.schema_graph(include_user_properties=False)
+        assert isinstance(result, SchemaGraphResult)
+        assert "Purchase" in result.event_to_properties
+
+    @patch("mixpanel_headless.cli.commands.inspect.get_workspace")
+    def test_cli_json(self, mock_get_ws: MagicMock) -> None:
+        """`mp inspect schema-graph` emits the structured dict as JSON."""
+        mock_ws = MagicMock()
+        mock_ws.schema_graph.return_value = _sample_result()
+        mock_get_ws.return_value = mock_ws
+
+        result = runner.invoke(app, ["inspect", "schema-graph"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["event_to_properties"] == {"Purchase": ["amount"]}
+
+    @patch("mixpanel_headless.cli.commands.inspect.get_workspace")
+    def test_cli_table_shows_relationships(self, mock_get_ws: MagicMock) -> None:
+        """`--format table` renders the relationship edge list."""
+        mock_ws = MagicMock()
+        mock_ws.schema_graph.return_value = _sample_result()
+        mock_get_ws.return_value = mock_ws
+
+        result = runner.invoke(app, ["inspect", "schema-graph", "--format", "table"])
+        assert result.exit_code == 0
+        assert "Purchase" in result.stdout
+        assert "amount" in result.stdout


### PR DESCRIPTION
## what this does

adds `Workspace.schema_graph()` (and `mp inspect schema-graph`): one call returns the full lexicon, event definitions, event properties, and user properties, plus the event<->property relationship graph, as a typed, dataframe-friendly result.

## the result

`SchemaGraphResult` is a frozen `ResultWithDataFrame`, same shape as `FlowQueryResult`. lazy, cached views:

- `events_df` / `properties_df` (event + user, with a `resource_type` column)
- `relationships_df`: one row per (event, property)
- `df`: the relationship edge list (the headline view)
- `to_graph()`: a networkx `DiGraph`, events -> properties, bipartite when event and property names are disjoint

plus `properties_for_event()`, `events_for_property()`, `orphan_properties()`, `to_dict()`.

the relationships come from one bulk call (`data-definitions/properties?includeEvents=true`), so it is one request for the project instead of a schema lookup per entity. the adjacency maps are built from the `events` list the api returns on each property.

## density

`densityLocal` is returned at the property level by the bulk call (verified live; it is not on the per-event entries, which only carry `{name}`). when `include_density` is requested, that per-property value is repeated onto each of the property's edges, and is `None` otherwise.

## verified live

on project `4025120`, `schema_graph(include_density=True)`:

```
events_df rows: 13
properties_df rows: 68 | resource_types: ['event', 'user']
relationships_df rows: 213
edges with density: 213 | sample: [1.0, 1.0]
graph: nodes=62 edges=213
```

a spot-checked event's properties match `mp inspect properties --event <e>`.

## scope / follow-ups

- group properties are not gathered yet (headless has no data-groups listing to enumerate them).
- the `data-definitions` bulk endpoints return a bare list (`app_request` already unwraps any `results` envelope), so the new client methods validate that shape and raise on anything else.

## power-tools reference

- getSchema https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L3851
- buildSchemaDependenciesBulk https://github.com/mixpanel/mixpanel-power-tools/blob/main/index.js#L4010

## tests

unit tests cover the result views and graph, the bulk client calls (params, bare-list, raise-on-unexpected-shape), the discovery adjacency build and caching (including `clear_cache` dropping the schema-graph cache and density flowing from the property level onto edges), the facade, and the cli. pbt locks the inverse-map and graph-count invariants.

`just check` is green (lint, format, mypy --strict, docstrings, coverage, build) and verified live against project `4025120`.
