### PR TITLE
Collect leads on hard 429 with rate-limit-increase form

### DIFF
--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -619,6 +619,7 @@ class MixpanelAPIClient:
                             request_method=method,
                             request_url=url,
                             request_params=params,
+                            project_id=self.project_id,
                         )
                     retry_after = self._parse_retry_after(response)
                     if retry_after is not None:
@@ -660,6 +661,7 @@ class MixpanelAPIClient:
             request_method=method,
             request_url=url,
             request_params=params,
+            project_id=self.project_id,
         )
 
     def _request(
@@ -1097,6 +1099,7 @@ class MixpanelAPIClient:
                             response_body=response_body,
                             request_method=method,
                             request_url=url,
+                            project_id=self.project_id,
                         )
                     retry_after = self._parse_retry_after(response)
                     if retry_after is not None:
@@ -1161,6 +1164,7 @@ class MixpanelAPIClient:
             "Rate limit exceeded after max retries",
             request_method=method,
             request_url=url,
+            project_id=self.project_id,
         )
 
     @property
@@ -1496,6 +1500,7 @@ class MixpanelAPIClient:
                                 request_method="GET",
                                 request_url=url,
                                 request_params=params,
+                                project_id=self.project_id,
                             )
                         retry_after = self._parse_retry_after(response)
                         if retry_after is not None:

--- a/src/mixpanel_headless/cli/utils.py
+++ b/src/mixpanel_headless/cli/utils.py
@@ -153,8 +153,17 @@ def handle_errors(func: F) -> F:
             if e.request_url:
                 endpoint = e.request_url.split("/")[-1].split("?")[0]
                 err_console.print(f"[dim]Endpoint: {rich_escape(endpoint)}[/dim]")
+            # Lead-collection nudge: invite a rate-limit-increase request,
+            # prefilling the project_id into the form URL when known. The URL is
+            # fully controlled (constants + digit project_id), so no escaping is
+            # needed; soft_wrap keeps the long URL on one unbroken line.
+            form_url = e.rate_limit_form_url
             err_console.print(
-                "[yellow]Tip:[/yellow] Wait and retry, or reduce your date range."
+                "\n[yellow]429: RATE LIMITED[/yellow] — want a higher rate limit?"
+            )
+            err_console.print(
+                f"Let us know: [link={form_url}]{form_url}[/link]",
+                soft_wrap=True,
             )
             raise typer.Exit(ExitCode.RATE_LIMIT) from None
         except EventNotFoundError as e:

--- a/src/mixpanel_headless/cli/utils.py
+++ b/src/mixpanel_headless/cli/utils.py
@@ -158,9 +158,8 @@ def handle_errors(func: F) -> F:
             # fully controlled (constants + digit project_id), so no escaping is
             # needed; soft_wrap keeps the long URL on one unbroken line.
             form_url = e.rate_limit_form_url
-            err_console.print(
-                "\n[yellow]429: RATE LIMITED[/yellow] — want a higher rate limit?"
-            )
+            err_console.print("")
+            err_console.print("[yellow]Want a higher rate limit?[/yellow]")
             err_console.print(
                 f"Let us know: [link={form_url}]{form_url}[/link]",
                 soft_wrap=True,

--- a/src/mixpanel_headless/exceptions.py
+++ b/src/mixpanel_headless/exceptions.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlencode
 
 if TYPE_CHECKING:
     from mixpanel_headless._internal.auth.account import Region
@@ -530,6 +531,44 @@ class AuthenticationError(APIError):
 
 # Rate Limit Exceptions
 
+# Rate-limit lead-collection form. Short forms.gle links can't carry prefill
+# query params, so the long-form URL is used whenever the project_id is known.
+_RATE_LIMIT_FORM_SHORT_URL = "https://forms.gle/7Y9UcUHe69bh8EgC7"
+_RATE_LIMIT_FORM_PREFILL_BASE = (
+    "https://docs.google.com/forms/d/e/"
+    "1FAIpQLSe8h0ZpB-V3zoK9qeUnUeh7vCs2lvP1IJ6IYMAiayHJ4g5LQA/viewform"
+)
+_RATE_LIMIT_FORM_PROJECT_FIELD = "entry.1636741534"
+
+
+def _build_rate_limit_form_url(project_id: str | None) -> str:
+    """Build the URL to the rate-limit-increase request form.
+
+    When ``project_id`` is known, returns the long-form Google Form URL with
+    the project id prefilled, so inbound leads arrive attributed to a project.
+    Short ``forms.gle`` links cannot carry prefill query params, so the short
+    link is used only as the no-project fallback.
+
+    Args:
+        project_id: Active Mixpanel project id, or ``None``/empty when unknown.
+
+    Returns:
+        The project-prefilled long-form URL when ``project_id`` is truthy,
+        otherwise the short form link.
+
+    Example:
+        ```python
+        _build_rate_limit_form_url("3018488")
+        # ".../viewform?usp=pp_url&entry.1636741534=3018488"
+        _build_rate_limit_form_url(None)
+        # "https://forms.gle/7Y9UcUHe69bh8EgC7"
+        ```
+    """
+    if not project_id:
+        return _RATE_LIMIT_FORM_SHORT_URL
+    query = urlencode({"usp": "pp_url", _RATE_LIMIT_FORM_PROJECT_FIELD: project_id})
+    return f"{_RATE_LIMIT_FORM_PREFILL_BASE}?{query}"
+
 
 class RateLimitError(APIError):
     """Mixpanel API rate limit exceeded (HTTP 429).
@@ -560,6 +599,7 @@ class RateLimitError(APIError):
         request_method: str | None = None,
         request_url: str | None = None,
         request_params: dict[str, Any] | None = None,
+        project_id: str | None = None,
     ) -> None:
         """Initialize RateLimitError.
 
@@ -571,8 +611,12 @@ class RateLimitError(APIError):
             request_method: HTTP method used.
             request_url: Full request URL.
             request_params: Query parameters sent.
+            project_id: Mixpanel project id active when the limit was hit, used
+                to prefill the rate-limit-increase request form. ``None`` when
+                unknown.
         """
         self._retry_after = retry_after
+        self._project_id = project_id
         if retry_after is not None:
             message = f"{message}. Retry after {retry_after} seconds."
 
@@ -588,11 +632,33 @@ class RateLimitError(APIError):
         # Add retry_after to details
         if retry_after is not None:
             self._details["retry_after"] = retry_after
+        # Add project_id to details so JSON consumers (to_dict) can attribute it.
+        if project_id is not None:
+            self._details["project_id"] = project_id
 
     @property
     def retry_after(self) -> int | None:
         """Seconds until retry is allowed, or None if unknown."""
         return self._retry_after
+
+    @property
+    def project_id(self) -> str | None:
+        """Mixpanel project id active when the rate limit was hit, if known."""
+        return self._project_id
+
+    @property
+    def rate_limit_form_url(self) -> str:
+        """URL to request a rate-limit increase.
+
+        Returns the project-prefilled Google Form URL when the project id is
+        known (so the lead is attributed to a project), otherwise the short
+        form link. Handy for surfacing in scripts or notebooks that catch this
+        error.
+
+        Returns:
+            The rate-limit-increase request form URL.
+        """
+        return _build_rate_limit_form_url(self._project_id)
 
 
 # Query Exceptions

--- a/src/mixpanel_headless/exceptions.py
+++ b/src/mixpanel_headless/exceptions.py
@@ -585,6 +585,7 @@ class RateLimitError(APIError):
         except RateLimitError as e:
             print(f"Rate limited! Retry after {e.retry_after}s")
             print(f"Request: {e.request_method} {e.request_url}")
+            print(f"Request a higher limit: {e.rate_limit_form_url}")
             time.sleep(e.retry_after or 60)
         ```
     """

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -297,6 +297,41 @@ class TestHandleErrors:
         # Should show endpoint
         assert "segmentation" in captured.err
 
+    def test_rate_limit_error_shows_prefilled_form_url(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """429 handler shows the project-prefilled rate-limit request form."""
+
+        @handle_errors
+        def rate_limited() -> None:
+            raise RateLimitError(
+                "Rate limit exceeded",
+                retry_after=60,
+                project_id="3018488",
+            )
+
+        with pytest.raises(click.exceptions.Exit):
+            rate_limited()
+
+        captured = capsys.readouterr()
+        assert "429: RATE LIMITED" in captured.err
+        assert "entry.1636741534=3018488" in captured.err
+
+    def test_rate_limit_error_shows_short_form_url_without_project(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """429 handler falls back to the short form link without a project_id."""
+
+        @handle_errors
+        def rate_limited() -> None:
+            raise RateLimitError("Rate limit exceeded")
+
+        with pytest.raises(click.exceptions.Exit):
+            rate_limited()
+
+        captured = capsys.readouterr()
+        assert "forms.gle/7Y9UcUHe69bh8EgC7" in captured.err
+
     def test_query_error_with_403_hint(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -314,7 +314,7 @@ class TestHandleErrors:
             rate_limited()
 
         captured = capsys.readouterr()
-        assert "429: RATE LIMITED" in captured.err
+        assert "Want a higher rate limit?" in captured.err
         assert "entry.1636741534=3018488" in captured.err
 
     def test_rate_limit_error_shows_short_form_url_without_project(

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -497,6 +497,8 @@ class TestRateLimiting:
             client.get_events()
 
         assert exc_info.value.retry_after == 0
+        # Carries the active project_id for the rate-limit lead-collection form.
+        assert exc_info.value.project_id == "12345"
 
     def test_successful_response_after_retry(self, test_credentials: Session) -> None:
         """Should return successful response after retry."""
@@ -1519,6 +1521,24 @@ class TestRetryStateResetRegression:
 
         # Should have exactly 5 events (not accumulated across attempts)
         assert len(events) == 5
+
+    def test_stream_rate_limit_error_carries_project_id(
+        self, test_credentials: Session
+    ) -> None:
+        """Stream export RateLimitError should carry the active project_id."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=1, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            list(client.export_events("2024-01-01", "2024-01-31"))
+
+        assert exc_info.value.project_id == "12345"
 
 
 # =============================================================================

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -500,6 +500,29 @@ class TestRateLimiting:
         # Carries the active project_id for the rate-limit lead-collection form.
         assert exc_info.value.project_id == "12345"
 
+    def test_execute_with_retry_fallthrough_carries_project_id(
+        self, test_credentials: Session
+    ) -> None:
+        """The defensive _execute_with_retry fallthrough carries project_id.
+
+        That raise is reached only when the retry loop is empty (max_retries
+        below zero); the test locks the project_id wiring on the
+        type-checker-satisfying site so it can't silently regress.
+        """
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=-1, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.get_events()
+
+        assert exc_info.value.project_id == "12345"
+
     def test_successful_response_after_retry(self, test_credentials: Session) -> None:
         """Should return successful response after retry."""
         call_count = 0

--- a/tests/unit/test_app_api_client.py
+++ b/tests/unit/test_app_api_client.py
@@ -136,6 +136,28 @@ class TestAppRequest:
 
         assert exc_info.value.project_id == "12345"
 
+    def test_rate_limit_fallthrough_carries_project_id(
+        self, oauth_credentials: Session
+    ) -> None:
+        """The defensive app_request fallthrough carries project_id.
+
+        That raise is reached only when the retry loop is empty (max_retries
+        below zero); the test locks the project_id wiring on the
+        type-checker-satisfying site so it can't silently regress.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"status": "ok", "results": []})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=oauth_credentials, max_retries=-1, _transport=transport
+        )
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.app_request("GET", "/dashboards")
+
+        assert exc_info.value.project_id == "12345"
+
     def test_unwraps_results_field(self, oauth_credentials: Session) -> None:
         """app_request() should unwrap 'results' field from response."""
 

--- a/tests/unit/test_app_api_client.py
+++ b/tests/unit/test_app_api_client.py
@@ -22,6 +22,7 @@ from mixpanel_headless.exceptions import (
     AuthenticationError,
     MixpanelHeadlessError,
     QueryError,
+    RateLimitError,
     ServerError,
     WorkspaceScopeError,
 )
@@ -117,6 +118,23 @@ class TestAppRequest:
 
         expected_base = ENDPOINTS["us"]["app"]
         assert captured_urls[0].startswith(f"{expected_base}/projects/12345/dashboards")
+
+    def test_rate_limit_error_carries_project_id(
+        self, oauth_credentials: Session
+    ) -> None:
+        """app_request() RateLimitError should carry the active project_id."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=oauth_credentials, max_retries=1, _transport=transport
+        )
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.app_request("GET", "/dashboards")
+
+        assert exc_info.value.project_id == "12345"
 
     def test_unwraps_results_field(self, oauth_credentials: Session) -> None:
         """app_request() should unwrap 'results' field from response."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -146,6 +146,36 @@ class TestOperationExceptions:
         assert exc.retry_after is None
         assert "retry_after" not in exc.details
 
+    def test_rate_limit_error_carries_project_id(self) -> None:
+        """RateLimitError should expose project_id and record it in details."""
+        exc = RateLimitError("Too many requests", project_id="3018488")
+
+        assert exc.project_id == "3018488"
+        assert exc.details["project_id"] == "3018488"
+
+    def test_rate_limit_error_no_project_id(self) -> None:
+        """RateLimitError without project_id omits it from details."""
+        exc = RateLimitError("Too many requests")
+
+        assert exc.project_id is None
+        assert "project_id" not in exc.details
+
+    def test_rate_limit_form_url_prefilled_with_project_id(self) -> None:
+        """rate_limit_form_url prefills the project_id into the long form URL."""
+        exc = RateLimitError("Too many requests", project_id="3018488")
+
+        url = exc.rate_limit_form_url
+        assert url.startswith("https://docs.google.com/forms/d/e/")
+        assert "viewform" in url
+        assert "usp=pp_url" in url
+        assert "entry.1636741534=3018488" in url
+
+    def test_rate_limit_form_url_short_without_project_id(self) -> None:
+        """rate_limit_form_url falls back to the short link without a project_id."""
+        exc = RateLimitError("Too many requests")
+
+        assert exc.rate_limit_form_url == "https://forms.gle/7Y9UcUHe69bh8EgC7"
+
     def test_query_error(self) -> None:
         """QueryError should have QUERY_FAILED code and inherit from APIError."""
         exc = QueryError(


### PR DESCRIPTION
## What

When a request exhausts retries and surfaces a hard HTTP 429, the CLI now invites the user to request a rate-limit increase via a Google Form, prefilled with the active `project_id` so inbound leads arrive attributed to a project.

## Why

A hard 429 is a friction moment with clear intent. Turn it into a lead for rate-limit-increase requests.

## Changes

- **`exceptions.py`** — `RateLimitError` gains a `project_id` kwarg (recorded in `.details`, so `to_dict()` carries it) plus `project_id` and `rate_limit_form_url` properties. The URL builder returns the project-prefilled long-form Google Form when the id is known, else the short `forms.gle` link (short links can't carry prefill params).
- **`api_client.py`** — all **five** 429 raise sites (query, app API, streaming export, plus two type-checker fallthroughs) pass `project_id=self.project_id`.
- **`cli/utils.py`** — the single 429 handler keeps the retry/endpoint diagnostics, drops the old "Tip" line, and appends the CTA. `soft_wrap=True` keeps the long URL on one unbroken, copy-pasteable line.

SDK callers reach the link via `e.rate_limit_form_url`; `message` stays URL-free to avoid the CLI printing it twice.

## Rendered output

\`\`\`
Rate limited: Rate limit exceeded after max retries. Retry after 42 seconds.
Wait 42 seconds before retrying.
Endpoint: segmentation

429: RATE LIMITED — want a higher rate limit?
Let us know: https://docs.google.com/forms/d/e/1FAIp…/viewform?usp=pp_url&entry.1636741534=3018488
\`\`\`

## Test plan

- New unit tests: `test_exceptions.py` (property + URL shapes), `test_api_client.py` + `test_app_api_client.py` (project_id rides the exception across query/stream/app paths), `cli/test_utils.py` (CTA + prefilled/short URL rendering).
- `just check` green: 6313 passed, coverage 92.13% (gate 90%), ruff + mypy --strict clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)