### PR TITLE
Fix latent error-handling bugs found during TS-port stress test

### DIFF
--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -91,6 +91,18 @@ def _error_message(response_body: str | dict[str, Any] | None, default: str) -> 
         The extracted message, or ``default`` when the body is missing,
         blank, or has no ``error`` key. Non-string ``error`` values (lists,
         nested objects) are stringified rather than returned as-is.
+
+    Example:
+        ```python
+        _error_message({"error": "Invalid project"}, "Request failed")
+        # "Invalid project"
+        _error_message({"error": ["bad steps", "bad dates"]}, "Request failed")
+        # "['bad steps', 'bad dates']"
+        _error_message("   ", "Request failed")
+        # "Request failed"  (blank text falls back to the default)
+        _error_message(None, "Request failed")
+        # "Request failed"
+        ```
     """
     if isinstance(response_body, dict):
         raw = response_body.get("error")

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -69,6 +69,40 @@ logger = logging.getLogger(__name__)
 # instead of aborting; 5xx / 401 / 429 / network errors still propagate.
 _FALLBACK_HTTP_STATUSES = frozenset({403, 404})
 
+# Exponential-backoff bounds shared by _calculate_backoff() and the
+# Retry-After clamp. A server-supplied Retry-After is honored up to
+# _BACKOFF_MAX_SECONDS; anything larger would park the process for hours.
+_BACKOFF_BASE_SECONDS = 1.0
+_BACKOFF_MAX_SECONDS = 60.0
+
+
+def _error_message(response_body: str | dict[str, Any] | None, default: str) -> str:
+    """Extract a human-readable error message from a parsed error body.
+
+    Mixpanel error bodies are either a JSON object with an ``error`` key, a
+    plain-text blob, or nothing at all. Any of those can be empty or blank,
+    which must not produce a blank exception message.
+
+    Args:
+        response_body: Parsed JSON object, raw text, or None.
+        default: Message to use when the body carries no usable error text.
+
+    Returns:
+        The extracted message, or ``default`` when the body is missing,
+        blank, or has no ``error`` key. Non-string ``error`` values (lists,
+        nested objects) are stringified rather than returned as-is.
+    """
+    if isinstance(response_body, dict):
+        raw = response_body.get("error")
+        if raw is None:
+            return default
+        text = raw if isinstance(raw, str) else str(raw)
+    elif isinstance(response_body, str):
+        text = response_body[:200]
+    else:
+        return default
+    return text if text.strip() else default
+
 
 def _iter_jsonl_lines(response: httpx.Response) -> Iterator[str]:
     """Iterate over JSONL lines from a streaming response with proper buffering.
@@ -519,6 +553,7 @@ class MixpanelAPIClient:
                 request_method=request_method,
                 request_url=request_url,
                 request_params=request_params,
+                request_body=request_body,
             )
         if response.status_code == 403:
             # 044-session-replay: a 403 mentioning SESSION_RECORDING_SENSITIVE_DATA
@@ -551,11 +586,7 @@ class MixpanelAPIClient:
                     request_params=request_params,
                     request_body=request_body,
                 )
-            error_msg = "Permission denied"
-            if isinstance(response_body, dict):
-                error_msg = response_body.get("error", "Permission denied")
-            elif isinstance(response_body, str):
-                error_msg = response_body[:200] or "Permission denied"
+            error_msg = _error_message(response_body, "Permission denied")
             raise QueryError(
                 error_msg,
                 status_code=response.status_code,
@@ -566,11 +597,7 @@ class MixpanelAPIClient:
                 request_body=request_body,
             )
         if response.status_code == 400:
-            error_msg = "Unknown error"
-            if isinstance(response_body, dict):
-                error_msg = response_body.get("error", "Unknown error")
-            elif isinstance(response_body, str):
-                error_msg = response_body[:200]
+            error_msg = _error_message(response_body, "Unknown error")
             raise QueryError(
                 error_msg,
                 status_code=response.status_code,
@@ -581,11 +608,7 @@ class MixpanelAPIClient:
                 request_body=request_body,
             )
         if response.status_code == 404:
-            error_msg = "Resource not found"
-            if isinstance(response_body, dict):
-                error_msg = response_body.get("error", "Resource not found")
-            elif isinstance(response_body, str):
-                error_msg = response_body[:200] or "Resource not found"
+            error_msg = _error_message(response_body, "Resource not found")
             raise QueryError(
                 error_msg,
                 status_code=response.status_code,
@@ -599,11 +622,7 @@ class MixpanelAPIClient:
             # Any other 4xx (e.g., 412 Precondition Failed) — preserve the
             # response body and status as a QueryError instead of letting it
             # fall through to a generic HTTP error in _execute_with_retry().
-            error_msg = "Request failed"
-            if isinstance(response_body, dict):
-                error_msg = response_body.get("error", "Request failed")
-            elif isinstance(response_body, str):
-                error_msg = response_body[:200] or "Request failed"
+            error_msg = _error_message(response_body, "Request failed")
             raise QueryError(
                 error_msg,
                 status_code=response.status_code,
@@ -615,11 +634,9 @@ class MixpanelAPIClient:
             )
         if response.status_code >= 500:
             # Extract error message from response body if available
-            error_msg = f"Server error: {response.status_code}"
-            if isinstance(response_body, dict) and "error" in response_body:
-                error_msg = f"Server error: {response_body['error']}"
-            elif isinstance(response_body, str) and response_body:
-                error_msg = f"Server error: {response_body[:200]}"
+            error_msg = "Server error: " + _error_message(
+                response_body, str(response.status_code)
+            )
 
             raise ServerError(
                 error_msg,
@@ -657,11 +674,32 @@ class MixpanelAPIClient:
         Returns:
             Delay in seconds including jitter.
         """
-        base = 1.0
-        max_delay = 60.0
-        delay: float = min(base * (2**attempt), max_delay)
+        delay: float = min(_BACKOFF_BASE_SECONDS * (2**attempt), _BACKOFF_MAX_SECONDS)
         jitter: float = random.uniform(0, delay * 0.1)  # noqa: S311
         return delay + jitter
+
+    def _retry_wait_seconds(self, retry_after: int | None, attempt: int) -> float:
+        """Resolve how long to wait before retrying a rate-limited request.
+
+        ``Retry-After`` is server-controlled and therefore untrusted input.
+        ``_parse_retry_after`` already rejects unparseable and negative
+        values; this method additionally caps an implausibly large header
+        (``Retry-After: 86400``) at the same ceiling the exponential backoff
+        uses, so a single header can never park the process for hours.
+
+        Args:
+            retry_after: Validated Retry-After value in seconds, or None when
+                the header was absent or unusable.
+            attempt: Zero-based attempt number, used for the backoff fallback.
+
+        Returns:
+            A non-negative delay in seconds, at most ``_BACKOFF_MAX_SECONDS``
+            when it came from the header (the backoff fallback adds its own
+            jitter on top of that ceiling).
+        """
+        if retry_after is None:
+            return self._calculate_backoff(attempt)
+        return min(float(retry_after), _BACKOFF_MAX_SECONDS)
 
     def _execute_with_retry(
         self,
@@ -738,11 +776,9 @@ class MixpanelAPIClient:
                             request_params=params,
                             project_id=self.project_id,
                         )
-                    retry_after = self._parse_retry_after(response)
-                    if retry_after is not None:
-                        wait_time = float(retry_after)
-                    else:
-                        wait_time = self._calculate_backoff(attempt)
+                    wait_time = self._retry_wait_seconds(
+                        self._parse_retry_after(response), attempt
+                    )
                     logger.warning(
                         "Rate limited, retrying in %.1f seconds (attempt %d/%d)",
                         wait_time,
@@ -1119,20 +1155,31 @@ class MixpanelAPIClient:
         return ref
 
     def _parse_retry_after(self, response: httpx.Response) -> int | None:
-        """Parse Retry-After header if present.
+        """Parse the Retry-After header if present and usable.
+
+        The header is attacker-controllable, so anything that is not a
+        non-negative integer count of seconds is treated as absent. In
+        particular a negative value is rejected: it would reach
+        ``time.sleep()`` (raising ValueError) and would be echoed as
+        ``RateLimitError.retry_after``, whose documented usage is
+        ``time.sleep(exc.retry_after or 60)``. HTTP-date form is not
+        supported and also reads as absent.
 
         Args:
             response: HTTP response.
 
         Returns:
-            Seconds to wait, or None if header not present.
+            Seconds to wait as a non-negative int, or None when the header is
+            missing, unparseable, or negative.
         """
         retry_after = response.headers.get("Retry-After")
         if retry_after is not None:
             try:
-                return int(retry_after)
+                parsed = int(retry_after)
             except ValueError:
-                pass
+                return None
+            if parsed >= 0:
+                return parsed
         return None
 
     # =========================================================================
@@ -1267,13 +1314,12 @@ class MixpanelAPIClient:
                             response_body=response_body,
                             request_method=method,
                             request_url=url,
+                            request_params=request_params,
                             project_id=self.project_id,
                         )
-                    retry_after = self._parse_retry_after(response)
-                    if retry_after is not None:
-                        wait_time = float(retry_after)
-                    else:
-                        wait_time = self._calculate_backoff(attempt)
+                    wait_time = self._retry_wait_seconds(
+                        self._parse_retry_after(response), attempt
+                    )
                     logger.warning(
                         "Rate limited, retrying in %.1f seconds (attempt %d/%d)",
                         wait_time,
@@ -1290,15 +1336,14 @@ class MixpanelAPIClient:
                         err_body = response.json()
                     except json.JSONDecodeError:
                         err_body = response.text[:500] if response.text else None
-                    error_msg = "Unprocessable entity"
-                    if isinstance(err_body, dict):
-                        error_msg = str(err_body.get("error", error_msg))
+                    error_msg = _error_message(err_body, "Unprocessable entity")
                     raise QueryError(
                         error_msg,
                         status_code=422,
                         response_body=err_body,
                         request_method=method,
                         request_url=url,
+                        request_params=request_params,
                         request_body=request_body,
                     )
 
@@ -1324,6 +1369,7 @@ class MixpanelAPIClient:
                         "error": str(e),
                         "request_method": method,
                         "request_url": url,
+                        "request_params": request_params,
                     },
                 ) from e
 
@@ -1332,6 +1378,7 @@ class MixpanelAPIClient:
             "Rate limit exceeded after max retries",
             request_method=method,
             request_url=url,
+            request_params=request_params,
             project_id=self.project_id,
         )
 
@@ -1833,11 +1880,9 @@ class MixpanelAPIClient:
                                 request_params=params,
                                 project_id=self.project_id,
                             )
-                        retry_after = self._parse_retry_after(response)
-                        if retry_after is not None:
-                            wait_time = float(retry_after)
-                        else:
-                            wait_time = self._calculate_backoff(attempt)
+                        wait_time = self._retry_wait_seconds(
+                            self._parse_retry_after(response), attempt
+                        )
                         time.sleep(wait_time)
                         continue
 
@@ -1853,16 +1898,12 @@ class MixpanelAPIClient:
                         # Need to read body for error
                         body = response.read()
                         response_body: str | dict[str, Any] | None = None
-                        error_msg = "Unknown error"
                         try:
                             response_body = json.loads(body)
-                            if isinstance(response_body, dict):
-                                error_msg = response_body.get("error", "Unknown error")
                         except json.JSONDecodeError:
                             response_body = body.decode()[:500] if body else None
-                            error_msg = body.decode()[:200] if body else "Unknown error"
                         raise QueryError(
-                            error_msg,
+                            _error_message(response_body, "Unknown error"),
                             status_code=response.status_code,
                             response_body=response_body,
                             request_method="GET",

--- a/src/mixpanel_headless/_internal/pagination.py
+++ b/src/mixpanel_headless/_internal/pagination.py
@@ -10,8 +10,8 @@ class methods instead of accessing this module directly.
 
 from __future__ import annotations
 
-import contextlib
 import logging
+import math
 import time
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
@@ -42,6 +42,44 @@ _BACKOFF_BASE: float = 1.0
 
 #: Maximum backoff delay in seconds.
 _BACKOFF_MAX: float = 60.0
+
+
+def _parse_retry_after(raw: str | None) -> float | None:
+    """Parse a ``Retry-After`` header value into a safe number of seconds.
+
+    The header is attacker- or bug-controlled input that would otherwise flow
+    straight into ``time.sleep()``, which raises ``ValueError`` on negative and
+    NaN values and ``OverflowError`` on infinity. Anything that is not a
+    finite, non-negative number is rejected so callers can fall back to the
+    exponential-backoff schedule.
+
+    HTTP-date form (RFC 9110) is not supported and is treated as unparseable,
+    matching the delta-seconds-only behaviour this module has always had.
+
+    Args:
+        raw: Raw header value, or ``None`` when the header is absent.
+
+    Returns:
+        The advertised delay in seconds, or ``None`` when the header is
+        absent, empty, unparseable, negative, NaN, or infinite. The value is
+        not capped — apply ``_BACKOFF_MAX`` at the point of sleeping.
+
+    Example:
+        ```python
+        _parse_retry_after("30")    # 30.0
+        _parse_retry_after("-1")    # None
+        _parse_retry_after("inf")   # None
+        ```
+    """
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return seconds
 
 
 def paginate_all(
@@ -85,7 +123,8 @@ def paginate_all(
         RateLimitError: Rate limit exceeded after max retries (429).
         ServerError: Server-side errors (5xx).
         MixpanelHeadlessError: Client errors (400, 404, 422), network/connection
-            errors, or pagination limit exceeded.
+            errors, pagination limit exceeded, or a malformed body (non-JSON,
+            or a ``results`` field that is neither a list nor null).
 
     Example:
         ```python
@@ -144,12 +183,9 @@ def paginate_all(
 
             # Handle 429 with retry/backoff
             if response.status_code == 429:
+                advertised = _parse_retry_after(response.headers.get("Retry-After"))
                 if attempt >= MAX_RATE_LIMIT_RETRIES:
-                    retry_after_raw = response.headers.get("Retry-After")
-                    retry_after: int | None = None
-                    if retry_after_raw:
-                        with contextlib.suppress(ValueError):
-                            retry_after = int(retry_after_raw)
+                    retry_after = None if advertised is None else int(advertised)
                     raise RateLimitError(
                         "Rate limit exceeded after max retries during pagination",
                         retry_after=retry_after,
@@ -158,15 +194,12 @@ def paginate_all(
                         request_method="GET",
                         request_url=url,
                     )
-                retry_after_raw = response.headers.get("Retry-After")
-                wait_time: float
-                if retry_after_raw:
-                    try:
-                        wait_time = float(retry_after_raw)
-                    except ValueError:
-                        wait_time = min(_BACKOFF_BASE * (2**attempt), _BACKOFF_MAX)
-                else:
+                # Honor a sane Retry-After, but never sleep longer than the
+                # backoff cap — a server-advertised hour would hang the walk.
+                if advertised is None:
                     wait_time = min(_BACKOFF_BASE * (2**attempt), _BACKOFF_MAX)
+                else:
+                    wait_time = min(advertised, _BACKOFF_MAX)
                 logger.warning(
                     "Rate limited during pagination, retrying in %.1f seconds "
                     "(attempt %d/%d)",
@@ -223,7 +256,22 @@ def paginate_all(
         # Extract results
         results: list[Any] = []
         if isinstance(data, dict):
-            results = data.get("results", [])
+            raw_results = data.get("results")
+            if raw_results is None:
+                # Absent key and explicit JSON null both mean "no items here";
+                # the cursor, not this field, decides when iteration stops.
+                results = []
+            elif isinstance(raw_results, list):
+                results = raw_results
+            else:
+                # Iterating a str would yield characters and a dict would yield
+                # keys — corrupt output dressed up as success.
+                raise MixpanelHeadlessError(
+                    "Malformed paginated response: 'results' must be a list, got "
+                    f"{type(raw_results).__name__}",
+                    code="INVALID_RESPONSE",
+                    details={"path": path, "results_type": type(raw_results).__name__},
+                )
         elif isinstance(data, list):
             results = data
 

--- a/src/mixpanel_headless/exceptions.py
+++ b/src/mixpanel_headless/exceptions.py
@@ -507,6 +507,7 @@ class AuthenticationError(APIError):
         request_method: str | None = None,
         request_url: str | None = None,
         request_params: dict[str, Any] | None = None,
+        request_body: dict[str, Any] | None = None,
     ) -> None:
         """Initialize AuthenticationError.
 
@@ -517,6 +518,8 @@ class AuthenticationError(APIError):
             request_method: HTTP method used.
             request_url: Full request URL.
             request_params: Query parameters sent.
+            request_body: Request body sent (for POST/PATCH requests), so a
+                401 carries the same context as the other error branches.
         """
         super().__init__(
             message,
@@ -525,6 +528,7 @@ class AuthenticationError(APIError):
             request_method=request_method,
             request_url=request_url,
             request_params=request_params,
+            request_body=request_body,
             code="AUTH_FAILED",
         )
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -6,6 +6,7 @@ Tests use httpx.MockTransport for deterministic HTTP mocking.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Callable, Iterator
 from datetime import date, timedelta
 from typing import Any
@@ -24,6 +25,7 @@ from mixpanel_headless._internal.auth.account import ServiceAccount
 from mixpanel_headless._internal.auth.session import Session
 from mixpanel_headless.exceptions import (
     AuthenticationError,
+    MixpanelHeadlessError,
     QueryError,
     RateLimitError,
 )
@@ -3458,3 +3460,656 @@ class TestActivityFeed:
                     ["user_1"],
                     search_properties=[{"value": "$city", "resourceType": "event"}],
                 )
+
+
+# =============================================================================
+# Retry-After hardening (hostile / invalid header values)
+# =============================================================================
+
+
+@pytest.fixture
+def recorded_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Capture every ``time.sleep`` call made by the api_client module.
+
+    The retry paths sleep for whatever the server asks; the tests need to see
+    the exact duration without actually waiting for it.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture (restores ``time.sleep``).
+
+    Returns:
+        A list that accumulates the seconds passed to each ``time.sleep``
+        call, in order.
+    """
+    calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        """Record a sleep instead of performing it.
+
+        Args:
+            seconds: Requested sleep duration.
+        """
+        calls.append(seconds)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    return calls
+
+
+class TestParseRetryAfter:
+    """Test ``_parse_retry_after`` header validation."""
+
+    def test_parses_positive_integer(self, test_credentials: Session) -> None:
+        """A well-formed integer header is returned as an int."""
+        client = MixpanelAPIClient(session=test_credentials)
+        response = httpx.Response(429, headers={"Retry-After": "7"})
+        assert client._parse_retry_after(response) == 7
+
+    def test_parses_zero(self, test_credentials: Session) -> None:
+        """``Retry-After: 0`` means "retry immediately" and is preserved."""
+        client = MixpanelAPIClient(session=test_credentials)
+        response = httpx.Response(429, headers={"Retry-After": "0"})
+        assert client._parse_retry_after(response) == 0
+
+    def test_missing_header_returns_none(self, test_credentials: Session) -> None:
+        """An absent Retry-After header yields None."""
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._parse_retry_after(httpx.Response(429)) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["abc", "5.5", "", "Wed, 21 Oct 2015 07:28:00 GMT", "1e3", "0x10", "nan"],
+    )
+    def test_unparseable_header_returns_none(
+        self, test_credentials: Session, raw: str
+    ) -> None:
+        """Non-integer header values are treated as absent.
+
+        Args:
+            test_credentials: Session fixture.
+            raw: A Retry-After value Python's ``int()`` cannot parse.
+        """
+        client = MixpanelAPIClient(session=test_credentials)
+        response = httpx.Response(429, headers={"Retry-After": raw})
+        assert client._parse_retry_after(response) is None
+
+    @pytest.mark.parametrize("raw", ["-1", "-3600"])
+    def test_negative_header_returns_none(
+        self, test_credentials: Session, raw: str
+    ) -> None:
+        """A negative Retry-After is invalid and must not reach ``time.sleep``.
+
+        ``time.sleep(-1)`` raises ValueError, so a hostile server could crash
+        the retry loop with a one-character header.
+
+        Args:
+            test_credentials: Session fixture.
+            raw: A negative Retry-After value.
+        """
+        client = MixpanelAPIClient(session=test_credentials)
+        response = httpx.Response(429, headers={"Retry-After": raw})
+        assert client._parse_retry_after(response) is None
+
+
+class TestRetryWaitSeconds:
+    """Test ``_retry_wait_seconds`` clamping and backoff fallback."""
+
+    def test_none_falls_back_to_backoff(self, test_credentials: Session) -> None:
+        """Without a header the exponential backoff value is used."""
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._retry_wait_seconds(None, 0) == pytest.approx(
+            client._calculate_backoff(0), rel=0.2
+        )
+
+    def test_honors_reasonable_header(self, test_credentials: Session) -> None:
+        """A header below the cap is honored verbatim."""
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._retry_wait_seconds(5, 3) == 5.0
+
+    def test_zero_header_is_honored(self, test_credentials: Session) -> None:
+        """``Retry-After: 0`` sleeps zero seconds rather than backing off."""
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._retry_wait_seconds(0, 5) == 0.0
+
+    @pytest.mark.parametrize("retry_after", [61, 3600, 86400, 2**40])
+    def test_huge_header_is_capped(
+        self, test_credentials: Session, retry_after: int
+    ) -> None:
+        """A huge Retry-After is capped at the backoff ceiling, not slept off.
+
+        Args:
+            test_credentials: Session fixture.
+            retry_after: An implausibly large Retry-After value.
+        """
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._retry_wait_seconds(retry_after, 0) == 60.0
+
+    def test_wait_never_exceeds_cap_for_late_attempts(
+        self, test_credentials: Session
+    ) -> None:
+        """The backoff fallback still honors its own ceiling plus jitter."""
+        client = MixpanelAPIClient(session=test_credentials)
+        assert client._retry_wait_seconds(None, 40) <= 66.0
+
+
+class TestRetryAfterHardening:
+    """End-to-end retry behavior with hostile Retry-After headers."""
+
+    @staticmethod
+    def _rate_limited_then_ok(
+        header: dict[str, str], payload: Any
+    ) -> Callable[[httpx.Request], httpx.Response]:
+        """Build a handler that 429s once and then succeeds.
+
+        Args:
+            header: Response headers for the 429.
+            payload: JSON payload returned on the second call.
+
+        Returns:
+            An httpx.MockTransport handler.
+        """
+        state = {"calls": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Return 429 on the first call, then the payload.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                The mocked response.
+            """
+            state["calls"] += 1
+            if state["calls"] == 1:
+                return httpx.Response(429, headers=header)
+            return httpx.Response(200, json=payload)
+
+        return handler
+
+    def test_negative_retry_after_uses_backoff(
+        self,
+        test_credentials: Session,
+        recorded_sleeps: list[float],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A negative Retry-After must not be passed to ``time.sleep``.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+            monkeypatch: Used to pin the backoff to a known value.
+        """
+        transport = httpx.MockTransport(
+            self._rate_limited_then_ok({"Retry-After": "-5"}, ["event1"])
+        )
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+        monkeypatch.setattr(client, "_calculate_backoff", lambda _attempt: 0.125)
+
+        with client:
+            assert client.get_events() == ["event1"]
+
+        assert recorded_sleeps == [0.125]
+
+    def test_huge_retry_after_is_capped(
+        self, test_credentials: Session, recorded_sleeps: list[float]
+    ) -> None:
+        """A day-long Retry-After is clamped to the 60s backoff ceiling.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+        """
+        transport = httpx.MockTransport(
+            self._rate_limited_then_ok({"Retry-After": "86400"}, ["event1"])
+        )
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+
+        with client:
+            assert client.get_events() == ["event1"]
+
+        assert recorded_sleeps == [60.0]
+
+    def test_garbage_retry_after_uses_backoff(
+        self,
+        test_credentials: Session,
+        recorded_sleeps: list[float],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unparseable Retry-After falls back to exponential backoff.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+            monkeypatch: Used to pin the backoff to a known value.
+        """
+        transport = httpx.MockTransport(
+            self._rate_limited_then_ok({"Retry-After": "soon"}, ["event1"])
+        )
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+        monkeypatch.setattr(client, "_calculate_backoff", lambda _attempt: 0.25)
+
+        with client:
+            assert client.get_events() == ["event1"]
+
+        assert recorded_sleeps == [0.25]
+
+    def test_negative_retry_after_omitted_from_error(
+        self, test_credentials: Session, recorded_sleeps: list[float]
+    ) -> None:
+        """A negative header is not echoed as ``retry_after`` on the error.
+
+        ``RateLimitError``'s documented usage is ``time.sleep(e.retry_after or
+        60)``, which a negative value would break in caller code too.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations (unused, guards timing).
+        """
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Always rate limit with a negative Retry-After.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                A 429 response.
+            """
+            return httpx.Response(429, headers={"Retry-After": "-5"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=0, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.get_events()
+
+        assert exc_info.value.retry_after is None
+        assert "Retry after" not in str(exc_info.value)
+
+    def test_huge_retry_after_reported_verbatim_on_error(
+        self, test_credentials: Session
+    ) -> None:
+        """The cap applies to sleeping, not to what the server is reported to say."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Always rate limit with a large Retry-After.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                A 429 response.
+            """
+            return httpx.Response(429, headers={"Retry-After": "3600"})
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=0, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.get_events()
+
+        assert exc_info.value.retry_after == 3600
+
+    def test_app_request_negative_retry_after_uses_backoff(
+        self,
+        test_credentials: Session,
+        recorded_sleeps: list[float],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """app_request's inline retry validates Retry-After too.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+            monkeypatch: Used to pin the backoff to a known value.
+        """
+        transport = httpx.MockTransport(
+            self._rate_limited_then_ok({"Retry-After": "-1"}, {"results": [1]})
+        )
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+        monkeypatch.setattr(client, "_calculate_backoff", lambda _attempt: 0.5)
+
+        with client:
+            assert client.app_request("GET", "/projects/12345/dashboards") == [1]
+
+        assert recorded_sleeps == [0.5]
+
+    def test_app_request_huge_retry_after_is_capped(
+        self, test_credentials: Session, recorded_sleeps: list[float]
+    ) -> None:
+        """app_request clamps an oversized Retry-After to the backoff ceiling.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+        """
+        transport = httpx.MockTransport(
+            self._rate_limited_then_ok({"Retry-After": "99999"}, {"results": [1]})
+        )
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+
+        with client:
+            assert client.app_request("GET", "/projects/12345/dashboards") == [1]
+
+        assert recorded_sleeps == [60.0]
+
+    def test_export_events_negative_retry_after_uses_backoff(
+        self,
+        test_credentials: Session,
+        recorded_sleeps: list[float],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The export stream retry validates Retry-After as well.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations.
+            monkeypatch: Used to pin the backoff to a known value.
+        """
+        calls = {"n": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Rate limit once with a negative Retry-After, then stream one event.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                The mocked response.
+            """
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "-30"})
+            return httpx.Response(
+                200, content=b'{"event":"A","properties":{"time":1}}\n'
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=2, _transport=transport
+        )
+        monkeypatch.setattr(client, "_calculate_backoff", lambda _attempt: 0.75)
+
+        with client:
+            events = list(client.export_events("2024-01-01", "2024-01-31"))
+
+        assert len(events) == 1
+        assert recorded_sleeps == [0.75]
+
+
+# =============================================================================
+# Error-message fallbacks for blank error bodies
+# =============================================================================
+
+
+class TestBlankErrorBodyFallbacks:
+    """A response with no usable error text must not produce a blank message."""
+
+    @staticmethod
+    def _client(credentials: Session, response: httpx.Response) -> MixpanelAPIClient:
+        """Build a client whose transport always returns ``response``.
+
+        Args:
+            credentials: Session fixture value.
+            response: The response to return for every request.
+
+        Returns:
+            A client wired to a single-response mock transport.
+        """
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Return the canned response.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                The canned response.
+            """
+            return response
+
+        return create_mock_client(credentials, handler)
+
+    def test_400_with_blank_text_body(self, test_credentials: Session) -> None:
+        """A 400 whose body is only whitespace falls back to a default message."""
+        with (
+            self._client(test_credentials, httpx.Response(400, text="   ")) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message.strip() == "Unknown error"
+
+    def test_400_with_blank_error_field(self, test_credentials: Session) -> None:
+        """A 400 body of ``{"error": ""}`` falls back to a default message."""
+        with (
+            self._client(
+                test_credentials, httpx.Response(400, json={"error": ""})
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == "Unknown error"
+
+    def test_403_with_blank_error_field(self, test_credentials: Session) -> None:
+        """A 403 body of ``{"error": ""}`` falls back to "Permission denied"."""
+        with (
+            self._client(
+                test_credentials, httpx.Response(403, json={"error": ""})
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == "Permission denied"
+
+    def test_404_with_blank_error_field(self, test_credentials: Session) -> None:
+        """A 404 body of ``{"error": ""}`` falls back to "Resource not found"."""
+        with (
+            self._client(
+                test_credentials, httpx.Response(404, json={"error": ""})
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == "Resource not found"
+
+    def test_generic_4xx_with_blank_error_field(
+        self, test_credentials: Session
+    ) -> None:
+        """A 412 body of ``{"error": ""}`` falls back to "Request failed"."""
+        with (
+            self._client(
+                test_credentials, httpx.Response(412, json={"error": ""})
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == "Request failed"
+
+    def test_400_with_structured_error_value(self, test_credentials: Session) -> None:
+        """A non-string ``error`` value is stringified, never leaked as a dict."""
+        with (
+            self._client(
+                test_credentials,
+                httpx.Response(400, json={"error": {"code": "BAD_SEGMENT"}}),
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert isinstance(exc_info.value.message, str)
+        assert "BAD_SEGMENT" in exc_info.value.message
+
+    def test_500_with_blank_error_field(self, test_credentials: Session) -> None:
+        """A 5xx body of ``{"error": ""}`` still names the status code."""
+        from mixpanel_headless.exceptions import ServerError
+
+        with (
+            self._client(
+                test_credentials, httpx.Response(500, json={"error": ""})
+            ) as client,
+            pytest.raises(ServerError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == "Server error: 500"
+
+    def test_400_message_preserved_when_present(
+        self, test_credentials: Session
+    ) -> None:
+        """A usable message is passed through untouched (no stripping)."""
+        with (
+            self._client(
+                test_credentials, httpx.Response(400, json={"error": " boom "})
+            ) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.get_events()
+
+        assert exc_info.value.message == " boom "
+
+
+# =============================================================================
+# Request-context symmetry across error branches
+# =============================================================================
+
+
+class TestErrorContextSymmetry:
+    """Every error branch should carry the same request context."""
+
+    def test_401_carries_request_body(self, test_credentials: Session) -> None:
+        """A 401 echoes the request body, like the 400/403/404 branches do."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Return an unauthenticated response.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                A 401 response.
+            """
+            return httpx.Response(401, json={"error": "nope"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(AuthenticationError) as exc_info,
+        ):
+            client.request(
+                "POST",
+                "https://mixpanel.com/api/app/test",
+                json_body={"name": "dash"},
+            )
+
+        exc = exc_info.value
+        assert exc.request_body == {"name": "dash"}
+        assert exc.details["request_body"] == {"name": "dash"}
+        assert exc.request_params is not None
+
+    def test_app_request_422_carries_request_params(
+        self, test_credentials: Session
+    ) -> None:
+        """The 422 branch carries query params, like every other error branch."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Return a validation failure.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                A 422 response.
+            """
+            return httpx.Response(422, json={"error": "bad field"})
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(QueryError) as exc_info,
+        ):
+            client.app_request(
+                "POST",
+                "/projects/12345/dashboards",
+                params={"workspace_id": "77"},
+                json_body={"title": "x"},
+            )
+
+        exc = exc_info.value
+        assert exc.request_params == {"workspace_id": "77"}
+        assert exc.request_body == {"title": "x"}
+
+    def test_app_request_rate_limit_carries_request_params(
+        self, test_credentials: Session, recorded_sleeps: list[float]
+    ) -> None:
+        """The app_request 429 exhaustion error carries query params.
+
+        Args:
+            test_credentials: Session fixture.
+            recorded_sleeps: Captured sleep durations (keeps the test fast).
+        """
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Always rate limit.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Returns:
+                A 429 response.
+            """
+            return httpx.Response(429)
+
+        transport = httpx.MockTransport(handler)
+        client = MixpanelAPIClient(
+            session=test_credentials, max_retries=0, _transport=transport
+        )
+
+        with client, pytest.raises(RateLimitError) as exc_info:
+            client.app_request(
+                "GET", "/projects/12345/dashboards", params={"workspace_id": "77"}
+            )
+
+        assert exc_info.value.request_params == {"workspace_id": "77"}
+        assert exc_info.value.project_id == "12345"
+
+    def test_app_request_http_error_details_carry_request_params(
+        self, test_credentials: Session
+    ) -> None:
+        """Transport failures report the params that were in flight."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Fail at the transport layer.
+
+            Args:
+                _request: The outgoing request (unused).
+
+            Raises:
+                httpx.ConnectError: Always.
+            """
+            raise httpx.ConnectError("connection refused")
+
+        with (
+            create_mock_client(test_credentials, handler) as client,
+            pytest.raises(MixpanelHeadlessError) as exc_info,
+        ):
+            client.app_request(
+                "GET", "/projects/12345/dashboards", params={"workspace_id": "77"}
+            )
+
+        assert exc_info.value.details["request_params"] == {"workspace_id": "77"}

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -503,6 +503,22 @@ class TestAPIErrorHierarchy:
         assert exc.status_code == 401
         assert exc.request_url == "https://api.example.com"
 
+    def test_authentication_error_carries_request_body(self) -> None:
+        """AuthenticationError accepts request_body like its sibling errors.
+
+        A 401 on a POST should expose the payload that was rejected, matching
+        the QueryError / ServerError branches.
+        """
+        exc = AuthenticationError(
+            "Invalid credentials",
+            request_method="POST",
+            request_url="https://api.example.com",
+            request_body={"name": "dash"},
+        )
+
+        assert exc.request_body == {"name": "dash"}
+        assert exc.to_dict()["details"]["request_body"] == {"name": "dash"}
+
     def test_rate_limit_error_inherits_from_api_error(self) -> None:
         """RateLimitError should inherit from APIError."""
         exc = RateLimitError(

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -15,7 +15,11 @@ import pytest
 
 from mixpanel_headless._internal.api_client import MixpanelAPIClient
 from mixpanel_headless._internal.auth.session import Session
-from mixpanel_headless._internal.pagination import paginate_all
+from mixpanel_headless._internal.pagination import (
+    _BACKOFF_MAX,
+    MAX_RATE_LIMIT_RETRIES,
+    paginate_all,
+)
 from mixpanel_headless.exceptions import (
     AuthenticationError,
     MixpanelHeadlessError,
@@ -403,7 +407,9 @@ class TestPaginateAllRobustness:
         """Verify that a 429 on the second page raises RateLimitError.
 
         Rate limits can occur mid-pagination; the error should propagate
-        as a proper RateLimitError.
+        as a proper RateLimitError. ``time.sleep`` is patched out so the retry
+        budget (3 x the advertised 30s) does not cost the suite 90 seconds of
+        real wall time.
         """
         call_count = 0
 
@@ -434,8 +440,14 @@ class TestPaginateAllRobustness:
             )
 
         client = create_mock_client(oauth_credentials, handler)
-        with client, pytest.raises(RateLimitError):
+        with (
+            patch("time.sleep") as mock_sleep,
+            client,
+            pytest.raises(RateLimitError),
+        ):
             list(paginate_all(client, "/projects/12345/items"))
+
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [30.0] * 3
 
     def test_http_500_mid_pagination(self, oauth_credentials: Session) -> None:
         """Verify that a 500 on the second page raises ServerError.
@@ -502,3 +514,311 @@ class TestPaginateAllRobustness:
         client = create_mock_client(oauth_credentials, handler)
         with client, pytest.raises(AuthenticationError):
             list(paginate_all(client, "/projects/12345/items"))
+
+
+class TestPaginateAllMalformedResults:
+    """Test paginate_all() handling of a malformed ``results`` field."""
+
+    def test_null_results_treated_as_empty_page(
+        self, oauth_credentials: Session
+    ) -> None:
+        """A JSON ``null`` ``results`` field must behave like an absent one.
+
+        A server that serializes an empty page as ``"results": null`` rather
+        than omitting the key must not crash the paginator with an unhandled
+        ``TypeError`` from ``yield from None``.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a page whose results field is JSON null.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Response with ``results`` set to null and no next cursor.
+            """
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": None,
+                    "pagination": {"page_size": 100, "next_cursor": None},
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/items"))
+
+        assert items == []
+
+    def test_null_results_still_follows_next_cursor(
+        self, oauth_credentials: Session
+    ) -> None:
+        """A null ``results`` page must not abort an otherwise healthy walk.
+
+        The cursor, not the results field, decides when iteration stops, so a
+        null page in the middle of a chain must be skipped and the next page
+        fetched.
+        """
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a null-results first page, then a normal second page.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Null-results page or the final page of items.
+            """
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "ok",
+                        "results": None,
+                        "pagination": {"page_size": 100, "next_cursor": "c2"},
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": [{"id": 1}],
+                    "pagination": {"page_size": 100, "next_cursor": None},
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client:
+            items = list(paginate_all(client, "/projects/12345/items"))
+
+        assert items == [{"id": 1}]
+        assert call_count == 2
+
+    @pytest.mark.parametrize(
+        "results_value",
+        ["abc", 42, {"id": 1}, True],
+        ids=["string", "int", "dict", "bool"],
+    )
+    def test_non_list_results_raises_invalid_response(
+        self, oauth_credentials: Session, results_value: object
+    ) -> None:
+        """A non-list, non-null ``results`` field must raise a typed error.
+
+        Iterating a string would silently yield individual characters and
+        iterating a dict would yield keys; both are corrupt output dressed up
+        as success. The paginator must reject the response instead.
+
+        Args:
+            oauth_credentials: Session fixture.
+            results_value: Malformed value to place in the ``results`` field.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Return a page whose results field is not a list.
+
+            Args:
+                request: The incoming request.
+
+            Returns:
+                Response with a malformed ``results`` field.
+            """
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "results": results_value,
+                    "pagination": {"page_size": 100, "next_cursor": None},
+                },
+            )
+
+        client = create_mock_client(oauth_credentials, handler)
+        with client, pytest.raises(MixpanelHeadlessError, match="must be a list") as ei:
+            list(paginate_all(client, "/projects/12345/items"))
+
+        assert ei.value.code == "INVALID_RESPONSE"
+
+
+def run_rate_limited_pagination(
+    credentials: Session,
+    retry_after: str | None,
+    *,
+    always_429: bool = False,
+) -> tuple[list[float], list[BaseException]]:
+    """Drive a rate-limited pagination run and capture the sleep durations.
+
+    Args:
+        credentials: Session used to build the mock-transport client.
+        retry_after: Value for the ``Retry-After`` header, or ``None`` to omit
+            the header entirely.
+        always_429: When True every response is a 429 so the retry budget is
+            exhausted; when False only the first response is a 429.
+
+    Returns:
+        Tuple of (sleep durations passed to ``time.sleep``, exceptions raised
+        by the pagination run).
+    """
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Return a 429 (with optional Retry-After) then a terminal page.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            Rate-limit response or the final page of results.
+        """
+        nonlocal call_count
+        call_count += 1
+        if always_429 or call_count == 1:
+            headers = {} if retry_after is None else {"Retry-After": retry_after}
+            return httpx.Response(429, json={"error": "rate_limited"}, headers=headers)
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "results": [{"id": 1}],
+                "pagination": {"page_size": 100, "next_cursor": None},
+            },
+        )
+
+    raised: list[BaseException] = []
+    client = create_mock_client(credentials, handler)
+    with patch("time.sleep") as mock_sleep, client:
+        try:
+            list(paginate_all(client, "/projects/12345/items"))
+        except BaseException as exc:  # noqa: BLE001 - recorded for assertions
+            raised.append(exc)
+    durations = [float(call.args[0]) for call in mock_sleep.call_args_list]
+    return durations, raised
+
+
+class TestPaginateAllRetryAfter:
+    """Test defensive parsing of the ``Retry-After`` header before sleeping."""
+
+    def test_valid_retry_after_is_honored(self, oauth_credentials: Session) -> None:
+        """A sane numeric Retry-After must be used verbatim as the wait."""
+        durations, raised = run_rate_limited_pagination(oauth_credentials, "30")
+
+        assert durations == [30.0]
+        assert raised == []
+
+    @pytest.mark.parametrize(
+        "retry_after",
+        ["-1", "-0.5", "nan", "NaN", "inf", "-inf", "abc", "", "1,000"],
+        ids=[
+            "negative-int",
+            "negative-float",
+            "nan",
+            "nan-mixed-case",
+            "infinity",
+            "negative-infinity",
+            "garbage",
+            "empty",
+            "thousands-separator",
+        ],
+    )
+    def test_hostile_retry_after_falls_back_to_backoff(
+        self, oauth_credentials: Session, retry_after: str
+    ) -> None:
+        """Invalid Retry-After values must never reach ``time.sleep``.
+
+        ``time.sleep`` raises ValueError on negatives and NaN and OverflowError
+        on infinity, so an unvalidated header value turns a retryable 429 into
+        an unhandled crash out of a public iterator. Each of these must instead
+        fall back to the exponential-backoff schedule.
+
+        Args:
+            oauth_credentials: Session fixture.
+            retry_after: Hostile header value under test.
+        """
+        durations, raised = run_rate_limited_pagination(oauth_credentials, retry_after)
+
+        assert durations == [1.0]
+        assert raised == []
+
+    @pytest.mark.parametrize(
+        "retry_after",
+        ["999999", "1e9", "86400"],
+        ids=["huge-int", "exponent", "one-day"],
+    )
+    def test_oversized_retry_after_is_clamped(
+        self, oauth_credentials: Session, retry_after: str
+    ) -> None:
+        """A Retry-After beyond the backoff cap must be clamped, not obeyed.
+
+        Sleeping for a server-chosen day inside a paginator is a hang, so the
+        wait is bounded by the same cap the computed backoff uses.
+
+        Args:
+            oauth_credentials: Session fixture.
+            retry_after: Oversized header value under test.
+        """
+        durations, raised = run_rate_limited_pagination(oauth_credentials, retry_after)
+
+        assert durations == [_BACKOFF_MAX]
+        assert raised == []
+
+    def test_missing_retry_after_uses_exponential_backoff(
+        self, oauth_credentials: Session
+    ) -> None:
+        """With no Retry-After header the backoff schedule is unchanged."""
+        durations, raised = run_rate_limited_pagination(oauth_credentials, None)
+
+        assert durations == [1.0]
+        assert raised == []
+
+    def test_exhausted_retries_backoff_schedule_is_bounded(
+        self, oauth_credentials: Session
+    ) -> None:
+        """Every sleep in an exhausted retry run stays within the cap."""
+        durations, raised = run_rate_limited_pagination(
+            oauth_credentials, "inf", always_429=True
+        )
+
+        assert durations == [1.0, 2.0, 4.0]
+        assert len(durations) == MAX_RATE_LIMIT_RETRIES
+        assert all(0.0 <= d <= _BACKOFF_MAX for d in durations)
+        assert isinstance(raised[0], RateLimitError)
+
+    @pytest.mark.parametrize(
+        "retry_after",
+        ["-5", "nan", "inf", "abc"],
+        ids=["negative", "nan", "infinity", "garbage"],
+    )
+    def test_hostile_retry_after_not_reported_on_error(
+        self, oauth_credentials: Session, retry_after: str
+    ) -> None:
+        """A hostile header must not be echoed back as ``RateLimitError.retry_after``.
+
+        The documented caller pattern is ``time.sleep(e.retry_after or 60)``,
+        so surfacing a negative or non-finite value would just relocate the
+        crash into user code.
+
+        Args:
+            oauth_credentials: Session fixture.
+            retry_after: Hostile header value under test.
+        """
+        _, raised = run_rate_limited_pagination(
+            oauth_credentials, retry_after, always_429=True
+        )
+
+        assert isinstance(raised[0], RateLimitError)
+        assert raised[0].retry_after is None
+
+    def test_valid_retry_after_reported_on_error(
+        self, oauth_credentials: Session
+    ) -> None:
+        """A sane header value is still reported on the raised RateLimitError."""
+        _, raised = run_rate_limited_pagination(
+            oauth_credentials, "45", always_429=True
+        )
+
+        assert isinstance(raised[0], RateLimitError)
+        assert raised[0].retry_after == 45


### PR DESCRIPTION
## Summary

While stress-testing the TypeScript port pipeline (independent reimplementations of `pagination.py` and the annotations client slice, diffed against the originals), the review agents surfaced six latent bugs in the retry and error-handling paths. This PR fixes them in Python first, per the port rulebook's bug-compatibility policy (R10.7): fixing before conformance-vector extraction keeps bug-compat vectors out of the port corpus.

## Fixes

1. **`Retry-After` hardening** — the header is server/attacker-controlled but flowed into `time.sleep()` unvalidated. Negative, non-finite (`inf`/`nan`), and unparseable values now fall back to exponential backoff; valid but huge values (e.g. `Retry-After: 86400`) are capped at the existing 60s backoff ceiling. Applied to all three retry sites: `_execute_with_retry`, `app_request`, and the paginator's own 429 loop.
2. **`results: null` in paginated responses** — previously an unhandled `TypeError`; JSON null is now treated as an empty page (the cursor decides termination).
3. **Non-list `results`** — a string would have been iterated character-by-character, a dict by keys; now raises `MixpanelHeadlessError` with `code="INVALID_RESPONSE"`.
4. **Blank error messages** — empty/whitespace error bodies could produce exceptions with empty messages; new `_error_message()` helper (with blank guard) replaces five divergent inline branches in `_handle_response`.
5. **401 context parity** — `AuthenticationError` now carries `request_body` like the sibling error branches.
6. **`request_params` attachment** — `app_request` now attaches `request_params` to 422 `QueryError`, `RateLimitError`, and network-error details, matching the query-path errors.

## Test plan

- TDD: every fix has failing-first tests in `tests/unit/test_pagination.py`, `tests/unit/test_api_client.py`, `tests/unit/test_exceptions.py` (+941 test LOC, 289 tests in the touched files)
- `just check` green: 6,768 passed, coverage 92.04% (floor 90%), mypy --strict, ruff, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)