### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project follows semver but is currently pre-1.0, so minor versions
 may include API changes.
 
-## Unreleased — Session Replay (044)
+## 0.2.0 — 2026-06-05
+
+Headline feature: **session replay (044)** — discovery, signing, CDN fetch,
+an rrweb analyzer, and DataFrame-shaped bundle analytics. This release also
+sunsets JQL (breaking) and folds in `schema_graph()`, workspace
+auto-resolution, and Lexicon enrichments merged since 0.1.1.
 
 ### Added
 
@@ -66,6 +71,23 @@ may include API changes.
   `--format json` for action list) and `mp replays for-user
   --include analyze --out-dir DIR` (the Mixpanel-events join is on by
   default; opt out with `--no-mixpanel-events`).
+- `Workspace.schema_graph()` — full Lexicon graph with event↔property
+  relationships (#190).
+
+### Changed
+
+- `activity_feed()` streams via the `stream/bookmark` endpoint instead of
+  `stream/query` (#187).
+- The workspace axis auto-resolves from the cached `/me` response, with a
+  project-metadata fallback, so workspace-scoped calls work without an
+  explicit `MP_WORKSPACE_ID` (#188).
+- Lexicon definitions now persist `display_name` and `example_value` (#189).
+- Hard 429s surface a rate-limit-increase form to collect lead info (#192).
+
+### Removed
+
+- **JQL support removed (breaking).** All JQL query functionality has been
+  sunset (#185).
 
 ### Security
 

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-headless",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_headless auth surface (Account → Project → Workspace hierarchy), API (5 query engines, discovery, entity CRUD), and Business Context read/write (the markdown documentation that grounds AI assistants, at org and project scopes), with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",

--- a/src/mixpanel_headless/__init__.py
+++ b/src/mixpanel_headless/__init__.py
@@ -291,7 +291,7 @@ from mixpanel_headless.types import (
 )
 from mixpanel_headless.workspace import Workspace
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     # Core

--- a/src/mixpanel_headless/_internal/client_metadata.py
+++ b/src/mixpanel_headless/_internal/client_metadata.py
@@ -61,7 +61,7 @@ def get_user_agent() -> str:
     Example:
         ```python
         get_user_agent()
-        # "mixpanel-headless/0.1.1 (entry=lib; python/3.11)"
+        # "mixpanel-headless/0.2.0 (entry=lib; python/3.11)"
         ```
     """
     # Lazy import: mixpanel_headless/__init__.py defines __version__ after


### PR DESCRIPTION
Minor release. Bumps `__version__`, the plugin manifest, and the
`get_user_agent()` docstring example from `0.1.1` → `0.2.0`, and rolls the
CHANGELOG's `Unreleased — Session Replay (044)` block into a dated `0.2.0`
entry.

The minor (not patch) bump is earned by the **JQL removal (#185)**, which is
a breaking change.

## What's in 0.2.0 (everything merged since 0.1.1)

- **Session replay (044)** — discovery, sign, CDN fetch, rrweb analyzer,
  `ReplayBundle` DataFrame analytics (#193)
- `schema_graph()` — full Lexicon graph with event↔property relationships (#190)
- Lexicon definitions write `display_name` + `example_value` (#189)
- Workspace auto-resolves from `/me` with a metadata fallback (#188)
- `activity_feed` migrated `stream/query` → `stream/bookmark` (#187)
- Rate-limit-increase lead form on hard 429 (#192)
- **JQL removed (breaking)** (#185)

## Releasing

After this squash-merges to `main`, publishing the `v0.2.0` GitHub release
triggers `.github/workflows/release.yml` → build → tag-verify → PyPI publish.

## Verification

- `mp.__version__`, plugin `version`, and `get_user_agent()` all resolve to
  `0.2.0` (checked locally).
- No test pins the version string — `test_client_metadata.py` reads
  `__version__` dynamically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)