### PR TITLE
fix(types): validate Filter operator on direct construction and accept factory-method aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,30 @@ may include API changes.
   `severity="error"` item and exits with `INVALID_ARGS` (3). Scripts that
   test for exit code 1 on those commands must be updated.
 
+### Fixed
+
+- **`Filter(...)` built positionally no longer serializes an unvalidated
+  operator.** `Filter("gold", "greater_than", 10, "number")` used to emit
+  `"filterOperator": "greater_than"` verbatim and fail server-side with HTTP
+  400 (`Unsupported operator for filter_type number`). `Filter.__post_init__`
+  now validates `_operator` against the `FilterOperator` literal and raises
+  `ValueError` immediately — naming the bad operator, listing the valid wire
+  operators, and pointing at the factory methods — instead of surfacing a
+  generic `QueryError` one HTTP round trip later. The factory-method spellings
+  are accepted as aliases and normalized to the wire operator
+  (`"greater_than"` → `"is greater than"`, `"is_set"` → `"is set"`,
+  `"not_between"` → `"not between"`, `"in_the_last"` → `"was in the"`, and so
+  on for every public `Filter` classmethod), so the positional call now
+  produces byte-identical output to the equivalent factory. The two
+  segmentation-`where` spellings that pre-date the literal, `"is equal to"`
+  and `"between"`, stay constructible as aliases of `"equals"` and
+  `"is between"` (same `==` / `><` segfilter output). On a `boolean`
+  property, `equals` / `does not equal` with a `True` / `False` value collapse
+  to `true` / `false` with `filterValue: null`, matching `Filter.is_true()` /
+  `Filter.is_false()`; any other operator on a boolean property is rejected.
+  Already-valid input is never rewritten. The `Filter` docstring no longer
+  claims the class is "never instantiated directly".
+
 ### Documentation
 
 - `FrequencyFilter` now documents that the query engine evaluates its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,13 @@ may include API changes.
   `"is between"` (same `==` / `><` segfilter output). On a `boolean`
   property, `equals` / `does not equal` with a `True` / `False` value collapse
   to `true` / `false` with `filterValue: null`, matching `Filter.is_true()` /
-  `Filter.is_false()`; any other operator on a boolean property is rejected.
+  `Filter.is_false()`; any other operator on a boolean property is rejected,
+  and `true` / `false` (however spelled) reject any non-`None` value. A
+  boolean `InlineCustomProperty` is governed by the same rules (the inline
+  type wins, as in `build_filter_entry`). Non-string operators raise the same
+  `ValueError` rather than `TypeError`. The `_operator` field is typed as the
+  new `FilterOperatorInput` literal (wire operators plus aliases) so the
+  positional call type-checks; the stored value is always canonical.
   Already-valid input is never rewritten. The `Filter` docstring no longer
   claims the class is "never instantiated directly".
 

--- a/conformance/differential/strategies.py
+++ b/conformance/differential/strategies.py
@@ -77,6 +77,7 @@ from mixpanel_headless.types import (
     RetentionEvent,
     TimeComparison,
     UserAction,
+    _filter_unchecked,
 )
 
 FuzzCall = tuple[str, dict[str, Any]]
@@ -238,10 +239,11 @@ _SELECTOR_OPERATORS: tuple[str, ...] = (
     "is not set",
     "true",
     "false",
-    # Unsupported spellings — the ES13 fallthrough. ``list_contains`` is
-    # deliberately absent: ``Filter.__post_init__`` rejects it without
-    # ``_list_item_filters``, so the draw would fail at CONSTRUCTION and
-    # never reach the translation under test.
+    # Unsupported spellings — the ES13 fallthrough. ``Filter.__post_init__``
+    # rejects these at construction, so the draw below rebuilds the Filter
+    # field-for-field via ``_filter_unchecked`` to reach the translation
+    # under test. ``list_contains`` is deliberately absent: it needs
+    # ``_list_item_filters`` / ``_list_item_quantifier`` to be meaningful.
     "",
     "was frobnicated",
     "is within",
@@ -252,9 +254,10 @@ _SELECTOR_OPERATORS: tuple[str, ...] = (
 def _escaping_filters(draw: st.DrawFn) -> Filter:
     """Draw a Filter with escaping-biased property names and values.
 
-    Filters are built through the dataclass constructor (not the typed
-    factories) so the drawn operator/value combinations can be mismatched
-    on purpose — every ES guard must be reachable.
+    Filters are built field-for-field via ``_filter_unchecked`` (not the
+    typed factories, and not the validating constructor) so the drawn
+    operator/value combinations can be mismatched on purpose — every ES
+    guard must be reachable.
 
     Args:
         draw: Hypothesis draw function.
@@ -283,10 +286,10 @@ def _escaping_filters(draw: st.DrawFn) -> Filter:
         )
     else:
         value = draw(st.one_of(st.none(), _ESCAPING_TEXT))
-    return Filter(
+    return _filter_unchecked(
         _property=draw(_ESCAPING_TEXT),
-        _operator=operator,  # type: ignore[arg-type]
-        _value=value,  # type: ignore[arg-type]
+        _operator=operator,
+        _value=value,
     )
 
 
@@ -390,7 +393,9 @@ _FILTERS_TO_SELECTOR = FuzzTarget(
             {
                 "filters": [
                     Filter.is_set("p"),
-                    Filter("p", "was frobnicated", None),  # type: ignore[arg-type]
+                    _filter_unchecked(
+                        _property="p", _operator="was frobnicated", _value=None
+                    ),
                 ]
             },
         ),
@@ -400,7 +405,9 @@ _FILTERS_TO_SELECTOR = FuzzTarget(
             {
                 "filters": [
                     Filter(123, "is set", None),  # type: ignore[arg-type]
-                    Filter("p", "was frobnicated", None),  # type: ignore[arg-type]
+                    _filter_unchecked(
+                        _property="p", _operator="was frobnicated", _value=None
+                    ),
                 ]
             },
         ),

--- a/conformance/differential/strategies.py
+++ b/conformance/differential/strategies.py
@@ -473,12 +473,14 @@ def _segfilter_row_sweep() -> tuple[FuzzCall, ...]:
             (
                 api,
                 {
-                    "f": Filter(
+                    # Built raw: "is equal to" is a NUMBER_OPERATOR_MAP row the
+                    # FilterOperator literal does not spell — the map is
+                    # deliberately wider (segfilter.py:59-70) — and the
+                    # constructor would normalize it to "equals" before the
+                    # sweep reached segfilter. Every row must arrive verbatim.
+                    "f": _filter_unchecked(
                         _property="p",
-                        # "is equal to" is a NUMBER_OPERATOR_MAP row the
-                        # FilterOperator literal does not spell — the map
-                        # is deliberately wider (segfilter.py:59-70).
-                        _operator=num_op,  # type: ignore[arg-type]
+                        _operator=num_op,
                         _value=None if num_op in setness else 5,
                         _property_type="number",
                     )
@@ -491,11 +493,13 @@ def _segfilter_row_sweep() -> tuple[FuzzCall, ...]:
             (
                 api,
                 {
-                    "f": Filter(
+                    # Built raw for the same reason: "between" is a
+                    # NUMBER_OPERATOR_MAP row outside the FilterOperator
+                    # literal that the constructor would rewrite to
+                    # "is between" (see above).
+                    "f": _filter_unchecked(
                         _property="p",
-                        # "between" is a NUMBER_OPERATOR_MAP row outside
-                        # the FilterOperator literal (see above).
-                        _operator=range_op,  # type: ignore[arg-type]
+                        _operator=range_op,
                         _value=range_value,
                         _property_type="number",
                     )

--- a/conformance/record/codecs.py
+++ b/conformance/record/codecs.py
@@ -474,7 +474,10 @@ def _tuple_fields(cls: type) -> frozenset[str]:
     )
 
 
-def _rebuild_dataclass(cls: type, kwargs: Mapping[str, Any]) -> Any:
+def _rebuild_dataclass(
+    cls: type,
+    kwargs: Mapping[str, Any],  # Any: values are decoded from arbitrary vector JSON
+) -> Any:  # Any: returns whichever codec dataclass ``cls`` names
     """Instantiate ``cls`` from decoded vector fields.
 
     Every codec dataclass goes through its own constructor — except

--- a/conformance/record/codecs.py
+++ b/conformance/record/codecs.py
@@ -474,8 +474,45 @@ def _tuple_fields(cls: type) -> frozenset[str]:
     )
 
 
+def _rebuild_dataclass(cls: type, kwargs: Mapping[str, Any]) -> Any:
+    """Instantiate ``cls`` from decoded vector fields.
+
+    Every codec dataclass goes through its own constructor — except
+    ``Filter``, which is rebuilt field-for-field via
+    ``mixpanel_headless.types._filter_unchecked`` so ``Filter.__post_init__``
+    does not run. The codec's job is to reproduce the *recorded* object
+    faithfully: pinned vectors capture the downstream builders' own guard
+    behaviour (engage ``ES13``, segfilter ``SG1`` / ``SG2`` / ``SG3``) on a
+    Filter that was already constructed at record time. Since the
+    constructor started rejecting non-literal operators and normalizing
+    alias spellings, re-running it here would either refuse to rebuild
+    those inputs or silently rewrite them before the builder under test
+    ever sees them. The builders' behaviour on the rebuilt Filter is
+    unchanged, so the pinned outputs still hold.
+
+    Args:
+        cls: The dataclass named by the payload's ``$type``.
+        kwargs: Decoded field values keyed by dataclass field name.
+
+    Returns:
+        A new ``cls`` instance carrying exactly the recorded fields.
+
+    Raises:
+        Exception: Whatever the constructor (or the unchecked rebuild)
+            raises for the given fields; the caller wraps it.
+    """
+    from mixpanel_headless.types import Filter, _filter_unchecked
+
+    if cls is Filter:
+        return _filter_unchecked(**kwargs)
+    return cls(**kwargs)
+
+
 def _decode_dataclass(cls: type, payload: Mapping[str, Any]) -> Any:
     """Reconstruct a frozen dataclass from its tagged-object fields.
+
+    ``Filter`` payloads are rebuilt without re-running ``__post_init__``;
+    see :func:`_rebuild_dataclass` for why.
 
     Args:
         cls: The dataclass named by the payload's ``$type``.
@@ -502,7 +539,7 @@ def _decode_dataclass(cls: type, payload: Mapping[str, Any]) -> Any:
             decoded = tuple(decoded)
         kwargs[name] = decoded
     try:
-        return cls(**kwargs)
+        return _rebuild_dataclass(cls, kwargs)
     except Exception as exc:
         raise UndecodableValueError(
             f"could not reconstruct {cls.__name__} from vector fields: {exc}"

--- a/conformance/tests/test_codecs_roundtrip.py
+++ b/conformance/tests/test_codecs_roundtrip.py
@@ -156,6 +156,79 @@ def test_filter_list_contains_restores_tuple_fields() -> None:
     assert isinstance(decoded._list_item_filters, tuple)
 
 
+@pytest.mark.parametrize(
+    "operator", ["was frobnicated", "is within", "magical_unicorn"]
+)
+def test_filter_decode_rehydrates_rejected_operators_verbatim(operator: str) -> None:
+    """A recorded Filter with a non-literal operator decodes without running ``__post_init__``.
+
+    Pinned vectors capture the *builders'* guard behaviour (ES13 / SG1 / SG2 /
+    SG3) on an already-constructed Filter. Since ``Filter.__post_init__``
+    started rejecting unknown operators, the codec must rebuild the recorded
+    object faithfully — field for field — rather than re-validate it, or those
+    vectors could never reach the guard they pin.
+
+    Args:
+        operator: An operator spelling ``Filter(...)`` now rejects.
+
+    Raises:
+        AssertionError: If decode raises or alters the recorded fields.
+    """
+    payload = {
+        "$type": "Filter",
+        "_property": "p",
+        "_operator": operator,
+        "_value": None,
+        "_property_type": "string",
+        "_resource_type": "events",
+        "_date_unit": None,
+        "_list_item_filters": None,
+        "_list_item_quantifier": None,
+    }
+    decoded = decode_value(payload)
+    assert isinstance(decoded, Filter)
+    assert decoded._operator == operator
+    assert decoded._property_type == "string"
+
+
+def test_filter_decode_does_not_normalize_alias_spellings() -> None:
+    """Decode is a faithful rebuild: an alias spelling stays verbatim, unlike ``Filter(...)``.
+
+    Raises:
+        AssertionError: If the codec rewrote ``_operator`` on the way in.
+    """
+    payload = {
+        "$type": "Filter",
+        "_property": "gold",
+        "_operator": "greater_than",
+        "_value": 10,
+        "_property_type": "number",
+    }
+    decoded = decode_value(payload)
+    assert isinstance(decoded, Filter)
+    # str() sidesteps mypy's Literal non-overlap check: the whole point is
+    # that the field holds a spelling outside the FilterOperator literal.
+    assert str(decoded._operator) == "greater_than"
+    assert decoded._resource_type == "events"
+
+
+def test_filter_decode_still_rejects_unknown_fields() -> None:
+    """The unknown-field guard runs before the faithful rebuild for Filter too.
+
+    Raises:
+        AssertionError: If an extra field slips through.
+    """
+    payload = {
+        "$type": "Filter",
+        "_property": "p",
+        "_operator": "is set",
+        "_value": None,
+        "_bogus": 1,
+    }
+    with pytest.raises(UndecodableValueError, match="_bogus"):
+        decode_value(payload)
+
+
 def test_cohort_definition_round_trip_preserves_to_dict() -> None:
     """``CohortDefinition`` (init=False) reconstructs via all_of/any_of.
 

--- a/src/mixpanel_headless/_literal_types.py
+++ b/src/mixpanel_headless/_literal_types.py
@@ -561,6 +561,73 @@ wire format and so mypy catches typos at every Filter classmethod
 factory call site.
 """
 
+FilterOperatorInput = Literal[
+    # --- FilterOperator members (the canonical wire spellings) ---
+    "contains",
+    "does not contain",
+    "does not equal",
+    "ends with",
+    "equals",
+    "false",
+    "is at least",
+    "is at most",
+    "is between",
+    "is greater than",
+    "is less than",
+    "is not set",
+    "is set",
+    "list_contains",
+    "not between",
+    "starts with",
+    "true",
+    "was before",
+    "was between",
+    "was in the",
+    "was in the next",
+    "was not between",
+    "was not in the",
+    "was not on",
+    "was on",
+    "was since",
+    # --- Filter factory-method names accepted as aliases ---
+    "at_least",
+    "at_most",
+    "before",
+    "between",
+    "date_between",
+    "date_not_between",
+    "ends_with",
+    "greater_than",
+    "in_cohort",
+    "in_the_last",
+    "in_the_next",
+    "is_false",
+    "is_not_set",
+    "is_set",
+    "is_true",
+    "less_than",
+    "not_between",
+    "not_contains",
+    "not_equals",
+    "not_in_cohort",
+    "not_in_the_last",
+    "not_on",
+    "on",
+    "since",
+    "starts_with",
+    # --- Segmentation-``where`` spelling kept constructible ---
+    "is equal to",
+]
+"""Every spelling ``Filter(...)`` accepts for ``_operator`` on direct construction.
+
+The union of :data:`FilterOperator`, the public ``Filter`` factory-method
+names (``"greater_than"``, ``"is_set"``, ...) and the segfilter-only
+``"is equal to"``. ``Filter.__post_init__`` normalizes any alias to its
+:data:`FilterOperator` member, so a constructed Filter always *stores* a
+canonical operator; this wider type only describes what may be passed in.
+Kept in lockstep with ``types._FILTER_OPERATOR_ALIASES`` by a unit test.
+"""
+
 FilterDateUnit = Literal["hour", "day", "week", "month"]
 """Time unit for relative date filters.
 

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -35,6 +35,7 @@ from typing import (
     Final,
     Generic,
     Literal,
+    TypeAlias,
     TypedDict,
     TypeVar,
     cast,
@@ -50,13 +51,14 @@ from mixpanel_headless._literal_types import (
 from mixpanel_headless._literal_types import CustomPropertyType as CustomPropertyType
 from mixpanel_headless._literal_types import FilterDateUnit as FilterDateUnit
 from mixpanel_headless._literal_types import FilterOperator as FilterOperator
-from mixpanel_headless._literal_types import FilterPropertyType as FilterPropertyType
-from mixpanel_headless._literal_types import FiltersCombinator as FiltersCombinator
 from mixpanel_headless._literal_types import (
+    FilterOperatorInput,
     FlowAnchorType,
     FlowNodeType,
     FlowSessionEvent,
 )
+from mixpanel_headless._literal_types import FilterPropertyType as FilterPropertyType
+from mixpanel_headless._literal_types import FiltersCombinator as FiltersCombinator
 from mixpanel_headless._literal_types import FlowChartType as FlowChartType
 from mixpanel_headless._literal_types import (
     FlowConversionWindowUnit as FlowConversionWindowUnit,
@@ -7144,6 +7146,16 @@ class Formula:
             )
 
 
+FilterValue: TypeAlias = (
+    str | int | float | list[str] | list[int | float] | list[dict[str, Any]] | None
+)
+"""Every shape ``Filter._value`` may hold.
+
+Lists of dicts carry cohort selectors (``Filter.in_cohort``), which is the
+one place a loosely-typed payload is unavoidable; everything else is a
+scalar, a list of scalars, or ``None`` for value-less operators.
+"""
+
 _FILTER_WIRE_OPERATORS: Final[frozenset[str]] = frozenset(get_args(FilterOperator))
 """Runtime view of :data:`FilterOperator` for construction-time validation."""
 
@@ -7196,6 +7208,34 @@ normalizing them changes nothing on the wire.
 
 _BOOLEAN_FILTER_OPERATORS: Final[frozenset[str]] = frozenset({"true", "false"})
 """The only operators the platform accepts for ``filterType == "boolean"``."""
+
+
+def _unknown_filter_operator_message(operator: object) -> str:
+    """Build the ``ValueError`` text for an operator ``Filter`` cannot accept.
+
+    Shared by the non-string guard and the literal-membership guard so both
+    failure modes read identically.
+
+    Args:
+        operator: The rejected ``_operator`` value (any type).
+
+    Returns:
+        A message naming the operator, listing the valid wire operators, and
+        pointing at the factory methods and the accepted alias spellings.
+
+    Example:
+        ```python
+        _unknown_filter_operator_message("bigger_than")
+        # "Unknown Filter operator 'bigger_than'. Valid operators: [...]. Prefer ..."
+        ```
+    """
+    return (
+        f"Unknown Filter operator {operator!r}. Valid operators: "
+        f"{sorted(_FILTER_WIRE_OPERATORS)}. Prefer the factory methods "
+        "(Filter.equals(), Filter.greater_than(), Filter.is_set(), "
+        "Filter.is_true(), ...); their names are also accepted as "
+        f"operator aliases: {sorted(_FILTER_OPERATOR_ALIASES)}."
+    )
 
 
 def _boolean_filter_value(value: object) -> bool | None:
@@ -7255,17 +7295,17 @@ class Filter:
     _property: str | CustomPropertyRef | InlineCustomProperty
     """Property to filter on (name, ref, or inline)."""
 
-    _operator: FilterOperator
-    """Internal operator string. Must be one of the values in :data:`FilterOperator`.
+    _operator: FilterOperatorInput
+    """Operator string. After construction, always a :data:`FilterOperator` member.
 
-    Direct construction also accepts the factory-method names listed in
-    :data:`_FILTER_OPERATOR_ALIASES`; ``__post_init__`` rewrites them to the
-    wire spelling before anything reads this field.
+    The declared type is the wider :data:`FilterOperatorInput` so direct
+    construction may pass a factory-method name (``"greater_than"``,
+    ``"is_set"``, ...); ``__post_init__`` rewrites any such alias to the wire
+    spelling before anything reads this field, so readers may treat the
+    stored value as :data:`FilterOperator`.
     """
 
-    _value: (
-        str | int | float | list[str] | list[int | float] | list[dict[str, Any]] | None
-    )
+    _value: FilterValue
     """Value(s) to compare against.
 
     Shape varies by operator: list for equals/not_equals, str for
@@ -7300,25 +7340,34 @@ class Filter:
         Runs on every construction, including the factory classmethods
         (whose output is already canonical and passes through untouched):
 
-        1. A factory-method spelling in :data:`_FILTER_OPERATOR_ALIASES`
-           (``"greater_than"``, ``"is_set"``, ...) is rewritten to the wire
-           operator that factory emits.
-        2. On a ``boolean`` property, ``equals`` / ``does not equal`` with a
+        1. ``_operator`` must be a string; a factory-method spelling in
+           :data:`_FILTER_OPERATOR_ALIASES` (``"greater_than"``, ``"is_set"``,
+           ...) is rewritten to the wire operator that factory emits, and the
+           result must be a :data:`FilterOperator` member.
+        2. The effective property type is derived the same way
+           ``build_filter_entry`` derives ``filterType``: an
+           ``InlineCustomProperty`` with a declared ``property_type`` wins
+           over ``_property_type``.
+        3. On a ``boolean`` property, ``equals`` / ``does not equal`` with a
            bool value collapse to ``true`` / ``false`` with ``_value=None``,
-           matching ``Filter.is_true()`` / ``Filter.is_false()``.
-        3. The operator must then be a :data:`FilterOperator` member, and a
-           ``boolean`` property must use ``true`` / ``false``.
-        4. The pre-existing ``list_contains`` shape guards run last.
+           matching ``Filter.is_true()`` / ``Filter.is_false()``; any other
+           operator on a boolean property is rejected.
+        4. ``true`` / ``false`` (however spelled) take no value: a non-``None``
+           ``_value`` is rejected on every property type, because the
+           platform serializes boolean filters with ``filterValue: null``.
+        5. The pre-existing ``list_contains`` shape guards run last.
 
         Already-valid input is never rewritten: a wire operator and its value
         serialize exactly as given.
 
         Raises:
-            ValueError: If ``_operator`` is neither a :data:`FilterOperator`
-                member nor a known alias, or if a ``boolean`` property uses
-                an operator other than ``true`` / ``false``. The message
-                names the offending operator, lists the valid operators, and
-                points at the factory methods.
+            ValueError: If ``_operator`` is not a string, is neither a
+                :data:`FilterOperator` member nor a known alias, is an
+                operator other than ``true`` / ``false`` on a boolean
+                property, or is ``true`` / ``false`` with a non-``None``
+                value. The message names the offending operator, lists the
+                valid operators where relevant, and points at the factory
+                methods.
             ParamValidationError: If ``_operator == "list_contains"`` but
                 ``_list_item_filters`` (``LC1_MISSING_ITEM_FILTERS``) or
                 ``_list_item_quantifier`` (``LC2_MISSING_QUANTIFIER``) is
@@ -7335,34 +7384,39 @@ class Filter:
             # ValueError: Unknown Filter operator 'bigger_than'. Valid operators: [...]
             ```
         """
-        operator: object = self._operator
-        if isinstance(operator, str) and operator in _FILTER_OPERATOR_ALIASES:
-            operator = _FILTER_OPERATOR_ALIASES[operator]
-        if self._property_type == "boolean" and operator in (
-            "equals",
-            "does not equal",
-        ):
+        raw: object = self._operator
+        # isinstance first: a list/dict/None operator must not reach a set
+        # lookup (TypeError: unhashable) — it gets the same ValueError.
+        if not isinstance(raw, str):
+            raise ValueError(_unknown_filter_operator_message(raw))
+        operator: str = _FILTER_OPERATOR_ALIASES.get(raw, raw)
+        if operator not in _FILTER_WIRE_OPERATORS:
+            raise ValueError(_unknown_filter_operator_message(operator))
+        # Mirror build_filter_entry: an inline custom property's declared
+        # type overrides _property_type for filterType / defaultType.
+        prop = self._property
+        effective_type: str = self._property_type
+        if isinstance(prop, InlineCustomProperty) and prop.property_type is not None:
+            effective_type = prop.property_type
+        if effective_type == "boolean" and operator in ("equals", "does not equal"):
             truth = _boolean_filter_value(self._value)
             if truth is not None:
                 operator = "true" if truth == (operator == "equals") else "false"
                 object.__setattr__(self, "_value", None)
-        if operator not in _FILTER_WIRE_OPERATORS:
-            raise ValueError(
-                f"Unknown Filter operator {operator!r}. Valid operators: "
-                f"{sorted(_FILTER_WIRE_OPERATORS)}. Prefer the factory methods "
-                "(Filter.equals(), Filter.greater_than(), Filter.is_set(), "
-                "Filter.is_true(), ...); their names are also accepted as "
-                f"operator aliases: {sorted(_FILTER_OPERATOR_ALIASES)}."
-            )
-        if (
-            self._property_type == "boolean"
-            and operator not in _BOOLEAN_FILTER_OPERATORS
-        ):
+        if effective_type == "boolean" and operator not in _BOOLEAN_FILTER_OPERATORS:
             raise ValueError(
                 f"Filter operator {operator!r} is not valid for a boolean property "
-                f"({self._property!r}); boolean filters only support 'true' and "
-                "'false' with no value. Use Filter.is_true() / Filter.is_false(), "
-                "or pass value True / False with operator 'equals'."
+                f"({prop!r}); boolean filters only support 'true' and 'false' "
+                "with no value. Use Filter.is_true() / Filter.is_false(), or pass "
+                "value True / False with operator 'equals'."
+            )
+        if operator in _BOOLEAN_FILTER_OPERATORS and self._value is not None:
+            raise ValueError(
+                f"Filter operator {operator!r} takes no value (got "
+                f"{self._value!r}); the platform serializes boolean filters with "
+                "filterValue null. Use Filter.is_true() / Filter.is_false(), or "
+                "pass value True / False with operator 'equals' on a boolean "
+                "property."
             )
         if operator != self._operator:
             object.__setattr__(self, "_operator", cast(FilterOperator, operator))

--- a/src/mixpanel_headless/types.py
+++ b/src/mixpanel_headless/types.py
@@ -23,12 +23,23 @@ import re
 import time
 import warnings
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from datetime import date as dt_date
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TypedDict, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Final,
+    Generic,
+    Literal,
+    TypedDict,
+    TypeVar,
+    cast,
+    get_args,
+)
 
 from mixpanel_headless._literal_types import (
     CohortAggregationType as CohortAggregationType,
@@ -7133,13 +7144,98 @@ class Formula:
             )
 
 
+_FILTER_WIRE_OPERATORS: Final[frozenset[str]] = frozenset(get_args(FilterOperator))
+"""Runtime view of :data:`FilterOperator` for construction-time validation."""
+
+_FILTER_OPERATOR_ALIASES: Final[dict[str, FilterOperator]] = {
+    "not_equals": "does not equal",
+    "not_contains": "does not contain",
+    "greater_than": "is greater than",
+    "less_than": "is less than",
+    "between": "is between",
+    "not_between": "not between",
+    "at_least": "is at least",
+    "at_most": "is at most",
+    "is_set": "is set",
+    "is_not_set": "is not set",
+    "starts_with": "starts with",
+    "ends_with": "ends with",
+    "is_true": "true",
+    "is_false": "false",
+    "in_cohort": "contains",
+    "not_in_cohort": "does not contain",
+    "on": "was on",
+    "not_on": "was not on",
+    "before": "was before",
+    "since": "was since",
+    "in_the_last": "was in the",
+    "not_in_the_last": "was not in the",
+    "date_between": "was between",
+    "date_not_between": "was not between",
+    "in_the_next": "was in the next",
+    # Segfilter-compat spelling: a ``NUMBER_OPERATOR_MAP`` row in
+    # ``_internal/segfilter.py`` that pre-dates the FilterOperator literal.
+    # ``equals`` maps to the same ``==`` there, so output is unchanged.
+    "is equal to": "equals",
+}
+"""Spellings accepted as ``_operator`` on direct construction and normalized.
+
+Each key is the name of a public ``Filter`` classmethod whose spelling differs
+from the wire operator it emits; the value is that wire operator. ``equals``,
+``contains`` and ``list_contains`` are absent because their names already
+*are* the wire spelling. ``Filter.__post_init__`` rewrites an alias to its
+wire operator so ``Filter("gold", "greater_than", 10, "number")`` serializes
+exactly like ``Filter.greater_than("gold", 10)``.
+
+Two entries also keep the segmentation ``where`` builder's wider operator
+map constructible: ``"between"`` (a factory name) and ``"is equal to"`` (not
+a factory name) are ``NUMBER_OPERATOR_MAP`` rows outside the literal; their
+targets map to the same segfilter operators (``><`` and ``==``), so
+normalizing them changes nothing on the wire.
+"""
+
+_BOOLEAN_FILTER_OPERATORS: Final[frozenset[str]] = frozenset({"true", "false"})
+"""The only operators the platform accepts for ``filterType == "boolean"``."""
+
+
+def _boolean_filter_value(value: object) -> bool | None:
+    """Extract the bool a directly-constructed boolean-equality Filter carries.
+
+    Args:
+        value: Raw ``_value`` payload — ``True`` / ``False`` or a one-element
+            list wrapping one (the ``Filter.equals`` list convention).
+
+    Returns:
+        The bool, or ``None`` when ``value`` is not a bare or singly-wrapped
+        bool (``1`` / ``0`` and strings deliberately do not qualify).
+
+    Example:
+        ```python
+        _boolean_filter_value(True)      # True
+        _boolean_filter_value([False])   # False
+        _boolean_filter_value(1)         # None
+        ```
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], bool):
+        return value[0]
+    return None
+
+
 @dataclass(frozen=True)
 class Filter:
     """Represents a typed filter condition on a property.
 
-    Constructed exclusively via class methods — never instantiated directly.
-    Each class method maps to specific filterType, filterOperator, and
-    filterValue format in the bookmark JSON.
+    The factory classmethods (``Filter.equals``, ``Filter.greater_than``,
+    ``Filter.is_set``, ...) are the recommended way to build a Filter: each
+    one maps to a specific filterType, filterOperator, and filterValue format
+    in the bookmark JSON. Direct construction is supported and validated:
+    ``_operator`` must be a :data:`FilterOperator` member or a factory-method
+    name (``"greater_than"``, ``"is_set"``, ...), which ``__post_init__``
+    normalizes to the wire spelling so both paths serialize identically.
+    Anything else raises ``ValueError`` at construction instead of surfacing
+    as an HTTP 400 from the query API.
 
     Example:
         ```python
@@ -7149,6 +7245,10 @@ class Filter:
         f2 = Filter.greater_than("age", 18)
         f3 = Filter.between("amount", 10, 100)
         f4 = Filter.is_set("email")
+
+        # Direct construction accepts the factory-method spelling as an alias
+        Filter("age", "greater_than", 18, "number") == f2   # True
+        Filter("won", "equals", True, "boolean") == Filter.is_true("won")  # True
         ```
     """
 
@@ -7156,7 +7256,12 @@ class Filter:
     """Property to filter on (name, ref, or inline)."""
 
     _operator: FilterOperator
-    """Internal operator string. Must be one of the values in :data:`FilterOperator`."""
+    """Internal operator string. Must be one of the values in :data:`FilterOperator`.
+
+    Direct construction also accepts the factory-method names listed in
+    :data:`_FILTER_OPERATOR_ALIASES`; ``__post_init__`` rewrites them to the
+    wire spelling before anything reads this field.
+    """
 
     _value: (
         str | int | float | list[str] | list[int | float] | list[dict[str, Any]] | None
@@ -7190,21 +7295,78 @@ class Filter:
     """Quantifier for ``list_contains``: ``"any"`` (≥1 item matches) or ``"all"`` (every item matches)."""
 
     def __post_init__(self) -> None:
-        """Validate Filter mode invariants.
+        """Normalize operator aliases and validate Filter invariants.
 
-        Only validates the ``list_contains`` mode today. Other operator
-        modes rely on classmethod-only validation; expanding this
-        coverage is a separate concern from this PR's list_contains
-        feature.
+        Runs on every construction, including the factory classmethods
+        (whose output is already canonical and passes through untouched):
+
+        1. A factory-method spelling in :data:`_FILTER_OPERATOR_ALIASES`
+           (``"greater_than"``, ``"is_set"``, ...) is rewritten to the wire
+           operator that factory emits.
+        2. On a ``boolean`` property, ``equals`` / ``does not equal`` with a
+           bool value collapse to ``true`` / ``false`` with ``_value=None``,
+           matching ``Filter.is_true()`` / ``Filter.is_false()``.
+        3. The operator must then be a :data:`FilterOperator` member, and a
+           ``boolean`` property must use ``true`` / ``false``.
+        4. The pre-existing ``list_contains`` shape guards run last.
+
+        Already-valid input is never rewritten: a wire operator and its value
+        serialize exactly as given.
 
         Raises:
+            ValueError: If ``_operator`` is neither a :data:`FilterOperator`
+                member nor a known alias, or if a ``boolean`` property uses
+                an operator other than ``true`` / ``false``. The message
+                names the offending operator, lists the valid operators, and
+                points at the factory methods.
             ParamValidationError: If ``_operator == "list_contains"`` but
                 ``_list_item_filters`` (``LC1_MISSING_ITEM_FILTERS``) or
                 ``_list_item_quantifier`` (``LC2_MISSING_QUANTIFIER``) is
                 ``None``. List-contains filters must be constructed
                 via ``Filter.list_contains(...)``.
+
+        Example:
+            ```python
+            Filter("gold", "greater_than", 10, "number") == Filter.greater_than("gold", 10)
+            # True
+            Filter("won", "equals", True, "boolean") == Filter.is_true("won")
+            # True
+            Filter("gold", "bigger_than", 10, "number")
+            # ValueError: Unknown Filter operator 'bigger_than'. Valid operators: [...]
+            ```
         """
-        if self._operator == "list_contains":
+        operator: object = self._operator
+        if isinstance(operator, str) and operator in _FILTER_OPERATOR_ALIASES:
+            operator = _FILTER_OPERATOR_ALIASES[operator]
+        if self._property_type == "boolean" and operator in (
+            "equals",
+            "does not equal",
+        ):
+            truth = _boolean_filter_value(self._value)
+            if truth is not None:
+                operator = "true" if truth == (operator == "equals") else "false"
+                object.__setattr__(self, "_value", None)
+        if operator not in _FILTER_WIRE_OPERATORS:
+            raise ValueError(
+                f"Unknown Filter operator {operator!r}. Valid operators: "
+                f"{sorted(_FILTER_WIRE_OPERATORS)}. Prefer the factory methods "
+                "(Filter.equals(), Filter.greater_than(), Filter.is_set(), "
+                "Filter.is_true(), ...); their names are also accepted as "
+                f"operator aliases: {sorted(_FILTER_OPERATOR_ALIASES)}."
+            )
+        if (
+            self._property_type == "boolean"
+            and operator not in _BOOLEAN_FILTER_OPERATORS
+        ):
+            raise ValueError(
+                f"Filter operator {operator!r} is not valid for a boolean property "
+                f"({self._property!r}); boolean filters only support 'true' and "
+                "'false' with no value. Use Filter.is_true() / Filter.is_false(), "
+                "or pass value True / False with operator 'equals'."
+            )
+        if operator != self._operator:
+            object.__setattr__(self, "_operator", cast(FilterOperator, operator))
+        if operator == "list_contains":
             if self._list_item_filters is None:
                 raise ParamValidationError(
                     "list_contains Filter requires _list_item_filters; "
@@ -8266,6 +8428,65 @@ class Filter:
             _list_item_filters=sub_filters,
             _list_item_quantifier=quantifier,
         )
+
+
+def _filter_unchecked(**values: object) -> Filter:
+    """Rebuild a ``Filter`` field-for-field without running ``__post_init__``.
+
+    ``Filter(...)`` validates ``_operator`` against :data:`FilterOperator`
+    and normalizes alias spellings. Two callers legitimately need the
+    pre-validation object instead:
+
+    - the conformance codec (``conformance/record/codecs.py``), which must
+      rehydrate a *recorded* Filter faithfully — pinned vectors capture the
+      downstream builders' own guard behaviour (engage ``ES13``, segfilter
+      ``SG1`` / ``SG2`` / ``SG3``) on an already-constructed Filter, so
+      re-validating or rewriting the fields on the way in would change what
+      the builder under test sees;
+    - tests and the differential harness that drive those same builder
+      guards with operators the constructor now rejects.
+
+    It is private; library code never calls it. Fields are looked up on the
+    dataclass, so adding a field to ``Filter`` needs no change here.
+
+    Args:
+        **values: Dataclass field values keyed by field name (``_property``,
+            ``_operator``, ``_value``, ``_property_type``, ``_resource_type``,
+            ``_date_unit``, ``_list_item_filters``,
+            ``_list_item_quantifier``). Fields with a dataclass default may
+            be omitted; those without one are required.
+
+    Returns:
+        A frozen ``Filter`` whose fields hold exactly the given values, with
+        no alias normalization, operator validation, or ``list_contains``
+        shape check applied.
+
+    Raises:
+        TypeError: If a required field is missing or an unknown field name
+            is supplied.
+
+    Example:
+        ```python
+        f = _filter_unchecked(_property="p", _operator="was frobnicated", _value=None)
+        f._operator            # "was frobnicated"  (Filter(...) would raise ValueError)
+        f._property_type       # "string"           (dataclass default applied)
+        ```
+    """
+    remaining = dict(values)
+    instance = object.__new__(Filter)
+    for spec in fields(Filter):
+        if spec.name in remaining:
+            value = remaining.pop(spec.name)
+        elif spec.default is not MISSING:
+            value = spec.default
+        else:
+            raise TypeError(f"_filter_unchecked() missing required field {spec.name!r}")
+        object.__setattr__(instance, spec.name, value)
+    if remaining:
+        raise TypeError(
+            f"_filter_unchecked() got unknown Filter field(s): {sorted(remaining)}"
+        )
+    return instance
 
 
 @dataclass(frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from mixpanel_headless._internal.api_client import MixpanelAPIClient
     from mixpanel_headless._internal.auth.session import Session
     from mixpanel_headless._internal.config import ConfigManager
+    from mixpanel_headless.types import Filter
 
 
 def make_session(
@@ -339,3 +340,48 @@ def rate_limit_handler() -> Callable[[httpx.Request], httpx.Response]:
         return httpx.Response(429, headers={"Retry-After": "60"})
 
     return handler
+
+
+def make_unchecked_filter(
+    property: str,
+    operator: str,
+    value: Any,
+    property_type: str = "string",
+    resource_type: str = "events",
+) -> Filter:
+    """Build a ``Filter`` that bypasses ``Filter.__post_init__`` entirely.
+
+    ``Filter`` validates and normalizes ``_operator`` at construction time, so
+    a deliberately invalid operator can no longer be smuggled through the
+    constructor. Tests that exercise the *downstream* operator guards
+    (segfilter ``SG1``/``SG2``/``SG3``, engage selector ``ES13``) use this
+    positional convenience wrapper around
+    ``mixpanel_headless.types._filter_unchecked`` to reach those branches
+    with the raw field values they need.
+
+    Args:
+        property: Raw ``_property`` value.
+        operator: Raw ``_operator`` value (may be deliberately invalid).
+        value: Raw ``_value`` payload.
+        property_type: Raw ``_property_type`` value (may be invalid).
+        resource_type: Raw ``_resource_type`` value.
+
+    Returns:
+        A frozen ``Filter`` whose fields are set verbatim, with no alias
+        normalization or operator validation applied.
+
+    Example:
+        ```python
+        f = make_unchecked_filter("p", "was frobnicated", None)
+        # f._operator == "was frobnicated"  (Filter(...) would raise ValueError)
+        ```
+    """
+    from mixpanel_headless.types import _filter_unchecked
+
+    return _filter_unchecked(
+        _property=property,
+        _operator=operator,
+        _value=value,
+        _property_type=property_type,
+        _resource_type=resource_type,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from mixpanel_headless._internal.api_client import MixpanelAPIClient
     from mixpanel_headless._internal.auth.session import Session
     from mixpanel_headless._internal.config import ConfigManager
-    from mixpanel_headless.types import Filter
+    from mixpanel_headless.types import Filter, FilterValue
 
 
 def make_session(
@@ -345,7 +345,7 @@ def rate_limit_handler() -> Callable[[httpx.Request], httpx.Response]:
 def make_unchecked_filter(
     property: str,
     operator: str,
-    value: Any,
+    value: FilterValue,
     property_type: str = "string",
     resource_type: str = "events",
 ) -> Filter:

--- a/tests/test_query_user_edge_cases.py
+++ b/tests/test_query_user_edge_cases.py
@@ -32,6 +32,7 @@ from mixpanel_headless._internal.query.user_validators import (
 )
 from mixpanel_headless.exceptions import BookmarkValidationError
 from mixpanel_headless.types import Filter, ProfilePageResult, UserQueryResult
+from tests.conftest import make_unchecked_filter
 
 # ---- 042 redesign: canonical fake Session for Workspace(session=…) ----
 _TEST_SESSION = Session(
@@ -689,12 +690,7 @@ class TestTier2CrashPaths:
         Verifies the catch-all at user_builders.py:142 raises a clear
         ValueError with the operator name.
         """
-        f = Filter(
-            _property="fake",
-            _operator="unknown_op",  # type: ignore[arg-type]
-            _value=None,
-            _property_type="string",
-        )
+        f = make_unchecked_filter("fake", "unknown_op", None, "string")
 
         with pytest.raises(ValueError, match="Unsupported filter operator.*unknown_op"):
             filter_to_selector(f)

--- a/tests/test_user_builders.py
+++ b/tests/test_user_builders.py
@@ -18,6 +18,7 @@ from mixpanel_headless._internal.query.user_builders import (
 )
 from mixpanel_headless.exceptions import ParamValidationError
 from mixpanel_headless.types import CohortCriteria, CohortDefinition, Filter
+from tests.conftest import make_unchecked_filter
 
 # =============================================================================
 # filter_to_selector — individual operator mapping
@@ -689,21 +690,21 @@ class TestCodedEngageSelectorCodes:
 
     def test_es13_direct_raises_coded_error(self) -> None:
         """Unsupported operator raises ES13."""
-        f = Filter("p", "was frobnicated", None)  # type: ignore[arg-type]
+        f = make_unchecked_filter("p", "was frobnicated", None)
         with pytest.raises(ParamValidationError) as excinfo:
             filter_to_selector(f)
         assert excinfo.value.code == "ES13_UNSUPPORTED_OPERATOR"
 
     def test_es13_seam_raises_coded_error(self) -> None:
         """filters_to_selector surfaces ES13 for unsupported operators."""
-        f = Filter("p", "is within", None)  # type: ignore[arg-type]
+        f = make_unchecked_filter("p", "is within", None)
         with pytest.raises(ParamValidationError) as excinfo:
             filters_to_selector([f])
         assert excinfo.value.code == "ES13_UNSUPPORTED_OPERATOR"
 
     def test_es_guards_stay_catchable_as_value_error(self) -> None:
         """Converted ES* guards remain catchable via bare ValueError."""
-        f = Filter("p", "was frobnicated", None)  # type: ignore[arg-type]
+        f = make_unchecked_filter("p", "was frobnicated", None)
         with pytest.raises(ValueError) as excinfo:
             filter_to_selector(f)
         assert isinstance(excinfo.value, ParamValidationError)

--- a/tests/test_workspace_query_user.py
+++ b/tests/test_workspace_query_user.py
@@ -32,7 +32,8 @@ from mixpanel_headless import Workspace
 from mixpanel_headless._internal.auth.account import ServiceAccount
 from mixpanel_headless._internal.auth.session import Project, Session
 from mixpanel_headless.exceptions import BookmarkValidationError
-from mixpanel_headless.types import Filter, ProfilePageResult, UserQueryResult
+from mixpanel_headless.types import ProfilePageResult, UserQueryResult
+from tests.conftest import make_unchecked_filter
 
 # ---- 042 redesign: canonical fake Session for Workspace(session=…) ----
 _TEST_SESSION = Session(
@@ -1340,7 +1341,7 @@ class TestQueryUserValueErrorWrapping:
         workspace_factory: Callable[..., Workspace],
     ) -> None:
         """Unsupported filter operator raises BookmarkValidationError."""
-        f = Filter("prop", "unsupported_op", "val")  # type: ignore[arg-type]
+        f = make_unchecked_filter("prop", "unsupported_op", "val")
         ws = workspace_factory()
         try:
             with pytest.raises(BookmarkValidationError):

--- a/tests/unit/test_query_pbt.py
+++ b/tests/unit/test_query_pbt.py
@@ -971,3 +971,35 @@ class TestFilterOperatorValidationInvariant:
             between_wire
         )
         assert build_segfilter_entry(between_alias)["filter"]["operator"] == "><"
+
+    @given(
+        op=st.sampled_from(["true", "false", "is_true", "is_false"]),
+        value=st.one_of(
+            st.text(min_size=1, max_size=10),
+            st.booleans(),
+            st.integers(),
+            st.lists(st.booleans(), min_size=1, max_size=3),
+        ),
+        property_type=st.sampled_from(["boolean", "string"]),
+    )
+    def test_true_false_with_any_non_none_value_is_rejected(
+        self, op: str, value: object, property_type: str
+    ) -> None:
+        """``true`` / ``false`` (and aliases) never accept a value — on any property type."""
+        with pytest.raises(ValueError, match="no value"):
+            _direct(op, value, property_type)
+
+    @given(
+        op=st.one_of(
+            st.none(),
+            st.integers(),
+            st.floats(allow_nan=False),
+            st.lists(st.text(max_size=5), max_size=3),
+            st.dictionaries(st.text(max_size=5), st.integers(), max_size=3),
+            st.tuples(st.text(max_size=5)),
+        )
+    )
+    def test_non_string_operator_is_rejected_with_value_error(self, op: object) -> None:
+        """Unhashable / non-string operators raise the same ValueError, never TypeError."""
+        with pytest.raises(ValueError, match="Unknown Filter operator"):
+            _direct(op, None)  # type: ignore[arg-type]

--- a/tests/unit/test_query_pbt.py
+++ b/tests/unit/test_query_pbt.py
@@ -12,8 +12,10 @@ Uses Hypothesis to verify:
 
 from __future__ import annotations
 
+from typing import get_args
 from unittest.mock import MagicMock
 
+import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 from pydantic import SecretStr
@@ -28,11 +30,14 @@ from mixpanel_headless._internal.bookmark_enums import (
     VALID_PROPERTY_TYPES,
     VALID_RESOURCE_TYPES,
 )
+from mixpanel_headless._internal.segfilter import build_segfilter_entry
 from mixpanel_headless._internal.validation import (
     validate_bookmark,
     validate_query_args,
 )
+from mixpanel_headless._literal_types import FilterOperator
 from mixpanel_headless.types import (
+    _FILTER_OPERATOR_ALIASES,
     Filter,
     Formula,
     GroupBy,
@@ -857,3 +862,112 @@ class TestFormulaPositionValidation:
                 f"Position {max_letter} valid with {n_events} events "
                 f"but invalid with {n_events + 1}"
             )
+
+
+# =============================================================================
+# Filter direct construction: operator validation + alias normalization
+# =============================================================================
+
+_WIRE_OPERATORS: frozenset[str] = frozenset(get_args(FilterOperator))
+"""Runtime view of the ``FilterOperator`` literal."""
+
+
+def _direct(
+    operator: str, value: object = None, property_type: str = "string"
+) -> Filter:
+    """Construct a Filter positionally with an untyped operator string.
+
+    Args:
+        operator: Raw operator spelling (wire operator, alias, or garbage).
+        value: Raw ``_value`` payload.
+        property_type: Raw ``_property_type`` value.
+
+    Returns:
+        The constructed ``Filter`` (after ``__post_init__`` ran).
+    """
+    return Filter("p", operator, value, property_type)  # type: ignore[arg-type]
+
+
+class TestFilterOperatorValidationInvariant:
+    """``Filter.__post_init__`` accepts wire operators, maps aliases, rejects the rest."""
+
+    @given(op=st.sampled_from(sorted(_WIRE_OPERATORS - {"list_contains"})))
+    def test_every_wire_operator_is_accepted_unchanged(self, op: str) -> None:
+        """Every FilterOperator literal member round-trips through the constructor."""
+        f = _direct(op, None)
+        assert f._operator == op
+        assert f._value is None
+
+    @given(alias=st.sampled_from(sorted(_FILTER_OPERATOR_ALIASES)))
+    def test_every_alias_normalizes_to_a_wire_operator(self, alias: str) -> None:
+        """Every factory-method spelling maps onto a FilterOperator literal member."""
+        f = _direct(alias, None)
+        assert f._operator == _FILTER_OPERATOR_ALIASES[alias]
+        assert f._operator in _WIRE_OPERATORS
+
+    @given(op=st.text())
+    def test_every_other_string_is_rejected(self, op: str) -> None:
+        """Any string outside the literal set and the alias set raises ValueError."""
+        assume(op not in _WIRE_OPERATORS)
+        assume(op not in _FILTER_OPERATOR_ALIASES)
+        with pytest.raises(ValueError, match="Unknown Filter operator"):
+            _direct(op, None)
+
+    @given(op=st.sampled_from(sorted(_WIRE_OPERATORS)))
+    def test_case_and_whitespace_variants_are_rejected(self, op: str) -> None:
+        """Upper-casing or padding a valid operator does not sneak through."""
+        for variant in (op.upper(), f" {op}", f"{op} "):
+            assume(variant not in _WIRE_OPERATORS)
+            assume(variant not in _FILTER_OPERATOR_ALIASES)
+            with pytest.raises(ValueError, match="Unknown Filter operator"):
+                _direct(variant, None)
+
+    @given(truth=st.booleans(), negated=st.booleans())
+    def test_boolean_equality_collapses_to_true_false(
+        self, truth: bool, negated: bool
+    ) -> None:
+        """Boolean equals/not-equals with a bool value equals the is_true/is_false twin."""
+        operator = "does not equal" if negated else "equals"
+        f = _direct(operator, truth, "boolean")
+        expected_true = truth != negated
+        twin = Filter.is_true("p") if expected_true else Filter.is_false("p")
+        assert f == twin
+        assert build_filter_entry(f) == build_filter_entry(twin)
+
+    @given(
+        op=st.sampled_from(sorted(_WIRE_OPERATORS - {"true", "false", "list_contains"}))
+    )
+    def test_boolean_type_rejects_every_non_boolean_wire_operator(
+        self, op: str
+    ) -> None:
+        """On a boolean property only ``true`` / ``false`` survive validation."""
+        with pytest.raises(ValueError, match="boolean"):
+            _direct(op, None, "boolean")
+
+    @given(
+        value=st.integers(min_value=-10_000, max_value=10_000),
+        low=st.integers(min_value=-10_000, max_value=10_000),
+        high=st.integers(min_value=-10_000, max_value=10_000),
+    )
+    def test_segfilter_compat_aliases_preserve_segfilter_output(
+        self, value: int, low: int, high: int
+    ) -> None:
+        """'is equal to' / 'between' yield the same segfilter entry as their literal twins.
+
+        Both spellings are ``NUMBER_OPERATOR_MAP`` rows outside the
+        ``FilterOperator`` literal; normalizing them must not change what
+        ``build_segfilter_entry`` emits (``==`` and ``><``).
+        """
+        equal_alias = _direct("is equal to", value, "number")
+        equal_wire = _direct("equals", value, "number")
+        assert equal_alias == equal_wire
+        assert build_segfilter_entry(equal_alias) == build_segfilter_entry(equal_wire)
+        assert build_segfilter_entry(equal_alias)["filter"]["operator"] == "=="
+
+        between_alias = _direct("between", [low, high], "number")
+        between_wire = Filter.between("p", low, high)
+        assert between_alias == between_wire
+        assert build_segfilter_entry(between_alias) == build_segfilter_entry(
+            between_wire
+        )
+        assert build_segfilter_entry(between_alias)["filter"]["operator"] == "><"

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -6,18 +6,23 @@ Formula dataclass, and QueryResult.df behavior per mode (T045, T049).
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
-from typing import Any
+from dataclasses import FrozenInstanceError
+from typing import Any, get_args
 
 import pytest
 
+from mixpanel_headless._internal.bookmark_builders import build_filter_entry
 from mixpanel_headless._internal.bookmark_enums import (
     MATH_NO_PER_USER,
     MATH_PROPERTY_OPTIONAL,
     MATH_REQUIRING_PROPERTY,
 )
+from mixpanel_headless._literal_types import FilterOperator
 from mixpanel_headless.exceptions import ParamTypeError, ParamValidationError
 from mixpanel_headless.types import (
+    _FILTER_OPERATOR_ALIASES,
     CustomPropertyRef,
     Filter,
     Formula,
@@ -28,6 +33,7 @@ from mixpanel_headless.types import (
     Metric,
     QueryResult,
     TimeComparison,
+    _filter_unchecked,
 )
 
 # =============================================================================
@@ -2217,3 +2223,348 @@ class TestCodedFrequencyFilterCodes:
         with pytest.raises(ParamValidationError) as excinfo:
             FrequencyFilter(**kwargs)
         assert excinfo.value.code == code
+
+
+# =============================================================================
+# Direct construction: operator validation + factory-method aliases
+# =============================================================================
+
+
+def _direct(
+    property: str, operator: str, value: Any, property_type: str = "string"
+) -> Filter:
+    """Construct a Filter positionally with an untyped operator string.
+
+    Args:
+        property: Property name.
+        operator: Raw operator spelling (wire operator, alias, or garbage).
+        value: Raw ``_value`` payload.
+        property_type: Raw ``_property_type`` value.
+
+    Returns:
+        The constructed ``Filter`` (after ``__post_init__`` ran).
+    """
+    return Filter(property, operator, value, property_type)  # type: ignore[arg-type]
+
+
+def _public_factory_names() -> set[str]:
+    """Enumerate ``Filter``'s public classmethod factories from the class body.
+
+    Returns:
+        Names of every ``@classmethod`` on ``Filter`` not prefixed with ``_``.
+    """
+    return {
+        name
+        for name, attr in vars(Filter).items()
+        if isinstance(attr, classmethod) and not name.startswith("_")
+    }
+
+
+_FACTORY_SAMPLE_CALLS: dict[str, Callable[[], Filter]] = {
+    "equals": lambda: Filter.equals("country", "US"),
+    "not_equals": lambda: Filter.not_equals("browser", "IE"),
+    "contains": lambda: Filter.contains("browser", "Chrome"),
+    "not_contains": lambda: Filter.not_contains("url", "test"),
+    "greater_than": lambda: Filter.greater_than("gold", 10),
+    "less_than": lambda: Filter.less_than("age", 30),
+    "between": lambda: Filter.between("amount", 10, 100),
+    "not_between": lambda: Filter.not_between("age", 18, 65),
+    "at_least": lambda: Filter.at_least("age", 18),
+    "at_most": lambda: Filter.at_most("age", 65),
+    "is_set": lambda: Filter.is_set("class"),
+    "is_not_set": lambda: Filter.is_not_set("class"),
+    "starts_with": lambda: Filter.starts_with("url", "https"),
+    "ends_with": lambda: Filter.ends_with("url", ".html"),
+    "is_true": lambda: Filter.is_true("flag"),
+    "is_false": lambda: Filter.is_false("flag"),
+    "in_cohort": lambda: Filter.in_cohort(123),
+    "not_in_cohort": lambda: Filter.not_in_cohort(123),
+    "on": lambda: Filter.on("signup", "2026-01-01"),
+    "not_on": lambda: Filter.not_on("signup", "2026-01-01"),
+    "before": lambda: Filter.before("signup", "2026-01-01"),
+    "since": lambda: Filter.since("signup", "2026-01-01"),
+    "in_the_last": lambda: Filter.in_the_last("signup", 7, "day"),
+    "not_in_the_last": lambda: Filter.not_in_the_last("signup", 7, "day"),
+    "date_between": lambda: Filter.date_between("signup", "2026-01-01", "2026-02-01"),
+    "date_not_between": lambda: Filter.date_not_between(
+        "signup", "2026-01-01", "2026-02-01"
+    ),
+    "in_the_next": lambda: Filter.in_the_next("renewal", 7, "day"),
+    "list_contains": lambda: Filter.list_contains("cart", sku="A1"),
+}
+"""One representative call per public factory, keyed by factory name."""
+
+
+def _wire(f: Filter) -> str:
+    """Serialize a Filter's bookmark entry to a canonical JSON string.
+
+    Args:
+        f: Filter to serialize.
+
+    Returns:
+        ``json.dumps(build_filter_entry(f), sort_keys=True)``.
+    """
+    return json.dumps(build_filter_entry(f), sort_keys=True)
+
+
+class TestFilterDirectConstruction:
+    """Direct ``Filter(...)`` construction validates and normalizes ``_operator``.
+
+    Regression coverage for the MP Bench report where the factory-method
+    spelling (``"greater_than"``, ``"is_set"``, boolean ``"equals"``) was
+    serialized verbatim as ``filterOperator`` and rejected by the query API
+    with HTTP 400.
+    """
+
+    # --- The report's table: factory path == positional path, byte for byte ---
+
+    def test_report_row_greater_than(self) -> None:
+        """Filter("gold", "greater_than", 10, "number") == Filter.greater_than("gold", 10)."""
+        factory = Filter.greater_than("gold", 10)
+        positional = Filter("gold", "greater_than", 10, "number")  # type: ignore[arg-type]
+        assert positional == factory
+        assert build_filter_entry(positional)["filterOperator"] == "is greater than"
+        assert _wire(positional) == _wire(factory)
+
+    def test_report_row_is_set(self) -> None:
+        """Filter("class", "is_set", None) == Filter.is_set("class")."""
+        factory = Filter.is_set("class")
+        positional = Filter("class", "is_set", None)  # type: ignore[arg-type]
+        assert positional == factory
+        assert build_filter_entry(positional)["filterOperator"] == "is set"
+        assert _wire(positional) == _wire(factory)
+
+    def test_report_row_boolean_equals_true(self) -> None:
+        """Filter("flag", "equals", True, "boolean") == Filter.is_true("flag")."""
+        factory = Filter.is_true("flag")
+        positional = Filter("flag", "equals", True, "boolean")
+        assert positional == factory
+        entry = build_filter_entry(positional)
+        assert entry["filterOperator"] == "true"
+        assert entry["filterValue"] is None
+        assert _wire(positional) == _wire(factory)
+
+    # --- Boolean normalization table ---
+
+    @pytest.mark.parametrize(
+        ("operator", "value", "expected"),
+        [
+            pytest.param("equals", True, "true", id="equals-True"),
+            pytest.param("equals", False, "false", id="equals-False"),
+            pytest.param("does not equal", True, "false", id="does-not-equal-True"),
+            pytest.param("does not equal", False, "true", id="does-not-equal-False"),
+            pytest.param("not_equals", True, "false", id="not_equals-alias-True"),
+            pytest.param("not_equals", False, "true", id="not_equals-alias-False"),
+            pytest.param("equals", [True], "true", id="equals-list-True"),
+            pytest.param("equals", [False], "false", id="equals-list-False"),
+            pytest.param("is_true", None, "true", id="is_true-alias"),
+            pytest.param("is_false", None, "false", id="is_false-alias"),
+        ],
+    )
+    def test_boolean_operators_normalize_to_true_false(
+        self, operator: str, value: Any, expected: str
+    ) -> None:
+        """Boolean equals/not-equals with a bool value collapse to true/false + None."""
+        f = _direct("flag", operator, value, "boolean")
+        assert f._operator == expected
+        assert f._value is None
+        twin = Filter.is_true("flag") if expected == "true" else Filter.is_false("flag")
+        assert f == twin
+        assert _wire(f) == _wire(twin)
+
+    @pytest.mark.parametrize(
+        ("operator", "value"),
+        [
+            pytest.param("is set", None, id="is-set"),
+            pytest.param("equals", "yes", id="equals-string"),
+            pytest.param("equals", 1, id="equals-int-not-bool"),
+            pytest.param("equals", None, id="equals-none"),
+            pytest.param("equals", [True, False], id="equals-two-bools"),
+            pytest.param("contains", "tr", id="contains"),
+        ],
+    )
+    def test_boolean_rejects_non_boolean_operators(
+        self, operator: str, value: Any
+    ) -> None:
+        """A boolean-typed Filter only accepts true/false after normalization."""
+        with pytest.raises(ValueError, match="boolean") as excinfo:
+            _direct("flag", operator, value, "boolean")
+        assert "Filter.is_true" in str(excinfo.value)
+        assert "Filter.is_false" in str(excinfo.value)
+
+    def test_boolean_wire_operators_accepted_unchanged(self) -> None:
+        """Filter("flag", "true", None, "boolean") stays exactly as given."""
+        assert _direct("flag", "true", None, "boolean") == Filter.is_true("flag")
+        assert _direct("flag", "false", None, "boolean") == Filter.is_false("flag")
+
+    # --- Unknown operators ---
+
+    def test_unknown_operator_raises_value_error_with_guidance(self) -> None:
+        """An operator outside the literal and alias sets fails immediately."""
+        with pytest.raises(ValueError) as excinfo:
+            Filter("gold", "bigger_than", 10, "number")  # type: ignore[arg-type]
+        message = str(excinfo.value)
+        assert "'bigger_than'" in message
+        for wire in get_args(FilterOperator):
+            assert f"'{wire}'" in message
+        assert "Filter.greater_than" in message
+
+    @pytest.mark.parametrize("operator", ["", "GREATER_THAN", "is greater than ", ">"])
+    def test_near_miss_spellings_are_rejected(self, operator: str) -> None:
+        """Case, whitespace, and symbol variants are not silently accepted."""
+        with pytest.raises(ValueError, match="Unknown Filter operator"):
+            _direct("gold", operator, 10, "number")
+
+    def test_unknown_operator_error_is_not_a_coded_guard(self) -> None:
+        """The construction guard is a plain ValueError (no registry code)."""
+        with pytest.raises(ValueError) as excinfo:
+            _direct("gold", "bigger_than", 10, "number")
+        assert not isinstance(excinfo.value, ParamValidationError)
+
+    # --- Already-valid inputs are untouched ---
+
+    @pytest.mark.parametrize(
+        ("operator", "value", "property_type"),
+        [
+            pytest.param("is greater than", 18, "number", id="number"),
+            pytest.param("equals", "US", "string", id="equals-bare-string"),
+            pytest.param("equals", ["US"], "string", id="equals-list"),
+            pytest.param("is set", None, "string", id="is-set"),
+            pytest.param("was on", ["2026-01-01"], "datetime", id="datetime"),
+            pytest.param("true", None, "string", id="true-on-string-type"),
+        ],
+    )
+    def test_valid_wire_operators_pass_through_unchanged(
+        self, operator: str, value: Any, property_type: str
+    ) -> None:
+        """No alias or value rewriting happens for an already-valid operator."""
+        f = _direct("p", operator, value, property_type)
+        assert f._operator == operator
+        assert f._value == value
+        assert f._property_type == property_type
+
+    def test_list_contains_guard_still_runs_after_normalization(self) -> None:
+        """The pre-existing LC1 guard is preserved behind the operator check."""
+        with pytest.raises(ParamValidationError) as excinfo:
+            _direct("cart", "list_contains", None, "object")
+        assert excinfo.value.code == "LC1_MISSING_ITEM_FILTERS"
+
+    # --- Alias table is derived from the factory methods on the class ---
+
+    def test_sample_calls_cover_every_public_factory(self) -> None:
+        """The sample-call table tracks the class: adding a factory fails here."""
+        assert set(_FACTORY_SAMPLE_CALLS) == _public_factory_names()
+
+    def test_alias_keys_are_factory_names(self) -> None:
+        """Every alias key is a public factory name or a documented segfilter spelling.
+
+        ``"is equal to"`` is the one non-factory key: it is a
+        ``NUMBER_OPERATOR_MAP`` row in ``segfilter.py`` that pre-dates the
+        ``FilterOperator`` literal and is kept constructible for that path.
+        """
+        assert set(_FILTER_OPERATOR_ALIASES) <= _public_factory_names() | {
+            "is equal to"
+        }
+
+    @pytest.mark.parametrize(
+        ("alias", "wire"),
+        [
+            pytest.param("is equal to", "equals", id="is-equal-to"),
+            pytest.param("between", "is between", id="between"),
+        ],
+    )
+    def test_segfilter_compat_spellings_normalize(self, alias: str, wire: str) -> None:
+        """The two segfilter-only spellings normalize to their literal twins."""
+        f = _direct("count", alias, 42, "number")
+        assert f._operator == wire
+        assert f == _direct("count", wire, 42, "number")
+
+
+class TestFilterUnchecked:
+    """``_filter_unchecked`` rebuilds a Filter verbatim, bypassing ``__post_init__``.
+
+    It exists for the conformance codec and for tests that drive downstream
+    builder guards with operators the constructor now rejects.
+    """
+
+    def test_sets_fields_verbatim_without_validation(self) -> None:
+        """An operator the constructor rejects is stored as given."""
+        f = _filter_unchecked(_property="p", _operator="was frobnicated", _value=None)
+        assert isinstance(f, Filter)
+        # str() sidesteps mypy's Literal non-overlap check: the whole point is
+        # that the field holds a spelling outside the FilterOperator literal.
+        assert str(f._operator) == "was frobnicated"
+        assert f._value is None
+
+    def test_does_not_normalize_aliases(self) -> None:
+        """Alias spellings are kept verbatim — faithful rehydration, not construction."""
+        f = _filter_unchecked(
+            _property="gold",
+            _operator="greater_than",
+            _value=10,
+            _property_type="number",
+        )
+        assert str(f._operator) == "greater_than"
+
+    def test_applies_dataclass_defaults(self) -> None:
+        """Omitted optional fields take the dataclass defaults."""
+        f = _filter_unchecked(_property="p", _operator="is set", _value=None)
+        assert f._property_type == "string"
+        assert f._resource_type == "events"
+        assert f._date_unit is None
+        assert f._list_item_filters is None
+        assert f._list_item_quantifier is None
+
+    def test_equals_constructed_filter_for_valid_fields(self) -> None:
+        """With canonical fields the result is equal to a normally built Filter."""
+        f = _filter_unchecked(
+            _property="gold",
+            _operator="is greater than",
+            _value=10,
+            _property_type="number",
+        )
+        assert f == Filter.greater_than("gold", 10)
+        assert _wire(f) == _wire(Filter.greater_than("gold", 10))
+
+    def test_missing_required_field_raises_type_error(self) -> None:
+        """Required fields (no dataclass default) must be supplied."""
+        with pytest.raises(TypeError, match="_value"):
+            _filter_unchecked(_property="p", _operator="is set")
+
+    def test_unknown_field_raises_type_error(self) -> None:
+        """Fields that are not on the dataclass are rejected, not silently dropped."""
+        with pytest.raises(TypeError, match="_bogus"):
+            _filter_unchecked(_property="p", _operator="is set", _value=None, _bogus=1)
+
+    def test_result_is_still_frozen(self) -> None:
+        """Bypassing ``__post_init__`` does not thaw the instance."""
+        f = _filter_unchecked(_property="p", _operator="is set", _value=None)
+        with pytest.raises(FrozenInstanceError):
+            f._operator = "equals"  # type: ignore[misc]
+
+    def test_alias_values_are_wire_operators(self) -> None:
+        """Every alias resolves to a member of the FilterOperator literal."""
+        assert set(_FILTER_OPERATOR_ALIASES.values()) <= set(get_args(FilterOperator))
+
+    @pytest.mark.parametrize("name", sorted(_FACTORY_SAMPLE_CALLS))
+    def test_alias_table_matches_operator_each_factory_emits(self, name: str) -> None:
+        """A factory whose name is not itself a wire operator must be aliased."""
+        factory = _FACTORY_SAMPLE_CALLS[name]()
+        assert factory._operator == _FILTER_OPERATOR_ALIASES.get(name, name)
+
+    @pytest.mark.parametrize(
+        "name", sorted(set(_FACTORY_SAMPLE_CALLS) - {"list_contains"})
+    )
+    def test_positional_alias_reproduces_factory_byte_for_byte(self, name: str) -> None:
+        """Rebuilding a factory result positionally via its name yields the same wire."""
+        factory = _FACTORY_SAMPLE_CALLS[name]()
+        positional = Filter(
+            factory._property,
+            name,  # type: ignore[arg-type]
+            factory._value,
+            factory._property_type,
+            factory._resource_type,
+            factory._date_unit,
+        )
+        assert positional == factory
+        assert _wire(positional) == _wire(factory)

--- a/tests/unit/test_query_types.py
+++ b/tests/unit/test_query_types.py
@@ -19,7 +19,7 @@ from mixpanel_headless._internal.bookmark_enums import (
     MATH_PROPERTY_OPTIONAL,
     MATH_REQUIRING_PROPERTY,
 )
-from mixpanel_headless._literal_types import FilterOperator
+from mixpanel_headless._literal_types import FilterOperator, FilterOperatorInput
 from mixpanel_headless.exceptions import ParamTypeError, ParamValidationError
 from mixpanel_headless.types import (
     _FILTER_OPERATOR_ALIASES,
@@ -29,8 +29,10 @@ from mixpanel_headless.types import (
     FrequencyBreakdown,
     FrequencyFilter,
     GroupBy,
+    InlineCustomProperty,
     ListItemGroupMode,
     Metric,
+    PropertyInput,
     QueryResult,
     TimeComparison,
     _filter_unchecked,
@@ -2321,7 +2323,7 @@ class TestFilterDirectConstruction:
     def test_report_row_greater_than(self) -> None:
         """Filter("gold", "greater_than", 10, "number") == Filter.greater_than("gold", 10)."""
         factory = Filter.greater_than("gold", 10)
-        positional = Filter("gold", "greater_than", 10, "number")  # type: ignore[arg-type]
+        positional = Filter("gold", "greater_than", 10, "number")
         assert positional == factory
         assert build_filter_entry(positional)["filterOperator"] == "is greater than"
         assert _wire(positional) == _wire(factory)
@@ -2329,7 +2331,7 @@ class TestFilterDirectConstruction:
     def test_report_row_is_set(self) -> None:
         """Filter("class", "is_set", None) == Filter.is_set("class")."""
         factory = Filter.is_set("class")
-        positional = Filter("class", "is_set", None)  # type: ignore[arg-type]
+        positional = Filter("class", "is_set", None)
         assert positional == factory
         assert build_filter_entry(positional)["filterOperator"] == "is set"
         assert _wire(positional) == _wire(factory)
@@ -2397,7 +2399,89 @@ class TestFilterDirectConstruction:
         assert _direct("flag", "true", None, "boolean") == Filter.is_true("flag")
         assert _direct("flag", "false", None, "boolean") == Filter.is_false("flag")
 
+    @pytest.mark.parametrize("operator", ["true", "false", "is_true", "is_false"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("yes", id="string"),
+            pytest.param(True, id="bool"),
+            pytest.param(1, id="int"),
+            pytest.param([True], id="list"),
+        ],
+    )
+    @pytest.mark.parametrize("property_type", ["boolean", "string"])
+    def test_true_false_operators_reject_non_none_value(
+        self, operator: str, value: Any, property_type: str
+    ) -> None:
+        """``true`` / ``false`` (and their aliases) carry no value; anything else is rejected."""
+        with pytest.raises(ValueError, match="no value") as excinfo:
+            _direct("flag", operator, value, property_type)
+        assert "Filter.is_true" in str(excinfo.value)
+        assert "Filter.is_false" in str(excinfo.value)
+
+    # --- Inline custom properties: the inline type wins ---
+
+    @staticmethod
+    def _inline(property_type: str | None) -> InlineCustomProperty:
+        """Build a one-input inline custom property with the given declared type.
+
+        Args:
+            property_type: The inline property's ``property_type`` (or ``None``).
+
+        Returns:
+            An ``InlineCustomProperty`` over a single ``plan`` input.
+        """
+        return InlineCustomProperty(
+            formula="A",
+            inputs={"A": PropertyInput("plan")},
+            property_type=property_type,  # type: ignore[arg-type]
+        )
+
+    def test_boolean_inline_custom_property_rejects_contains(self) -> None:
+        """A boolean inline custom property is governed by the boolean rules."""
+        with pytest.raises(ValueError, match="boolean"):
+            Filter(self._inline("boolean"), "contains", "tr", "string")
+
+    def test_boolean_inline_custom_property_collapses_equals_true(self) -> None:
+        """``equals`` + ``True`` on a boolean inline custom property becomes ``true``/None."""
+        f = Filter(self._inline("boolean"), "equals", True, "string")
+        assert f._operator == "true"
+        assert f._value is None
+        entry = build_filter_entry(f)
+        assert entry["filterType"] == "boolean"
+        assert entry["filterOperator"] == "true"
+        assert entry["filterValue"] is None
+
+    def test_inline_custom_property_without_type_uses_filter_type(self) -> None:
+        """With no inline type declared, the Filter's own ``_property_type`` governs."""
+        f = Filter(self._inline(None), "equals", ["x"], "string")
+        assert f._operator == "equals"
+        assert f._value == ["x"]
+        with pytest.raises(ValueError, match="boolean"):
+            Filter(self._inline(None), "contains", "tr", "boolean")
+
     # --- Unknown operators ---
+
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            pytest.param(["equals"], id="list"),
+            pytest.param({"op": "equals"}, id="dict"),
+            pytest.param(None, id="none"),
+            pytest.param(7, id="int"),
+        ],
+    )
+    def test_non_string_operator_raises_value_error(self, operator: object) -> None:
+        """Unhashable or non-string operators get the same ValueError, not TypeError."""
+        with pytest.raises(ValueError, match="Unknown Filter operator") as excinfo:
+            Filter("gold", operator, 10, "number")  # type: ignore[arg-type]
+        assert "Filter.greater_than" in str(excinfo.value)
+
+    def test_filter_operator_input_is_literal_union_of_wire_and_aliases(self) -> None:
+        """``FilterOperatorInput`` spells exactly the wire operators plus every alias."""
+        assert set(get_args(FilterOperatorInput)) == set(
+            get_args(FilterOperator)
+        ) | set(_FILTER_OPERATOR_ALIASES)
 
     def test_unknown_operator_raises_value_error_with_guidance(self) -> None:
         """An operator outside the literal and alias sets fails immediately."""

--- a/tests/unit/test_segfilter.py
+++ b/tests/unit/test_segfilter.py
@@ -187,12 +187,12 @@ class TestSegfilterNumberOperators:
 
         ``"is equal to"`` is a ``NUMBER_OPERATOR_MAP`` row outside the
         ``FilterOperator`` literal; ``Filter.__post_init__`` accepts it as
-        an alias of ``"equals"`` (hence the type: ignore) and the segfilter
-        output is unchanged.
+        an alias of ``"equals"`` (it is a ``FilterOperatorInput`` member)
+        and the segfilter output is unchanged.
         """
         f = Filter(
             _property="count",
-            _operator="is equal to",  # type: ignore[arg-type]
+            _operator="is equal to",
             _value=42,
             _property_type="number",
             _resource_type="events",
@@ -205,7 +205,7 @@ class TestSegfilterNumberOperators:
         """'is equal to' and 'equals' produce identical segfilter entries."""
         alias = Filter(
             _property="count",
-            _operator="is equal to",  # type: ignore[arg-type]
+            _operator="is equal to",
             _value=42,
             _property_type="number",
         )
@@ -224,7 +224,7 @@ class TestSegfilterNumberOperators:
         bounds: list[int | float] = [1, 10]
         alias = Filter(
             _property="amount",
-            _operator="between",  # type: ignore[arg-type]
+            _operator="between",
             _value=bounds,
             _property_type="number",
         )

--- a/tests/unit/test_segfilter.py
+++ b/tests/unit/test_segfilter.py
@@ -20,6 +20,7 @@ from mixpanel_headless._internal.segfilter import (
 )
 from mixpanel_headless.exceptions import ParamValidationError
 from mixpanel_headless.types import Filter
+from tests.conftest import make_unchecked_filter
 
 # =============================================================================
 # String Operators
@@ -184,9 +185,10 @@ class TestSegfilterNumberOperators:
     def test_is_equal_to_number(self) -> None:
         """Number 'is equal to' maps to '==' with stringified operand.
 
-        Exercises segfilter's backward-compat dispatch for the
-        ``"is equal to"`` alias (no Filter classmethod produces this
-        value, hence the type: ignore).
+        ``"is equal to"`` is a ``NUMBER_OPERATOR_MAP`` row outside the
+        ``FilterOperator`` literal; ``Filter.__post_init__`` accepts it as
+        an alias of ``"equals"`` (hence the type: ignore) and the segfilter
+        output is unchanged.
         """
         f = Filter(
             _property="count",
@@ -198,7 +200,41 @@ class TestSegfilterNumberOperators:
         result = build_segfilter_entry(f)
 
         assert result["filter"]["operator"] == "=="
-        assert result["filter"]["operand"] == "42"
+
+    def test_is_equal_to_alias_matches_equals_output(self) -> None:
+        """'is equal to' and 'equals' produce identical segfilter entries."""
+        alias = Filter(
+            _property="count",
+            _operator="is equal to",  # type: ignore[arg-type]
+            _value=42,
+            _property_type="number",
+        )
+        canonical = Filter(
+            _property="count", _operator="equals", _value=42, _property_type="number"
+        )
+        assert alias._operator == "equals"
+        assert build_segfilter_entry(alias) == build_segfilter_entry(canonical)
+        assert build_segfilter_entry(alias)["filter"] == {
+            "operator": "==",
+            "operand": "42",
+        }
+
+    def test_between_alias_matches_is_between_output(self) -> None:
+        """'between' and 'is between' produce identical segfilter entries."""
+        bounds: list[int | float] = [1, 10]
+        alias = Filter(
+            _property="amount",
+            _operator="between",  # type: ignore[arg-type]
+            _value=bounds,
+            _property_type="number",
+        )
+        canonical = Filter.between("amount", 1, 10)
+        assert alias == canonical
+        assert build_segfilter_entry(alias) == build_segfilter_entry(canonical)
+        assert build_segfilter_entry(alias)["filter"] == {
+            "operator": "><",
+            "operand": ["1", "10"],
+        }
 
     def test_not_equals_number(self) -> None:
         """Number 'does not equal' maps to '!=' with stringified operand."""
@@ -499,37 +535,19 @@ class TestSegfilterEdgeCases:
 
     def test_unknown_operator_raises(self) -> None:
         """Unknown operator for a property type raises ValueError."""
-        f = Filter(
-            _property="x",
-            _operator="magical_unicorn",  # type: ignore[arg-type]
-            _value="y",
-            _property_type="string",
-            _resource_type="events",
-        )
+        f = make_unchecked_filter("x", "magical_unicorn", "y", "string")
         with pytest.raises(ValueError, match="Unknown string operator"):
             build_segfilter_entry(f)
 
     def test_unknown_number_operator_raises(self) -> None:
         """Unknown number operator raises ValueError."""
-        f = Filter(
-            _property="x",
-            _operator="magical_unicorn",  # type: ignore[arg-type]
-            _value=1,
-            _property_type="number",
-            _resource_type="events",
-        )
+        f = make_unchecked_filter("x", "magical_unicorn", 1, "number")
         with pytest.raises(ValueError, match="Unknown number operator"):
             build_segfilter_entry(f)
 
     def test_unknown_datetime_operator_raises(self) -> None:
         """Unknown datetime operator raises ValueError."""
-        f = Filter(
-            _property="x",
-            _operator="magical_unicorn",  # type: ignore[arg-type]
-            _value="2026-01-01",
-            _property_type="datetime",
-            _resource_type="events",
-        )
+        f = make_unchecked_filter("x", "magical_unicorn", "2026-01-01", "datetime")
         with pytest.raises(ValueError, match="Unknown datetime operator"):
             build_segfilter_entry(f)
 
@@ -560,16 +578,11 @@ def _filter_with(operator: str, value: Any, property_type: str) -> Filter:
         property_type: Raw ``_property_type`` value (may be invalid).
 
     Returns:
-        A ``Filter`` bypassing the classmethod constructors, matching the
-        edge-case construction pattern used elsewhere in this file.
+        A ``Filter`` bypassing both the classmethod constructors and
+        ``Filter.__post_init__`` validation, matching the edge-case
+        construction pattern used elsewhere in this file.
     """
-    return Filter(
-        _property="x",
-        _operator=operator,  # type: ignore[arg-type]
-        _value=value,
-        _property_type=property_type,  # type: ignore[arg-type]
-        _resource_type="events",
-    )
+    return make_unchecked_filter("x", operator, value, property_type)
 
 
 class TestCodedSegfilterCodes:


### PR DESCRIPTION
## Summary

`Filter(...)` built positionally with the *factory-method* spelling of the operator (`"greater_than"`, `"is_set"`, boolean `"equals"`) serialized that string verbatim as `filterOperator`, and the Mixpanel query API rejected it with HTTP 400 one round trip later (`Unsupported operator for filter_type number: greater_than`). The factory methods were always correct; only direct construction was unvalidated. Bug report: `context/mp-bench-headless/bug-reports/python-filter-direct-construction-unvalidated-operator.md` (implements its option 2).

`Filter.__post_init__` now:

- **Validates** `_operator` against the `FilterOperator` literal and raises `ValueError` immediately. The message names the bad operator, lists the valid wire operators, and points at the factory methods (and lists the accepted aliases).
- **Accepts the factory-method spellings as aliases** and normalizes them to the wire operator, so the positional call produces byte-identical output to the equivalent factory. The alias table is derived from the public classmethods on `Filter` (a test introspects the class and fails if a factory is added without an alias decision): `not_equals`, `not_contains`, `greater_than`, `less_than`, `between`, `not_between`, `at_least`, `at_most`, `is_set`, `is_not_set`, `starts_with`, `ends_with`, `is_true`, `is_false`, `in_cohort`, `not_in_cohort`, `on`, `not_on`, `before`, `since`, `in_the_last`, `not_in_the_last`, `date_between`, `date_not_between`, `in_the_next`. `equals`, `contains`, `list_contains` already are the wire spelling.
- Keeps the two segmentation-`where` spellings that pre-date the literal constructible: `"is equal to"` -> `"equals"` and `"between"` -> `"is between"` (`NUMBER_OPERATOR_MAP` maps both pairs to the same `==` / `><`, so segfilter output is unchanged).
- **Boolean collapse**: on a `boolean` property, `equals` / `does not equal` with a `True` / `False` value (bare or single-element list) collapse to `true` / `false` with `filterValue: null`, matching `Filter.is_true()` / `Filter.is_false()`. Any other operator on a boolean property is rejected.
- **Never rewrites already-valid input**: a wire operator and its value serialize exactly as given.

The `Filter` docstring no longer claims the class is "never instantiated directly"; it now says the factories are the recommended path and direct construction is validated with aliases accepted. The guard is a plain `ValueError` (not a new coded `ParamValidationError`) because the conformance contract pins the coded-guard registry at 126 entries.

## Before / after

| Call | `filterType` | `filterOperator` before | after | `filterValue` after | Result |
|---|---|---|---|---|---|
| `Filter.greater_than("gold", 10)` | number | `is greater than` | `is greater than` | 10 | 200 |
| `Filter("gold", "greater_than", 10, "number")` | number | `greater_than` (400) | `is greater than` | 10 | 200 |
| `Filter.is_set("class")` | string | `is set` | `is set` | null | 200 |
| `Filter("class", "is_set", None)` | string | `is_set` (400) | `is set` | null | 200 |
| `Filter.is_true("flag")` | boolean | `true` | `true` | null | 200 |
| `Filter("flag", "equals", True, "boolean")` | boolean | `equals` (400) | `true` | null | 200 |
| `Filter("gold", "bigger_than", 10, "number")` | — | `bigger_than` (400) | `ValueError` at construction | — | — |

## Conformance

**Expected CI failure.** The `conformance` job fails on this PR in the "Record-mode drift check" step (97 findings: 93 new vectors from the direct-construction tests, two bundle headers, `manifest.json`, and one changed vector, the segfilter `is equal to` case whose recorded `_operator` becomes `equals`). Under the two-step corpus protocol in `conformance/record/README.md` that failure is the expected signal; the vectors are recorded in a follow-up re-pin PR stamped with this change's squash SHA (shared with #235).

`Filter.__post_init__` running on construction had two knock-on effects on the corpus tooling, both resolved with **tooling** changes — nothing under `conformance/vectors/`, `conformance/goldens/`, the manifest, or the stamps is touched:

- A private `mixpanel_headless.types._filter_unchecked(**fields)` rebuilds a `Filter` field-for-field via `object.__new__` + `object.__setattr__`, without running `__post_init__`. It exists for the codec and for tests / the differential harness that drive the downstream builder guards (engage `ES13`, segfilter `SG1`/`SG2`/`SG3`) with operators the constructor now rejects. `tests/conftest.py::make_unchecked_filter` is a positional wrapper over it.
- `conformance/record/codecs.py` now rehydrates `$type: Filter` payloads through `_filter_unchecked` instead of `cls(**kwargs)` (every other type still goes through its constructor). Rationale: the codec must rebuild the *recorded* object faithfully. The pinned vectors capture the builders' own guard behaviour on an already-constructed Filter; re-running the constructor on replay would either refuse to rebuild those inputs (`"was frobnicated"`, `"magical_unicorn"`, ...) or silently rewrite alias spellings before the builder under test saw them. The builders' behaviour on the rebuilt Filter is unchanged, so the pinned outputs still hold.
- `conformance/differential/strategies.py` builds its deliberately invalid ES13 probes (the import-time edges and the `_escaping_filters` draws) through `_filter_unchecked`.

Result: the 11 pinned vectors that rehydrate a Filter with a non-literal operator (engage `filter_to_selector` / `filters_to_selector` ES13 x4, segfilter SG1/SG2/SG3 seams + edge cases x6, segfilter `is equal to` x1) replay clean, and `conformance/tests` (including the fuzz-harness import) is green. `just check` passes end to end.

## Test plan

- [x] `tests/unit/test_query_types.py::TestFilterDirectConstruction`: the report's three rows assert `build_filter_entry(positional) == build_filter_entry(factory)` and `json.dumps(..., sort_keys=True)` byte-equality; boolean collapse table (equals/not-equals x True/False, list-wrapped bools, `is_true`/`is_false` aliases); boolean rejects `is set` / string / int / None / two-element list; unknown operator raises `ValueError` whose message contains the operator, every wire operator, and `Filter.greater_than`; near-miss spellings (`""`, upper-case, trailing space, `>`) rejected; already-valid wire operators pass through untouched; LC1 guard still runs; alias keys are factory names (plus the documented `is equal to`), alias values are literal members, every factory's emitted operator matches the table, and every factory result rebuilt positionally via its own name is byte-identical.
- [x] `tests/unit/test_query_types.py::TestFilterUnchecked`: verbatim fields, no alias normalization, dataclass defaults, equality with normal construction for valid fields, `TypeError` on missing / unknown fields, instance still frozen.
- [x] `tests/unit/test_query_pbt.py::TestFilterOperatorValidationInvariant` (Hypothesis): every `FilterOperator` member accepted unchanged; every alias maps into the literal; every other `st.text()` string raises; case/whitespace variants raise; boolean collapse equals the `is_true`/`is_false` twin; boolean rejects every other wire operator; `is equal to` / `between` yield the same segfilter entry as their literal twins across random numeric values.
- [x] `tests/unit/test_segfilter.py`: `test_is_equal_to_number` back to plain construction (proves the alias), plus `is equal to`≡`equals` and `between`≡`is between` output equality; genuinely invalid operators use `make_unchecked_filter`.
- [x] `conformance/tests/test_codecs_roundtrip.py`: Filter payloads with rejected operators decode verbatim; alias spellings are not normalized on decode; unknown fields still rejected.
- [x] Existing ES13 / SG* / `BookmarkValidationError`-wrapping tests keep their ids and expectations via the bypass helper.
- [x] `just check` green (lint, fmt-check, typecheck, docstring-cov, test-cov, conformance, build); full non-live suite passes; 11 previously affected vectors replay clean.

## Follow-ups

- **Conformance vector family for `Filter.__post_init__`** (positional construction, alias normalization, boolean collapse, the `ValueError` on unknown operators): a follow-up re-pin PR per the corpus stamp protocol, so the TS port stops agreeing with Python only by both being permissive.
- Re-recording the touched tests will change the recorded `_operator` for `test_is_equal_to_number` from `"is equal to"` to `"equals"`; that lands with the same re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

