### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project follows semver but is currently pre-1.0, so minor versions
 may include API changes.
 
+## 0.2.1 — 2026-08-13
+
+Patch release: workspace-scoped Query API correctness and fresh-install
+fixes.
+
+### Fixed
+
+- Query API requests now inject the pinned `workspace_id`, so data view
+  filters apply to segmentation/funnels/retention and other live queries
+  when a workspace is selected. (#199)
+- Declare the `click` dependency explicitly so fresh installs work, and
+  stop the plugin setup skill from executing `mp login` on the user's
+  behalf. (#200)
+
 ## 0.2.0 — 2026-06-05
 
 Headline feature: **session replay (044)** — discovery, signing, CDN fetch,

--- a/src/mixpanel_headless/__init__.py
+++ b/src/mixpanel_headless/__init__.py
@@ -291,7 +291,7 @@ from mixpanel_headless.types import (
 )
 from mixpanel_headless.workspace import Workspace
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Core

--- a/src/mixpanel_headless/_internal/client_metadata.py
+++ b/src/mixpanel_headless/_internal/client_metadata.py
@@ -61,7 +61,7 @@ def get_user_agent() -> str:
     Example:
         ```python
         get_user_agent()
-        # "mixpanel-headless/0.2.0 (entry=lib; python/3.11)"
+        # "mixpanel-headless/0.2.1 (entry=lib; python/3.11)"
         ```
     """
     # Lazy import: mixpanel_headless/__init__.py defines __version__ after


### PR DESCRIPTION
## Summary

Version bump for the v0.2.1 patch release, covering the two fixes merged since v0.2.0:

- #199 — Inject pinned `workspace_id` into Query API requests so data view filters apply
- #200 — Fix fresh installs: declare `click` dependency; stop setup.sh executing `mp login`

## Changes

- `src/mixpanel_headless/__init__.py` — `__version__` → `0.2.1` (single source of truth; hatch reads it dynamically)
- `src/mixpanel_headless/_internal/client_metadata.py` — User-Agent docstring example updated
- `CHANGELOG.md` — new `0.2.1` section

`mixpanel-plugin/.claude-plugin/plugin.json` was already bumped to 0.2.1 in #200.

## Release steps after merge

Tag the merge commit `v0.2.1` and publish a GitHub Release — `release.yml` then builds and trusted-publishes to PyPI.

## Verification

`just check` passes locally: 6701 tests, 91.89% coverage, build produces `mixpanel_headless-0.2.1` sdist + wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)