### PR TITLE
fix(plugin): drop invalid colon from setup skill name

### DIFF
--- a/mixpanel-plugin/skills/setup/SKILL.md
+++ b/mixpanel-plugin/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mixpanel-headless:setup
+name: setup
 description: This skill installs mixpanel_headless, pandas, numpy, matplotlib, seaborn, networkx, anytree, scipy (and pyarrow on Python 3.11+), then verifies Mixpanel credentials. It should be invoked when setting up a new environment for Mixpanel data analysis, when dependencies are missing, or when configuring service account or OAuth credentials for the first time.
 disable-model-invocation: true
 allowed-tools: Bash


### PR DESCRIPTION
`mixpanel-plugin/skills/setup/SKILL.md` declared `name: mixpanel-headless:setup`.

Skill names must be lowercase `a-z0-9-` only. The colon makes the skill fail to load:

```
name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)
  mixpanel-plugin/skills/setup/SKILL.md
```

The `mixpanel-headless:` prefix is the plugin namespace, applied automatically by the loader — sibling skills `dashboard-expert` and `mixpanelyst` already use the bare name and load fine.

Docs referencing `/mixpanel-headless:setup` are unchanged; that is still the correct invocation.