### PR TITLE
Inject pinned workspace_id into Query API requests so data view filters apply

### DIFF
--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -852,12 +852,16 @@ class MixpanelAPIClient:
             params = {}
         if inject_project_id:
             params["project_id"] = self._session.project.id
-        if (
-            inject_workspace_id
-            and self._workspace_id is not None
-            and url.startswith(ENDPOINTS[self._session.account.region]["query"])
+        if inject_workspace_id and url.startswith(
+            ENDPOINTS[self._session.account.region]["query"]
         ):
-            params.setdefault("workspace_id", self._workspace_id)
+            if self._workspace_id is not None:
+                params.setdefault("workspace_id", self._workspace_id)
+            else:
+                logger.debug(
+                    "_request - no workspace pinned; Query API call runs "
+                    "project-wide (data view filters do not apply)"
+                )
 
         logger.debug(
             "_request - method: %s, url: %s, final params: %s",

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -835,6 +835,18 @@ class MixpanelAPIClient:
             QueryError: Invalid parameters (400).
             ServerError: Server-side errors (5xx).
             MixpanelHeadlessError: Network/connection errors.
+
+        Example:
+            ```python
+            client.set_workspace_id(84)
+            url = client._build_url("query", "/events/names")
+            # Pin + Query host → workspace_id=84 injected alongside project_id
+            client._request("GET", url, params={"type": "general"})
+            # Opt out to force a project-wide query despite the pin
+            client._request(
+                "GET", url, params={"type": "general"}, inject_workspace_id=False
+            )
+            ```
         """
         if params is None:
             params = {}

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -791,11 +791,25 @@ class MixpanelAPIClient:
         form_data: dict[str, Any] | None = None,
         timeout: float | None = None,
         inject_project_id: bool = True,
+        inject_workspace_id: bool = True,
     ) -> Any:
-        """Make an authenticated request with optional project_id injection.
+        """Make an authenticated request with project/workspace param injection.
 
         Used internally by API methods. Handles rate limiting with exponential
         backoff.
+
+        Workspace scoping: when a workspace is explicitly pinned
+        (``Session.workspace`` at construction, ``set_workspace_id()``, or
+        ``use(workspace=...)``) and the URL is on the Query API host
+        (``/api/query``, which includes the engage/user-profile base), the pin
+        is injected as a ``workspace_id`` query parameter via ``setdefault`` —
+        a caller-supplied ``workspace_id`` in ``params`` always wins. This
+        makes Mixpanel data view filters apply to query and discovery calls.
+        The injection is EXPLICIT-ONLY: no pin means nothing is injected and
+        no workspace auto-resolution is triggered. The App API host scopes via
+        ``/workspaces/{id}/`` URL paths instead, and the raw export host
+        (``data.mixpanel.com``) stays project-scoped by design — data view
+        filters never apply to raw export streaming.
 
         Args:
             method: HTTP method (GET, POST, etc.).
@@ -807,6 +821,10 @@ class MixpanelAPIClient:
             inject_project_id: If True (default), automatically adds project_id
                 to query params. Set to False for APIs where project_id is
                 already in the URL path (e.g., Lexicon Schemas API).
+            inject_workspace_id: If True (default), adds the explicitly pinned
+                workspace ID as ``workspace_id`` on Query-host requests. Set
+                to False to force a project-scoped query even when a
+                workspace is pinned.
 
         Returns:
             Parsed JSON response.
@@ -822,6 +840,12 @@ class MixpanelAPIClient:
             params = {}
         if inject_project_id:
             params["project_id"] = self._session.project.id
+        if (
+            inject_workspace_id
+            and self._workspace_id is not None
+            and url.startswith(ENDPOINTS[self._session.account.region]["query"])
+        ):
+            params.setdefault("workspace_id", self._workspace_id)
 
         logger.debug(
             "_request - method: %s, url: %s, final params: %s",
@@ -973,6 +997,14 @@ class MixpanelAPIClient:
         The underlying ``httpx.Client`` instance is preserved; only the
         ``_credentials`` shim and per-axis caches change.
 
+        Workspace scoping: ``use(workspace=W)`` pins the workspace, so
+        subsequent Query-host requests carry ``workspace_id=W`` and Mixpanel
+        data view filters apply (see :meth:`_request`); raw export streaming
+        stays project-scoped. Any call that does not supply ``workspace=``
+        (including a zero-axis ``use()``) clears both ``session.workspace``
+        and the pin, reverting queries to unscoped — the pin always tracks
+        the session's workspace axis.
+
         Args:
             account: Replacement account.
             project: Replacement project (``Project`` object or numeric-string
@@ -1012,13 +1044,15 @@ class MixpanelAPIClient:
         if account is not None or project is not None:
             self._resolved_workspace = new_session.workspace
             self._cached_workspace_id = None
-            # Sync the int-id pin with the new session — without this,
-            # `maybe_scoped_path()` keeps emitting `/workspaces/<old>/…`
-            # and routes requests to a workspace that may not exist under
-            # the new project / account.
-            self._workspace_id = (
-                new_session.workspace.id if new_session.workspace else None
-            )
+        # Sync the int-id pin with the new session unconditionally —
+        # without this, `maybe_scoped_path()` keeps emitting
+        # `/workspaces/<old>/…` (routing requests to a workspace that may
+        # not exist under the new project / account), and `_request()`
+        # keeps injecting a stale `workspace_id` on Query-host calls.
+        # The unconditional sync also covers the zero-axis case
+        # (`use()` with no arguments), where `Session.replace` clears
+        # `session.workspace` — the pin must follow it to None.
+        self._workspace_id = new_session.workspace.id if new_session.workspace else None
         if workspace_obj is not None:
             self._workspace_id = workspace_obj.id
             self._resolved_workspace = workspace_obj
@@ -1297,9 +1331,13 @@ class MixpanelAPIClient:
     def set_workspace_id(self, workspace_id: int | None) -> None:
         """Set or clear the explicit workspace ID for scoped requests.
 
-        When set, ``maybe_scoped_path()`` will use workspace-scoped paths.
-        Setting to ``None`` clears both the explicit ID and the cached
-        auto-discovered ID, reverting to project-scoped paths.
+        When set, ``maybe_scoped_path()`` will use workspace-scoped paths,
+        AND every Query-host request (queries, discovery, engage) carries a
+        ``workspace_id`` parameter so Mixpanel data view filters apply (see
+        :meth:`_request`). Raw export streaming remains project-scoped by
+        design. Setting to ``None`` clears both the explicit ID and the
+        cached auto-discovered ID, reverting to project-scoped paths and
+        unscoped queries.
 
         Args:
             workspace_id: Workspace ID to use, or None to clear.

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -548,10 +548,11 @@ class Workspace:
         ``workspace=``. The HTTP transport is preserved across all switches
         (per Research R5).
 
-        ``use(workspace=N)`` explicitly pins the workspace: subsequent Query
-        API and discovery calls carry ``workspace_id=N`` so Mixpanel data
-        view filters apply, and App API calls scope via
-        ``/workspaces/N/...`` paths. Raw export streaming
+        ``use(workspace=<workspace_id>)`` explicitly pins the workspace:
+        subsequent Query API and discovery calls carry that workspace ID as
+        the ``workspace_id`` parameter so Mixpanel data view filters apply,
+        and App API calls scope via ``/workspaces/{workspace_id}/...``
+        paths. Raw export streaming
         (``stream_events()`` / ``stream_profiles()``) remains project-scoped
         by design. Swapping the account or project axis clears the pin
         (unless a new workspace is supplied), and the lazy discovery service

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -548,6 +548,15 @@ class Workspace:
         ``workspace=``. The HTTP transport is preserved across all switches
         (per Research R5).
 
+        ``use(workspace=N)`` explicitly pins the workspace: subsequent Query
+        API and discovery calls carry ``workspace_id=N`` so Mixpanel data
+        view filters apply, and App API calls scope via
+        ``/workspaces/N/...`` paths. Raw export streaming
+        (``stream_events()`` / ``stream_profiles()``) remains project-scoped
+        by design. Swapping the account or project axis clears the pin
+        (unless a new workspace is supplied), and the lazy discovery service
+        — including its result cache — is rebuilt on every switch.
+
         When ``account=`` is supplied, the project axis re-resolves through
         the FR-017 chain ending at the new account's ``default_project``
         (env ``MP_PROJECT_ID`` > explicit ``project=`` > new account's

--- a/tests/unit/test_query_workspace_scoping.py
+++ b/tests/unit/test_query_workspace_scoping.py
@@ -317,7 +317,7 @@ class TestNonQueryHostsUnaffected:
         assert len(events) == 1
         assert len(captured) == 1
         request = captured[0]
-        assert "data.mixpanel.com" in str(request.url)
+        assert request.url.host == "data.mixpanel.com"
         assert "workspace_id" not in request.url.params
 
 

--- a/tests/unit/test_query_workspace_scoping.py
+++ b/tests/unit/test_query_workspace_scoping.py
@@ -1,0 +1,435 @@
+"""Failing-first tests for issue #198 — queries must honor the workspace pin.
+
+An explicitly pinned workspace (``Session.workspace`` /
+``set_workspace_id()`` / ``Workspace.use(workspace=...)``) must be
+injected as a ``workspace_id`` query parameter on every Query-host
+request (GET and POST) so Mixpanel data view filters apply. The
+injection is EXPLICIT-ONLY: an unpinned session injects nothing and
+triggers no workspace auto-resolution. Non-query hosts are unaffected:
+the App API keeps its ``/workspaces/{id}/`` path scoping, and the
+export host stays project-scoped by design.
+
+Tests use ``httpx.MockTransport`` for deterministic HTTP mocking,
+mirroring ``tests/unit/test_api_client.py`` and
+``tests/unit/test_api_client_session.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from mixpanel_headless._internal.api_client import MixpanelAPIClient
+from mixpanel_headless._internal.auth.session import Session
+from mixpanel_headless.workspace import Workspace
+from tests.conftest import make_session
+
+_PINNED_WORKSPACE_ID = 777
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate ``$HOME`` and ``MP_CONFIG_PATH`` for hermetic tests.
+
+    ``Workspace.use(...)`` constructs a :class:`ConfigManager` even for
+    workspace-only swaps, so every test in this module must be walled
+    off from the developer's real ``~/.mp/config.toml``.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MP_CONFIG_PATH", str(tmp_path / ".mp" / "config.toml"))
+
+
+@pytest.fixture
+def pinned_session() -> Session:
+    """Return a Session with an explicitly pinned workspace.
+
+    Returns:
+        A ``Session`` whose ``workspace`` axis carries
+        ``_PINNED_WORKSPACE_ID``, so ``MixpanelAPIClient`` treats the
+        workspace as an explicit pin (``_workspace_id`` is set).
+    """
+    return make_session(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="us",
+        workspace_id=_PINNED_WORKSPACE_ID,
+    )
+
+
+@pytest.fixture
+def unpinned_session() -> Session:
+    """Return a Session with NO workspace pinned.
+
+    Returns:
+        A ``Session`` whose ``workspace`` axis is ``None`` (lazy).
+    """
+    return make_session(
+        username="test_user",
+        secret="test_secret",
+        project_id="12345",
+        region="us",
+    )
+
+
+def make_capture_client(
+    session: Session,
+    captured: list[httpx.Request],
+    *,
+    response_json: object = None,
+    response_content: bytes | None = None,
+) -> MixpanelAPIClient:
+    """Create a client whose transport records every outgoing request.
+
+    Args:
+        session: The Session to bind the client to.
+        captured: List that each outgoing ``httpx.Request`` is appended to.
+        response_json: JSON body every response carries (used when
+            ``response_content`` is None; defaults to an empty list).
+        response_content: Raw byte body (e.g. JSONL for export streams).
+            Mutually exclusive with ``response_json`` by construction.
+
+    Returns:
+        A ``MixpanelAPIClient`` wired to an ``httpx.MockTransport`` that
+        captures requests and returns a canned 200 response.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Record the request and return the canned 200 response.
+
+        Args:
+            request: The outgoing request under test.
+
+        Returns:
+            A 200 ``httpx.Response`` with the configured body.
+        """
+        captured.append(request)
+        if response_content is not None:
+            return httpx.Response(200, content=response_content)
+        body = response_json if response_json is not None else []
+        return httpx.Response(200, json=body)
+
+    transport = httpx.MockTransport(handler)
+    return MixpanelAPIClient(session=session, _transport=transport)
+
+
+# =============================================================================
+# Query host — workspace_id MUST be injected when a workspace is pinned
+# (these tests FAIL against current main behavior; the fix makes them pass)
+# =============================================================================
+
+
+class TestQueryHostInjectionWhenPinned:
+    """A pinned workspace scopes Query-host requests via ``workspace_id``."""
+
+    def test_pinned_workspace_get_includes_workspace_id(
+        self, pinned_session: Session
+    ) -> None:
+        """Query-host GET (``/events/names``) carries ``workspace_id``.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(pinned_session, captured) as client:
+            client.get_events()
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert "/api/query/events/names" in str(request.url)
+        assert request.url.params.get("workspace_id") == str(_PINNED_WORKSPACE_ID)
+
+    def test_pinned_workspace_post_includes_workspace_id(
+        self, pinned_session: Session
+    ) -> None:
+        """Query-host POST (``insights_query``) carries ``workspace_id``.
+
+        The pin rides in the query string; the server merges it with the
+        JSON body (verified live against POST /insights).
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        client = make_capture_client(
+            pinned_session,
+            captured,
+            response_json={"headers": [], "series": {}},
+        )
+        with client:
+            client.insights_query({"bookmark": {}, "project_id": 12345})
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.method == "POST"
+        assert "/api/query/insights" in str(request.url)
+        assert request.url.params.get("workspace_id") == str(_PINNED_WORKSPACE_ID)
+
+    def test_set_workspace_id_pin_scopes_subsequent_queries(
+        self, unpinned_session: Session
+    ) -> None:
+        """``set_workspace_id(N)`` after construction scopes later queries.
+
+        Args:
+            unpinned_session: Session with no workspace pinned initially.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(unpinned_session, captured) as client:
+            client.set_workspace_id(_PINNED_WORKSPACE_ID)
+            client.get_events()
+
+        assert len(captured) == 1
+        assert captured[0].url.params.get("workspace_id") == str(_PINNED_WORKSPACE_ID)
+
+
+class TestInjectionOptOut:
+    """``inject_workspace_id=False`` suppresses the pin per-request."""
+
+    def test_inject_workspace_id_false_omits_param_even_when_pinned(
+        self, pinned_session: Session
+    ) -> None:
+        """``_request(..., inject_workspace_id=False)`` sends no workspace_id.
+
+        Currently fails with ``TypeError`` because the parameter does not
+        exist yet — the fix adds it to ``_request``.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(pinned_session, captured) as client:
+            url = client._build_url("query", "/events/names")  # noqa: SLF001
+            client._request(  # noqa: SLF001
+                "GET",
+                url,
+                params={"type": "general"},
+                inject_workspace_id=False,
+            )
+
+        assert len(captured) == 1
+        assert "workspace_id" not in captured[0].url.params
+
+
+# =============================================================================
+# Guardrails — these tests PASS today and must KEEP passing after the fix
+# =============================================================================
+
+
+class TestNoWorkspacePinned:
+    """Unpinned sessions inject nothing and never auto-resolve (passes today)."""
+
+    def test_unpinned_query_has_no_workspace_id_and_no_discovery(
+        self, unpinned_session: Session
+    ) -> None:
+        """No pin → no ``workspace_id`` param AND no auto-resolution call.
+
+        EXPLICIT-ONLY gating: ``_request`` must never consult
+        ``resolve_workspace_id()``, so exactly one request goes out and
+        none touches a ``/workspaces`` discovery endpoint.
+
+        Args:
+            unpinned_session: Session with no workspace pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(unpinned_session, captured) as client:
+            client.get_events()
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert "workspace_id" not in request.url.params
+        assert "/workspaces" not in str(request.url)
+
+    def test_caller_supplied_workspace_id_is_preserved(
+        self, pinned_session: Session
+    ) -> None:
+        """A caller-supplied ``workspace_id`` param survives untouched.
+
+        The fix uses ``params.setdefault(...)``, so an explicit value in
+        ``params`` must win over the session pin — before AND after the
+        fix this request carries exactly the caller's value.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(pinned_session, captured) as client:
+            url = client._build_url("query", "/events/names")  # noqa: SLF001
+            client._request(  # noqa: SLF001
+                "GET",
+                url,
+                params={"type": "general", "workspace_id": 111},
+            )
+
+        assert len(captured) == 1
+        assert captured[0].url.params.get("workspace_id") == "111"
+
+
+class TestNonQueryHostsUnaffected:
+    """App API and export host never receive a ``workspace_id`` param."""
+
+    def test_app_request_carries_no_workspace_id_param(
+        self, pinned_session: Session
+    ) -> None:
+        """App API calls keep path scoping only — no query param (passes today).
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        client = make_capture_client(
+            pinned_session, captured, response_json={"results": []}
+        )
+        with client:
+            path = client.maybe_scoped_path("dashboards")
+            assert path == f"/workspaces/{_PINNED_WORKSPACE_ID}/dashboards"
+            client.app_request("GET", path)
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert f"/api/app/workspaces/{_PINNED_WORKSPACE_ID}/dashboards" in str(
+            request.url
+        )
+        assert "workspace_id" not in request.url.params
+
+    def test_export_stream_carries_no_workspace_id_param(
+        self, pinned_session: Session
+    ) -> None:
+        """Export-host streaming stays project-scoped by design (passes today).
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        client = make_capture_client(
+            pinned_session,
+            captured,
+            response_content=b'{"event":"A","properties":{"time":1}}\n',
+        )
+        with client:
+            events = list(client.export_events("2024-01-01", "2024-01-31"))
+
+        assert len(events) == 1
+        assert len(captured) == 1
+        request = captured[0]
+        assert "data.mixpanel.com" in str(request.url)
+        assert "workspace_id" not in request.url.params
+
+
+class TestPinLifecycle:
+    """Axis swaps that clear the pin must clear it at the request level."""
+
+    def test_use_project_clears_pin_from_query_params(
+        self, pinned_session: Session
+    ) -> None:
+        """``use(project=...)`` drops the pin → no ``workspace_id`` sent.
+
+        Passes today (nothing is ever injected); after the fix it locks
+        the request-level consequence of the pin-clearing behavior
+        already covered by ``TestUseClearsStaleWorkspaceId``.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(pinned_session, captured) as client:
+            assert client._workspace_id == _PINNED_WORKSPACE_ID  # noqa: SLF001
+            client.use(project="99999")
+            client.get_events()
+
+        assert len(captured) == 1
+        assert "workspace_id" not in captured[0].url.params
+
+    def test_zero_axis_use_clears_pin_from_query_params(
+        self, pinned_session: Session
+    ) -> None:
+        """Zero-axis ``use()`` keeps the pin in lockstep with the session.
+
+        ``use()`` with no axes clears ``session.workspace`` (the
+        ``workspace=None`` argument reaches ``Session.replace``, which
+        treats ``None`` as "clear"), so the int-id pin must be cleared
+        too — otherwise subsequent Query-host requests silently carry a
+        ``workspace_id`` that the session no longer holds.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        captured: list[httpx.Request] = []
+        with make_capture_client(pinned_session, captured) as client:
+            assert client._workspace_id == _PINNED_WORKSPACE_ID  # noqa: SLF001
+            client.use()
+            assert client.session.workspace is None
+            assert client._workspace_id is None  # noqa: SLF001
+            client.get_events()
+
+        assert len(captured) == 1
+        assert "workspace_id" not in captured[0].url.params
+
+
+# =============================================================================
+# Workspace facade — ws.use(workspace=N) must scope subsequent discovery
+# =============================================================================
+
+
+class TestWorkspaceFacadeScoping:
+    """``ws.use(workspace=N)`` scopes discovery/query calls (fails today)."""
+
+    def test_use_workspace_then_discovery_call_sends_workspace_id(
+        self, unpinned_session: Session
+    ) -> None:
+        """``ws.use(workspace=N)`` then ``ws.events()`` sends the pin.
+
+        Args:
+            unpinned_session: Session with no workspace pinned initially.
+        """
+        captured: list[httpx.Request] = []
+        client = make_capture_client(unpinned_session, captured)
+        ws = Workspace(session=unpinned_session, _api_client=client)
+        with ws:
+            ws.use(workspace=4242)
+            ws.events()
+
+        assert len(captured) == 1
+        assert captured[0].url.params.get("workspace_id") == "4242"
+
+
+class TestDiscoveryCacheAcrossUse:
+    """Lock: ``Workspace.use(...)`` discards the discovery cache.
+
+    Investigated for spec item 5: the staleness hazard is NOT real —
+    ``Workspace.use()`` unconditionally sets ``self._discovery = None``,
+    and ``DiscoveryService`` keeps its cache on the instance, so a
+    workspace swap always rebuilds the service with an empty cache.
+    This test locks that invariant (passes today, must keep passing).
+    """
+
+    def test_use_workspace_discards_cached_discovery_results(
+        self, unpinned_session: Session
+    ) -> None:
+        """``ws.events()`` → ``use(workspace=N)`` → ``ws.events()`` refetches.
+
+        Without the cache discard, the second ``events()`` would serve
+        stale unscoped results from before the workspace swap.
+
+        Args:
+            unpinned_session: Session with no workspace pinned initially.
+        """
+        captured: list[httpx.Request] = []
+        client = make_capture_client(unpinned_session, captured)
+        ws = Workspace(session=unpinned_session, _api_client=client)
+        with ws:
+            ws.events()
+            ws.events()
+            # Cache hit: the repeat call must NOT issue a second request.
+            assert len(captured) == 1
+
+            ws.use(workspace=4242)
+            ws.events()
+
+        # The swap discarded the cache, so a fresh request went out.
+        assert len(captured) == 2


### PR DESCRIPTION
Fixes #198

## Root cause

`MixpanelAPIClient._request` injected only `project_id` into outgoing params. The workspace pin (`self._workspace_id`, set via `set_workspace_id()` / `Session.workspace` / `Workspace.use(workspace=...)`) was consumed only by `maybe_scoped_path()` / `workspace_scoped_path()` (App API URL rewriting) and by `activity_feed`'s POST body — no Query API request ever carried `workspace_id`, so Mixpanel data view (workspace) filters never applied to queries or discovery.

## Design

**Single injection point in `_request`, explicit-only gating.** After the existing `project_id` injection, when `inject_workspace_id=True` (new parameter, default) AND a workspace is explicitly pinned AND the URL is on the Query API host (`url.startswith(ENDPOINTS[region]["query"])`), the pin is added via `params.setdefault("workspace_id", ...)` so a caller-supplied value always wins. `_request` never calls `resolve_workspace_id()` — if no workspace is pinned, nothing is injected: zero behavior change and zero new network calls for unpinned sessions (auto-resolution here would force discovery on every unpinned session's first query and change existing callers' results). The engage/user-profile base URL sits under the query base, so those calls are covered automatically; the App API base does not match and keeps its `/workspaces/{id}/` path scoping.

**Verified server-side merge:** tested live that the query host honors `workspace_id`, and that a `workspace_id` passed only in the query string merges with a JSON POST body server-side (POST `/insights` and GET `/events/names`) — so the one injection point covers both GET and POST query-host calls.

**Review-panel follow-through:** the panel flagged that a zero-axis `use()` clears `session.workspace` but previously skipped the pin re-sync, leaving subsequent requests carrying a stale pin (pre-existing quirk the new injection would have widened). Fixed: `MixpanelAPIClient.use()` now syncs the int-id pin with the session workspace unconditionally, with a regression test.

## Intentionally out of scope

- **Export host stays project-scoped** — raw export (`data.mixpanel.com`) never matches the query base and is project-scoped by design; documented in the `_request` docstring.
- **"Scope to the default view when no workspace is picked"** — deferred as an open follow-up question (would require auto-resolution and change existing behavior).
- **`LiveQueryService` POST bodies untouched** — the verified query-string/body merge makes the single injection point sufficient.
- **`activity_feed` untouched** — it already sends `workspace_id` in its body; with a pinned workspace both values agree.
- **Discovery-cache staleness (spec item 5)** — investigated and confirmed NOT a hazard: `Workspace.use()` unconditionally rebuilds the discovery service (and its cache); a lock test guards the invariant.

## Test coverage added

`tests/unit/test_query_workspace_scoping.py` (12 tests, written failing-first per TDD):
- Pinned workspace + query-host GET (`/events/names`) → `workspace_id` in params
- Pinned workspace + query-host POST (`insights_query`) → `workspace_id` in query string
- `set_workspace_id(N)` after construction scopes later queries
- `inject_workspace_id=False` → param absent even when pinned
- Unpinned session → param absent AND no auto-resolution network call
- Caller-supplied `workspace_id` wins over the pin (`setdefault` semantics)
- App API call with pinned workspace → path scoping only, no query param
- Export-host call with pinned workspace → no `workspace_id` param
- `use(project=...)` after a pin → pin cleared, no param sent
- Zero-axis `use()` → pin cleared in lockstep with `session.workspace` (review-panel finding)
- Facade level: `ws.use(workspace=N)` then `ws.events()` → param present
- Lock test: `Workspace.use(...)` discards the discovery result cache

## Verification

- `just check` fully passes: lint, format, mypy --strict, 6701 tests passed / 1 skipped, coverage 91.89% (>=90% gate), build OK.
- Live smoke test:
  ```
  unscoped rows: 8 | scoped-to-Dogfood rows: 0
  SMOKE TEST PASSED
  ```
  (`$campaign_link_click` over the last 7 days returns rows unscoped and an empty frame after `ws.use(workspace=84)`, confirming the Dogfood data view filter now applies.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)