### PR TITLE
fix: rename storage-root env var to MP_STORAGE_DIR (deprecated alias kept)

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -521,7 +521,7 @@ These resolve via `env > param > target > bridge > [active] > default_project` â
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
-| `MP_OAUTH_STORAGE_DIR` | Override storage root (`~/.mp`) |
+| `MP_STORAGE_DIR` | Override storage root (`~/.mp`); `MP_OAUTH_STORAGE_DIR` is a deprecated alias |
 
 ## Examples
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -62,7 +62,7 @@ Service accounts are the right default for unattended automation. OAuth browser 
 | `MP_REGION` | Data residency region (`us`, `eu`, `in`) |
 | `MP_AUTH_FILE` | Override path to the Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
-| `MP_OAUTH_STORAGE_DIR` | Override storage root (`~/.mp`) |
+| `MP_STORAGE_DIR` | Override storage root (`~/.mp`); `MP_OAUTH_STORAGE_DIR` is a deprecated alias |
 
 These map onto the [credential resolution chain](#credential-resolution-chain) below.
 

--- a/src/mixpanel_headless/_internal/auth/storage.py
+++ b/src/mixpanel_headless/_internal/auth/storage.py
@@ -5,8 +5,10 @@ permission-restricted directory (``~/.mp/oauth/`` by default).
 Directory permissions are set to ``0o700`` and file permissions to ``0o600``
 to protect sensitive credential material.
 
-The storage directory can be overridden via the ``MP_OAUTH_STORAGE_DIR``
-environment variable for testing or custom deployments.
+The storage directory can be overridden via the ``MP_STORAGE_DIR``
+environment variable for testing or custom deployments. The pre-rename
+name ``MP_OAUTH_STORAGE_DIR`` is honored as a deprecated alias — it was
+never OAuth-specific, and its value is a directory path, not a secret.
 
 Per-account paths (introduced by 042-auth-architecture-redesign):
 - ``account_dir(name)`` and ``ensure_account_dir(name)`` return / create
@@ -49,35 +51,44 @@ logger = logging.getLogger(__name__)
 
 _ACCOUNT_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
+#: Env vars that override the storage root, in precedence order.
+#: ``MP_STORAGE_DIR`` is the canonical name. ``MP_OAUTH_STORAGE_DIR`` is
+#: the pre-rename alias, kept for backwards compatibility — the root was
+#: never OAuth-specific (see the module docstring).
+_STORAGE_ROOT_ENV_VARS = ("MP_STORAGE_DIR", "MP_OAUTH_STORAGE_DIR")
+
 
 def _storage_root() -> Path:
     """Return the root directory under which mixpanel_headless writes account state.
 
     Resolved at every call so test isolation via ``$HOME`` /
-    ``MP_OAUTH_STORAGE_DIR`` monkeypatching takes effect — a module-level
+    ``MP_STORAGE_DIR`` monkeypatching takes effect — a module-level
     constant captured at import time would silently leak the developer's
     real ``~/.mp/`` into hermetic tests.
 
-    Despite the name, ``MP_OAUTH_STORAGE_DIR`` controls EVERY on-disk
-    artifact written by mixpanel_headless (per-account dirs, OAuth tokens,
-    ``/me`` cache, client registration), not just the OAuth subtree. The
-    name is preserved as a backwards-compat env var only — the root is
-    used by both :func:`account_dir` and
-    :meth:`OAuthStorage._default_storage_dir`.
+    The root controls EVERY on-disk artifact written by mixpanel_headless
+    (per-account dirs, OAuth tokens, ``/me`` cache, client registration).
+    It is used by both :func:`account_dir` and
+    :meth:`OAuthStorage._default_storage_dir`. The env vars are consulted
+    in :data:`_STORAGE_ROOT_ENV_VARS` order, so the canonical
+    ``MP_STORAGE_DIR`` wins over the deprecated ``MP_OAUTH_STORAGE_DIR``
+    alias when both are set.
 
     Returns:
-        ``$MP_OAUTH_STORAGE_DIR`` if set, else ``$HOME/.mp``.
+        The first set env var from :data:`_STORAGE_ROOT_ENV_VARS`, else
+        ``$HOME/.mp``.
     """
-    env_dir = os.environ.get("MP_OAUTH_STORAGE_DIR")
-    if env_dir:
-        return Path(env_dir)
+    for env_var in _STORAGE_ROOT_ENV_VARS:
+        env_dir = os.environ.get(env_var)
+        if env_dir:
+            return Path(env_dir)
     return Path.home() / ".mp"
 
 
 def accounts_root() -> Path:
     """Return the directory holding every per-account state directory.
 
-    Resolves to ``$MP_OAUTH_STORAGE_DIR/accounts/`` when the env var is
+    Resolves to ``$MP_STORAGE_DIR/accounts/`` when the env var is
     set, else ``~/.mp/accounts/``. Used by callers that need to operate
     on the parent of :func:`account_dir` (placeholder dirs, enumeration)
     while still honoring the storage-root override.
@@ -91,7 +102,7 @@ def accounts_root() -> Path:
 def account_dir(name: str) -> Path:
     """Return the per-account directory for ``name``.
 
-    Resolves to ``$MP_OAUTH_STORAGE_DIR/accounts/{name}/`` when the env
+    Resolves to ``$MP_STORAGE_DIR/accounts/{name}/`` when the env
     var is set, else ``~/.mp/accounts/{name}/``. Does not create the
     directory — use :func:`ensure_account_dir` for that.
 
@@ -198,7 +209,7 @@ class OAuthStorage:
     of files (``tokens_{region}.json`` and ``client_{region}.json``).
 
     The storage directory defaults to ``~/.mp/oauth/`` but can be
-    overridden via the ``MP_OAUTH_STORAGE_DIR`` environment variable
+    overridden via the ``MP_STORAGE_DIR`` environment variable
     or the ``storage_dir`` constructor parameter.
 
     Security:
@@ -213,7 +224,7 @@ class OAuthStorage:
     def _default_storage_dir(cls) -> Path:
         """Return the default OAuth storage path, resolved lazily.
 
-        Routes through :func:`_storage_root` so the ``MP_OAUTH_STORAGE_DIR``
+        Routes through :func:`_storage_root` so the ``MP_STORAGE_DIR``
         env var (and ``$HOME`` for tests) takes effect at call time, not
         import time.
 
@@ -228,7 +239,7 @@ class OAuthStorage:
         Args:
             storage_dir: Override the storage directory. When not provided,
                 falls back to :meth:`_default_storage_dir` which honors
-                ``MP_OAUTH_STORAGE_DIR``.
+                ``MP_STORAGE_DIR``.
 
         Example:
             ```python

--- a/src/mixpanel_headless/_internal/auth/token_resolver.py
+++ b/src/mixpanel_headless/_internal/auth/token_resolver.py
@@ -41,7 +41,7 @@ def _account_tokens_path(name: str) -> Path:
     """Return ``<account-dir>/tokens.json`` for the given account name.
 
     Routes through :func:`account_dir` so the
-    ``MP_OAUTH_STORAGE_DIR`` env-var override is honored — hard-coding
+    ``MP_STORAGE_DIR`` env-var override is honored — hard-coding
     ``~/.mp/accounts/`` here would silently bypass test isolation and
     custom-deployment overrides.
 

--- a/src/mixpanel_headless/_internal/io_utils.py
+++ b/src/mixpanel_headless/_internal/io_utils.py
@@ -238,7 +238,7 @@ def _open_credential_fd(path: Path) -> int:
 
     Threat model: a same-UID attacker can plant symlinks anywhere they
     have write access — practically, anywhere under :func:`Path.home`
-    (or the configured ``MP_OAUTH_STORAGE_DIR`` / ``MP_CONFIG_PATH`` /
+    (or the configured ``MP_STORAGE_DIR`` / ``MP_CONFIG_PATH`` /
     ``MP_AUTH_FILE`` trees, if those env vars point inside their reach).
     Outside those trees, paths typically traverse system-owned dirs
     (``/var``, ``/private``, ``/Users``) that the user trusts the OS to
@@ -351,7 +351,7 @@ def _open_leaf_only(path: Path) -> int:
 
     Used when the path is outside :func:`Path.home` — typically an
     explicit env-var override (``MP_CONFIG_PATH``, ``MP_AUTH_FILE``,
-    ``MP_OAUTH_STORAGE_DIR``) where the user has opted into a non-home
+    ``MP_STORAGE_DIR``) where the user has opted into a non-home
     location. Same protection level as the original PR.
 
     Args:

--- a/src/mixpanel_headless/accounts.py
+++ b/src/mixpanel_headless/accounts.py
@@ -904,7 +904,7 @@ def _client_info_path(region: Region) -> Path:
 
     Returns:
         Absolute path to the client info JSON (may not exist yet).
-        Honors ``MP_OAUTH_STORAGE_DIR`` so a hermetic test environment
+        Honors ``MP_STORAGE_DIR`` so a hermetic test environment
         or Cowork-style sandbox sees the override-path; the prior
         hard-coded ``~/.mp/oauth/`` lied to callers under override.
     """
@@ -1339,7 +1339,7 @@ def _persist_me_cache(account_name: str, me_resp: MeResponse) -> None:
     """Write ``me.json`` for the named account, honoring the storage root.
 
     Wraps :class:`MeCache` so the orchestrator does not have to reason
-    about ``MP_OAUTH_STORAGE_DIR`` overrides — passes ``storage_dir=
+    about ``MP_STORAGE_DIR`` overrides — passes ``storage_dir=
     account_dir(name)`` so the cache lands alongside ``tokens.json`` /
     ``client.json`` in the same per-account directory.
 
@@ -1622,7 +1622,7 @@ def _login_unified_new_browser(
     auth_region: Region = region if region is not None else "us"
 
     # Placeholder dir: hidden so `mp account list` doesn't enumerate it.
-    # Routed through accounts_root() so MP_OAUTH_STORAGE_DIR overrides reach
+    # Routed through accounts_root() so MP_STORAGE_DIR overrides reach
     # the placeholder tree — otherwise tokens land under $HOME but the
     # resolver looks under the override and the new account never works.
     # Wrap in os.umask(0o077) so any intermediate parent (typically

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ _MP_ENV_VARS = (
     "MP_AUTH_FILE",
     "MP_WORKSPACE_ID",
     "MP_STORAGE_DIR",
+    "MP_OAUTH_STORAGE_DIR",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ _MP_ENV_VARS = (
     "MP_OAUTH_TOKEN",
     "MP_AUTH_FILE",
     "MP_WORKSPACE_ID",
+    "MP_STORAGE_DIR",
 )
 
 
@@ -230,7 +231,7 @@ def _no_test_writes_to_real_home_mp(
         pytest.fail(
             "Test(s) leaked writes to the developer's real ~/.mp/.\n"
             "Each test MUST monkeypatch HOME / MP_CONFIG_PATH / "
-            "MP_OAUTH_STORAGE_DIR to a tmp_path. Offenders:\n"
+            "MP_STORAGE_DIR to a tmp_path. Offenders:\n"
             f"  changed: {changed}\n"
             f"  new:     {new}\n"
             f"  removed: {removed}"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -74,12 +74,33 @@ class TestAccountDirNameValidation:
 
 
 class TestStorageRoot:
-    """``_storage_root`` honors ``MP_OAUTH_STORAGE_DIR`` and resolves lazily."""
+    """``_storage_root`` honors the env overrides and resolves lazily.
+
+    ``MP_STORAGE_DIR`` is the canonical override; ``MP_OAUTH_STORAGE_DIR``
+    is the deprecated pre-rename alias and must keep working.
+    """
+
+    def test_canonical_env_var_overrides_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MP_STORAGE_DIR`` takes precedence over ``$HOME/.mp``."""
+        monkeypatch.delenv("MP_OAUTH_STORAGE_DIR", raising=False)
+        monkeypatch.setenv("MP_STORAGE_DIR", str(tmp_path))
+        assert _storage_root() == tmp_path
+
+    def test_canonical_wins_over_deprecated_alias(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With both vars set, ``MP_STORAGE_DIR`` wins over the alias."""
+        monkeypatch.setenv("MP_STORAGE_DIR", str(tmp_path / "canonical"))
+        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path / "alias"))
+        assert _storage_root() == tmp_path / "canonical"
 
     def test_env_var_overrides_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``MP_OAUTH_STORAGE_DIR`` takes precedence over ``$HOME/.mp``."""
+        """The deprecated ``MP_OAUTH_STORAGE_DIR`` alias still works alone."""
+        monkeypatch.delenv("MP_STORAGE_DIR", raising=False)
         monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path))
         assert _storage_root() == tmp_path
 
@@ -87,6 +108,7 @@ class TestStorageRoot:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """With no env override, the root is ``$HOME/.mp``."""
+        monkeypatch.delenv("MP_STORAGE_DIR", raising=False)
         monkeypatch.delenv("MP_OAUTH_STORAGE_DIR", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
         assert _storage_root() == tmp_path / ".mp"
@@ -95,10 +117,11 @@ class TestStorageRoot:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Setting the env var after import takes effect on the next call."""
+        monkeypatch.delenv("MP_STORAGE_DIR", raising=False)
         monkeypatch.delenv("MP_OAUTH_STORAGE_DIR", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
         first = _storage_root()
-        monkeypatch.setenv("MP_OAUTH_STORAGE_DIR", str(tmp_path / "alt"))
+        monkeypatch.setenv("MP_STORAGE_DIR", str(tmp_path / "alt"))
         second = _storage_root()
         assert first != second
         assert second == tmp_path / "alt"


### PR DESCRIPTION
## Summary
- `MP_OAUTH_STORAGE_DIR` was a misnomer: it overrides the storage root for every on-disk artifact, not just OAuth files, and its value is a directory path, not a secret. The canonical name is now `MP_STORAGE_DIR`; the old name stays as a documented deprecated alias, and the canonical name wins when both are set.
- The misnomer had a second cost: CodeQL's name heuristic classified the env value as a password, so every log line that includes a path derived from the storage root fired `py/clear-text-logging-sensitive-data`. All nine open code-scanning alerts trace to this single `os.environ.get` call (verified via the SARIF related locations). This PR fixes them at the source.

## Test plan
- New tests pin the precedence contract: canonical alone, canonical over alias, alias alone (back-compat).
- `MP_STORAGE_DIR` added to the hermetic-test env scrub list.
- `just check` passes: 6,703 tests, 91.89% coverage, lint/typecheck/build clean.
- Expect the code-scanning check on this PR to report the 9 alerts as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)