### PR TITLE
feat(api-client): MP_API_BASE_URL routes every API family at one alternate host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ may include API changes.
 
 ### Added
 
+- **`MP_API_BASE_URL` — route every API family at one alternate host.** When
+  set (trailing slash tolerated; read per request, not at import), the
+  per-region `ENDPOINTS` lookup is bypassed and the four families resolve to
+  path prefixes on that single base: `query` → `{base}/api/query`, `export` →
+  `{base}/api/2.0`, `engage` → `{base}/api/query/engage`, `app` →
+  `{base}/api/app`. The `mp` CLI inherits it with no flag. App-vs-Query
+  timeout selection and pinned `workspace_id` injection key off the family,
+  so they behave identically under the override. `mp login`'s region probe
+  collapses to one probe at the base (region label from `MP_REGION` when
+  valid, else `us`). Plain `http://` bases are accepted and intended for
+  local / headless deployments only. `MP_REGION` remains required and
+  meaningful for non-URL uses. Optional `MP_APP_BASE_URL` re-homes only the
+  App API family at `{app_base}/api/app`. With both unset, behaviour is
+  byte-identical to before.
 - **Report links** (045, AIE-561 / AIE-562). Share a headless query as a
   Mixpanel report URL and resolve a report URL back into runnable params.
   - `Workspace.create_report_link(params_or_result, *, report_type=, name=,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,8 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_WORKSPACE_ID` | Workspace ID for App API operations |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file location |
+| `MP_API_BASE_URL` | Route every API family at one alternate host (read per request; trailing slash tolerated). Bypasses the per-region `ENDPOINTS` table: `query` → `{base}/api/query`, `export` → `{base}/api/2.0`, `engage` → `{base}/api/query/engage`, `app` → `{base}/api/app`. Plain `http://` bases are accepted (local / headless deployments only). `mp login`'s region probe collapses to a single probe at the base (`MP_REGION` when valid, else `us`). `MP_REGION` stays required for non-URL uses. |
+| `MP_APP_BASE_URL` | Optional: re-home only the App API family at `{app_base}/api/app` (works alone or on top of `MP_API_BASE_URL`) |
 
 Recommended starter command: `mp login` (one-shot orchestrator covering region probe, `/me`-driven project pick, and account-name derivation; backed by `mp.accounts.login_unified()` in Python).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ just mutate-check        # Check score meets 80% threshold
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file location |
 | `MP_API_BASE_URL` | Route every API family at one alternate host (read per request; trailing slash tolerated). Bypasses the per-region `ENDPOINTS` table: `query` → `{base}/api/query`, `export` → `{base}/api/2.0`, `engage` → `{base}/api/query/engage`, `app` → `{base}/api/app`. Plain `http://` bases are accepted (local / headless deployments only). `mp login`'s region probe collapses to a single probe at the base (`MP_REGION` when valid, else `us`). `MP_REGION` stays required for non-URL uses. |
-| `MP_APP_BASE_URL` | Optional: re-home only the App API family at `{app_base}/api/app` (works alone or on top of `MP_API_BASE_URL`) |
+| `MP_APP_BASE_URL` | Optional: re-home only the App API family at `{app_base}/api/app` (works alone or on top of `MP_API_BASE_URL`). Alone it does not collapse the `mp login` region probe — the persisted region still routes the live Query/Export/Engage families |
 
 Recommended starter command: `mp login` (one-shot orchestrator covering region probe, `/me`-driven project pick, and account-name derivation; backed by `mp.accounts.login_unified()` in Python).
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -522,6 +522,8 @@ These resolve via `env > param > target > bridge > [active] > default_project` �
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
 | `MP_STORAGE_DIR` | Override storage root (`~/.mp`); `MP_OAUTH_STORAGE_DIR` is a deprecated alias |
+| `MP_API_BASE_URL` | Route every API family at one alternate host (`{base}/api/query`, `{base}/api/2.0`, `{base}/api/query/engage`, `{base}/api/app`); no CLI flag needed — see [Configuration → Alternate API host](../getting-started/configuration.md#alternate-api-host-mp_api_base_url) |
+| `MP_APP_BASE_URL` | Optional: re-home only the App API family (`{app_base}/api/app`) |
 
 ## Examples
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -102,7 +102,8 @@ Details:
 - **`MP_REGION` is still required** and still meaningful for everything that is not a URL (account records, `/me` domain cross-checks, report-link hostnames). Report links (`create_report_link` / `saved_report_link`) keep producing real `*.mixpanel.com` URLs.
 - **`mp login` region probe.** Probing `us → eu → in` against one host is pointless, so under the override the probe runs once against the base and labels the account with `MP_REGION` (when it is `us`/`eu`/`in`) or `us`.
 - **Plain `http://` bases are accepted** with no extra flag. They are intended for local or headless deployments only — never send real credentials over cleartext to a remote host.
-- **`MP_APP_BASE_URL`** (optional) re-homes just the App API family at `{app_base}/api/app`. It works on its own (the other three families stay live) or on top of `MP_API_BASE_URL` (App API moves to the second host).
+- **`MP_APP_BASE_URL`** (optional) re-homes just the App API family at `{app_base}/api/app`. It works on its own (the other three families stay live) or on top of `MP_API_BASE_URL` (App API moves to the second host). With only `MP_APP_BASE_URL` set, `mp login` still walks `us → eu → in` (each `/me` probe hits the App override base) because the region it persists still decides which live cluster the Query, Export and Engage families use.
+- **Family detection is longest-prefix.** The App-vs-Query timeout and the `workspace_id` injection classify a URL by the family whose base is its longest prefix, so split configs where one base sits under the other (for example `MP_API_BASE_URL=https://proxy` with `MP_APP_BASE_URL=https://proxy/api/query`) still classify every request correctly.
 
 With neither variable set, behaviour is byte-identical to the per-region defaults.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -63,6 +63,8 @@ Service accounts are the right default for unattended automation. OAuth browser 
 | `MP_AUTH_FILE` | Override path to the Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file path (`~/.mp/config.toml`) |
 | `MP_STORAGE_DIR` | Override storage root (`~/.mp`); `MP_OAUTH_STORAGE_DIR` is a deprecated alias |
+| `MP_API_BASE_URL` | Route every API family at one alternate host — see [Alternate API host](#alternate-api-host-mp_api_base_url) |
+| `MP_APP_BASE_URL` | Optional: re-home only the App API family (`{app_base}/api/app`) |
 
 These map onto the [credential resolution chain](#credential-resolution-chain) below.
 
@@ -71,6 +73,38 @@ These map onto the [credential resolution chain](#credential-resolution-chain) b
 
 !!! note "`mp login` auth-type detection"
     The same env presence drives `mp login`'s auth-type detection: `MP_USERNAME` + `MP_SECRET` set → `service_account`; `MP_OAUTH_TOKEN` set → `oauth_token`; otherwise the browser PKCE flow. Pass `--service-account` or `--token-env VAR` to force a non-browser path.
+
+## Alternate API host (`MP_API_BASE_URL`)
+
+By default the client picks its hosts per region (`mixpanel.com`, `eu.mixpanel.com`, `in.mixpanel.com`, plus the `data*.mixpanel.com` export hosts). Set `MP_API_BASE_URL` to point **every** API family at one alternate host instead — a headless Mixpanel pod behind a single nginx front door, a local proxy, or an in-sandbox fake server:
+
+```bash
+export MP_API_BASE_URL=http://devbox:8080
+export MP_USERNAME=... MP_SECRET=... MP_PROJECT_ID=... MP_REGION=us
+
+mp inspect events          # → GET http://devbox:8080/api/query/events/names
+```
+
+When set (a trailing slash is tolerated), the region lookup is bypassed and the families resolve to fixed path prefixes on that base:
+
+| API family | URL under the override | Live `us` equivalent |
+|---|---|---|
+| Query (`/insights`, `/segmentation`, `/events/names`, …) | `{base}/api/query` | `https://mixpanel.com/api/query` |
+| Export (`stream_events`) | `{base}/api/2.0` | `https://data.mixpanel.com/api/2.0` |
+| Engage (`query_user`, `stream_profiles`) | `{base}/api/query/engage` | `https://mixpanel.com/api/query/engage` |
+| App API (dashboards, cohorts, Lexicon, `/me`, …) | `{base}/api/app` | `https://mixpanel.com/api/app` |
+
+Details:
+
+- **Read per request, not at import.** `Workspace.use(account=...)` swaps, long-lived processes, and test monkeypatching all see the current value.
+- **The `mp` CLI and the Python library share the client**, so the CLI needs no extra flag.
+- **Route-aware behaviour is preserved.** The App-vs-Query read-timeout choice and the pinned `workspace_id` injection key off the API family, not the hostname, so they behave identically under the override.
+- **`MP_REGION` is still required** and still meaningful for everything that is not a URL (account records, `/me` domain cross-checks, report-link hostnames). Report links (`create_report_link` / `saved_report_link`) keep producing real `*.mixpanel.com` URLs.
+- **`mp login` region probe.** Probing `us → eu → in` against one host is pointless, so under the override the probe runs once against the base and labels the account with `MP_REGION` (when it is `us`/`eu`/`in`) or `us`.
+- **Plain `http://` bases are accepted** with no extra flag. They are intended for local or headless deployments only — never send real credentials over cleartext to a remote host.
+- **`MP_APP_BASE_URL`** (optional) re-homes just the App API family at `{app_base}/api/app`. It works on its own (the other three families stay live) or on top of `MP_API_BASE_URL` (App API moves to the second host).
+
+With neither variable set, behaviour is byte-identical to the per-region defaults.
 
 ## Setting Up an Account
 

--- a/mixpanel-plugin/docs/getting-started-guide.md
+++ b/mixpanel-plugin/docs/getting-started-guide.md
@@ -529,6 +529,8 @@ ws.stream_events(from_date="...", to_date="...")  # Stream events
 | `MP_TARGET` | Apply a saved target (mutually exclusive with `MP_ACCOUNT`/`MP_PROJECT_ID`/`MP_WORKSPACE_ID`) |
 | `MP_AUTH_FILE` | Override path to the v2 Cowork bridge file |
 | `MP_CONFIG_PATH` | Override config file location |
+| `MP_API_BASE_URL` | Route every API family at one alternate host (`{base}/api/query`, `{base}/api/2.0`, `{base}/api/query/engage`, `{base}/api/app`); plain `http://` allowed for local / headless deployments; `MP_REGION` still required |
+| `MP_APP_BASE_URL` | Optional: re-home only the App API family (`{app_base}/api/app`) |
 
 ### Output Formats
 

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -2,7 +2,9 @@
 
 Low-level HTTP client for all Mixpanel APIs. Handles:
 - Authentication via HTTP Basic auth (service accounts) or OAuth 2.0 Bearer tokens
-- Regional endpoint routing (US, EU, India)
+- Regional endpoint routing (US, EU, India), or a single alternate host via
+  ``MP_API_BASE_URL`` / ``MP_APP_BASE_URL`` (read per request, see
+  :func:`_endpoints_for`)
 - Automatic rate limit handling with exponential backoff
 - Streaming JSONL parsing for large exports
 
@@ -21,7 +23,7 @@ import time
 from collections.abc import Callable, Iterator
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import quote, urljoin, urlsplit
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 
 import httpx
 
@@ -29,6 +31,7 @@ from mixpanel_headless._internal.auth.account import (
     Account,
     OAuthBrowserAccount,
     OAuthTokenAccount,
+    Region,
     ServiceAccount,
     TokenResolver,
 )
@@ -222,6 +225,156 @@ QUERY_API_SERVER_DEADLINE_S: float = 488.0
 _SERVER_DEADLINE_MARGIN_S: float = 15.0
 DEFAULT_APP_TIMEOUT_S: float = APP_API_SERVER_DEADLINE_S + _SERVER_DEADLINE_MARGIN_S
 DEFAULT_QUERY_TIMEOUT_S: float = QUERY_API_SERVER_DEADLINE_S + _SERVER_DEADLINE_MARGIN_S
+
+# Alternate-host override. When ``MP_API_BASE_URL`` is set, the per-region
+# table above is bypassed and every API family resolves to a fixed path
+# prefix on that one base (the prefixes a headless Mixpanel pod's nginx
+# routes on). ``MP_APP_BASE_URL`` optionally re-homes just the App API.
+API_BASE_URL_ENV = "MP_API_BASE_URL"
+APP_BASE_URL_ENV = "MP_APP_BASE_URL"
+_OVERRIDE_PATH_PREFIXES: dict[str, str] = {
+    "query": "/api/query",
+    "export": "/api/2.0",
+    "engage": "/api/query/engage",
+    "app": "/api/app",
+}
+
+
+def _base_url_override(env_name: str) -> str:
+    """Read one base-URL override env var, normalised for concatenation.
+
+    Args:
+        env_name: ``API_BASE_URL_ENV`` or ``APP_BASE_URL_ENV``.
+
+    Returns:
+        The value with trailing slashes stripped, or ``""`` when the variable
+        is unset, empty, or consists only of slashes (all treated as unset).
+
+    Example:
+        ```python
+        os.environ["MP_API_BASE_URL"] = "http://127.0.0.1:8080/"
+        _base_url_override("MP_API_BASE_URL")
+        # "http://127.0.0.1:8080"
+        ```
+    """
+    return os.environ.get(env_name, "").rstrip("/")
+
+
+def _endpoints_for(region: str) -> dict[str, str]:
+    """Resolve the API-family → base-URL table for ``region``, honouring overrides.
+
+    Reads ``MP_API_BASE_URL`` / ``MP_APP_BASE_URL`` from ``os.environ`` on
+    every call (never at import time) so ``use(account=...)`` swaps and test
+    monkeypatching keep working. Every read of :data:`ENDPOINTS` inside the
+    client goes through this function so the ``startswith`` checks that pick
+    the App-vs-Query timeout and inject ``workspace_id`` stay correct under
+    an override.
+
+    Args:
+        region: Mixpanel region key (``"us"`` / ``"eu"`` / ``"in"``).
+
+    Returns:
+        With neither variable set: the live ``ENDPOINTS[region]`` object
+        itself (byte-identical behaviour). With ``MP_API_BASE_URL`` set: a
+        fresh table mapping ``query`` → ``{base}/api/query``, ``export`` →
+        ``{base}/api/2.0``, ``engage`` → ``{base}/api/query/engage`` and
+        ``app`` → ``{base}/api/app``. With ``MP_APP_BASE_URL`` set: the
+        ``app`` entry becomes ``{app_base}/api/app`` on top of whichever
+        table applies. The live table is never mutated.
+
+    Raises:
+        KeyError: ``region`` is not a key of :data:`ENDPOINTS` (only reachable
+            when no override applies, matching prior behaviour).
+
+    Example:
+        ```python
+        os.environ["MP_API_BASE_URL"] = "http://devbox:8080"
+        _endpoints_for("eu")["export"]
+        # "http://devbox:8080/api/2.0"
+        ```
+    """
+    api_base = _base_url_override(API_BASE_URL_ENV)
+    app_base = _base_url_override(APP_BASE_URL_ENV)
+    if not api_base and not app_base:
+        return ENDPOINTS[region]
+    if api_base:
+        table = {
+            family: f"{api_base}{prefix}"
+            for family, prefix in _OVERRIDE_PATH_PREFIXES.items()
+        }
+    else:
+        table = dict(ENDPOINTS[region])
+    if app_base:
+        table["app"] = f"{app_base}{_OVERRIDE_PATH_PREFIXES['app']}"
+    return table
+
+
+_VALID_REGIONS: tuple[Region, ...] = ("us", "eu", "in")
+
+
+def _override_probe_order() -> tuple[Region, ...] | None:
+    """Return the single-region probe order when an API-host override is active.
+
+    Used by ``auth.region_probe.probe_region_for_credential``. With
+    ``MP_API_BASE_URL`` or ``MP_APP_BASE_URL`` set, all three regions resolve
+    to the same host, so walking ``us → eu → in`` would hit it three times
+    on failure for no gain. The region label still has to be *some* valid
+    region (it is persisted on the account and used for non-URL purposes),
+    so it is taken from ``MP_REGION`` when that is valid, else ``us``.
+
+    Returns:
+        A one-element tuple when an override is active; ``None`` when neither
+        variable is set (callers then use ``probe_region``'s default order).
+
+    Example:
+        ```python
+        os.environ["MP_API_BASE_URL"] = "http://127.0.0.1:8080"
+        os.environ["MP_REGION"] = "eu"
+        _override_probe_order()
+        # ("eu",)
+        ```
+    """
+    if not (
+        _base_url_override(API_BASE_URL_ENV) or _base_url_override(APP_BASE_URL_ENV)
+    ):
+        return None
+    requested = os.environ.get("MP_REGION", "")
+    for region in _VALID_REGIONS:
+        if requested == region:
+            return (region,)
+    return ("us",)
+
+
+def _probe_base_url(app_url: str) -> str:
+    """Derive the ``httpx.Client`` base for the ``/api/app/me`` region probe.
+
+    ``probe_region`` issues ``/api/app/me`` relative to the client base, so
+    the base must be the App API URL *minus* its ``/api/app`` suffix. That
+    keeps any extra path prefix an override base carries (e.g.
+    ``https://proxy.example/mp``) in front of ``/api/app/me``. When the URL
+    does not end in ``/api/app`` the path is dropped entirely and the
+    scheme + host are used (the pre-override behaviour).
+
+    Args:
+        app_url: The App API base URL for a region (live or overridden).
+
+    Returns:
+        The base URL to bind the probe client to, without a trailing slash.
+
+    Example:
+        ```python
+        _probe_base_url("https://mixpanel.com/api/app")
+        # "https://mixpanel.com"
+        _probe_base_url("https://proxy.example/mp/api/app/")
+        # "https://proxy.example/mp"
+        ```
+    """
+    trimmed = app_url.rstrip("/")
+    app_prefix = _OVERRIDE_PATH_PREFIXES["app"]
+    if trimmed.endswith(app_prefix):
+        return trimmed[: -len(app_prefix)]
+    parts = urlsplit(trimmed)
+    return urlunsplit((parts.scheme, parts.netloc, "", "", ""))
 
 
 def _parse_feed_date(value: str, field: str) -> datetime:
@@ -480,10 +633,11 @@ class MixpanelAPIClient:
             path: API endpoint path (e.g., "/segmentation").
 
         Returns:
-            Full URL for the endpoint.
+            Full URL for the endpoint. Honours ``MP_API_BASE_URL`` /
+            ``MP_APP_BASE_URL`` via :func:`_endpoints_for`.
         """
         region = self._session.account.region
-        base = ENDPOINTS[region][api_type]
+        base = _endpoints_for(region)[api_type]
         # Ensure path starts with /
         if not path.startswith("/"):
             path = f"/{path}"
@@ -530,7 +684,7 @@ class MixpanelAPIClient:
         """
         if self._timeout is not None:
             return self._timeout
-        if url.startswith(ENDPOINTS[self._session.account.region]["app"]):
+        if url.startswith(_endpoints_for(self._session.account.region)["app"]):
             return DEFAULT_APP_TIMEOUT_S
         return DEFAULT_QUERY_TIMEOUT_S
 
@@ -982,7 +1136,7 @@ class MixpanelAPIClient:
         if inject_project_id:
             params["project_id"] = self._session.project.id
         if inject_workspace_id and url.startswith(
-            ENDPOINTS[self._session.account.region]["query"]
+            _endpoints_for(self._session.account.region)["query"]
         ):
             if self._workspace_id is not None:
                 params.setdefault("workspace_id", self._workspace_id)

--- a/src/mixpanel_headless/_internal/api_client.py
+++ b/src/mixpanel_headless/_internal/api_client.py
@@ -20,7 +20,7 @@ import os
 import random
 import re
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote, urljoin, urlsplit, urlunsplit
@@ -309,22 +309,73 @@ def _endpoints_for(region: str) -> dict[str, str]:
     return table
 
 
+# Families whose requests are scoped by the pinned ``workspace_id``. Engage
+# is included because its live URL sits under the Query prefix
+# (``/api/query/engage``), which is how the old ``startswith(query)`` check
+# classified it; keeping it here preserves that behaviour exactly.
+_WORKSPACE_SCOPED_FAMILIES = frozenset({"query", "engage"})
+
+
+def _api_family_for(url: str, endpoints: Mapping[str, str]) -> str | None:
+    """Classify ``url`` by the API family whose base is its longest prefix.
+
+    Longest-prefix (rather than first-match) matters in two places: live
+    Engage URLs also start with the Query base, and split overrides can nest
+    one family's base under another's (``MP_API_BASE_URL=https://proxy`` with
+    ``MP_APP_BASE_URL=https://proxy/api/query`` puts the App base under the
+    Query prefix). Picking the longest matching base classifies both cases
+    correctly; ``startswith`` against a single family does not.
+
+    Args:
+        url: The full request URL.
+        endpoints: A family → base-URL table, normally from
+            :func:`_endpoints_for`.
+
+    Returns:
+        The matching family name (``"query"`` / ``"export"`` / ``"engage"`` /
+        ``"app"``), or ``None`` when no base is a prefix of ``url`` (for
+        example a foreign host passed to ``request``).
+
+    Example:
+        ```python
+        _api_family_for("https://mixpanel.com/api/query/engage/", ENDPOINTS["us"])
+        # "engage"
+        _api_family_for("https://example.com/x", ENDPOINTS["us"])
+        # None
+        ```
+    """
+    best: str | None = None
+    best_len = -1
+    for family, base in endpoints.items():
+        if len(base) > best_len and url.startswith(base):
+            best, best_len = family, len(base)
+    return best
+
+
 _VALID_REGIONS: tuple[Region, ...] = ("us", "eu", "in")
 
 
 def _override_probe_order() -> tuple[Region, ...] | None:
-    """Return the single-region probe order when an API-host override is active.
+    """Return the single-region probe order when ``MP_API_BASE_URL`` is active.
 
     Used by ``auth.region_probe.probe_region_for_credential``. With
-    ``MP_API_BASE_URL`` or ``MP_APP_BASE_URL`` set, all three regions resolve
-    to the same host, so walking ``us → eu → in`` would hit it three times
-    on failure for no gain. The region label still has to be *some* valid
-    region (it is persisted on the account and used for non-URL purposes),
-    so it is taken from ``MP_REGION`` when that is valid, else ``us``.
+    ``MP_API_BASE_URL`` set, every family — and therefore every region —
+    resolves to the same host, so walking ``us → eu → in`` would hit it
+    three times on failure for no gain. The region label still has to be
+    *some* valid region (it is persisted on the account and used for non-URL
+    purposes), so it is taken from ``MP_REGION`` when that is valid, else
+    ``us``.
+
+    ``MP_APP_BASE_URL`` on its own deliberately does **not** collapse the
+    walk: Query, Export and Engage still go to the live regional hosts, so
+    the region the probe discovers still decides where those requests land.
+    Collapsing to ``us`` there would persist the wrong region for an EU or
+    India credential. (Each probe then hits the App override base, which is
+    harmless.)
 
     Returns:
-        A one-element tuple when an override is active; ``None`` when neither
-        variable is set (callers then use ``probe_region``'s default order).
+        A one-element tuple when ``MP_API_BASE_URL`` is set; ``None``
+        otherwise (callers then use ``probe_region``'s default order).
 
     Example:
         ```python
@@ -334,15 +385,47 @@ def _override_probe_order() -> tuple[Region, ...] | None:
         # ("eu",)
         ```
     """
-    if not (
-        _base_url_override(API_BASE_URL_ENV) or _base_url_override(APP_BASE_URL_ENV)
-    ):
+    if not _base_url_override(API_BASE_URL_ENV):
         return None
     requested = os.environ.get("MP_REGION", "")
     for region in _VALID_REGIONS:
         if requested == region:
             return (region,)
     return ("us",)
+
+
+def _override_probe_narration() -> str | None:
+    """Build the first ``mp login`` probe narration line under an override.
+
+    Names whichever override variable(s) are active so a user debugging a
+    login failure sees the configuration that actually shaped the probe.
+
+    Returns:
+        ``None`` when neither variable is set (the caller emits its legacy
+        line). With ``MP_API_BASE_URL`` set: a line naming the single probe
+        base. With only ``MP_APP_BASE_URL`` set: a line saying regions are
+        still walked, at the App override base.
+
+    Example:
+        ```python
+        os.environ["MP_APP_BASE_URL"] = "http://app.internal:9000"
+        _override_probe_narration()
+        # "Probing regions at http://app.internal:9000 (MP_APP_BASE_URL override) for /me access ..."
+        ```
+    """
+    active = [
+        name
+        for name in (API_BASE_URL_ENV, APP_BASE_URL_ENV)
+        if _base_url_override(name)
+    ]
+    if not active:
+        return None
+    # The App URL is region-independent under either override.
+    base = _probe_base_url(_endpoints_for("us")["app"])
+    label = f"({' + '.join(active)} override)"
+    if _base_url_override(API_BASE_URL_ENV):
+        return f"Probing {base} {label} for /me ..."
+    return f"Probing regions at {base} {label} for /me access ..."
 
 
 def _probe_base_url(app_url: str) -> str:
@@ -684,7 +767,8 @@ class MixpanelAPIClient:
         """
         if self._timeout is not None:
             return self._timeout
-        if url.startswith(_endpoints_for(self._session.account.region)["app"]):
+        family = _api_family_for(url, _endpoints_for(self._session.account.region))
+        if family == "app":
             return DEFAULT_APP_TIMEOUT_S
         return DEFAULT_QUERY_TIMEOUT_S
 
@@ -1135,8 +1219,10 @@ class MixpanelAPIClient:
             params = {}
         if inject_project_id:
             params["project_id"] = self._session.project.id
-        if inject_workspace_id and url.startswith(
-            _endpoints_for(self._session.account.region)["query"]
+        if (
+            inject_workspace_id
+            and _api_family_for(url, _endpoints_for(self._session.account.region))
+            in _WORKSPACE_SCOPED_FAMILIES
         ):
             if self._workspace_id is not None:
                 params.setdefault("workspace_id", self._workspace_id)

--- a/src/mixpanel_headless/_internal/auth/region_probe.py
+++ b/src/mixpanel_headless/_internal/auth/region_probe.py
@@ -20,6 +20,12 @@ Design constraints (per ``contracts/python-api.md`` §2.1):
 - **No logging or stderr writes.** Progress narration is the caller's
   job; the function returns or raises with structured data.
 
+Alternate-host override: when ``MP_API_BASE_URL`` (or ``MP_APP_BASE_URL``)
+is set, every region maps to the same host, so
+``probe_region_for_credential`` collapses the walk to a single probe at
+that base — the region is ``MP_REGION`` when it names a valid region,
+else ``us``. See ``api_client._override_probe_order``.
+
 Reference: ``specs/043-frictionless-auth/contracts/python-api.md`` §2.1.
 """
 
@@ -27,7 +33,6 @@ from __future__ import annotations
 
 import base64
 import os
-import urllib.parse
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -202,6 +207,11 @@ def probe_region_for_credential(
 ) -> Region:
     """Build the credential header, probe ``us → eu → in``, return the region.
 
+    Under an API-host override (``MP_API_BASE_URL`` / ``MP_APP_BASE_URL``)
+    the walk collapses to one probe at the override base and the returned
+    region is ``MP_REGION`` (when valid) or ``us`` — see
+    ``api_client._override_probe_order``.
+
     Replaces the two near-identical inlined blocks that
     ``cli/commands/account.py::_probe_region_for_credential`` and
     ``accounts.py::_login_unified_new_credential`` used to carry. Both
@@ -227,7 +237,8 @@ def probe_region_for_credential(
             leave it ``None`` for silent operation.
 
     Returns:
-        The first region whose ``/me`` returned 200.
+        The first region whose ``/me`` returned 200 (under an override: the
+        single probed region).
 
     Raises:
         ConfigError: Missing credential material for the given
@@ -236,7 +247,11 @@ def probe_region_for_credential(
         RegionProbeError / RegionProbeNetworkError: Propagated from
             :func:`probe_region` when no region accepts the credential.
     """
-    from mixpanel_headless._internal.api_client import ENDPOINTS
+    from mixpanel_headless._internal.api_client import (
+        _endpoints_for,
+        _override_probe_order,
+        _probe_base_url,
+    )
 
     if account_type == "service_account":
         if username is None or secret is None:
@@ -265,21 +280,30 @@ def probe_region_for_credential(
         )
 
     def _factory(region: Region) -> httpx.Client:
-        """Build a region-scoped ``httpx.Client`` bound to the API host."""
-        app_url = ENDPOINTS[region]["app"]
-        # ``ENDPOINTS[*]["app"]`` is currently
-        # ``https://mixpanel.com/api/app`` — strip the path so
-        # ``probe_region`` can issue ``/api/app/me`` against the host
-        # root. ``urlsplit`` handles trailing slashes, future version
-        # segments, query strings, and fragments without a fragile
-        # substring search.
-        parts = urllib.parse.urlsplit(app_url)
-        base = urllib.parse.urlunsplit((parts.scheme, parts.netloc, "", "", ""))
-        return httpx.Client(base_url=base)
+        """Build a region-scoped ``httpx.Client`` bound to the API host.
 
+        Args:
+            region: The region whose App API host to bind to (ignored for
+                URL purposes under an API-host override).
+
+        Returns:
+            A client whose ``base_url`` is the App API URL minus
+            ``/api/app`` (see ``api_client._probe_base_url``) so
+            ``probe_region`` can issue ``/api/app/me`` relative to it.
+        """
+        return httpx.Client(base_url=_probe_base_url(_endpoints_for(region)["app"]))
+
+    override_order = _override_probe_order()
     if narrate is not None:
-        narrate("Probing regions for /me access ...")
-    result = probe_region(_factory, headers)
+        if override_order is None:
+            narrate("Probing regions for /me access ...")
+        else:
+            override_base = _probe_base_url(_endpoints_for(override_order[0])["app"])
+            narrate(f"Probing {override_base} (MP_API_BASE_URL override) for /me ...")
+    if override_order is None:
+        result = probe_region(_factory, headers)
+    else:
+        result = probe_region(_factory, headers, order=override_order)
     if narrate is not None:
         for region_name, status in result.attempts:
             marker = "✓" if status == 200 else "✗"

--- a/src/mixpanel_headless/_internal/auth/region_probe.py
+++ b/src/mixpanel_headless/_internal/auth/region_probe.py
@@ -20,11 +20,13 @@ Design constraints (per ``contracts/python-api.md`` §2.1):
 - **No logging or stderr writes.** Progress narration is the caller's
   job; the function returns or raises with structured data.
 
-Alternate-host override: when ``MP_API_BASE_URL`` (or ``MP_APP_BASE_URL``)
-is set, every region maps to the same host, so
-``probe_region_for_credential`` collapses the walk to a single probe at
-that base — the region is ``MP_REGION`` when it names a valid region,
-else ``us``. See ``api_client._override_probe_order``.
+Alternate-host override: when ``MP_API_BASE_URL`` is set, every region maps
+to the same host, so ``probe_region_for_credential`` collapses the walk to
+a single probe at that base — the region is ``MP_REGION`` when it names a
+valid region, else ``us``. ``MP_APP_BASE_URL`` alone re-homes ``/me`` but
+keeps the full ``us → eu → in`` walk, because the discovered region still
+routes the live Query / Export / Engage hosts. See
+``api_client._override_probe_order``.
 
 Reference: ``specs/043-frictionless-auth/contracts/python-api.md`` §2.1.
 """
@@ -249,6 +251,7 @@ def probe_region_for_credential(
     """
     from mixpanel_headless._internal.api_client import (
         _endpoints_for,
+        _override_probe_narration,
         _override_probe_order,
         _probe_base_url,
     )
@@ -280,26 +283,34 @@ def probe_region_for_credential(
         )
 
     def _factory(region: Region) -> httpx.Client:
-        """Build a region-scoped ``httpx.Client`` bound to the API host.
+        """Build a region-scoped ``httpx.Client`` bound to the App API host.
 
         Args:
-            region: The region whose App API host to bind to (ignored for
-                URL purposes under an API-host override).
+            region: The region whose App API host to bind to. Ignored for
+                URL purposes when an API-host override is active.
 
         Returns:
             A client whose ``base_url`` is the App API URL minus
-            ``/api/app`` (see ``api_client._probe_base_url``) so
+            ``/api/app`` (see ``api_client._probe_base_url``), so
             ``probe_region`` can issue ``/api/app/me`` relative to it.
+
+        Raises:
+            KeyError: ``region`` is not a key of ``api_client.ENDPOINTS``.
+                Unreachable via ``probe_region``, which only passes
+                ``us`` / ``eu`` / ``in``.
+
+        Example:
+            ```python
+            client = _factory("eu")
+            str(client.base_url)  # "https://eu.mixpanel.com/"
+            client.close()
+            ```
         """
         return httpx.Client(base_url=_probe_base_url(_endpoints_for(region)["app"]))
 
     override_order = _override_probe_order()
     if narrate is not None:
-        if override_order is None:
-            narrate("Probing regions for /me access ...")
-        else:
-            override_base = _probe_base_url(_endpoints_for(override_order[0])["app"])
-            narrate(f"Probing {override_base} (MP_API_BASE_URL override) for /me ...")
+        narrate(_override_probe_narration() or "Probing regions for /me access ...")
     if override_order is None:
         result = probe_region(_factory, headers)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,8 @@ _MP_ENV_VARS = (
     "MP_WORKSPACE_ID",
     "MP_STORAGE_DIR",
     "MP_OAUTH_STORAGE_DIR",
+    "MP_API_BASE_URL",
+    "MP_APP_BASE_URL",
 )
 
 

--- a/tests/unit/test_api_base_url_override.py
+++ b/tests/unit/test_api_base_url_override.py
@@ -26,6 +26,7 @@ from mixpanel_headless._internal.api_client import (
     DEFAULT_QUERY_TIMEOUT_S,
     ENDPOINTS,
     MixpanelAPIClient,
+    _api_family_for,
     _endpoints_for,
 )
 from mixpanel_headless._internal.auth.session import Session
@@ -754,6 +755,162 @@ class TestWorkspaceIdInjectionUnderOverride:
         ) as client:
             client.get_events()
         assert "workspace_id" not in recorder.requests[0].url.params
+
+
+# =============================================================================
+# _api_family_for — longest-prefix family classification
+# =============================================================================
+
+
+class TestApiFamilyFor:
+    """``_api_family_for`` picks the family whose base is the longest URL prefix."""
+
+    @pytest.mark.parametrize(
+        ("url", "family"),
+        [
+            ("https://mixpanel.com/api/query/insights", "query"),
+            ("https://mixpanel.com/api/query/engage/", "engage"),
+            ("https://mixpanel.com/api/query/engage/stats", "engage"),
+            ("https://data.mixpanel.com/api/2.0/export", "export"),
+            ("https://mixpanel.com/api/app/projects/1/dashboards", "app"),
+            ("https://example.com/api/query/insights", None),
+        ],
+    )
+    def test_live_table_classification(self, url: str, family: str | None) -> None:
+        """Live URLs classify by their own family; engage beats query as a prefix.
+
+        Args:
+            url: The request URL.
+            family: The expected family, or ``None`` for a foreign host.
+        """
+        assert _api_family_for(url, ENDPOINTS["us"]) == family
+
+    def test_longest_prefix_wins_under_collision(self) -> None:
+        """When one base is a prefix of another family's URL, the longer base wins."""
+        table = {
+            "query": "https://proxy/api/query",
+            "export": "https://proxy/api/2.0",
+            "engage": "https://proxy/api/query/engage",
+            "app": "https://proxy/api/query/api/app",
+        }
+        assert _api_family_for("https://proxy/api/query/api/app/x", table) == "app"
+        assert _api_family_for("https://proxy/api/query/insights", table) == "query"
+        assert _api_family_for("https://proxy/api/query/engage/", table) == "engage"
+
+
+class TestPrefixCollisionConfigs:
+    """Split configs where one base is a prefix of another family stay correct."""
+
+    @staticmethod
+    def _seen_for(
+        session: Session,
+        call: str,
+        monkeypatch: pytest.MonkeyPatch,
+        env: dict[str, str],
+    ) -> httpx.Request:
+        """Issue one request under ``env`` and return it for inspection.
+
+        Args:
+            session: Session for the client (pinned to workspace 777).
+            call: ``"app"`` to issue an App API GET, ``"query"`` for ``get_events``.
+            monkeypatch: pytest monkeypatch fixture.
+            env: Override variables to export for the call.
+
+        Returns:
+            The single captured ``httpx.Request``.
+        """
+        for name, value in env.items():
+            monkeypatch.setenv(name, value)
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            if call == "app":
+                client.app_request("GET", "/projects/12345/dashboards")
+            else:
+                client.get_events()
+        assert len(recorder.requests) == 1
+        return recorder.requests[0]
+
+    _APP_UNDER_QUERY = {
+        "MP_API_BASE_URL": "https://proxy",
+        "MP_APP_BASE_URL": "https://proxy/api/query",
+    }
+    """App base nested under the query prefix (reviewer config 1)."""
+
+    _QUERY_UNDER_APP = {
+        "MP_API_BASE_URL": "https://proxy/api/app",
+        "MP_APP_BASE_URL": "https://proxy",
+    }
+    """Query prefix nested under the app base (the colliding reverse)."""
+
+    _REVERSE_LITERAL = {
+        "MP_API_BASE_URL": "https://proxy/api/query",
+        "MP_APP_BASE_URL": "https://proxy",
+    }
+    """The literal reverse of config 1 (no textual overlap; must still be right)."""
+
+    @pytest.mark.parametrize(
+        "env", [_APP_UNDER_QUERY, _QUERY_UNDER_APP, _REVERSE_LITERAL]
+    )
+    def test_app_request_is_app_family(
+        self,
+        env: dict[str, str],
+        pinned_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """App requests get the App timeout and no ``workspace_id`` in every config.
+
+        Args:
+            env: Override variables for the config under test.
+            pinned_session: Session with workspace 777 pinned.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        request = self._seen_for(pinned_session, "app", monkeypatch, env)
+        assert request.url.path.endswith("/api/app/projects/12345/dashboards")
+        assert request.extensions["timeout"]["read"] == DEFAULT_APP_TIMEOUT_S
+        assert "workspace_id" not in request.url.params
+
+    @pytest.mark.parametrize(
+        "env", [_APP_UNDER_QUERY, _QUERY_UNDER_APP, _REVERSE_LITERAL]
+    )
+    def test_query_request_is_query_family(
+        self,
+        env: dict[str, str],
+        pinned_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Query requests get the Query timeout and carry ``workspace_id`` in every config.
+
+        Args:
+            env: Override variables for the config under test.
+            pinned_session: Session with workspace 777 pinned.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        request = self._seen_for(pinned_session, "query", monkeypatch, env)
+        assert request.url.path.endswith("/api/query/events/names")
+        assert request.extensions["timeout"]["read"] == DEFAULT_QUERY_TIMEOUT_S
+        assert request.url.params.get("workspace_id") == "777"
+
+    def test_live_engage_request_still_carries_workspace_id(
+        self, pinned_session: Session
+    ) -> None:
+        """Unchanged live rule: Engage URLs are workspace-scoped like Query URLs.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+        """
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=pinned_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.engage_stats()
+        request = recorder.requests[0]
+        assert str(request.url).startswith(
+            "https://mixpanel.com/api/query/engage/stats"
+        )
+        assert request.url.params.get("workspace_id") == "777"
+        assert request.extensions["timeout"]["read"] == DEFAULT_QUERY_TIMEOUT_S
 
 
 # =============================================================================

--- a/tests/unit/test_api_base_url_override.py
+++ b/tests/unit/test_api_base_url_override.py
@@ -1,0 +1,934 @@
+"""Unit tests for the ``MP_API_BASE_URL`` / ``MP_APP_BASE_URL`` host override.
+
+When ``MP_API_BASE_URL`` is set, the per-region ``ENDPOINTS`` lookup is
+bypassed and every API family resolves to a fixed path prefix on that one
+base (``/api/query``, ``/api/2.0``, ``/api/query/engage``, ``/api/app``).
+``MP_APP_BASE_URL`` optionally re-homes just the App API family. Both are
+read at request time, so ``use(account=...)`` swaps and env monkeypatching
+keep working. With both unset the live table is returned untouched.
+
+Tests use ``httpx.MockTransport`` and assert the full request URL per
+family, mirroring ``tests/unit/test_api_client.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from mixpanel_headless._internal.api_client import (
+    DEFAULT_APP_TIMEOUT_S,
+    DEFAULT_QUERY_TIMEOUT_S,
+    ENDPOINTS,
+    MixpanelAPIClient,
+    _endpoints_for,
+)
+from mixpanel_headless._internal.auth.session import Session
+from mixpanel_headless.workspace import Workspace
+from tests.conftest import make_session
+
+_BASE = "http://127.0.0.1:8080"
+"""Override base used throughout; a plain-``http`` loopback host."""
+
+_EXPECTED: dict[str, str] = {
+    "query": f"{_BASE}/api/query",
+    "export": f"{_BASE}/api/2.0",
+    "engage": f"{_BASE}/api/query/engage",
+    "app": f"{_BASE}/api/app",
+}
+"""The prefix table from the work order, anchored at ``_BASE``."""
+
+_INSIGHTS_BODY: dict[str, Any] = {
+    "computed_at": "2025-01-15T12:00:00",
+    "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+    "headers": ["$event"],
+    "series": {"A. Login": {"2025-01-01": 10}},
+    "meta": {"sampling_factor": 1.0},
+}
+"""Minimal insights response (copied from ``test_query_limit.py``)."""
+
+_FUNNEL_BODY: dict[str, Any] = {
+    "computed_at": "2025-01-15T12:00:00",
+    "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+    "headers": ["$funnel"],
+    "series": {
+        "steps": [
+            {
+                "event": "Signup",
+                "count": 1000,
+                "step_conv_ratio": 1.0,
+                "overall_conv_ratio": 1.0,
+                "avg_time": 0.0,
+                "avg_time_from_start": 0.0,
+            },
+            {
+                "event": "Purchase",
+                "count": 120,
+                "step_conv_ratio": 0.12,
+                "overall_conv_ratio": 0.12,
+                "avg_time": 86400.0,
+                "avg_time_from_start": 86400.0,
+            },
+        ]
+    },
+    "meta": {"sampling_factor": 1.0},
+}
+"""Minimal ``arb_funnels`` response (copied from ``test_query_limit.py``)."""
+
+_RETENTION_BODY: dict[str, Any] = {
+    "computed_at": "2025-01-15T12:00:00",
+    "date_range": {"from_date": "2025-01-01", "to_date": "2025-01-31"},
+    "headers": ["$retention"],
+    "series": {"2025-01-01": {"counts": [100, 40], "first": 100}},
+    "meta": {"sampling_factor": 1.0},
+}
+"""Minimal insights-mode retention response (copied from ``test_query_limit.py``)."""
+
+_LEGACY_FUNNEL_BODY: dict[str, Any] = {
+    "meta": {"dates": ["2024-01-01"]},
+    "data": {
+        "2024-01-01": {
+            "steps": [
+                {
+                    "count": 10,
+                    "step_label": "Login",
+                    "event": "Login",
+                    "goal": "Login",
+                    "overall_conv_ratio": 1.0,
+                    "step_conv_ratio": 1.0,
+                    "avg_time": None,
+                }
+            ],
+            "analysis": {
+                "completion": 10,
+                "starting_amount": 10,
+                "steps": 1,
+                "worst": 1,
+            },
+        }
+    },
+}
+"""Minimal legacy ``GET /funnels`` response."""
+
+_LEGACY_RETENTION_BODY: dict[str, Any] = {
+    "2024-01-01": {"counts": [10, 4], "first": 10},
+}
+"""Minimal legacy ``GET /retention`` response."""
+
+_STATS_BODY: dict[str, Any] = {
+    "results": 42,
+    "status": "ok",
+    "computed_at": "2025-01-15T10:00:00",
+}
+"""Minimal Engage ``stats`` response."""
+
+_ENGAGE_BODY: dict[str, Any] = {
+    "results": [{"$distinct_id": "u1", "$properties": {"$last_seen": "2025-01-15"}}],
+    "page": 0,
+    "page_size": 1000,
+    "session_id": "sess",
+    "total": 1,
+    "status": "ok",
+}
+"""Minimal Engage profile page."""
+
+_EXPORT_LINE = (
+    b'{"event":"Login","properties":{"distinct_id":"u1","time":1705328400}}\n'
+)
+"""One JSONL export line."""
+
+
+def _insights_body_for(request: httpx.Request) -> dict[str, Any]:
+    """Pick the canned ``/insights`` body from the posted report definition.
+
+    ``query``, ``query_funnel`` and ``query_retention`` all POST to
+    ``/insights`` with ``{"bookmark": <params>, "project_id": ...,
+    "queryLimits": ...}``; the params' ``sections.show[0].behavior.type``
+    says which report it is.
+
+    Args:
+        request: The captured ``POST /insights`` request.
+
+    Returns:
+        ``_FUNNEL_BODY``, ``_RETENTION_BODY`` or ``_INSIGHTS_BODY``.
+    """
+    if not request.content:
+        return _INSIGHTS_BODY
+    payload = json.loads(request.content)
+    params = payload.get("bookmark", payload)
+    show = params.get("sections", {}).get("show", [])
+    behavior_type = show[0].get("behavior", {}).get("type") if show else None
+    if behavior_type == "funnel":
+        return _FUNNEL_BODY
+    if behavior_type == "retention":
+        return _RETENTION_BODY
+    return _INSIGHTS_BODY
+
+
+class _Recorder:
+    """Mock-transport handler that logs every request and answers per route.
+
+    The response body is chosen from the request path and method so the
+    full ``Workspace`` facade can run end to end against the recorder.
+
+    Attributes:
+        requests: Every ``httpx.Request`` seen, in order.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty request log."""
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Record ``request`` and return a canned 200 for its route.
+
+        Args:
+            request: The outgoing request under test.
+
+        Returns:
+            A 200 ``httpx.Response`` whose body matches the route family.
+        """
+        self.requests.append(request)
+        path = request.url.path
+        if path.endswith("/export"):
+            return httpx.Response(200, content=_EXPORT_LINE)
+        if path.endswith("/insights"):
+            return httpx.Response(200, json=_insights_body_for(request))
+        if path.endswith("/arb_funnels"):
+            return httpx.Response(200, json=_FUNNEL_BODY)
+        if path.endswith("/retention"):
+            if request.method == "POST":
+                return httpx.Response(200, json=_RETENTION_BODY)
+            return httpx.Response(200, json=_LEGACY_RETENTION_BODY)
+        if path.endswith("/funnels"):
+            return httpx.Response(200, json=_LEGACY_FUNNEL_BODY)
+        if path.endswith("/engage/stats"):
+            return httpx.Response(200, json=_STATS_BODY)
+        if path.endswith("/engage"):
+            return httpx.Response(200, json=_ENGAGE_BODY)
+        if path.endswith("/events/names"):
+            return httpx.Response(200, json=["Login"])
+        return httpx.Response(200, json={"results": []})
+
+    def urls(self) -> list[str]:
+        """Return every recorded URL with its query string stripped.
+
+        Returns:
+            Ordered list of ``scheme://host[:port]/path`` strings.
+        """
+        return [str(r.url.copy_with(query=None)) for r in self.requests]
+
+
+def _no_mixpanel_hosts(recorder: _Recorder) -> None:
+    """Assert every recorded request went to the loopback override host.
+
+    Args:
+        recorder: The recorder whose requests are checked.
+
+    Raises:
+        AssertionError: A request left for any host other than
+            ``127.0.0.1:8080``.
+    """
+    assert recorder.requests, "expected at least one request"
+    for request in recorder.requests:
+        assert request.url.host == "127.0.0.1", str(request.url)
+        assert request.url.port == 8080, str(request.url)
+        assert "mixpanel.com" not in str(request.url)
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    """Force every ``MixpanelAPIClient`` built during the test onto ``recorder``.
+
+    ``Workspace()`` and the ``mp`` CLI build their client internally with no
+    transport hook, so this wraps the constructor to inject one. The wrapper
+    only fills ``_transport`` when the caller left it unset.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture (restores the constructor).
+        recorder: The handler backing the injected ``httpx.MockTransport``.
+    """
+    original_init = MixpanelAPIClient.__init__
+    transport = httpx.MockTransport(recorder)
+
+    def _init(self: MixpanelAPIClient, **kwargs: Any) -> None:
+        """Delegate to the real constructor with the mock transport injected.
+
+        Args:
+            self: The client under construction.
+            **kwargs: Constructor keyword arguments (``Any`` because the
+                wrapper forwards whatever the caller passed).
+        """
+        kwargs.setdefault("_transport", transport)
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(MixpanelAPIClient, "__init__", _init)
+
+
+@pytest.fixture
+def us_session() -> Session:
+    """Return a US service-account Session with no workspace pinned.
+
+    Returns:
+        A ``Session`` for project ``12345`` in region ``us``.
+    """
+    return make_session(project_id="12345", region="us")
+
+
+@pytest.fixture
+def pinned_session() -> Session:
+    """Return a US Session with workspace ``777`` pinned.
+
+    Returns:
+        A ``Session`` whose ``workspace`` axis carries id ``777``.
+    """
+    return make_session(project_id="12345", region="us", workspace_id=777)
+
+
+@pytest.fixture
+def override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set ``MP_API_BASE_URL`` to the loopback base for the test.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("MP_API_BASE_URL", _BASE)
+
+
+@pytest.fixture
+def env_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, override_env: None
+) -> _Recorder:
+    """Wire env-var auth plus the override so a bare ``Workspace()`` resolves.
+
+    Pins ``$HOME`` / ``MP_CONFIG_PATH`` to ``tmp_path``, exports the
+    service-account quad, and routes every client onto a fresh recorder.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        tmp_path: pytest temporary directory.
+        override_env: Ensures ``MP_API_BASE_URL`` is exported.
+
+    Returns:
+        The recorder capturing every request the workspace issues.
+    """
+    del override_env
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MP_CONFIG_PATH", str(tmp_path / ".mp" / "config.toml"))
+    monkeypatch.setenv("MP_USERNAME", "svc")
+    monkeypatch.setenv("MP_SECRET", "s3cret")
+    monkeypatch.setenv("MP_PROJECT_ID", "12345")
+    monkeypatch.setenv("MP_REGION", "us")
+    recorder = _Recorder()
+    _install_transport(monkeypatch, recorder)
+    return recorder
+
+
+# =============================================================================
+# _endpoints_for resolver
+# =============================================================================
+
+
+class TestEndpointsForResolver:
+    """``_endpoints_for`` picks the override table or the live region table."""
+
+    @pytest.mark.parametrize("region", ["us", "eu", "in"])
+    def test_unset_returns_live_table_object(self, region: str) -> None:
+        """With both vars unset the live ``ENDPOINTS[region]`` object is returned.
+
+        Args:
+            region: Region under test.
+        """
+        assert _endpoints_for(region) is ENDPOINTS[region]
+
+    @pytest.mark.parametrize("region", ["us", "eu", "in"])
+    def test_override_ignores_region(self, region: str, override_env: None) -> None:
+        """Every region resolves to the same prefix table under the override.
+
+        Args:
+            region: Region under test.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        assert _endpoints_for(region) == _EXPECTED
+
+    @pytest.mark.parametrize("suffix", ["/", "//", "///"])
+    def test_trailing_slashes_are_stripped(
+        self, suffix: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trailing slashes on the base never produce ``//api`` URLs.
+
+        Args:
+            suffix: Slash run appended to the base.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", f"{_BASE}{suffix}")
+        assert _endpoints_for("us") == _EXPECTED
+
+    @pytest.mark.parametrize("value", ["", "/", "//"])
+    def test_empty_or_slash_only_value_means_unset(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty (or slash-only) value is treated as unset, not as base ``""``.
+
+        Args:
+            value: The degenerate env value.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", value)
+        assert _endpoints_for("eu") is ENDPOINTS["eu"]
+
+    def test_path_prefixed_base_is_preserved(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A base with its own path segment keeps that segment ahead of the prefix.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "https://proxy.example/mp/")
+        table = _endpoints_for("us")
+        assert table["query"] == "https://proxy.example/mp/api/query"
+        assert table["export"] == "https://proxy.example/mp/api/2.0"
+        assert table["engage"] == "https://proxy.example/mp/api/query/engage"
+        assert table["app"] == "https://proxy.example/mp/api/app"
+
+    def test_live_table_is_never_mutated(self, override_env: None) -> None:
+        """Resolving the override must not write into ``ENDPOINTS``.
+
+        Args:
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        before = {r: dict(t) for r, t in ENDPOINTS.items()}
+        _endpoints_for("us")
+        _endpoints_for("eu")
+        assert before == ENDPOINTS
+        assert ENDPOINTS["us"]["query"] == "https://mixpanel.com/api/query"
+
+    def test_app_base_alone_overrides_only_app_family(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MP_APP_BASE_URL`` on its own re-homes the App API and nothing else.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000/")
+        table = _endpoints_for("eu")
+        assert table["app"] == "http://app.internal:9000/api/app"
+        for family in ("query", "export", "engage"):
+            assert table[family] == ENDPOINTS["eu"][family]
+        # The live table itself is untouched.
+        assert ENDPOINTS["eu"]["app"] == "https://eu.mixpanel.com/api/app"
+
+    def test_app_base_wins_over_api_base_for_app_family(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With both set, ``MP_APP_BASE_URL`` decides the App API host.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", _BASE)
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000")
+        table = _endpoints_for("us")
+        assert table["app"] == "http://app.internal:9000/api/app"
+        assert table["query"] == _EXPECTED["query"]
+        assert table["export"] == _EXPECTED["export"]
+        assert table["engage"] == _EXPECTED["engage"]
+
+
+# =============================================================================
+# _build_url — read at request time
+# =============================================================================
+
+
+class TestBuildUrlUnderOverride:
+    """``_build_url`` honours the override for every family, lazily."""
+
+    @pytest.mark.parametrize("api_type", ["query", "export", "engage", "app"])
+    def test_each_family_uses_prefix(
+        self, api_type: str, us_session: Session, override_env: None
+    ) -> None:
+        """``_build_url(api_type, "/x")`` is ``{base}{prefix}/x``.
+
+        Args:
+            api_type: API family under test.
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        client = MixpanelAPIClient(session=us_session)
+        try:
+            assert client._build_url(api_type, "/x") == f"{_EXPECTED[api_type]}/x"
+        finally:
+            client.close()
+
+    def test_env_is_read_per_call_not_at_construction(
+        self, us_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Setting the var after the client exists still redirects the next URL.
+
+        Args:
+            us_session: US session fixture.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        client = MixpanelAPIClient(session=us_session)
+        try:
+            live = client._build_url("query", "/segmentation")
+            assert live == "https://mixpanel.com/api/query/segmentation"
+            monkeypatch.setenv("MP_API_BASE_URL", _BASE)
+            assert (
+                client._build_url("query", "/segmentation")
+                == f"{_BASE}/api/query/segmentation"
+            )
+            monkeypatch.delenv("MP_API_BASE_URL")
+            assert client._build_url("query", "/segmentation") == live
+        finally:
+            client.close()
+
+    def test_eu_session_is_redirected_too(self, override_env: None) -> None:
+        """A non-US session is routed at the same base (region is URL-irrelevant).
+
+        Args:
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        client = MixpanelAPIClient(session=make_session(region="eu"))
+        try:
+            assert client._build_url("export", "/export") == f"{_BASE}/api/2.0/export"
+        finally:
+            client.close()
+
+
+# =============================================================================
+# Full request URL per family through the client
+# =============================================================================
+
+
+class TestClientRequestsHitOverride:
+    """Each client family method sends its request to the override host."""
+
+    def test_get_events_hits_query_prefix(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """``get_events`` → ``{base}/api/query/events/names``.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.get_events()
+        assert recorder.urls() == [f"{_BASE}/api/query/events/names"]
+        _no_mixpanel_hosts(recorder)
+
+    def test_export_events_hits_export_prefix(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """``export_events`` → ``{base}/api/2.0/export``.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            rows = list(
+                client.export_events(from_date="2024-01-01", to_date="2024-01-01")
+            )
+        assert len(rows) == 1
+        assert recorder.urls() == [f"{_BASE}/api/2.0/export"]
+        _no_mixpanel_hosts(recorder)
+
+    def test_engage_stats_hits_engage_prefix(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """``engage_stats`` → ``{base}/api/query/engage/stats``.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.engage_stats()
+        assert recorder.urls() == [f"{_BASE}/api/query/engage/stats"]
+        _no_mixpanel_hosts(recorder)
+
+    def test_app_request_hits_app_prefix(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """``app_request`` → ``{base}/api/app/...``.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.app_request("GET", "/projects/12345/dashboards")
+        assert recorder.urls() == [f"{_BASE}/api/app/projects/12345/dashboards"]
+        _no_mixpanel_hosts(recorder)
+
+    def test_trailing_slash_base_yields_clean_urls(
+        self, us_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MP_API_BASE_URL=http://127.0.0.1:8080/`` produces no double slash.
+
+        Args:
+            us_session: US session fixture.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", f"{_BASE}/")
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.get_events()
+            client.app_request("GET", "/projects/12345/dashboards")
+        assert recorder.urls() == [
+            f"{_BASE}/api/query/events/names",
+            f"{_BASE}/api/app/projects/12345/dashboards",
+        ]
+        for url in recorder.urls():
+            assert "//api" not in url
+
+
+# =============================================================================
+# Timeout selection and workspace_id injection
+# =============================================================================
+
+
+class TestTimeoutSelectionUnderOverride:
+    """Route-aware timeouts still key off the App-vs-Query family."""
+
+    @staticmethod
+    def _capture_client(session: Session, seen: dict[str, Any]) -> MixpanelAPIClient:
+        """Build a client whose transport records the per-request timeout.
+
+        Args:
+            session: Session for the client.
+            seen: Dict the handler writes the request timeout into.
+
+        Returns:
+            A client wired to the capturing MockTransport.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Record the timeout extension and answer 200.
+
+            Args:
+                request: The outgoing request.
+
+            Returns:
+                An empty-results 200 response.
+            """
+            seen["timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200, json={"results": []})
+
+        return MixpanelAPIClient(
+            session=session, _transport=httpx.MockTransport(handler)
+        )
+
+    def test_app_request_keeps_app_timeout(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """App API requests at the override still get the App read timeout.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        seen: dict[str, Any] = {}
+        with self._capture_client(us_session, seen) as client:
+            client.app_request("GET", "/projects/12345/dashboards")
+        assert seen["timeout"]["read"] == DEFAULT_APP_TIMEOUT_S
+
+    def test_query_request_keeps_query_timeout(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """Query-family requests at the override get the Query read timeout.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        seen: dict[str, Any] = {}
+        with self._capture_client(us_session, seen) as client:
+            client.get_events()
+        assert seen["timeout"]["read"] == DEFAULT_QUERY_TIMEOUT_S
+        with self._capture_client(us_session, seen) as client:
+            client.request("GET", f"{_BASE}/api/query/segmentation")
+        assert seen["timeout"]["read"] == DEFAULT_QUERY_TIMEOUT_S
+
+    def test_split_app_host_still_selects_app_timeout(
+        self, us_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``MP_APP_BASE_URL`` set, App routes on the second host keep 135s.
+
+        Args:
+            us_session: US session fixture.
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", _BASE)
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000")
+        seen: dict[str, Any] = {}
+        with self._capture_client(us_session, seen) as client:
+            client.app_request("GET", "/projects/12345/dashboards")
+        assert seen["timeout"]["read"] == DEFAULT_APP_TIMEOUT_S
+
+
+class TestWorkspaceIdInjectionUnderOverride:
+    """``workspace_id`` injection keys off the Query family, not the host."""
+
+    def test_pinned_query_request_carries_workspace_id(
+        self, pinned_session: Session, override_env: None
+    ) -> None:
+        """A pinned workspace is injected on Query-family requests at the override.
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=pinned_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.get_events()
+        params = recorder.requests[0].url.params
+        assert params.get("workspace_id") == "777"
+        assert params.get("project_id") == "12345"
+
+    def test_pinned_app_request_does_not_carry_workspace_id(
+        self, pinned_session: Session, override_env: None
+    ) -> None:
+        """App API requests are never given ``workspace_id`` (same as live).
+
+        Args:
+            pinned_session: Session with workspace 777 pinned.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=pinned_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.app_request("GET", "/projects/12345/dashboards")
+        assert "workspace_id" not in recorder.requests[0].url.params
+
+    def test_unpinned_query_request_has_no_workspace_id(
+        self, us_session: Session, override_env: None
+    ) -> None:
+        """No pin → no ``workspace_id`` param, exactly as live.
+
+        Args:
+            us_session: US session fixture.
+            override_env: Exports ``MP_API_BASE_URL``.
+        """
+        del override_env
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=us_session, _transport=httpx.MockTransport(recorder)
+        ) as client:
+            client.get_events()
+        assert "workspace_id" not in recorder.requests[0].url.params
+
+
+# =============================================================================
+# Workspace() from env — the acceptance list
+# =============================================================================
+
+
+class TestWorkspaceFacadeHitsOverride:
+    """``Workspace()`` built from env vars routes every facade call at the base."""
+
+    def test_events(self, env_workspace: _Recorder) -> None:
+        """``Workspace().events()`` → ``{base}/api/query/events/names``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            assert ws.events() == ["Login"]
+        assert env_workspace.urls() == [f"{_BASE}/api/query/events/names"]
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_query(self, env_workspace: _Recorder) -> None:
+        """``Workspace().query(...)`` → ``{base}/api/query/insights``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.query("Login", from_date="2025-01-01", to_date="2025-01-31")
+        assert f"{_BASE}/api/query/insights" in env_workspace.urls()
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_query_funnel(self, env_workspace: _Recorder) -> None:
+        """``Workspace().query_funnel(...)`` → ``POST {base}/api/query/insights``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.query_funnel(
+                ["Signup", "Purchase"], from_date="2025-01-01", to_date="2025-01-31"
+            )
+        assert env_workspace.urls() == [f"{_BASE}/api/query/insights"]
+        assert env_workspace.requests[0].method == "POST"
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_query_retention(self, env_workspace: _Recorder) -> None:
+        """``Workspace().query_retention(...)`` → ``POST {base}/api/query/insights``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.query_retention(
+                "Signup", "Login", from_date="2025-01-01", to_date="2025-01-31"
+            )
+        assert env_workspace.urls() == [f"{_BASE}/api/query/insights"]
+        assert env_workspace.requests[0].method == "POST"
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_legacy_funnel(self, env_workspace: _Recorder) -> None:
+        """``Workspace().funnel(...)`` → ``{base}/api/query/funnels``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.funnel(1, from_date="2024-01-01", to_date="2024-01-01")
+        assert f"{_BASE}/api/query/funnels" in env_workspace.urls()
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_legacy_retention(self, env_workspace: _Recorder) -> None:
+        """``Workspace().retention(...)`` → ``{base}/api/query/retention``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.retention(
+                born_event="Signup",
+                return_event="Login",
+                from_date="2024-01-01",
+                to_date="2024-01-01",
+            )
+        assert f"{_BASE}/api/query/retention" in env_workspace.urls()
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_query_user_aggregate(self, env_workspace: _Recorder) -> None:
+        """``Workspace().query_user(mode="aggregate")`` → engage ``stats``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.query_user(mode="aggregate", aggregate="count")
+        assert f"{_BASE}/api/query/engage/stats" in env_workspace.urls()
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_query_user_profiles(self, env_workspace: _Recorder) -> None:
+        """``Workspace().query_user(mode="profiles")`` → ``{base}/api/query/engage/``.
+
+        The trailing slash is the live shape too: the Engage root is built
+        with ``_build_url("engage", "")``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            ws.query_user(mode="profiles", limit=1)
+        assert env_workspace.urls() == [f"{_BASE}/api/query/engage/"]
+        _no_mixpanel_hosts(env_workspace)
+
+    def test_stream_events(self, env_workspace: _Recorder) -> None:
+        """``Workspace().stream_events(...)`` → ``{base}/api/2.0/export``.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        with Workspace() as ws:
+            rows = list(ws.stream_events(from_date="2024-01-15", to_date="2024-01-15"))
+        assert len(rows) == 1
+        assert env_workspace.urls() == [f"{_BASE}/api/2.0/export"]
+        _no_mixpanel_hosts(env_workspace)
+
+
+# =============================================================================
+# CLI inherits the override with no flag
+# =============================================================================
+
+
+class TestCliInheritsOverride:
+    """The ``mp`` CLI shares the client, so the env var alone redirects it."""
+
+    def test_mp_inspect_events_hits_override(self, env_workspace: _Recorder) -> None:
+        """``mp inspect events`` with the var set queries the loopback base.
+
+        Args:
+            env_workspace: Recorder behind the env-resolved workspace.
+        """
+        from mixpanel_headless.cli.main import app
+
+        result = CliRunner().invoke(app, ["inspect", "events"])
+        assert result.exit_code == 0, result.output
+        assert "Login" in result.output
+        assert env_workspace.urls() == [f"{_BASE}/api/query/events/names"]
+        _no_mixpanel_hosts(env_workspace)
+
+
+# =============================================================================
+# Unset → byte-identical live behaviour
+# =============================================================================
+
+
+class TestUnsetIsLive:
+    """Without the var, URLs are exactly the live per-region hosts."""
+
+    @pytest.mark.parametrize(
+        ("region", "expected"),
+        [
+            ("us", "https://mixpanel.com/api/query/events/names"),
+            ("eu", "https://eu.mixpanel.com/api/query/events/names"),
+            ("in", "https://in.mixpanel.com/api/query/events/names"),
+        ],
+    )
+    def test_query_url_matches_live_region(self, region: str, expected: str) -> None:
+        """``get_events`` targets the region's live Query host when unset.
+
+        Args:
+            region: Region under test.
+            expected: The live URL for that region.
+        """
+        recorder = _Recorder()
+        with MixpanelAPIClient(
+            session=make_session(region=region),
+            _transport=httpx.MockTransport(recorder),
+        ) as client:
+            client.get_events()
+        assert recorder.urls() == [expected]

--- a/tests/unit/test_api_base_url_override_pbt.py
+++ b/tests/unit/test_api_base_url_override_pbt.py
@@ -1,0 +1,164 @@
+"""Property-based tests for the ``MP_API_BASE_URL`` host override.
+
+Properties tested:
+- For any well-formed base URL and any run of trailing slashes, every API
+  family resolves to ``base.rstrip("/") + prefix`` — no double slashes, no
+  region influence, and ``_build_url`` appends the normalised path after it.
+- With the override unset, ``_endpoints_for`` returns the live table object
+  and the live table is never modified by resolving an override.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from mixpanel_headless._internal.api_client import (
+    ENDPOINTS,
+    MixpanelAPIClient,
+    _endpoints_for,
+)
+from tests.conftest import make_session
+
+_PREFIXES: dict[str, str] = {
+    "query": "/api/query",
+    "export": "/api/2.0",
+    "engage": "/api/query/engage",
+    "app": "/api/app",
+}
+"""The documented per-family path prefixes."""
+
+_LIVE_SNAPSHOT: dict[str, dict[str, str]] = {
+    region: dict(table) for region, table in ENDPOINTS.items()
+}
+"""Deep copy of the live table at import, to detect any later mutation."""
+
+# =============================================================================
+# Strategies
+# =============================================================================
+
+regions = st.sampled_from(["us", "eu", "in"])
+api_types = st.sampled_from(sorted(_PREFIXES))
+
+_label = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=8
+)
+_hosts = st.one_of(
+    st.just("127.0.0.1"),
+    st.just("localhost"),
+    st.lists(_label, min_size=1, max_size=3).map(".".join),
+)
+_ports = st.one_of(st.none(), st.integers(min_value=1, max_value=65535))
+_path_segments = st.lists(
+    st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789-_", min_size=1, max_size=8),
+    max_size=3,
+)
+
+
+@st.composite
+def base_urls(draw: st.DrawFn) -> str:
+    """Generate a normalised base URL with no trailing slash.
+
+    Args:
+        draw: Hypothesis draw function.
+
+    Returns:
+        A URL like ``http://host:port/seg/seg`` with no trailing slash.
+    """
+    scheme = draw(st.sampled_from(["http", "https"]))
+    host = draw(_hosts)
+    port = draw(_ports)
+    segments = draw(_path_segments)
+    netloc = host if port is None else f"{host}:{port}"
+    path = "".join(f"/{seg}" for seg in segments)
+    return f"{scheme}://{netloc}{path}"
+
+
+slash_runs = st.integers(min_value=0, max_value=5).map(lambda n: "/" * n)
+
+
+# =============================================================================
+# Properties
+# =============================================================================
+
+
+@given(base=base_urls(), slashes=slash_runs, region=regions)
+def test_override_table_is_base_plus_prefix(
+    base: str, slashes: str, region: str
+) -> None:
+    """Every family URL is exactly ``base + prefix`` regardless of slashes/region.
+
+    Args:
+        base: Normalised base URL (no trailing slash).
+        slashes: Trailing slash run appended to the env value.
+        region: Region passed to the resolver (must not matter).
+    """
+    with mock.patch.dict(os.environ, {"MP_API_BASE_URL": f"{base}{slashes}"}):
+        table = _endpoints_for(region)
+    assert table == {family: f"{base}{prefix}" for family, prefix in _PREFIXES.items()}
+    for url in table.values():
+        assert url.startswith(base)
+        assert "//" not in url[len(base) :]
+
+
+@given(base=base_urls(), slashes=slash_runs, region=regions, api_type=api_types)
+def test_build_url_appends_normalised_path(
+    base: str, slashes: str, region: str, api_type: str
+) -> None:
+    """``_build_url`` yields ``base + prefix + "/" + path`` (leading slash added once).
+
+    Args:
+        base: Normalised base URL.
+        slashes: Trailing slash run appended to the env value.
+        region: Session region (must not matter).
+        api_type: API family.
+    """
+    client = MixpanelAPIClient(session=make_session(region=region))
+    try:
+        with mock.patch.dict(os.environ, {"MP_API_BASE_URL": f"{base}{slashes}"}):
+            with_slash = client._build_url(api_type, "/segmentation")
+            without_slash = client._build_url(api_type, "segmentation")
+    finally:
+        client.close()
+    expected = f"{base}{_PREFIXES[api_type]}/segmentation"
+    assert with_slash == expected
+    assert without_slash == expected
+
+
+@given(region=regions)
+def test_unset_returns_live_table_untouched(region: str) -> None:
+    """With the vars absent the resolver hands back the pristine live table.
+
+    Args:
+        region: Region under test.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("MP_API_BASE_URL", "MP_APP_BASE_URL")
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        table = _endpoints_for(region)
+    assert table is ENDPOINTS[region]
+    assert table == _LIVE_SNAPSHOT[region]
+
+
+@given(base=base_urls(), slashes=slash_runs, region=regions)
+def test_resolving_override_never_mutates_live_table(
+    base: str, slashes: str, region: str
+) -> None:
+    """Resolving under the override leaves ``ENDPOINTS`` equal to its import-time copy.
+
+    Args:
+        base: Normalised base URL.
+        slashes: Trailing slash run appended to the env value.
+        region: Region under test.
+    """
+    with mock.patch.dict(os.environ, {"MP_API_BASE_URL": f"{base}{slashes}"}):
+        _endpoints_for(region)
+    with mock.patch.dict(os.environ, {"MP_APP_BASE_URL": f"{base}{slashes}"}):
+        _endpoints_for(region)
+    assert ENDPOINTS == _LIVE_SNAPSHOT

--- a/tests/unit/test_region_probe.py
+++ b/tests/unit/test_region_probe.py
@@ -607,10 +607,14 @@ class TestRegionProbeUnderApiBaseUrlOverride:
         bases, _orders = self._run_with_spy(monkeypatch)
         assert bases == ["https://proxy.example/mp"]
 
-    def test_app_base_alone_also_collapses_probe(
+    def test_app_base_alone_keeps_three_region_order(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``MP_APP_BASE_URL`` alone re-homes ``/me`` and collapses the order too.
+        """``MP_APP_BASE_URL`` alone re-homes ``/me`` but must NOT collapse the walk.
+
+        Query / Export / Engage still use the live regional hosts, so the
+        region the probe persists still matters; collapsing to ``us`` would
+        mislabel an EU or India credential.
 
         Args:
             monkeypatch: pytest monkeypatch fixture.
@@ -618,7 +622,20 @@ class TestRegionProbeUnderApiBaseUrlOverride:
         monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000/")
         bases, orders = self._run_with_spy(monkeypatch)
         assert bases == ["http://app.internal:9000"]
-        assert orders == [("us",)]
+        assert orders == [("us", "eu", "in")]
+
+    def test_app_base_alone_ignores_mp_region_for_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App-only override + ``MP_REGION=eu`` still walks the full order.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000")
+        monkeypatch.setenv("MP_REGION", "eu")
+        _bases, orders = self._run_with_spy(monkeypatch)
+        assert orders == [("us", "eu", "in")]
 
     def test_unset_keeps_live_host_and_default_order(
         self, monkeypatch: pytest.MonkeyPatch
@@ -632,13 +649,15 @@ class TestRegionProbeUnderApiBaseUrlOverride:
         assert bases == ["https://mixpanel.com"]
         assert orders == [("us", "eu", "in")]
 
-    def test_narration_mentions_override_base(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """With ``narrate`` supplied, the first line names the override base.
+    @staticmethod
+    def _narration_lines(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Run the probe with a canned success and return the narration lines.
 
         Args:
             monkeypatch: pytest monkeypatch fixture.
+
+        Returns:
+            Every string passed to ``narrate``, in order.
         """
         from pydantic import SecretStr
 
@@ -646,8 +665,6 @@ class TestRegionProbeUnderApiBaseUrlOverride:
         from mixpanel_headless._internal.auth.region_probe import (
             probe_region_for_credential,
         )
-
-        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
 
         def _spy_probe(
             client_factory: object,
@@ -680,5 +697,59 @@ class TestRegionProbeUnderApiBaseUrlOverride:
             narrate=lines.append,
         )
         assert lines
-        assert "http://127.0.0.1:8080" in lines[0]
-        assert "MP_API_BASE_URL" in lines[0]
+        return lines
+
+    def test_narration_names_api_base_url_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """API-only override: first line names the base and ``MP_API_BASE_URL`` only.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
+        first = self._narration_lines(monkeypatch)[0]
+        assert "http://127.0.0.1:8080" in first
+        assert "MP_API_BASE_URL" in first
+        assert "MP_APP_BASE_URL" not in first
+
+    def test_narration_names_app_base_url_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App-only override: first line names the App base and ``MP_APP_BASE_URL`` only.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000")
+        first = self._narration_lines(monkeypatch)[0]
+        assert "http://app.internal:9000" in first
+        assert "MP_APP_BASE_URL" in first
+        assert "MP_API_BASE_URL" not in first
+
+    def test_narration_names_both_when_both_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both set: first line names the App base (where ``/me`` lives) and both vars.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000")
+        first = self._narration_lines(monkeypatch)[0]
+        assert "http://app.internal:9000" in first
+        assert "MP_API_BASE_URL" in first
+        assert "MP_APP_BASE_URL" in first
+
+    def test_narration_unchanged_without_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No override: the legacy first line is emitted verbatim.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        assert self._narration_lines(monkeypatch)[0] == (
+            "Probing regions for /me access ..."
+        )

--- a/tests/unit/test_region_probe.py
+++ b/tests/unit/test_region_probe.py
@@ -484,3 +484,201 @@ class TestRegionProbeFactoryURLStripping:
         assert captured_base_urls
         observed = captured_base_urls[0].rstrip("/")
         assert observed == "https://mixpanel.com"
+
+
+class TestRegionProbeUnderApiBaseUrlOverride:
+    """``MP_API_BASE_URL`` collapses the probe to one attempt at the override.
+
+    Probing ``us → eu → in`` makes no sense when every region maps to the
+    same host, so the factory binds to the override base and the probe
+    order becomes a single region: ``MP_REGION`` when it is a valid region,
+    else ``us``.
+    """
+
+    @staticmethod
+    def _run_with_spy(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[list[str], list[tuple[Region, ...]]]:
+        """Run ``probe_region_for_credential`` with ``probe_region`` replaced by a spy.
+
+        The spy calls the factory for the first region in ``order``,
+        records the resulting ``base_url`` and the ``order`` tuple it was
+        handed, and returns a canned success for that region.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+
+        Returns:
+            ``(captured_base_urls, captured_orders)`` after one call.
+        """
+        from pydantic import SecretStr
+
+        from mixpanel_headless._internal.auth import region_probe as rp_mod
+        from mixpanel_headless._internal.auth.region_probe import (
+            probe_region_for_credential,
+        )
+
+        captured_base_urls: list[str] = []
+        captured_orders: list[tuple[Region, ...]] = []
+
+        def _spy_probe(
+            client_factory: object,
+            headers: dict[str, str],
+            *,
+            timeout_seconds: float = 5.0,
+            order: tuple[Region, ...] = ("us", "eu", "in"),
+        ) -> rp_mod.RegionProbeResult:
+            """Record the factory base URL and order, then succeed.
+
+            Args:
+                client_factory: The region → client factory under test.
+                headers: Ignored credential headers.
+                timeout_seconds: Ignored.
+                order: The probe ordering handed in by the caller.
+
+            Returns:
+                A canned success for ``order[0]``.
+            """
+            captured_orders.append(order)
+            client = client_factory(order[0])  # type: ignore[operator]
+            captured_base_urls.append(str(client.base_url).rstrip("/"))
+            client.close()
+            return rp_mod.RegionProbeResult(region=order[0], attempts=[(order[0], 200)])
+
+        monkeypatch.setattr(rp_mod, "probe_region", _spy_probe)
+        probe_region_for_credential(
+            account_type="service_account",
+            username="u",
+            secret=SecretStr("s"),
+            token=None,
+            token_env=None,
+        )
+        return captured_base_urls, captured_orders
+
+    def test_override_binds_factory_to_base_and_probes_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Override set, ``MP_REGION`` unset → one ``us`` probe at the base.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080/")
+        bases, orders = self._run_with_spy(monkeypatch)
+        assert bases == ["http://127.0.0.1:8080"]
+        assert orders == [("us",)]
+
+    def test_override_uses_mp_region_when_valid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MP_REGION=eu`` under the override → single ``eu`` probe.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
+        monkeypatch.setenv("MP_REGION", "eu")
+        bases, orders = self._run_with_spy(monkeypatch)
+        assert bases == ["http://127.0.0.1:8080"]
+        assert orders == [("eu",)]
+
+    def test_override_ignores_invalid_mp_region(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrecognised ``MP_REGION`` falls back to ``us`` (no crash).
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
+        monkeypatch.setenv("MP_REGION", "mars")
+        _bases, orders = self._run_with_spy(monkeypatch)
+        assert orders == [("us",)]
+
+    def test_override_with_path_prefix_keeps_prefix_in_base(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path-prefixed base keeps its prefix so ``/api/app/me`` lands under it.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_API_BASE_URL", "https://proxy.example/mp")
+        bases, _orders = self._run_with_spy(monkeypatch)
+        assert bases == ["https://proxy.example/mp"]
+
+    def test_app_base_alone_also_collapses_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MP_APP_BASE_URL`` alone re-homes ``/me`` and collapses the order too.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("MP_APP_BASE_URL", "http://app.internal:9000/")
+        bases, orders = self._run_with_spy(monkeypatch)
+        assert bases == ["http://app.internal:9000"]
+        assert orders == [("us",)]
+
+    def test_unset_keeps_live_host_and_default_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the override the factory binds to ``mixpanel.com`` and probes all.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        bases, orders = self._run_with_spy(monkeypatch)
+        assert bases == ["https://mixpanel.com"]
+        assert orders == [("us", "eu", "in")]
+
+    def test_narration_mentions_override_base(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``narrate`` supplied, the first line names the override base.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        from pydantic import SecretStr
+
+        from mixpanel_headless._internal.auth import region_probe as rp_mod
+        from mixpanel_headless._internal.auth.region_probe import (
+            probe_region_for_credential,
+        )
+
+        monkeypatch.setenv("MP_API_BASE_URL", "http://127.0.0.1:8080")
+
+        def _spy_probe(
+            client_factory: object,
+            headers: dict[str, str],
+            *,
+            timeout_seconds: float = 5.0,
+            order: tuple[Region, ...] = ("us", "eu", "in"),
+        ) -> rp_mod.RegionProbeResult:
+            """Return a canned success without touching the factory.
+
+            Args:
+                client_factory: Ignored.
+                headers: Ignored.
+                timeout_seconds: Ignored.
+                order: The probe ordering handed in by the caller.
+
+            Returns:
+                A canned success for ``order[0]``.
+            """
+            return rp_mod.RegionProbeResult(region=order[0], attempts=[(order[0], 200)])
+
+        monkeypatch.setattr(rp_mod, "probe_region", _spy_probe)
+        lines: list[str] = []
+        probe_region_for_credential(
+            account_type="service_account",
+            username="u",
+            secret=SecretStr("s"),
+            token=None,
+            token_env=None,
+            narrate=lines.append,
+        )
+        assert lines
+        assert "http://127.0.0.1:8080" in lines[0]
+        assert "MP_API_BASE_URL" in lines[0]


### PR DESCRIPTION
## Summary

Adds one environment variable, `MP_API_BASE_URL`, that routes every Mixpanel API family at a single alternate host. It is read at request time (never at import), so `Workspace.use(account=...)` swaps, long-lived processes, and test monkeypatching all see the current value. With the variable unset, behaviour is byte-identical to today.

Implements `context/mp-bench-headless/work-orders/mp-api-base-url-override.md`. This lets MP Bench (skill mode, MCP mode, and the containerised Inspect/Opik profile) run the unmodified library and `mp` CLI against headless Mixpanel pods and retire the `sitecustomize.py` shim that mutates a private dict.

**Design**

- One resolver, `_endpoints_for(region)` in `_internal/api_client.py`, returns the override table when `MP_API_BASE_URL` is set (after `rstrip("/")`) and the live `ENDPOINTS[region]` object otherwise. All four former `ENDPOINTS` read sites go through it: `_build_url`, the App-vs-Query timeout selection, the pinned `workspace_id` injection, and the `mp login` `/me` region probe.
- `MP_APP_BASE_URL` (optional, from the work order) is implemented: it re-homes only the App API family at `{app_base}/api/app`, alone or on top of `MP_API_BASE_URL`. It cost three lines in the resolver.
- Region probe: when `MP_API_BASE_URL` is set, probing `us -> eu -> in` against one host is pointless, so `probe_region_for_credential` probes once at the base and labels the account with `MP_REGION` (when it is `us`/`eu`/`in`) or `us`. When only `MP_APP_BASE_URL` is set, the normal three-region order still runs, because query, export, and engage still use the live regional hosts. A path-prefixed base (`https://proxy.example/mp`) keeps its prefix in front of `/api/app/me`. The narration names the active variable(s).
- `MP_API_INSECURE` is not needed: httpx accepts `http://` bases today. The docs state plain-`http://` bases are accepted and intended for local/headless deployments only.
- `MP_REGION` stays required and meaningful for non-URL uses (`_domain_to_region`, report-link hostnames in `_internal/report_links.py`, which remain out of scope).

## Prefix table

| `api_type` | Override URL | Live `us` equivalent |
|---|---|---|
| `query` | `{base}/api/query` | `https://mixpanel.com/api/query` |
| `export` | `{base}/api/2.0` | `https://data.mixpanel.com/api/2.0` |
| `engage` | `{base}/api/query/engage` | `https://mixpanel.com/api/query/engage` |
| `app` | `{base}/api/app` | `https://mixpanel.com/api/app` |

## Acceptance (from the work order)

- [x] `MP_API_BASE_URL=http://127.0.0.1:8080` + `MP_PROJECT_ID/MP_USERNAME/MP_SECRET/MP_REGION` -> `Workspace().events()`, `.query(...)`, `.funnel(...)` / `.query_funnel(...)`, `.retention(...)` / `.query_retention(...)`, `.query_user(...)` (aggregate and profiles), `.stream_events(...)` all hit `127.0.0.1:8080` with the prefixes above and nothing touches `*.mixpanel.com`. Proven by `httpx.MockTransport` unit tests that assert the full request URL per family (`tests/unit/test_api_base_url_override.py::TestWorkspaceFacadeHitsOverride`, `::TestClientRequestsHitOverride`). The tests build a bare `Workspace()` from env vars, exactly as the acceptance text reads.
- [x] Trailing slash on the base is tolerated (`http://127.0.0.1:8080/`, `//`, `///`; plus a Hypothesis property over 0-5 trailing slashes).
- [x] App-API timeout and `workspace_id` injection behave the same under the override as live (`::TestTimeoutSelectionUnderOverride`, `::TestWorkspaceIdInjectionUnderOverride`, including the split `MP_APP_BASE_URL` host).
- [x] `mp login` / region probe honours the override: single probe at the base when `MP_API_BASE_URL` is set (region from `MP_REGION` or `us`), three-region order kept for an App-only override, path-prefixed bases preserved, narration names the active variable (`tests/unit/test_region_probe.py::TestRegionProbeUnderApiBaseUrlOverride`).
- [x] `mp` CLI inherits it with no flag: `CliRunner` runs `mp inspect events` with the env var set and a mock transport injected into the shared client constructor; the only request goes to `http://127.0.0.1:8080/api/query/events/names` (`::TestCliInheritsOverride`).
- [x] Unset var -> `tests/unit/test_api_client*.py`, `test_region_probe.py`, `test_app_api_client.py`, `test_lexicon_schemas.py` pass unchanged (only additions were made to `test_region_probe.py`; no existing test was edited).
- [x] Row added to the Environment Variables table in `CLAUDE.md`, `docs/getting-started/configuration.md` (plus a new "Alternate API host" section with the prefix table and the `http://` note), `docs/cli/index.md`, and `mixpanel-plugin/docs/getting-started-guide.md`. `README.md` has no env-var table, so nothing to add there.
- [x] `CHANGELOG.md` `## Unreleased` -> `### Added` entry (the section already existed on `main`; the entry was added at its top).

## Test plan

- [x] `just check` passes locally (lint, fmt-check, typecheck, docstring-cov, test-cov, conformance, build).
- [x] New: `tests/unit/test_api_base_url_override.py` (resolver, `_build_url` laziness, per-family request URLs, trailing slash, timeout selection, `workspace_id` injection, `Workspace()`-from-env facade calls, CLI, unset-is-live).
- [x] New: `tests/unit/test_api_base_url_override_pbt.py` (Hypothesis: for any base URL and any number of trailing slashes every family URL is `base + prefix` with no double slash; `_build_url` appends the normalised path; unset returns the live table object; resolving never mutates `ENDPOINTS`).
- [x] Extended: `tests/unit/test_region_probe.py` (probe under override).
- [x] `tests/conftest.py` autouse scrub now also deletes `MP_API_BASE_URL` / `MP_APP_BASE_URL`, so a developer's real shell value cannot leak into unrelated tests.
- [ ] Live smoke against an MP Bench headless pod (`eval-runner.sh --backend headless --backend-url ...` with the `PYTHONPATH` shim line removed) -- not run from this branch; the pods are only reachable over the MP Bench Tailscale network. Left to the MP Bench side before deleting the shim.

## Follow-ups

- MP Bench: delete `mp-bench/headless/sitecustomize/sitecustomize.py` and the `PYTHONPATH` line at `eval-runner.sh:131` once this ships in a release; the `MP_API_BASE_URL` export at `eval-runner.sh:129` already matches.
- The `mp login` `oauth_browser` (PKCE) path still talks to the real Mixpanel OAuth endpoints; the override only governs the API families. That is consistent with the work order (service-account / static-token credentials are what the pods use) but worth stating if a browser-auth headless scenario ever appears.
- `_domain_to_region` and report-link URLs are intentionally untouched; under the override `create_report_link` still emits real `*.mixpanel.com` URLs.
- TypeScript port: mirror the resolver if/when the TS client wants the same override (not required for MP Bench today).

## Conformance

The CI `conformance` job fails on this PR in the "Record-mode drift check" step. That failure is expected under the two-step corpus protocol in `conformance/record/README.md`: a library PR must not touch `conformance/vectors/` or `conformance/contract/`, and the drift check going red is the signal that recorded behaviour changed. Nothing under `conformance/` is modified here.

The re-extraction on CI reports 9 findings, all additive plus the two derived files:

- seven new bundles from the new override tests, one per recorded family: `bookmarks/`, `discovery/`, `engage/`, `entities/`, `funnels/`, `retention/`, `streaming/` `test_api_base_url_override.jsonl`
- `api-index.json` (new module-level names in `_internal/api_client.py`)
- `manifest.json`

A single conformance-only re-pin PR, stamped with the squash SHA of this change on `main`, will record these vectors after merge (shared with #236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


