### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project follows semver but is currently pre-1.0, so minor versions
 may include API changes.
 
+## 0.2.2 — 2026-09-01
+
+Patch release: `schema_graph()` on large projects, query-engine bookmark
+correctness, retry/error-path hardening, and a storage env-var rename.
+
+### Changed
+
+- The storage-root environment variable is now `MP_STORAGE_DIR`. The old
+  name `MP_OAUTH_STORAGE_DIR` still works as a deprecated alias and loses
+  when both are set. (#216)
+
+### Fixed
+
+- `schema_graph()` no longer times out on very large projects.
+  Relationship edges now come from the query API's per-event property
+  gather (the same surface the Lexicon UI uses), and client timeouts are
+  route-aware so they outlast the server-side deadlines instead of
+  pre-empting them. (#215)
+- Query-engine bookmark fixes: frequency-filter clauses now emit the
+  platform-native shape (the previous shape drew a server 500);
+  `data_group_id` is string-coerced in group clauses and emitted as the
+  contract's `globalDataGroupId` at the sections level; a `TypeError` in
+  the sensitive-data 403 sniff is fixed; OAuth bearer tokens are redacted
+  from error-detail payloads. (#208)
+- Retry and error paths hardened: negative, non-finite, or garbage
+  `Retry-After` values fall back to exponential backoff and are capped at
+  the 60s ceiling; a JSON-null `results` page is treated as empty and a
+  non-list `results` raises a typed error instead of mis-iterating; blank
+  error bodies no longer produce empty exception messages; 401 and App
+  API errors now carry request context for parity with the query paths.
+  (#206)
+- Plugin: the setup skill name no longer contains a colon, which made the
+  skill fail to load. (#218)
+
 ## 0.2.1 — 2026-08-13
 
 Patch release: workspace-scoped Query API correctness and fresh-install

--- a/src/mixpanel_headless/__init__.py
+++ b/src/mixpanel_headless/__init__.py
@@ -294,7 +294,7 @@ from mixpanel_headless.types import (
 )
 from mixpanel_headless.workspace import Workspace
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     # Core

--- a/src/mixpanel_headless/_internal/client_metadata.py
+++ b/src/mixpanel_headless/_internal/client_metadata.py
@@ -61,7 +61,7 @@ def get_user_agent() -> str:
     Example:
         ```python
         get_user_agent()
-        # "mixpanel-headless/0.2.1 (entry=lib; python/3.11)"
+        # "mixpanel-headless/0.2.2 (entry=lib; python/3.11)"
         ```
     """
     # Lazy import: mixpanel_headless/__init__.py defines __version__ after


### PR DESCRIPTION
Release prep for v0.2.2.

- `__version__` 0.2.1 → 0.2.2 (plus the docstring example in `client_metadata.py`)
- CHANGELOG entry for 0.2.2 covering #206, #208, #215, #216, #218

After merge: publish the GitHub release `v0.2.2`, which triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)