### PR TITLE
docs(types): document FrequencyFilter per-bucket evaluation and 0.2.1 upgrade note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ may include API changes.
   `severity="error"` item and exits with `INVALID_ARGS` (3). Scripts that
   test for exit code 1 on those commands must be updated.
 
+### Documentation
+
+- `FrequencyFilter` now documents that the query engine evaluates its
+  threshold **per query time bucket** (`unit`), not over the whole report
+  date range. With the default `unit="day"`, `FrequencyFilter("Login",
+  value=5)` keeps only users who logged in 5+ times on a single day and
+  returns an empty series when nobody does, even if thousands did so across
+  the month; pass `unit="month"` (or a single-bucket range) for "N times
+  over the period". The `Workspace.query(where=...)` docstring, the query
+  guide, and the mixpanelyst skill carry the same warning. The
+  `date_range_value` / `date_range_unit` parameters are documented as having
+  no observable effect on inline insights filters in a 2026-09-11 probe
+  (unverified against platform fixtures); they are unchanged on the wire.
+
 ## 0.2.2 — 2026-09-01
 
 Patch release: `schema_graph()` on large projects, query-engine bookmark
@@ -84,6 +98,11 @@ correctness, retry/error-path hardening, and a storage env-var rename.
   contract's `globalDataGroupId` at the sections level; a `TypeError` in
   the sensitive-data 403 sniff is fixed; OAuth bearer tokens are redacted
   from error-detail payloads. (#208)
+    - Upgrade note: on 0.2.1 every `Workspace.query(where=FrequencyFilter(...))`
+      call fails with a server 5xx (`ServerError: Server error: An unknown
+      error occurred.`) because the query engine cannot evaluate the old
+      clause shape. The failure gives no hint at its cause and there is no
+      client-side workaround; upgrade to `mixpanel-headless>=0.2.2`.
 - Retry and error paths hardened: negative, non-finite, or garbage
   `Retry-After` values fall back to exponential backoff and are capped at
   the 60s ceiling; a JSON-null `results` page is treated as empty and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ may include API changes.
   date range. With the default `unit="day"`, `FrequencyFilter("Login",
   value=5)` keeps only users who logged in 5+ times on a single day and
   returns an empty series when nobody does, even if thousands did so across
-  the month; pass `unit="month"` (or a single-bucket range) for "N times
-  over the period". The `Workspace.query(where=...)` docstring, the query
+  the month; choose the `unit` that matches the threshold period
+  (`"month"` for "N times in a month"). The `Workspace.query(where=...)`
+  docstring, the query
   guide, and the mixpanelyst skill carry the same warning. The
   `date_range_value` / `date_range_unit` parameters are documented as having
   no observable effect on inline insights filters in a 2026-09-11 probe

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -691,7 +691,7 @@ Filter to users who performed an event a certain number of times using `Frequenc
 ```python
 from mixpanel_headless import FrequencyFilter
 
-# Only users who purchased at least 3 times
+# Only users who purchased at least 3 times in a month
 result = ws.query(
     "Login",
     where=FrequencyFilter(
@@ -699,24 +699,52 @@ result = ws.query(
         value=3,
         operator="is at least",
     ),
-    last=30,
-)
-
-# With a lookback window — purchased at least 3 times in the last 30 days
-result = ws.query(
-    "Login",
-    where=FrequencyFilter(
-        event="Purchase",
-        value=3,
-        operator="is at least",
-        date_range_value=30,
-        date_range_unit="day",
-    ),
-    last=90,
+    last=3,
+    unit="month",
 )
 ```
 
 Operators: `"is at least"`, `"is at most"`, `"is greater than"`, `"is less than"`, `"is equal to"`.
+
+!!! warning "The count is evaluated per time bucket, not over the date range"
+    The query engine evaluates a `FrequencyFilter` threshold **inside each
+    time bucket of the query** (`unit`). With the default `unit="day"`,
+    `FrequencyFilter("Purchase", value=3)` keeps only users who purchased three
+    or more times *on the same day*; a user who purchased 30 times in a month
+    but never three times on one day is excluded from every daily bucket. An
+    empty `series` / zero-row `df` is the expected result when no user reaches
+    the threshold inside one bucket, not a sign that the filter failed.
+
+    When you mean "at least N times over the period", pass `unit="month"`
+    (or pick a `unit` and date range that form a single bucket).
+
+    Measured on a seeded 10,000-user dataset (event `enter dungeon`,
+    2026-03-01 to 2026-03-31), with every library number matching a DuckDB
+    ground-truth count over the raw events:
+
+    | Query | Library result | What was counted |
+    |---|---|---|
+    | unfiltered, `unit="day"`, summed | 30,541 | 30,541 events from 8,281 users |
+    | `FrequencyFilter(value=2)`, `unit="day"`, summed | 3,893 | users with 2+ **on the same day** (1,894 user-days) |
+    | `FrequencyFilter(value=3)`, `unit="day"` | 305 | same-day 3+ |
+    | `FrequencyFilter(value=4)`, `unit="day"` | 20 | same-day 4+ |
+    | `FrequencyFilter(value=5)`, `unit="day"` | **empty series** | same-day 5+: none. Whole-month 5+: 2,571 users, 16,363 events |
+    | `FrequencyFilter(value=2)`, `unit="month"`, total | 29,188 | whole-month 2+ (6,928 users) |
+    | `FrequencyFilter(value=2)`, `unit="month"`, unique | 6,928 | 6,928 users |
+
+!!! note "`date_range_value` / `date_range_unit` are unverified for inline filters"
+    These two parameters render as a `behavior.dateRange` lookback on the
+    wire. In a 2026-09-11 probe against the analytics query API they had no
+    observable effect on inline insights filters: a 31-day lookback returned
+    the same numbers as no lookback. Their behavior for inline filters has not
+    been verified against Mixpanel's internal fixtures. Do not rely on them to
+    widen the counting window; use `unit` instead.
+
+!!! tip "On 0.2.1? Upgrade"
+    `mixpanel-headless` 0.2.1 emitted a frequency-filter clause the query
+    engine could not evaluate, so every `FrequencyFilter` query failed with
+    `ServerError: Server error: An unknown error occurred.` There is no
+    client-side workaround; upgrade to `>=0.2.2`.
 
 ## Data Groups
 

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -691,7 +691,7 @@ Filter to users who performed an event a certain number of times using `Frequenc
 ```python
 from mixpanel_headless import FrequencyFilter
 
-# Only users who purchased at least 3 times in a month
+# Logins in March by users who purchased at least 3 times that month
 result = ws.query(
     "Login",
     where=FrequencyFilter(
@@ -699,7 +699,8 @@ result = ws.query(
         value=3,
         operator="is at least",
     ),
-    last=3,
+    from_date="2026-03-01",
+    to_date="2026-03-31",
     unit="month",
 )
 ```
@@ -715,22 +716,27 @@ Operators: `"is at least"`, `"is at most"`, `"is greater than"`, `"is less than"
     empty `series` / zero-row `df` is the expected result when no user reaches
     the threshold inside one bucket, not a sign that the filter failed.
 
-    When you mean "at least N times over the period", pass `unit="month"`
-    (or pick a `unit` and date range that form a single bucket).
+    Choose the `unit` that matches the period you mean: `"day"` for "N times
+    in a day", `"month"` for "N times in a month". `unit="month"` over a
+    multi-month range still yields one threshold per month; "N times over the
+    whole period" needs a date range that fits inside a single bucket. `last=`
+    is always a number of *days* regardless of `unit`, so pin a month with
+    `from_date` / `to_date`.
 
     Measured on a seeded 10,000-user dataset (event `enter dungeon`,
     2026-03-01 to 2026-03-31), with every library number matching a DuckDB
-    ground-truth count over the raw events:
+    ground-truth count over the raw events. The default `math="total"` counts
+    events; `math="unique"` counts users.
 
-    | Query | Library result | What was counted |
-    |---|---|---|
-    | unfiltered, `unit="day"`, summed | 30,541 | 30,541 events from 8,281 users |
-    | `FrequencyFilter(value=2)`, `unit="day"`, summed | 3,893 | users with 2+ **on the same day** (1,894 user-days) |
-    | `FrequencyFilter(value=3)`, `unit="day"` | 305 | same-day 3+ |
-    | `FrequencyFilter(value=4)`, `unit="day"` | 20 | same-day 4+ |
-    | `FrequencyFilter(value=5)`, `unit="day"` | **empty series** | same-day 5+: none. Whole-month 5+: 2,571 users, 16,363 events |
-    | `FrequencyFilter(value=2)`, `unit="month"`, total | 29,188 | whole-month 2+ (6,928 users) |
-    | `FrequencyFilter(value=2)`, `unit="month"`, unique | 6,928 | 6,928 users |
+    | Query | `math` | Library result | Ground truth |
+    |---|---|---|---|
+    | unfiltered, `unit="day"`, summed over days | `total` (default) | 30,541 | 30,541 events from 8,281 users |
+    | `FrequencyFilter(value=2)`, `unit="day"`, summed over days | `total` | 3,893 | 3,893 events by users with 2+ **on the same day** (1,894 user-days) |
+    | `FrequencyFilter(value=3)`, `unit="day"` | `total` | 305 | 305 events, same-day 3+ |
+    | `FrequencyFilter(value=4)`, `unit="day"` | `total` | 20 | 20 events, same-day 4+ |
+    | `FrequencyFilter(value=5)`, `unit="day"` | `total` | **empty series** | same-day 5+: no user-days. Whole-month 5+: 2,571 users, 16,363 events (not what a daily query measures) |
+    | `FrequencyFilter(value=2)`, `unit="month"` | `total` | 29,188 | 29,188 events by the 6,928 users with 2+ in the month |
+    | `FrequencyFilter(value=2)`, `unit="month"` | `unique` | 6,928 | 6,928 users with 2+ in the month |
 
 !!! note "`date_range_value` / `date_range_unit` are unverified for inline filters"
     These two parameters render as a `behavior.dateRange` lookback on the

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -881,17 +881,26 @@ result = ws.query("Login", math='unique',
     last=30, mode='total')
 # Reveals: do frequent purchasers also log in more?
 
-# Filter to users who purchased 3+ times in 30 days, then analyze their flow
-result = ws.query_flow("Login", forward=3,
-    where=FrequencyFilter("Purchase", value=3, date_range_value=30, date_range_unit="day"),
-    last=30)
-# Reveals: what do repeat purchasers do after logging in?
+# Logins by users who purchased 3+ times in a month.
+# ALWAYS pass unit="month" (or a single-bucket range) with FrequencyFilter:
+# the threshold is counted PER TIME BUCKET, not over the date range.
+result = ws.query("Login", math='unique',
+    where=FrequencyFilter("Purchase", value=3),
+    last=3, unit='month')
+# Reveals: how many repeat purchasers are active each month?
 ```
+
+**FrequencyFilter counts per bucket, not per date range.** The engine evaluates the threshold inside each `unit` bucket. With the default `unit="day"`, `FrequencyFilter("Login", value=5)` keeps only users with 5+ logins *on the same day*, and returns an EMPTY series when nobody does, even if thousands of users logged in 5+ times across the month. An empty result is the expected outcome for a threshold nobody reaches within one bucket; do not report it as "no such users". For "at least N times over the period", use `unit="month"` (or a range that is a single bucket). `date_range_value` / `date_range_unit` had no observable effect on inline filters in a 2026-09-11 probe and are unverified; do not rely on them to widen the window. `FrequencyFilter` is accepted by `query()` / `build_params()` only, not by `query_flow()`.
+
+| `FrequencyFilter("Login", value=5)`, March 1-31 | Result |
+|---|---|
+| `unit="day"` (default) | empty series (no user had 5+ logins on one day) |
+| `unit="month"` | 2,571 users who logged in 5+ times in March |
 
 **When to reach for each:**
 - Property values are messy or need derivation → **Custom Property**
 - Population requires behavioral criteria (did X, didn't do Y, frequency thresholds) → **Inline Cohort**
-- You need to segment by event frequency (how often, not just whether) → **FrequencyBreakdown/Filter**
+- You need to segment by event frequency (how often, not just whether) → **FrequencyBreakdown/Filter** (with `unit="month"` for whole-period thresholds)
 - You need to compare in-cohort vs out-of-cohort behavior → **CohortBreakdown** with `include_negated=True`
 - You need to track a segment's size as a time series → **CohortMetric** (saved cohorts only)
 
@@ -1076,7 +1085,7 @@ Full reference: `WebFetch(url="https://mixpanel.github.io/mixpanel-headless/api/
 | `FlowStep` | Flow anchor event with per-step forward/reverse configuration |
 | `TimeComparison` | Period-over-period comparison (`.relative("month")`, `.absolute_start(...)`) |
 | `FrequencyBreakdown` | Break down by how often users performed an event |
-| `FrequencyFilter` | Filter by how often users performed an event |
+| `FrequencyFilter` | Filter by how often users performed an event (counted per `unit` bucket; pass `unit="month"` for "over the period") |
 | `CohortBreakdown` | Break down results by cohort membership |
 | `CohortDefinition` | Inline cohort definition for user queries |
 | `CohortCriteria` | Atomic condition for cohort membership |

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -892,10 +892,12 @@ result = ws.query("Login", math='unique',
 
 **FrequencyFilter counts per bucket, not per date range.** The engine evaluates the threshold inside each `unit` bucket. With the default `unit="day"`, `FrequencyFilter("Login", value=5)` keeps only users with 5+ logins *on the same day*, and returns an EMPTY series when nobody does, even if thousands of users logged in 5+ times across the month. An empty result is the expected outcome for a threshold nobody reaches within one bucket; do not report it as "no such users". For "at least N times over the period", use `unit="month"` (or a range that is a single bucket). `date_range_value` / `date_range_unit` had no observable effect on inline filters in a 2026-09-11 probe and are unverified; do not rely on them to widen the window. `FrequencyFilter` is accepted by `query()` / `build_params()` only, not by `query_flow()`.
 
-| `FrequencyFilter("Login", value=5)`, March 1-31 | Result |
+Measured on a seeded gaming dataset (10,000 users, March 2026), `FrequencyFilter("enter dungeon", value=5)`, 2026-03-01 to 2026-03-31:
+
+| Query unit | Result |
 |---|---|
-| `unit="day"` (default) | empty series (no user had 5+ logins on one day) |
-| `unit="month"` | 2,571 users who logged in 5+ times in March |
+| `unit="day"` (default) | empty series (no user entered the dungeon 5+ times on one day) |
+| `unit="month"` | 2,571 of 8,281 active users (5+ entries anywhere in March) |
 
 **When to reach for each:**
 - Property values are messy or need derivation → **Custom Property**

--- a/mixpanel-plugin/skills/mixpanelyst/SKILL.md
+++ b/mixpanel-plugin/skills/mixpanelyst/SKILL.md
@@ -881,28 +881,28 @@ result = ws.query("Login", math='unique',
     last=30, mode='total')
 # Reveals: do frequent purchasers also log in more?
 
-# Logins by users who purchased 3+ times in a month.
-# ALWAYS pass unit="month" (or a single-bucket range) with FrequencyFilter:
-# the threshold is counted PER TIME BUCKET, not over the date range.
+# Logins in March by users who purchased 3+ times that month.
+# The threshold is counted per `unit` bucket, so pick the unit that matches
+# the period you mean. `last=` is always days, so pin a month with dates.
 result = ws.query("Login", math='unique',
     where=FrequencyFilter("Purchase", value=3),
-    last=3, unit='month')
-# Reveals: how many repeat purchasers are active each month?
+    from_date="2026-03-01", to_date="2026-03-31", unit='month')
+# Reveals: how many repeat purchasers were active in March?
 ```
 
-**FrequencyFilter counts per bucket, not per date range.** The engine evaluates the threshold inside each `unit` bucket. With the default `unit="day"`, `FrequencyFilter("Login", value=5)` keeps only users with 5+ logins *on the same day*, and returns an EMPTY series when nobody does, even if thousands of users logged in 5+ times across the month. An empty result is the expected outcome for a threshold nobody reaches within one bucket; do not report it as "no such users". For "at least N times over the period", use `unit="month"` (or a range that is a single bucket). `date_range_value` / `date_range_unit` had no observable effect on inline filters in a 2026-09-11 probe and are unverified; do not rely on them to widen the window. `FrequencyFilter` is accepted by `query()` / `build_params()` only, not by `query_flow()`.
+**FrequencyFilter counts per bucket, not per date range.** The engine evaluates the threshold inside each `unit` bucket. With the default `unit="day"`, `FrequencyFilter("Login", value=5)` keeps only users with 5+ logins *on the same day*, and returns an EMPTY series when nobody does, even if thousands of users logged in 5+ times across the month. An empty result is the expected outcome for a threshold nobody reaches within one bucket; do not report it as "no such users". Choose the `unit` that matches the period you mean (`"day"` for "N times in a day", `"month"` for "N times in a month"); `unit="month"` over a multi-month range still yields one threshold per month, and "over the whole period" needs a date range that fits inside one bucket. `last=` is always a day count, so pin a month with `from_date` / `to_date`. `date_range_value` / `date_range_unit` had no observable effect on inline filters in a 2026-09-11 probe and are unverified; do not rely on them to widen the window. `FrequencyFilter` is accepted by `query()` / `build_params()` only, not by `query_flow()`.
 
 Measured on a seeded gaming dataset (10,000 users, March 2026), `FrequencyFilter("enter dungeon", value=5)`, 2026-03-01 to 2026-03-31:
 
-| Query unit | Result |
+| Query | Result |
 |---|---|
-| `unit="day"` (default) | empty series (no user entered the dungeon 5+ times on one day) |
-| `unit="month"` | 2,571 of 8,281 active users (5+ entries anywhere in March) |
+| `unit="day"` (default), default `math="total"` | empty series (no user entered the dungeon 5+ times on one day) |
+| `unit="month"`, `math="unique"` | 2,571 of 8,281 active users (5+ entries anywhere in March; ground truth. Default `math="total"` would report their events instead) |
 
 **When to reach for each:**
 - Property values are messy or need derivation → **Custom Property**
 - Population requires behavioral criteria (did X, didn't do Y, frequency thresholds) → **Inline Cohort**
-- You need to segment by event frequency (how often, not just whether) → **FrequencyBreakdown/Filter** (with `unit="month"` for whole-period thresholds)
+- You need to segment by event frequency (how often, not just whether) → **FrequencyBreakdown/Filter** (pick `unit` to match the threshold period)
 - You need to compare in-cohort vs out-of-cohort behavior → **CohortBreakdown** with `include_negated=True`
 - You need to track a segment's size as a time series → **CohortMetric** (saved cohorts only)
 
@@ -1087,7 +1087,7 @@ Full reference: `WebFetch(url="https://mixpanel.github.io/mixpanel-headless/api/
 | `FlowStep` | Flow anchor event with per-step forward/reverse configuration |
 | `TimeComparison` | Period-over-period comparison (`.relative("month")`, `.absolute_start(...)`) |
 | `FrequencyBreakdown` | Break down by how often users performed an event |
-| `FrequencyFilter` | Filter by how often users performed an event (counted per `unit` bucket; pass `unit="month"` for "over the period") |
+| `FrequencyFilter` | Filter by how often users performed an event (counted per `unit` bucket; pick the `unit` that matches the threshold period) |
 | `CohortBreakdown` | Break down results by cohort membership |
 | `CohortDefinition` | Inline cohort definition for user queries |
 | `CohortCriteria` | Atomic condition for cohort membership |

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -9573,9 +9573,13 @@ class FrequencyFilter:
     is excluded from every daily bucket. An empty series (zero-row
     DataFrame) is therefore the expected result when no user reaches
     the threshold inside one bucket, not a sign that the filter failed.
-    When the intent is "at least N times over the period", pass
-    ``unit="month"`` or choose a ``unit`` and date range that together
-    form a single bucket.
+    Choose the ``unit`` that matches the period you mean: ``"day"`` for
+    "N times in a day", ``"month"`` for "N times in a month".
+    ``unit="month"`` over a multi-month range still yields one threshold
+    per month; "N times over the whole period" needs a date range that
+    fits inside a single bucket. ``last=`` is always a number of days
+    regardless of ``unit``, so pin a month with ``from_date`` /
+    ``to_date``.
 
     ``date_range_value`` / ``date_range_unit`` render as a
     ``behavior.dateRange`` lookback on the wire. In a 2026-09-11 probe
@@ -9613,9 +9617,9 @@ class FrequencyFilter:
         # "Users who logged in at least 5 times": the count is taken per
         # bucket, so the query's unit decides what "5 times" means.
 
-        # Per DAY (default unit): only users with 5+ logins on the same
-        # day. Often an empty series even when thousands of users logged
-        # in 5+ times across the month.
+        # Per DAY (default unit): purchases by users with 5+ logins on
+        # the same day. Often an empty series even when thousands of
+        # users logged in 5+ times across the month.
         daily = ws.query(
             "Purchase",
             where=FrequencyFilter("Login", value=5),
@@ -9623,7 +9627,7 @@ class FrequencyFilter:
             to_date="2026-03-31",
         )
 
-        # Per MONTH: users with 5+ logins anywhere in March.
+        # Per MONTH: purchases by users with 5+ logins anywhere in March.
         monthly = ws.query(
             "Purchase",
             where=FrequencyFilter("Login", value=5),
@@ -9632,7 +9636,7 @@ class FrequencyFilter:
             unit="month",
         )
 
-        # Count only purchases over 50, at least 3 per month
+        # Logins by users with 3+ purchases over 50 in the month
         result = ws.query(
             "Login",
             where=FrequencyFilter(
@@ -9640,7 +9644,8 @@ class FrequencyFilter:
                 value=3,
                 event_filters=[Filter.greater_than("amount", 50)],
             ),
-            last=3,
+            from_date="2026-03-01",
+            to_date="2026-03-31",
             unit="month",
         )
         ```
@@ -9656,10 +9661,12 @@ class FrequencyFilter:
     """Comparison operator."""
 
     date_range_value: int | None = None
-    """Lookback window size (no observable effect on inline insights filters)."""
+    """Lookback window size. No observable effect on inline insights filters in
+    a 2026-09-11 probe; unverified against platform fixtures."""
 
     date_range_unit: Literal["day", "week", "month"] | None = None
-    """Lookback window unit (no observable effect on inline insights filters)."""
+    """Lookback window unit. No observable effect on inline insights filters in
+    a 2026-09-11 probe; unverified against platform fixtures."""
 
     event_filters: list[Filter] | None = None
     """Property filters applied to the frequency event."""

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -9565,12 +9565,35 @@ class FrequencyFilter:
     ``where=`` parameter to restrict results to users meeting a
     frequency threshold.
 
+    The threshold is evaluated **per query time bucket** (the query's
+    ``unit``), not over the whole report date range. With the default
+    ``unit="day"``, ``FrequencyFilter("Login", value=5)`` keeps only
+    users who logged in five or more times within a single day; a user
+    who logged in 30 times in a month but never five times on one day
+    is excluded from every daily bucket. An empty series (zero-row
+    DataFrame) is therefore the expected result when no user reaches
+    the threshold inside one bucket, not a sign that the filter failed.
+    When the intent is "at least N times over the period", pass
+    ``unit="month"`` or choose a ``unit`` and date range that together
+    form a single bucket.
+
+    ``date_range_value`` / ``date_range_unit`` render as a
+    ``behavior.dateRange`` lookback on the wire. In a 2026-09-11 probe
+    against the analytics query API they had no observable effect on
+    inline insights filters: results were identical with and without a
+    31-day lookback. Their behavior for inline filters has not been
+    verified against Mixpanel's internal fixtures. Do not rely on them
+    to widen the counting window; use ``unit`` instead.
+
     Attributes:
         event: Event name to count frequency for.
         operator: Comparison operator. Default: ``"is at least"``.
-        value: Threshold value for the comparison.
+        value: Threshold value for the comparison, counted per query
+            time bucket (see above).
         date_range_value: Lookback window size. Must be paired with
-            ``date_range_unit``.
+            ``date_range_unit``. Emitted as ``behavior.dateRange``; no
+            observable effect on inline insights filters (unverified,
+            see above).
         date_range_unit: Lookback window unit (``"day"``, ``"week"``,
             ``"month"``). Must be paired with ``date_range_value``.
         event_filters: Property filters applied to the frequency event
@@ -9585,20 +9608,40 @@ class FrequencyFilter:
 
     Example:
         ```python
-        from mixpanel_headless import FrequencyFilter
+        from mixpanel_headless import Filter, FrequencyFilter
 
-        # Users who logged in at least 5 times
-        result = ws.query("Purchase", where=FrequencyFilter("Login", value=5))
+        # "Users who logged in at least 5 times": the count is taken per
+        # bucket, so the query's unit decides what "5 times" means.
 
-        # Users who purchased 3+ times in the last 30 days
+        # Per DAY (default unit): only users with 5+ logins on the same
+        # day. Often an empty series even when thousands of users logged
+        # in 5+ times across the month.
+        daily = ws.query(
+            "Purchase",
+            where=FrequencyFilter("Login", value=5),
+            from_date="2026-03-01",
+            to_date="2026-03-31",
+        )
+
+        # Per MONTH: users with 5+ logins anywhere in March.
+        monthly = ws.query(
+            "Purchase",
+            where=FrequencyFilter("Login", value=5),
+            from_date="2026-03-01",
+            to_date="2026-03-31",
+            unit="month",
+        )
+
+        # Count only purchases over 50, at least 3 per month
         result = ws.query(
             "Login",
             where=FrequencyFilter(
                 "Purchase",
                 value=3,
-                date_range_value=30,
-                date_range_unit="day",
+                event_filters=[Filter.greater_than("amount", 50)],
             ),
+            last=3,
+            unit="month",
         )
         ```
     """
@@ -9607,16 +9650,16 @@ class FrequencyFilter:
     """Event name to count frequency for."""
 
     value: int | float
-    """Threshold value for the comparison."""
+    """Threshold value for the comparison, counted per query time bucket."""
 
     operator: FrequencyFilterOperator = "is at least"
     """Comparison operator."""
 
     date_range_value: int | None = None
-    """Lookback window size."""
+    """Lookback window size (no observable effect on inline insights filters)."""
 
     date_range_unit: Literal["day", "week", "month"] | None = None
-    """Lookback window unit."""
+    """Lookback window unit (no observable effect on inline insights filters)."""
 
     event_filters: list[Filter] | None = None
     """Property filters applied to the frequency event."""

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -2426,8 +2426,15 @@ class Workspace:
             group_by: Break down results by property or cohort membership.
                 Accepts a string, ``GroupBy``, ``CohortBreakdown``, or
                 list of any mix.
-            where: Filter results by conditions. Accepts a Filter
-                or list of Filters.
+            where: Filter results by conditions. Accepts a Filter, a
+                FrequencyFilter, or a list mixing both. A
+                ``FrequencyFilter`` threshold is evaluated per time
+                bucket (``unit``), not over the whole date range: with
+                the default ``unit="day"`` it keeps only users who reach
+                the count within a single day, and an empty series is the
+                expected result when nobody does. Use ``unit="month"`` (or
+                a single-bucket range) for "N times over the period". See
+                ``FrequencyFilter``.
             formula: Formula expression referencing events by position
                 (A, B, C...). Requires 2+ events. Cannot be combined
                 with Formula objects in ``events``.
@@ -2615,7 +2622,9 @@ class Workspace:
             group_by: Break down results by property or cohort membership.
                 Accepts a string, ``GroupBy``, ``CohortBreakdown``, or
                 list of any mix.
-            where: Filter results by conditions.
+            where: Filter results by conditions. A ``FrequencyFilter``
+                threshold is evaluated per ``unit`` bucket, not over the
+                whole date range; see ``FrequencyFilter`` and ``query``.
             formula: Formula expression referencing events by position.
             formula_label: Display label for formula result.
             rolling: Rolling window size in periods.

--- a/src/mixpanel_headless/workspace.py
+++ b/src/mixpanel_headless/workspace.py
@@ -2432,8 +2432,12 @@ class Workspace:
                 bucket (``unit``), not over the whole date range: with
                 the default ``unit="day"`` it keeps only users who reach
                 the count within a single day, and an empty series is the
-                expected result when nobody does. Use ``unit="month"`` (or
-                a single-bucket range) for "N times over the period". See
+                expected result when nobody does. Choose the ``unit`` that
+                matches the period you mean (``"day"`` for "N times in a
+                day", ``"month"`` for "N times in a month");
+                ``unit="month"`` over a multi-month range still yields one
+                threshold per month, and "over the whole period" needs a
+                date range that fits inside one bucket. See
                 ``FrequencyFilter``.
             formula: Formula expression referencing events by position
                 (A, B, C...). Requires 2+ events. Cannot be combined


### PR DESCRIPTION
## Summary

Docs-only. `FrequencyFilter` thresholds are evaluated by the query engine **per query time bucket** (`unit`), not over the report date range. With the default `unit="day"`, `FrequencyFilter("Login", value=5)` keeps only users who logged in 5+ times on a single day and returns an empty series when nobody does, even when thousands of users did so across the month. Agents in the MP Bench Phase-3 runs copied the skill's `FrequencyFilter("Login", value=5)` example verbatim 12 times and read the empty result as "no such users". This PR documents the semantics everywhere the type is described and adds an upgrade note for the 0.2.1 server crash.

Source: `context/mp-bench-headless/bug-reports/python-frequency-filter-0.2.1-crash-site-and-per-bucket-semantics.md` (2026-09-11), extending the 2026-08-15 clause-shape report. No wire output changes; `date_range_value` / `date_range_unit` are kept as-is.

## Day vs month, verified against ground truth

Seeded gaming dataset (10,000 users), event `enter dungeon`, 2026-03-01 to 2026-03-31, library at HEAD (0.2.2+). Every library number matched a DuckDB count over the raw events.

| Query | Library result | Ground truth |
|---|---|---|
| unfiltered total, `unit="day"`, summed | 30,541 | 30,541 events, 8,281 users |
| `FrequencyFilter(value=2)`, `unit="day"`, summed | 3,893 | users with 2+ **on the same day**: 1,894 user-days, 3,893 events |
| `FrequencyFilter(value=3)`, `unit="day"` | 305 | same-day 3+: 305 events |
| `FrequencyFilter(value=4)`, `unit="day"` | 20 | same-day 4+: 20 events |
| `FrequencyFilter(value=5)`, `unit="day"` | **0 (empty series)** | same-day 5+: 0; **whole-month 5+: 2,571 users, 16,363 events** |
| `FrequencyFilter(value=2)`, `unit="month"`, total | 29,188 | whole-month 2+: 6,928 users, 29,188 events |
| `FrequencyFilter(value=2)`, `unit="month"`, unique | 6,928 | 6,928 users |

Adding `date_range_value=31, date_range_unit="day"` (emits `behavior.dateRange = {"type": "in the last", ...}`) produced identical numbers to the no-lookback call.

## What changed

- `src/mixpanel_headless/types.py` — `FrequencyFilter` class docstring: per-bucket evaluation, `unit="month"` recommendation, empty-result-is-expected, plain statement that `date_range_value` / `date_range_unit` had no observable effect on inline insights filters in the 2026-09-11 probe and are unverified; new `Example:` block contrasting `unit="day"` vs `unit="month"`. Field docstrings updated to match. The old example that showcased the lookback parameters is replaced by an `event_filters` example so the docstring no longer teaches a parameter with no observable effect.
- `src/mixpanel_headless/workspace.py` — `Workspace.query(where=...)` and `build_params(where=...)` arg docs carry the warning and point to `FrequencyFilter`.
- `docs/guide/query.md` — "Frequency Filter" section: example now passes `unit="month"`, plus `warning` (per-bucket + the table above), `note` (lookback params unverified), and `tip` (0.2.1 upgrade) admonitions. `docs/api/types.md` is mkdocstrings and picks up the docstring automatically.
- `mixpanel-plugin/skills/mixpanelyst/SKILL.md` — the `FrequencyFilter` example now uses `ws.query(..., unit="month")`; a bold per-bucket warning paragraph and a two-row day/month table follow it; the "when to reach for" bullet and the type-reference table row carry the `unit="month"` hint. The previous example called `ws.query_flow(..., where=FrequencyFilter(...))`, but `query_flow`'s `where` is typed `Filter | list[Filter] | None` and its builders (`build_flow_property_filter` / `build_flow_cohort_filter`) have no `FrequencyFilter` path, so that example could never have worked; it is replaced rather than annotated. `help.py` introspects docstrings live, so nothing to regenerate.
- `CHANGELOG.md` — `### Documentation` entry under `## Unreleased`, and an upgrade note appended to the 0.2.2 `#208` Fixed bullet: 0.2.1 `FrequencyFilter` calls fail with `ServerError: Server error: An unknown error occurred.` with no client-side workaround; upgrade to `>=0.2.2`.

Note: `origin/main` already has an `## Unreleased` section and no `## 0.2.3` heading (the bump lives on `release/v0.2.3`), so the entry was added to the existing block. A conflict with sibling PRs touching Unreleased is expected.

## Test plan

- [x] `just check` (lint, fmt-check, mypy --strict, interrogate docstring coverage, test-cov, conformance, build) passes locally
- [x] `ruff check` / `ruff format --check` on the two touched source files
- [x] `python mixpanel-plugin/skills/mixpanelyst/scripts/help.py FrequencyFilter` renders the new docstring text
- [x] No wire-output change: `build_frequency_filter_entry` and conformance vectors untouched

## Follow-ups

- **Verify `behavior.dateRange` against platform fixtures.** `build_frequency_filter_entry` (`src/mixpanel_headless/_internal/bookmark_builders.py:873-878`) emits `{"type": "in the last", "unit": U, "window": {"unit": U, "value": N}}` under `behavior.dateRange`. Check this against `analytics/api/version_2_0/insights/test.py` around the `$frequency` cases to decide whether the engine ignores `dateRange` for inline insights filters (platform limitation) or reads a different key/shape (clause bug). For reference, the report-level date-range builder in the same file (`bookmark_builders.py:100-125`) uses `dateRangeType` rather than `type` for the same concept, and the inline-cohort behavior builder (`bookmark_builders.py:804`) always emits `"dateRange": None`; neither is authoritative for the `$frequency` behavior clause, so this is a pointer, not a diagnosis.
- **Decide keep / drop for `date_range_value` / `date_range_unit`.** If the fixtures confirm the engine ignores it for inline filters, either remove the two parameters (breaking change, needs a deprecation cycle) or document them as cohort-only. Left unchanged here because the finding is unverified.
- **Optional: a startup or first-call warning on 0.2.1** is out of scope for a docs PR, but the changelog note is the only signal 0.2.1 users currently get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
