### PR TITLE
Fix fresh installs: declare click dependency; stop setup.sh executing mp login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project follows semver but is currently pre-1.0, so minor versions
 may include API changes.
 
+## Unreleased
+
+### Fixed
+
+- Declared `click>=8.0` as a direct dependency. `cli/options.py` and
+  `cli/commands/business_context.py` import Click for `click.Choice` option
+  types, but Click previously arrived only transitively through Typer — and
+  Typer 0.27.0 dropped its Click dependency, so fresh (unlocked) installs
+  resolved a broken `mp` CLI (`ModuleNotFoundError: No module named 'click'`
+  on every invocation, including the `mp login` that setup guidance
+  recommends first).
+- The plugin setup script no longer executes `mp login` as a side effect of
+  printing credential guidance: the guidance text sat in backticks inside the
+  double-quoted `python -c` string, and bash command-substitutes backticks
+  inside double quotes on every run. The backticks are gone and the script is
+  now shellcheck-clean.
+
 ## 0.2.0 — 2026-06-05
 
 Headline feature: **session replay (044)** — discovery, signing, CDN fetch,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,6 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project follows semver but is currently pre-1.0, so minor versions
 may include API changes.
 
-## Unreleased
-
-### Fixed
-
-- Declared `click>=8.0` as a direct dependency. `cli/options.py` and
-  `cli/commands/business_context.py` import Click for `click.Choice` option
-  types, but Click previously arrived only transitively through Typer — and
-  Typer 0.27.0 dropped its Click dependency, so fresh (unlocked) installs
-  resolved a broken `mp` CLI (`ModuleNotFoundError: No module named 'click'`
-  on every invocation, including the `mp login` that setup guidance
-  recommends first).
-- The plugin setup script no longer executes `mp login` as a side effect of
-  printing credential guidance: the guidance text sat in backticks inside the
-  double-quoted `python -c` string, and bash command-substitutes backticks
-  inside double quotes on every run. The backticks are gone and the script is
-  now shellcheck-clean.
-
 ## 0.2.0 — 2026-06-05
 
 Headline feature: **session replay (044)** — discovery, signing, CDN fetch,

--- a/mixpanel-plugin/.claude-plugin/plugin.json
+++ b/mixpanel-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-headless",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Query and analyze Mixpanel data with Python. Provides the mixpanel_headless auth surface (Account → Project → Workspace hierarchy), API (5 query engines, discovery, entity CRUD), and Business Context read/write (the markdown documentation that grounds AI assistants, at org and project scopes), with a live documentation system (help.py) for method signatures, type lookup, fuzzy search, and hosted docs.",
   "author": {
     "name": "Jared McFarland",

--- a/mixpanel-plugin/skills/setup/scripts/setup.sh
+++ b/mixpanel-plugin/skills/setup/scripts/setup.sh
@@ -11,7 +11,7 @@ for cmd in python3 python; do
   if command -v "$cmd" &>/dev/null; then
     major=$("$cmd" -c "import sys; print(sys.version_info.major)" 2>/dev/null || echo 0)
     minor=$("$cmd" -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo 0)
-    if [ "$major" -gt 3 ] || ([ "$major" -eq 3 ] && [ "$minor" -ge 10 ]); then
+    if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 10 ]; }; then
       version=$("$cmd" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
       python_cmd="$cmd"
       echo "✓ Python $version ($cmd)"
@@ -116,7 +116,7 @@ try:
         print('  Service account:  mp account add team --type service_account --username sa_xxx --project 12345 --region us')
 except Exception as e:
     print(f'⚠ Could not read ~/.mp/config.toml: {e}')
-    print('  Run `mp login`, set env vars (service-account quad or OAuth triple), or run mp account add ...')
+    print('  Run mp login, set env vars (service-account quad or OAuth triple), or run mp account add ...')
 "
 
 # Cowork detection: check for bridge file
@@ -124,6 +124,9 @@ if [ -d "/sessions" ] || [ -n "${CLAUDE_COWORK:-}" ]; then
   echo ""
   echo "Cowork environment detected."
   BRIDGE_FOUND=""
+  # Single candidate path today; kept as a loop so more bridge locations can be
+  # appended. The one-iteration loop over a quoted word is intentional.
+  # shellcheck disable=SC2066
   for f in "$HOME/.claude/mixpanel/auth.json"; do
     if [ -f "$f" ]; then
       echo "✓ Auth bridge file found: $f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pyarrow>=17.0; python_version >= '3.11'",
     "httpx>=0.27",
     "typer>=0.12",
+    "click>=8.0",
     "rich>=13.0",
     "jq>=1.9.0",
     "networkx>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-22T06:36:59.531145Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1300,6 +1300,7 @@ name = "mixpanel-headless"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },
+    { name = "click" },
     { name = "httpx" },
     { name = "jq" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1352,6 +1353,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anytree", specifier = ">=2.12" },
+    { name = "click", specifier = ">=8.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=6.151.13" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7" },


### PR DESCRIPTION
## Summary

Two first-use bugs found while QA'ing the plugin's fresh-install flow (surfaced by mixpanel/analytics#99985, which makes this plugin a default install for the monorepo):

### 1. Fresh installs get a broken `mp` CLI — `click` was never declared

- `cli/options.py` and `cli/commands/business_context.py` import Click directly (`click_type=click.Choice(...)`), but `pyproject.toml` only declared `typer>=0.12`. Click always arrived transitively — until **Typer 0.27.0 dropped its Click dependency** (its requires are now just `annotated-doc, rich, shellingham`).
- Any unlocked install today (the plugin's `setup.sh`, or plain `pip install mixpanel-headless`) resolves typer 0.27.0, and every `mp` invocation dies at import time with `ModuleNotFoundError: No module named 'click'` (`main.py` `_register_commands` → `alerts` → `options` → `import click`). That includes `mp login` — the first command the setup guidance tells a new user to run.
- Dev/CI never saw it because `uv.lock` pins typer 0.25.1, which still pulls click.
- **Fix:** declare `click>=8.0`. Verified in a fresh venv against typer 0.27.0 + click 8.4.2: the CLI imports and runs, and `click.Choice` is still enforced — invalid values are rejected with `BadParameter` (exit 1) where click-backed Typer raised a usage error (exit 2); semantics preserved, rendering/exit code differ.

### 2. `setup.sh` executed `mp login` as a side effect of *printing* guidance

- The credential check passes Python source to `python -c` inside a **double-quoted** shell string, and the unreadable-config guidance line contained `` `mp login` `` in backticks. Bash command-substitutes backticks inside double quotes, so every setup run *executed* `mp login` while building that string — before Python ran, regardless of which branch Python takes.
- Today that injects bug 1's traceback into the middle of setup output; with a working CLI it would start a real login flow mid-setup.
- **Fix:** drop the backticks (the neighboring guidance lines already reference mp commands unquoted). Verified with a stub `mp` on PATH that logs invocations: pre-fix the run logs `login`; post-fix the log is empty, the script completes, and the guidance line prints correctly in the unreadable-config branch.
- Drive-by: `setup.sh` is now shellcheck-clean (SC2235 brace grouping; documented `disable=SC2066` for the intentional single-item bridge-path loop).

## Notes

- `uv.lock`: click added as a direct dependency (stays at the already-locked 8.3.3; no other version changes). Current uv also rewrote the `exclude-newer` header to its sentinel/backwards-compat form as part of re-locking.
- `just test`: 6701 passed, 1 skipped.
- The click fix only reaches fresh installs once released to PyPI (0.2.1); the `setup.sh` fix reaches plugin users on their next plugin update. Version bump left to the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)